### PR TITLE
Release v1.1.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Verify package
+        run: |
+          pip install dist/*.whl
+          android-agent --help
+          python -c "from gitd.mcp_server import main; print('MCP entry point OK')"
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_PROJECT_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -27,9 +27,8 @@ reference/
 *.swp
 *.swo
 
-# Claude / MCP config
+# Claude session data (not the MCP config — that ships with the repo)
 .claude/
-.mcp.json
 
 # OS
 .DS_Store

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "android-agent": {
+      "command": ".venv/bin/python",
+      "args": ["-m", "gitd.mcp_server"]
+    }
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to Ghost in the Droid are documented here.
+
+Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) · Versioning: [Semantic](https://semver.org/)
+
+## [Unreleased]
+
+## [1.1.0] — 2026-04-16
+
+### Added
+- **Ollama support** — multi-turn tool-using loop for local models. Zero API keys needed. Pre-filled dropdown: `llama3.2:3b`, `llama3.2:1b`, `gemma3:4b`, `qwen3:4b`, `phi4-mini:3.8b`, `mistral:7b`.
+- **`_parse_tool_calls()`** — robust tool-call extractor handling common LLM JSON quirks (doubled braces from gemma/qwen, trailing commas, etc.).
+- **Ollama unload button** — free GPU memory between chats.
+- **Emulator support (full stack)** — FastAPI router, Pool management, 4 Vue components, 21 REST endpoints. See `gitd/services/emulator_service.py`.
+- **Mac / Apple Silicon support** — HVF hardware acceleration, arm64-v8a auto-detection, Homebrew SDK path detection.
+- **MCP distribution** — `.mcp.json` ships with the repo; 35 tools available on first clone.
+- **PyPI package** — `uvx --from ghost-in-the-droid android-agent-mcp` runs the MCP server without cloning.
+- **CI/CD release pipeline** — push a `v*` tag → auto-publish to PyPI.
+
+### Changed
+- **Flask → FastAPI** — emulator router fully migrated to `APIRouter` + Pydantic models.
+- **README & SETUP.md** — MCP install docs, emulator install docs, multi-client install snippets (Claude Code, Claude Desktop, Cursor, VS Code Copilot, Windsurf).
+
+### Fixed
+- `pyproject.toml` — `dependencies` was mis-nested under `[project.urls]`.
+- Import sort in `gitd/app.py` (ruff I001).
+
+## [1.0.0] — 2026-04-08
+
+Initial open-source release of Ghost in the Droid.
+
+### Added
+- FastAPI backend (`gitd/` package), Vue 3 frontend
+- Skills framework (Action / Workflow / Skill with YAML element locators)
+- ADB automation primitives (`Device` class: tap, swipe, type, XML dump, screen classification)
+- Portal companion APK for on-device streaming & notifications
+- MCP server with 35 tools for Android control
+- WebRTC screen streaming
+- Skill Hub (registry of reusable skills)
+- Agent Chat (LLM-driven device control via Claude / Claude Code / OpenRouter / Ollama)
+
+[Unreleased]: https://github.com/ghost-in-the-droid/android-agent/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/ghost-in-the-droid/android-agent/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/ghost-in-the-droid/android-agent/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ Copy `.env.example` to `.env` (if provided) or create a `.env` file in the proje
 | `OPENROUTER_API_KEY` | OpenRouter LLM provider |
 | `DEFAULT_DEVICE` | ADB serial (auto-detected if empty) |
 
+**No API keys needed for local models:** Select Ollama in the Phone Agent tab — runs entirely on your machine with [Ollama](https://ollama.com). Install, pull a model, go:
+
+```bash
+brew install ollama       # or curl -fsSL https://ollama.com/install.sh | sh
+ollama serve &
+ollama pull llama3.2:3b   # 2GB, fast, good tool-use
+```
+
 ---
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -165,7 +165,79 @@ API domains: phone, streaming, skills, creator, explorer, agent-chat, bot, sched
 | Tools | Utility tools hub |
 | Manual Run | Start/stop bot jobs, queue management, logs |
 | Tests | Per-device test runner with screen recording playback |
-| Emulators | Headless emulator management (coming soon) |
+| Emulators | Create, boot, snapshot, and manage Android emulators |
+
+---
+
+## MCP Server — Give Any AI Agent an Android Body
+
+The project ships an [MCP](https://modelcontextprotocol.io) server with 35 tools for Android control. Any MCP-compatible AI client (Claude Code, Claude Desktop, Cursor, VS Code Copilot, Windsurf) can use them.
+
+### Install
+
+One command — works with Claude Code, Codex, Cursor, VS Code Copilot, Windsurf:
+
+```bash
+claude mcp add android-agent -- uvx --from ghost-in-the-droid android-agent-mcp
+```
+
+That's it. `uvx` installs the package, creates an isolated env, and runs the MCP server. No clone, no venv, no manual setup.
+
+**Other clients** — same command, different registration:
+
+```bash
+# Codex (OpenAI)
+codex mcp add android-agent -- uvx --from ghost-in-the-droid android-agent-mcp
+```
+
+**Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+```json
+{
+  "mcpServers": {
+    "android-agent": {
+      "command": "uvx",
+      "args": ["--from", "ghost-in-the-droid", "android-agent-mcp"]
+    }
+  }
+}
+```
+
+**VS Code Copilot** (`.vscode/mcp.json`):
+```json
+{
+  "servers": {
+    "android-agent": {
+      "command": "uvx",
+      "args": ["--from", "ghost-in-the-droid", "android-agent-mcp"]
+    }
+  }
+}
+```
+
+**Cursor** (`.cursor/mcp.json`) / **Windsurf** (`~/.codeium/windsurf/mcp_config.json`):
+```json
+{
+  "mcpServers": {
+    "android-agent": {
+      "command": "uvx",
+      "args": ["--from", "ghost-in-the-droid", "android-agent-mcp"]
+    }
+  }
+}
+```
+
+**For contributors** who clone the repo: the `.mcp.json` is already there — 35 tools available on first `claude` launch.
+
+### Available tools
+
+| Category | Tools |
+|----------|-------|
+| Screen | `screenshot`, `get_elements`, `get_screen_tree`, `get_screen_xml`, `screenshot_annotated`, `screenshot_cropped` |
+| Interaction | `tap`, `tap_element`, `swipe`, `long_press`, `type_text`, `type_unicode`, `press_back`, `press_home`, `press_key` |
+| Apps | `launch_app`, `search_apps`, `list_apps`, `launch_intent` |
+| Context | `get_phone_state`, `classify_screen`, `find_on_screen`, `ocr_screen`, `ocr_region` |
+| Device | `list_devices`, `clipboard_get`, `clipboard_set`, `get_notifications`, `open_notifications`, `toggle_overlay` |
+| Skills | `list_skills`, `run_workflow`, `run_action`, `create_skill`, `explore_app` |
 
 ---
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,217 @@
+# Release Process
+
+How we cut a new release of Ghost in the Droid and publish it to GitHub + PyPI.
+
+---
+
+## Versioning — Semantic (SemVer)
+
+`MAJOR.MINOR.PATCH`
+
+- **MAJOR** — breaking changes (DB schema incompatible, API removed, skill framework rewrite)
+- **MINOR** — new features, backwards compatible (new provider, new skill, new tab)
+- **PATCH** — bug fixes only, no new features
+
+Examples: `1.0.0 → 1.1.0` (Ollama added), `1.1.0 → 1.1.1` (fix parse bug), `1.1.0 → 2.0.0` (skills YAML format changes).
+
+---
+
+## Repo Flow
+
+```
+   private-mirror (work here)
+        │
+        │ open PR against private-mirror/main
+        ▼
+   private-mirror/main  ← first merge here; CI runs
+        │
+        │ sync main → feature branch on public
+        ▼
+   public/android-agent (release target)
+        │
+        │ tag vX.Y.Z on public main
+        ▼
+   [publish.yml fires]
+        │
+        ├─► PyPI: ghost-in-the-droid==X.Y.Z
+        │
+        └─► GitHub Release: v X.Y.Z with notes
+```
+
+**Never push directly to public `main`.** Always go through private mirror PR → public PR → tag.
+
+---
+
+## Release Checklist
+
+### 1. Land all features on private mirror `main`
+
+- All PRs merged, CI green
+- Manual smoke test: `python3 run.py` starts, dashboard loads, one end-to-end flow works (e.g. take screenshot on a real device)
+
+### 2. Bump version + update changelog
+
+On private-mirror `main`:
+
+```bash
+# Update pyproject.toml
+sed -i 's/^version = "1.0.0"/version = "1.1.0"/' pyproject.toml
+
+# Move [Unreleased] → [1.1.0] — YYYY-MM-DD in CHANGELOG.md
+# Add the compare link at the bottom
+```
+
+Commit message: `Bump version to X.Y.Z`
+
+### 3. Create release PR on public repo
+
+```bash
+# Push private mirror/main as a feature branch on public
+git remote add public https://github.com/ghost-in-the-droid/android-agent.git
+git fetch public main
+git push public origin/main:refs/heads/release/vX.Y.Z
+
+# Open PR
+gh pr create --repo ghost-in-the-droid/android-agent \
+  --base main --head release/vX.Y.Z \
+  --title "Release vX.Y.Z" \
+  --body-file CHANGELOG_SECTION.md
+```
+
+Wait for CI to pass on public. Review. Merge.
+
+### 4. Tag the release
+
+```bash
+# On the merged public main
+git checkout main && git pull public main
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
+git push public vX.Y.Z
+```
+
+This triggers `.github/workflows/publish.yml`:
+- Builds the package (`python -m build`)
+- Verifies entry points (`android-agent --help`, MCP import)
+- Publishes to PyPI via `PYPI_PROJECT_TOKEN`
+
+### 5. Create GitHub Release
+
+```bash
+gh release create vX.Y.Z \
+  --repo ghost-in-the-droid/android-agent \
+  --title "vX.Y.Z" \
+  --notes-file CHANGELOG_SECTION.md \
+  --latest
+```
+
+(Or via the GitHub UI: Releases → Draft a new release → pick tag `vX.Y.Z` → paste changelog section.)
+
+### 6. Verify
+
+```bash
+# Clean environment
+uvx --from ghost-in-the-droid==X.Y.Z android-agent-mcp --help
+
+# PyPI page
+open https://pypi.org/project/ghost-in-the-droid/X.Y.Z/
+
+# GitHub release page
+open https://github.com/ghost-in-the-droid/android-agent/releases/tag/vX.Y.Z
+```
+
+---
+
+## What's Automated vs Manual
+
+| Step | Automated | Manual |
+|------|-----------|--------|
+| CI (lint, test, type-check, frontend build) | ✅ on every PR | — |
+| PyPI publish | ✅ on `v*` tag push | push the tag |
+| Package verification (install + entry points) | ✅ in publish.yml | — |
+| GitHub Release | ⚠️ partial (can be scripted below) | click "Publish release" |
+| CHANGELOG.md | ❌ | write release notes |
+| Version bump | ❌ | `sed` command |
+| Private → Public sync | ❌ | push branch + PR |
+
+---
+
+## GitHub Secrets (already configured)
+
+| Secret | Where used | Purpose |
+|--------|-----------|---------|
+| `PYPI_PROJECT_TOKEN` | `publish.yml` | PyPI upload (project-scoped token) |
+| `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY` | `ci.yml` | Integration tests (optional) |
+
+---
+
+## Automation Roadmap
+
+Full automation would reduce manual steps to: **write CHANGELOG entry → click a button**.
+
+### Phase 1 (easy wins)
+- [ ] Add a `release.sh` script that does: version bump + CHANGELOG stamp (move `[Unreleased]` → `[X.Y.Z]` with today's date) + commit + tag + push
+- [ ] Add auto-create GitHub Release in `publish.yml` (use `softprops/action-gh-release@v2` after PyPI upload, pulls notes from CHANGELOG.md section)
+- [ ] Pre-commit hook that runs `ruff check` + secret-scan (detect-secrets or gitleaks) on every commit
+
+### Phase 2 (medium effort)
+- [ ] `release-please` bot — reads conventional commits, auto-generates changelog + opens release PR on every merge to main
+- [ ] Branch protection on public `main`: require PR, require CI green, require 1 review, no force push
+- [ ] Dependabot for pip + npm
+
+### Phase 3 (nice to have)
+- [ ] Trusted Publishing to PyPI (OIDC, no stored token)
+- [ ] Sigstore attestations on releases (supply chain security)
+- [ ] Multi-package support if we split `gitd` into `gitd-core` + `gitd-cli` + `gitd-mcp`
+- [ ] Matrix CI: Python 3.10/3.11/3.12 × ubuntu/macos × latest/minimum deps
+
+---
+
+## Hotfix Process
+
+For urgent fixes on a released version:
+
+```bash
+# Branch from the tag
+git checkout -b hotfix/1.1.1 v1.1.0
+
+# Apply fix, commit
+...
+
+# Bump PATCH version, update CHANGELOG
+sed -i 's/version = "1.1.0"/version = "1.1.1"/' pyproject.toml
+
+# Push, PR to private-mirror/main, then public/main, then tag v1.1.1
+```
+
+Same flow as a regular release, just smaller scope.
+
+---
+
+## Rollback
+
+If a release is broken:
+
+**PyPI** — you can't delete a version, but you can yank it (prevents installs without explicit pin):
+
+```bash
+pip install twine
+twine upload --repository pypi dist/* --skip-existing
+# Go to https://pypi.org/manage/project/ghost-in-the-droid/ → Yank
+```
+
+**GitHub Release** — delete via UI or `gh release delete vX.Y.Z --yes`.
+
+**Tag** — `git push --delete public vX.Y.Z` (leaves PyPI version yanked).
+
+Then cut a new PATCH release with the fix.
+
+---
+
+## Release Cadence
+
+No fixed cadence. Release whenever:
+- A meaningful feature lands (MINOR)
+- A user-visible bug is fixed (PATCH)
+- Accumulated ~2-4 PRs on main
+
+Don't batch fixes if they're blocking users. Don't release daily — cut noise.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -162,10 +162,52 @@ DEVICE=SERIAL python3 -m pytest tests/ -v
 
 ---
 
+## MCP Server (AI Agent Tools)
+
+The project includes an MCP server that exposes 35 Android automation tools to any AI client. If you cloned this repo, the `.mcp.json` is already configured.
+
+**Claude Code / Codex** (if not using the repo's `.mcp.json`):
+```bash
+claude mcp add android-agent -- uvx --from ghost-in-the-droid android-agent-mcp
+codex mcp add android-agent -- uvx --from ghost-in-the-droid android-agent-mcp
+```
+
+**Claude Desktop / Cursor / VS Code / Windsurf** — see the [MCP section in README.md](../README.md#mcp-server--give-any-ai-agent-an-android-body) for config snippets.
+
+Verify it works:
+```bash
+# List available tools
+python3 -c "from gitd.mcp_server import mcp; print(len(mcp._tool_manager.list_tools()), 'tools')"
+```
+
+---
+
+## Emulators (Optional)
+
+Run Android emulators alongside physical devices. Requires Android SDK:
+
+```bash
+# macOS (Homebrew)
+brew install --cask android-commandlinetools
+sdkmanager "platform-tools" "emulator"
+sdkmanager "system-images;android-35;google_apis_playstore;arm64-v8a"
+
+# Create an AVD
+echo "no" | avdmanager create avd -n test_api35 \
+  -k "system-images;android-35;google_apis_playstore;arm64-v8a" -d medium_phone
+
+# Or use the API/dashboard after starting the server
+```
+
+The Emulators tab in the dashboard handles creation, boot, snapshots, and pool management.
+
+---
+
 ## Next Steps
 
-1. Open `http://localhost:6175` and explore the 9-tab dashboard
+1. Open `http://localhost:6175` and explore the dashboard
 2. Navigate to **Phone Agent** to verify your device appears
-3. Try **Multi Device > Start All (MJPEG)** to see your phone screen
+3. Try the live MJPEG stream to see your phone screen
 4. Browse **Skill Hub** to see installed skills and run them
-5. Read [ARCHITECTURE.md](ARCHITECTURE.md) for how the system fits together
+5. Open Claude Code in this project — the MCP tools are ready to use
+6. Read [ARCHITECTURE.md](ARCHITECTURE.md) for how the system fits together

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -101,7 +101,7 @@ API docs auto-generated at http://localhost:5055/docs
 
 ## Environment Variables
 
-Core ADB automation works without any API keys. AI features need keys in `.env`:
+Core ADB automation works without any API keys. For AI-powered phone control, either use Ollama (free, local, no keys) or add API keys in `.env`:
 
 | Variable | Purpose | Required? |
 |----------|---------|-----------|
@@ -109,6 +109,29 @@ Core ADB automation works without any API keys. AI features need keys in `.env`:
 | `OPENAI_API_KEY` | LLM features (Skill Creator, Content Agent) | For AI features |
 | `ANTHROPIC_API_KEY` | Alternative LLM provider | Optional |
 | `OPENROUTER_API_KEY` | LLM routing (content planning) | For content pipeline |
+
+---
+
+## Ollama (Local LLM — No API Keys)
+
+Run a tool-using Android agent entirely on your machine:
+
+```bash
+# Install Ollama
+brew install ollama       # macOS
+# or: curl -fsSL https://ollama.com/install.sh | sh  # Linux
+
+# Start server + pull a model
+ollama serve &
+ollama pull llama3.2:3b   # 2GB, fast, good tool-use
+
+# Other good options:
+# ollama pull gemma3:4b    # Google, multilingual
+# ollama pull qwen3:4b     # strong reasoning
+# ollama pull phi4-mini:3.8b  # Microsoft, efficient
+```
+
+In the dashboard: Phone Agent tab > Provider: Ollama > pick a model > chat. The agent can see the screen, tap elements, type, navigate — multi-turn with tool execution.
 
 ---
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -137,15 +137,7 @@ async function restartServer() {
       <ToolsHubView v-else-if="activeTab === 'tools'" />
       <BotView v-else-if="activeTab === 'bot'" />
       <TestsView v-else-if="activeTab === 'tests'" />
-      <div v-else-if="activeTab === 'emulators'">
-        <div style="display:flex;flex-direction:column;align-items:center;justify-content:center;padding:5rem 2rem;text-align:center">
-          <img src="/mascot/27-idle.png" alt="Ghost sleeping" style="width:120px;height:120px;object-fit:contain;margin-bottom:1.5rem;opacity:0.8" />
-          <h2 style="font-size:1.5rem;font-weight:700;color:var(--text-1);margin-bottom:0.5rem">The ghost is sleeping on this one.</h2>
-          <p style="color:var(--text-3);max-width:400px;font-size:0.9rem;line-height:1.6">
-            Headless emulator management is under active development. Spin up, control, and schedule jobs on virtual devices — no hardware required.
-          </p>
-        </div>
-      </div>
+      <EmulatorTab v-else-if="activeTab === 'emulators'" />
       <!-- Premium tabs: rendered as iframes from premium frontend server -->
       <iframe
         v-else-if="premiumTabs.some(t => t.id === activeTab)"

--- a/frontend/src/components/emulator/EmulatorTab.vue
+++ b/frontend/src/components/emulator/EmulatorTab.vue
@@ -140,13 +140,13 @@ onUnmounted(() => {
     </div>
 
     <div
-      v-if="store.prerequisites && !store.prerequisites.kvm"
+      v-if="store.prerequisites && !store.prerequisites.hw_accel"
       class="card mb-4 px-4 py-3"
       style="border-color: #f59e0b; background: #f59e0b10"
     >
-      <div class="text-sm font-semibold" style="color: #f59e0b">KVM Not Available</div>
+      <div class="text-sm font-semibold" style="color: #f59e0b">Hardware Acceleration Not Available</div>
       <div class="text-xs mt-1" style="color: var(--text-3)">
-        /dev/kvm not found. Emulators will run without hardware acceleration (very slow).
+        {{ store.prerequisites.hw_accel_type }} not available. Emulators will run without hardware acceleration (very slow).
       </div>
     </div>
 

--- a/frontend/src/stores/emulators.ts
+++ b/frontend/src/stores/emulators.ts
@@ -26,7 +26,10 @@ export interface Prerequisites {
   emulator_binary: boolean
   adb_binary: boolean
   cmdline_tools: boolean
-  kvm: boolean
+  hw_accel: boolean
+  hw_accel_type: 'HVF' | 'KVM'
+  platform: string
+  arch: string
   avd_home: string
 }
 

--- a/frontend/src/views/PhoneAdminView.vue
+++ b/frontend/src/views/PhoneAdminView.vue
@@ -538,9 +538,22 @@ const CHAT_PROVIDERS = [
   { id: 'claude-code', label: 'Claude Code (free)', models: ['sonnet', 'opus', 'haiku'] },
   { id: 'anthropic', label: 'Claude API', models: ['claude-sonnet-4-20250514', 'claude-opus-4-20250514'] },
   { id: 'openrouter', label: 'OpenRouter', models: ['anthropic/claude-sonnet-4', 'google/gemini-2.5-pro'] },
-  { id: 'ollama', label: 'Ollama', models: [] },
+  { id: 'ollama', label: 'Ollama (local)', models: ['llama3.2:3b', 'llama3.2:1b', 'gemma3:4b', 'qwen3:4b', 'phi4-mini:3.8b', 'mistral:7b'] },
 ]
 const chatConversations = ref<{id: string; title: string; provider: string; model: string; message_count: number; updated_at: string}[]>([])
+
+async function ollamaUnload() {
+  try {
+    await fetch('http://localhost:11434/api/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: chatModel.value, keep_alive: 0 }),
+    })
+    chatMessages.value.push({ role: 'system', content: `Unloaded ${chatModel.value} from memory.` })
+  } catch (e: any) {
+    chatMessages.value.push({ role: 'system', content: `Failed to unload: ${e.message}` })
+  }
+}
 
 async function loadConversations() {
   if (!selectedDevice.value) return
@@ -803,6 +816,9 @@ onUnmounted(() => {
             style="font-size: 10px; padding: 2px 6px; background: var(--bg-deep); border: 1px solid var(--border); border-radius: 4px; color: var(--text-3); max-width: 140px">
             <option v-for="m in (CHAT_PROVIDERS.find(p => p.id === chatProvider)?.models || [])" :key="m" :value="m">{{ m }}</option>
           </select>
+          <button v-if="chatProvider === 'ollama'" @click="ollamaUnload"
+            style="font-size: 9px; padding: 2px 8px; background: #1a1f2e; border: 1px solid #ef4444; border-radius: 4px; color: #ef4444; cursor: pointer"
+            title="Unload model from GPU memory">Unload</button>
           <span style="margin-left: auto; display: flex; align-items: center; gap: 6px">
             <button @click="chatVerbose = !chatVerbose"
               style="font-size: 9px; padding: 2px 6px; border-radius: 4px; cursor: pointer; border: 1px solid #2a3044"

--- a/gitd/app.py
+++ b/gitd/app.py
@@ -12,6 +12,8 @@ from gitd.models.base import Base, engine
 from gitd.routers.agent_chat import router as agent_chat_router
 from gitd.routers.bot import router as bot_router
 from gitd.routers.creator import router as creator_router
+from gitd.routers.emulators import pool_router as emulator_pool_router
+from gitd.routers.emulators import router as emulators_router
 from gitd.routers.explorer import router as explorer_router
 from gitd.routers.misc import router as misc_router
 from gitd.routers.phone import router as phone_router
@@ -60,6 +62,7 @@ TAGS_METADATA = [
     {"name": "stats", "description": "Dashboard stats"},
     {"name": "tools", "description": "Utility tools hub"},
     {"name": "misc", "description": "Health, logs, server management"},
+    {"name": "emulators", "description": "Emulator lifecycle, AVDs, snapshots, pool management"},
 ]
 
 
@@ -106,6 +109,8 @@ def create_app() -> FastAPI:
     app.include_router(bot_router)
     app.include_router(scheduler_router)
     app.include_router(tests_router)
+    app.include_router(emulators_router)
+    app.include_router(emulator_pool_router)
 
     # Plugin hook: load premium features if installed
     try:

--- a/gitd/mcp_server.py
+++ b/gitd/mcp_server.py
@@ -552,5 +552,9 @@ def create_skill(name: str, app_package: str, steps: str) -> str:
     return f"Skill '{name}' created at skills/{name}/ with {len(parsed_steps)} steps"
 
 
-if __name__ == "__main__":
+def main():
     mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/gitd/routers/emulators.py
+++ b/gitd/routers/emulators.py
@@ -1,11 +1,14 @@
 """
-Emulator management API — Flask Blueprint.
+Emulator management API — FastAPI Router.
 
 All emulator lifecycle operations: list, create, delete, start, stop,
 setup, install APK, snapshots, system images, pool management.
 """
 
-from flask import Blueprint, jsonify, request
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
 
 from gitd.services.emulator_service import (
     EmulatorConfig,
@@ -13,246 +16,265 @@ from gitd.services.emulator_service import (
     get_pool,
 )
 
-bp = Blueprint("emulators", __name__, url_prefix="/api/emulators")
-pool_bp = Blueprint("emulator_pool", __name__, url_prefix="/api/emulator-pool")
+router = APIRouter(prefix="/api/emulators", tags=["emulators"])
+pool_router = APIRouter(prefix="/api/emulator-pool", tags=["emulators"])
 
 
-# ── Prerequisites ────────────────────────────────────────────────────────────
+# ── Request models ──────────────────────────────────────────────────────────
 
 
-@bp.route("/prerequisites", methods=["GET"])
+class CreateAVDRequest(BaseModel):
+    name: str
+    api_level: int = 35
+    target: str = "google_apis_playstore"
+    arch: str = ""
+    device_profile: str = "medium_phone"
+    ram_mb: int = 2048
+    disk_mb: int = 6144
+    resolution: str = "1080x2400"
+    dpi: int = 420
+    gpu: str = "auto"
+    cores: int = 2
+    headless: bool = False
+    snapshot: bool = True
+
+
+class StartRequest(BaseModel):
+    headless: bool = False
+    gpu: str = "auto"
+    cold_boot: bool = False
+    extra_args: Optional[list[str]] = None
+
+
+class StopBySerialRequest(BaseModel):
+    serial: str
+
+
+class ApkRequest(BaseModel):
+    apk_path: str
+
+
+class SnapshotRequest(BaseModel):
+    snapshot_name: str = "automation_ready"
+
+
+class ImageInstallRequest(BaseModel):
+    api_level: int
+    target: str = "google_apis_playstore"
+    arch: str = ""
+
+
+class PoolScaleUpRequest(BaseModel):
+    count: int = 1
+    config: Optional[dict] = None
+
+
+class PoolScaleDownRequest(BaseModel):
+    count: Optional[int] = None
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _find_running_serial(name: str) -> str:
+    """Find the serial for a running emulator by AVD name. Raises 404 if not running."""
+    mgr = get_manager()
+    for info in mgr.list_running():
+        if info["name"] == name:
+            return info["serial"]
+    raise HTTPException(status_code=404, detail=f'Emulator "{name}" is not running')
+
+
+# ── Prerequisites ───────────────────────────────────────────────────────────
+
+
+@router.get("/prerequisites", summary="Check SDK Prerequisites")
 def prerequisites():
-    """Check SDK tool availability."""
+    """Check SDK tool availability and hardware acceleration."""
     mgr = get_manager()
-    return jsonify(mgr.check_prerequisites())
+    return mgr.check_prerequisites()
 
 
-# ── AVD CRUD ─────────────────────────────────────────────────────────────────
+# ── AVD CRUD ────────────────────────────────────────────────────────────────
 
 
-@bp.route("", methods=["GET"])
+@router.get("", summary="List All AVDs")
 def list_avds():
-    """List all AVDs (created + running status)."""
+    """List all AVDs with running status annotation."""
     mgr = get_manager()
-    return jsonify(mgr.list_avds())
+    return mgr.list_avds()
 
 
-@bp.route("", methods=["POST"])
-def create_avd():
-    """Create a new AVD.
-    Body: {name, api_level?, target?, device_profile?, ram_mb?, disk_mb?,
-           resolution?, dpi?, gpu?, cores?, headless?, snapshot?}
-    """
-    data = request.json or {}
-    name = data.get("name")
-    if not name:
-        return jsonify({"ok": False, "error": "name is required"}), 400
-
+@router.post("", summary="Create AVD", status_code=201)
+def create_avd(req: CreateAVDRequest):
+    """Create a new Android Virtual Device."""
     config = EmulatorConfig(
-        name=name,
-        api_level=data.get("api_level", 35),
-        target=data.get("target", "google_apis_playstore"),
-        arch=data.get("arch", "x86_64"),
-        device_profile=data.get("device_profile", "medium_phone"),
-        ram_mb=data.get("ram_mb", 2048),
-        disk_mb=data.get("disk_mb", 6144),
-        resolution=data.get("resolution", "1080x2400"),
-        dpi=data.get("dpi", 420),
-        gpu=data.get("gpu", "auto"),
-        cores=data.get("cores", 2),
-        headless=data.get("headless", False),
-        snapshot=data.get("snapshot", True),
+        name=req.name,
+        api_level=req.api_level,
+        target=req.target,
+        arch=req.arch,
+        device_profile=req.device_profile,
+        ram_mb=req.ram_mb,
+        disk_mb=req.disk_mb,
+        resolution=req.resolution,
+        dpi=req.dpi,
+        gpu=req.gpu,
+        cores=req.cores,
+        headless=req.headless,
+        snapshot=req.snapshot,
     )
     mgr = get_manager()
     result = mgr.create(config)
-    status_code = 201 if result.get("ok") else 400
-    return jsonify(result), status_code
+    if not result.get("ok"):
+        raise HTTPException(status_code=400, detail=result.get("error", "Create failed"))
+    return result
 
 
-@bp.route("/<name>", methods=["DELETE"])
-def delete_avd(name):
-    """Delete an AVD."""
+@router.delete("/{name}", summary="Delete AVD")
+def delete_avd(name: str):
+    """Delete an AVD and all its data."""
     mgr = get_manager()
     result = mgr.delete(name)
-    status_code = 200 if result.get("ok") else 404
-    return jsonify(result), status_code
+    if not result.get("ok"):
+        raise HTTPException(status_code=404, detail=result.get("error", "Not found"))
+    return result
 
 
-# ── Lifecycle ────────────────────────────────────────────────────────────────
+# ── Lifecycle ───────────────────────────────────────────────────────────────
 
 
-@bp.route("/<name>/start", methods=["POST"])
-def start_emulator(name):
-    """Start an emulator.
-    Body: {headless?: bool, gpu?: str, cold_boot?: bool, extra_args?: list}
-    """
-    data = request.json or {}
+@router.post("/{name}/start", summary="Start Emulator")
+def start_emulator(name: str, req: StartRequest = StartRequest()):
+    """Boot an emulator by AVD name."""
     mgr = get_manager()
     result = mgr.start(
         name,
-        headless=data.get("headless", False),
-        gpu=data.get("gpu", "auto"),
-        cold_boot=data.get("cold_boot", False),
-        extra_args=data.get("extra_args"),
+        headless=req.headless,
+        gpu=req.gpu,
+        cold_boot=req.cold_boot,
+        extra_args=req.extra_args,
     )
-    status_code = 200 if result.get("ok") else 400
-    return jsonify(result), status_code
+    if not result.get("ok"):
+        raise HTTPException(status_code=400, detail=result.get("error", "Start failed"))
+    return result
 
 
-@bp.route("/<name>/stop", methods=["POST"])
-def stop_emulator(name):
-    """Stop an emulator by AVD name — finds its serial first."""
+@router.post("/{name}/stop", summary="Stop Emulator by Name")
+def stop_emulator(name: str):
+    """Stop a running emulator by AVD name."""
+    serial = _find_running_serial(name)
     mgr = get_manager()
-    for info in mgr.list_running():
-        if info["name"] == name:
-            result = mgr.stop(info["serial"])
-            return jsonify(result)
-    return jsonify({"ok": False, "error": f'Emulator "{name}" is not running'}), 404
+    return mgr.stop(serial)
 
 
-@bp.route("/stop-by-serial", methods=["POST"])
-def stop_by_serial():
-    """Stop an emulator by serial. Body: {serial}"""
-    data = request.json or {}
-    serial = data.get("serial")
-    if not serial:
-        return jsonify({"ok": False, "error": "serial is required"}), 400
+@router.post("/stop-by-serial", summary="Stop Emulator by Serial")
+def stop_by_serial(req: StopBySerialRequest):
+    """Stop a running emulator by ADB serial."""
     mgr = get_manager()
-    result = mgr.stop(serial)
-    return jsonify(result)
+    return mgr.stop(req.serial)
 
 
-@bp.route("/running", methods=["GET"])
+@router.get("/running", summary="List Running Emulators")
 def list_running():
     """List running emulators with serials and AVD names."""
     mgr = get_manager()
-    return jsonify(mgr.list_running())
+    return mgr.list_running()
 
 
-@bp.route("/<name>/boot-status", methods=["GET"])
-def boot_status(name):
-    """Check if an emulator has booted. Finds serial by name."""
+@router.get("/{name}/boot-status", summary="Check Boot Status")
+def boot_status(name: str):
+    """Check if a named emulator has finished booting."""
+    serial = _find_running_serial(name)
     mgr = get_manager()
-    for info in mgr.list_running():
-        if info["name"] == name:
-            return jsonify(mgr.get_boot_status(info["serial"]))
-    return jsonify({"booted": False, "error": f'Emulator "{name}" is not running'}), 404
+    return mgr.get_boot_status(serial)
 
 
-# ── Setup & Apps ─────────────────────────────────────────────────────────────
+# ── Setup & Apps ────────────────────────────────────────────────────────────
 
 
-@bp.route("/<name>/setup", methods=["POST"])
-def setup_emulator(name):
-    """Run automation setup (disable animations, max timeout, etc.)."""
+@router.post("/{name}/setup", summary="Setup for Automation")
+def setup_emulator(name: str):
+    """Disable animations, set max timeout, configure for automation."""
+    serial = _find_running_serial(name)
     mgr = get_manager()
-    for info in mgr.list_running():
-        if info["name"] == name:
-            result = mgr.setup_for_automation(info["serial"])
-            return jsonify(result)
-    return jsonify({"ok": False, "error": f'Emulator "{name}" is not running'}), 404
+    return mgr.setup_for_automation(serial)
 
 
-@bp.route("/<name>/install-apk", methods=["POST"])
-def install_apk(name):
-    """Install APK on emulator. Body: {apk_path}"""
-    data = request.json or {}
-    apk_path = data.get("apk_path")
-    if not apk_path:
-        return jsonify({"ok": False, "error": "apk_path is required"}), 400
+@router.post("/{name}/install-apk", summary="Install APK")
+def install_apk(name: str, req: ApkRequest):
+    """Install an APK file on a running emulator."""
+    serial = _find_running_serial(name)
     mgr = get_manager()
-    for info in mgr.list_running():
-        if info["name"] == name:
-            result = mgr.install_apk(info["serial"], apk_path)
-            return jsonify(result)
-    return jsonify({"ok": False, "error": f'Emulator "{name}" is not running'}), 404
+    return mgr.install_apk(serial, req.apk_path)
 
 
-# ── Snapshots ────────────────────────────────────────────────────────────────
+# ── Snapshots ───────────────────────────────────────────────────────────────
 
 
-@bp.route("/<name>/snapshot/save", methods=["POST"])
-def snapshot_save(name):
-    """Save emulator snapshot. Body: {snapshot_name?: str}"""
-    data = request.json or {}
-    snap_name = data.get("snapshot_name", "automation_ready")
+@router.post("/{name}/snapshot/save", summary="Save Snapshot")
+def snapshot_save(name: str, req: SnapshotRequest = SnapshotRequest()):
+    """Save emulator state to a named snapshot."""
+    serial = _find_running_serial(name)
     mgr = get_manager()
-    for info in mgr.list_running():
-        if info["name"] == name:
-            result = mgr.snapshot_save(info["serial"], snap_name)
-            return jsonify(result)
-    return jsonify({"ok": False, "error": f'Emulator "{name}" is not running'}), 404
+    return mgr.snapshot_save(serial, req.snapshot_name)
 
 
-@bp.route("/<name>/snapshot/load", methods=["POST"])
-def snapshot_load(name):
-    """Load emulator snapshot. Body: {snapshot_name?: str}"""
-    data = request.json or {}
-    snap_name = data.get("snapshot_name", "automation_ready")
+@router.post("/{name}/snapshot/load", summary="Load Snapshot")
+def snapshot_load(name: str, req: SnapshotRequest = SnapshotRequest()):
+    """Restore emulator state from a named snapshot."""
+    serial = _find_running_serial(name)
     mgr = get_manager()
-    for info in mgr.list_running():
-        if info["name"] == name:
-            result = mgr.snapshot_load(info["serial"], snap_name)
-            return jsonify(result)
-    return jsonify({"ok": False, "error": f'Emulator "{name}" is not running'}), 404
+    return mgr.snapshot_load(serial, req.snapshot_name)
 
 
-@bp.route("/<name>/snapshots", methods=["GET"])
-def list_snapshots(name):
-    """List snapshots for a running emulator."""
+@router.get("/{name}/snapshots", summary="List Snapshots")
+def list_snapshots(name: str):
+    """List available snapshots for a running emulator."""
+    serial = _find_running_serial(name)
     mgr = get_manager()
-    for info in mgr.list_running():
-        if info["name"] == name:
-            result = mgr.list_snapshots(info["serial"])
-            return jsonify(result)
-    return jsonify({"ok": False, "error": f'Emulator "{name}" is not running'}), 404
+    return mgr.list_snapshots(serial)
 
 
-# ── System Images ────────────────────────────────────────────────────────────
+# ── System Images ───────────────────────────────────────────────────────────
 
 
-@bp.route("/system-images", methods=["GET"])
+@router.get("/system-images", summary="List System Images")
 def list_system_images():
-    """List installed system images."""
+    """List installed Android system images."""
     mgr = get_manager()
-    return jsonify(mgr.list_system_images())
+    return mgr.list_system_images()
 
 
-@bp.route("/system-images/install", methods=["POST"])
-def install_system_image():
-    """Download a new system image. Body: {api_level, target?, arch?}"""
-    data = request.json or {}
-    api_level = data.get("api_level")
-    if not api_level:
-        return jsonify({"ok": False, "error": "api_level is required"}), 400
+@router.post("/system-images/install", summary="Install System Image")
+def install_system_image(req: ImageInstallRequest):
+    """Download and install a system image via sdkmanager."""
     mgr = get_manager()
     result = mgr.install_system_image(
-        api_level=int(api_level),
-        target=data.get("target", "google_apis_playstore"),
-        arch=data.get("arch", "x86_64"),
+        api_level=req.api_level,
+        target=req.target,
+        arch=req.arch or "",
     )
-    status_code = 200 if result.get("ok") else 400
-    return jsonify(result), status_code
+    if not result.get("ok"):
+        raise HTTPException(status_code=400, detail=result.get("error", "Install failed"))
+    return result
 
 
-# ── Emulator Pool ────────────────────────────────────────────────────────────
+# ── Emulator Pool ───────────────────────────────────────────────────────────
 
 
-@pool_bp.route("/status", methods=["GET"])
+@pool_router.get("/status", summary="Pool Status")
 def pool_status():
-    """Pool status (active, idle, busy counts + resources)."""
+    """Get pool status: active, idle, busy counts + resource usage."""
     pool = get_pool()
-    return jsonify(pool.status())
+    return pool.status()
 
 
-@pool_bp.route("/scale-up", methods=["POST"])
-def pool_scale_up():
-    """Start N emulators. Body: {count, config?: {api_level, ram_mb, ...}}"""
-    data = request.json or {}
-    count = data.get("count", 1)
-    cfg_data = data.get("config", {})
+@pool_router.post("/scale-up", summary="Scale Up Pool")
+def pool_scale_up(req: PoolScaleUpRequest):
+    """Start N emulators in the pool."""
+    cfg_data = req.config or {}
     config = EmulatorConfig(
-        name="_template",  # ignored — pool generates names
+        name="_template",
         api_level=cfg_data.get("api_level", 35),
         target=cfg_data.get("target", "google_apis_playstore"),
         ram_mb=cfg_data.get("ram_mb", 2048),
@@ -262,31 +284,28 @@ def pool_scale_up():
         headless=True,
     )
     pool = get_pool()
-    result = pool.scale_up(count, config)
-    status_code = 200 if result.get("ok") else 400
-    return jsonify(result), status_code
+    result = pool.scale_up(req.count, config)
+    if not result.get("ok"):
+        raise HTTPException(status_code=400, detail=result.get("error", "Scale up failed"))
+    return result
 
 
-@pool_bp.route("/scale-down", methods=["POST"])
-def pool_scale_down():
-    """Stop N idle emulators. Body: {count?: int} (null = all idle)"""
-    data = request.json or {}
-    count = data.get("count")
+@pool_router.post("/scale-down", summary="Scale Down Pool")
+def pool_scale_down(req: PoolScaleDownRequest = PoolScaleDownRequest()):
+    """Stop N idle emulators from the pool."""
     pool = get_pool()
-    result = pool.scale_down(count)
-    return jsonify(result)
+    return pool.scale_down(req.count)
 
 
-@pool_bp.route("/stop-all", methods=["POST"])
+@pool_router.post("/stop-all", summary="Stop All Pool Emulators")
 def pool_stop_all():
-    """Stop all pool emulators."""
+    """Stop every emulator managed by the pool."""
     pool = get_pool()
-    result = pool.stop_all()
-    return jsonify(result)
+    return pool.stop_all()
 
 
-@pool_bp.route("/resources", methods=["GET"])
+@pool_router.get("/resources", summary="System Resources")
 def pool_resources():
-    """System resource usage (CPU, RAM, disk)."""
+    """Get system resource usage (CPU, RAM, disk)."""
     pool = get_pool()
-    return jsonify(pool.resource_usage())
+    return pool.resource_usage()

--- a/gitd/services/_emulator_helpers.py
+++ b/gitd/services/_emulator_helpers.py
@@ -6,6 +6,7 @@ EmulatorConfig dataclass, and discovery/query functions.
 import configparser
 import logging
 import os
+import platform
 import shutil
 import subprocess
 import threading
@@ -19,7 +20,29 @@ logger = logging.getLogger(__name__)
 
 # ── SDK paths ────────────────────────────────────────────────────────────────
 
-SDK_ROOT = Path(os.environ.get("ANDROID_SDK_ROOT", os.environ.get("ANDROID_HOME", Path.home() / "Android" / "Sdk")))
+
+def _detect_sdk_root() -> Path:
+    """Auto-detect Android SDK root across platforms."""
+    for var in ("ANDROID_SDK_ROOT", "ANDROID_HOME"):
+        val = os.environ.get(var)
+        if val and Path(val).exists():
+            return Path(val)
+    # macOS: Homebrew commandline-tools
+    brew = Path("/opt/homebrew/share/android-commandlinetools")
+    if brew.exists():
+        return brew
+    # macOS: Android Studio default
+    mac_studio = Path.home() / "Library" / "Android" / "sdk"
+    if mac_studio.exists():
+        return mac_studio
+    # Linux default
+    linux = Path.home() / "Android" / "Sdk"
+    if linux.exists():
+        return linux
+    return brew if platform.system() == "Darwin" else linux
+
+
+SDK_ROOT = _detect_sdk_root()
 
 EMULATOR_BIN = SDK_ROOT / "emulator" / "emulator"
 ADB_BIN = shutil.which("adb") or str(SDK_ROOT / "platform-tools" / "adb")
@@ -48,8 +71,30 @@ def _adb(serial: str, *args, timeout: int = 30) -> str:
     return r.stdout.strip()
 
 
+def _safe_int(val: str, default: int = 0) -> int:
+    """Parse int from string, stripping size suffixes like 'M', 'G', '2G'."""
+    val = val.strip()
+    if not val:
+        return default
+    for suffix in ("MB", "GB", "KB", "M", "G", "K"):
+        if val.upper().endswith(suffix):
+            val = val[: -len(suffix)]
+            break
+    try:
+        return int(val)
+    except ValueError:
+        return default
+
+
 def is_emulator(serial: str) -> bool:
     return serial.startswith("emulator-")
+
+
+def default_arch() -> str:
+    """Return the correct emulator arch for this platform."""
+    if platform.machine().lower() in ("arm64", "aarch64"):
+        return "arm64-v8a"
+    return "x86_64"
 
 
 # ── Config dataclass ─────────────────────────────────────────────────────────
@@ -60,7 +105,7 @@ class EmulatorConfig:
     name: str
     api_level: int = 35
     target: str = "google_apis_playstore"  # google_apis | google_apis_playstore | default
-    arch: str = "x86_64"
+    arch: str = ""  # auto-detected if empty
     device_profile: str = "medium_phone"  # hardware profile name
     ram_mb: int = 2048
     disk_mb: int = 6144
@@ -70,6 +115,10 @@ class EmulatorConfig:
     cores: int = 2
     headless: bool = False
     snapshot: bool = True
+
+    def __post_init__(self):
+        if not self.arch:
+            self.arch = default_arch()
 
     def system_image_pkg(self) -> str:
         api = f"android-{self.api_level}"
@@ -87,13 +136,18 @@ class EmulatorConfig:
 
 def check_prerequisites() -> dict:
     """Check what SDK tools are available."""
+    is_mac = platform.system() == "Darwin"
+    hw_accel = True if is_mac else Path("/dev/kvm").exists()
     return {
         "sdk_root": str(SDK_ROOT),
         "sdk_exists": SDK_ROOT.exists(),
         "emulator_binary": EMULATOR_BIN.exists(),
         "adb_binary": shutil.which("adb") is not None or (SDK_ROOT / "platform-tools" / "adb").exists(),
         "cmdline_tools": _has_cmdline_tools(),
-        "kvm": Path("/dev/kvm").exists(),
+        "hw_accel": hw_accel,
+        "hw_accel_type": "HVF" if is_mac else "KVM",
+        "platform": platform.system(),
+        "arch": default_arch(),
         "avd_home": str(AVD_HOME),
     }
 
@@ -127,8 +181,10 @@ def list_system_images() -> list[dict]:
     return images
 
 
-def install_system_image(api_level: int, target: str = "google_apis_playstore", arch: str = "x86_64") -> dict:
+def install_system_image(api_level: int, target: str = "google_apis_playstore", arch: str = "") -> dict:
     """Download a system image via sdkmanager. Requires cmdline-tools."""
+    if not arch:
+        arch = default_arch()
     if not _has_cmdline_tools():
         return {
             "ok": False,
@@ -157,7 +213,6 @@ def list_avds(running_list: list[dict]) -> list[dict]:
     for ini_file in sorted(AVD_HOME.glob("*.ini")):
         if ini_file.suffix != ".ini":
             continue
-        # skip .avd directories, only process top-level .ini
         name_from_file = ini_file.stem
 
         cfg = configparser.ConfigParser()
@@ -171,7 +226,6 @@ def list_avds(running_list: list[dict]) -> list[dict]:
             "target": cfg.get("root", "target", fallback=""),
         }
 
-        # Read detailed config from the .avd/config.ini
         config_ini = avd_path / "config.ini" if avd_path else None
         if config_ini and config_ini.exists():
             lines = config_ini.read_text().splitlines()
@@ -189,16 +243,15 @@ def list_avds(running_list: list[dict]) -> list[dict]:
                     "target_flavor": kv.get("tag.display", ""),
                     "abi": kv.get("abi.type", ""),
                     "resolution": f"{kv.get('hw.lcd.width', '?')}x{kv.get('hw.lcd.height', '?')}",
-                    "dpi": int(kv.get("hw.lcd.density", 0)),
-                    "ram_mb": int(kv.get("hw.ramSize", 0)),
+                    "dpi": _safe_int(kv.get("hw.lcd.density", "0")),
+                    "ram_mb": _safe_int(kv.get("hw.ramSize", "0")),
                     "disk": kv.get("disk.dataPartition.size", ""),
                     "gpu_mode": kv.get("hw.gpu.mode", ""),
-                    "cores": int(kv.get("hw.cpu.ncore", 0)),
+                    "cores": _safe_int(kv.get("hw.cpu.ncore", "0")),
                     "playstore": kv.get("PlayStore.enabled", "false").lower() == "true",
                 }
             )
 
-        # Running status
         run_info = running.get(name_from_file)
         if run_info:
             adb_state = run_info.get("adb_state", "device")
@@ -215,14 +268,7 @@ def list_avds(running_list: list[dict]) -> list[dict]:
 
 
 def list_running(procs: dict, lock: threading.Lock) -> list[dict]:
-    """List running emulators with serials and AVD names.
-
-    Picks up both 'device' (fully booted) and 'offline' (booting) emulators.
-
-    Args:
-        procs: the EmulatorManager._procs dict (serial -> Popen).
-        lock: the EmulatorManager._lock.
-    """
+    """List running emulators with serials and AVD names."""
     try:
         r = _run([ADB_BIN, "devices"], timeout=10, check=False)
     except (subprocess.SubprocessError, OSError):
@@ -232,13 +278,11 @@ def list_running(procs: dict, lock: threading.Lock) -> list[dict]:
         parts = line.split()
         if len(parts) >= 2 and parts[0].startswith("emulator-") and parts[1] in ("device", "offline"):
             serial = parts[0]
-            adb_state = parts[1]  # 'device' or 'offline'
-            # get AVD name (only works if device is online)
+            adb_state = parts[1]
             avd_name = "unknown"
             if adb_state == "device":
                 name_out = _adb(serial, "emu", "avd", "name", timeout=5)
                 avd_name = name_out.splitlines()[0].strip() if name_out else "unknown"
-            # get pid from tracked procs or from system
             pid = None
             with lock:
                 proc = procs.get(serial)

--- a/gitd/services/agent_chat.py
+++ b/gitd/services/agent_chat.py
@@ -60,7 +60,17 @@ PROVIDERS = {
     "claude-code": {"label": "Claude Code (free)", "models": ["sonnet", "opus", "haiku"]},
     "anthropic": {"label": "Claude API", "models": ["claude-sonnet-4-20250514", "claude-opus-4-20250514"]},
     "openrouter": {"label": "OpenRouter", "models": ["anthropic/claude-sonnet-4", "google/gemini-2.5-pro"]},
-    "ollama": {"label": "Ollama (local)", "models": []},
+    "ollama": {
+        "label": "Ollama (local)",
+        "models": [
+            "llama3.2:3b",
+            "llama3.2:1b",
+            "gemma3:4b",
+            "qwen3:4b",
+            "phi4-mini:3.8b",
+            "mistral:7b",
+        ],
+    },
 }
 
 
@@ -645,12 +655,43 @@ def _chat_openrouter(session: ChatSession, user_message: str):
 # ── Ollama ───────────────────────────────────────────────────────────────────
 
 
+def _parse_tool_calls(text: str) -> list[dict]:
+    """Extract tool calls from LLM output. Handles ```tool blocks and common LLM quirks."""
+    import re
+
+    calls = []
+    for match in re.finditer(r"```tool\s*\n?(.*?)\n?```", text, re.DOTALL):
+        raw = match.group(1).strip()
+        # Try parsing as-is first (valid JSON)
+        try:
+            call = json.loads(raw)
+            if isinstance(call, dict) and "tool" in call:
+                calls.append(call)
+                continue
+        except json.JSONDecodeError:
+            pass
+        # Fallback: some models wrap JSON in doubled braces {{ ... }}
+        fixed = raw
+        for _ in range(3):
+            fixed = re.sub(r"\{\{", "{", fixed)
+            fixed = re.sub(r"\}\}", "}", fixed)
+            try:
+                call = json.loads(fixed)
+                if isinstance(call, dict) and "tool" in call:
+                    calls.append(call)
+                    break
+            except json.JSONDecodeError:
+                continue
+    return calls
+
+
 def _chat_ollama(session: ChatSession, user_message: str):
-    """Use local Ollama model."""
+    """Use local Ollama model with multi-turn tool execution loop."""
     import requests
 
     session.messages.append(ChatMessage(role="user", content=user_message))
 
+    # Build screen context
     context = ""
     try:
         tree = get_screen_tree(session.device)
@@ -659,45 +700,77 @@ def _chat_ollama(session: ChatSession, user_message: str):
     except Exception:
         pass
 
-    tool_list = "\n".join(f"- {t['name']}: {t['description']}" for t in TOOLS)
+    # Build tool list with param names so the LLM knows what args to send
+    tool_list = "\n".join(
+        f"- {t['name']}: {t['description']}  params: {list(t.get('input_schema', {}).get('properties', {}).keys())}"
+        for t in TOOLS
+    )
     system = DEFAULT_SYSTEM.replace("{tool_list}", tool_list)
 
-    try:
-        r = requests.post(
-            "http://localhost:11434/api/chat",
-            json={
-                "model": session.model or "llama3",
-                "messages": [
-                    {"role": "system", "content": system},
-                    {"role": "user", "content": f"{context}Device: {session.device}\n\n{user_message}"},
-                ],
-                "stream": False,
-            },
-            timeout=120,
-        )
-        reply = r.json().get("message", {}).get("content", "")
+    messages = [
+        {"role": "system", "content": system},
+        {"role": "user", "content": f"{context}Device: {session.device}\n\n{user_message}"},
+    ]
 
-        if reply:
-            session.messages.append(ChatMessage(role="assistant", content=reply))
-            yield {"type": "text", "content": reply}
+    model = session.model or "llama3.2:3b"
 
-            # Parse tool calls from response (same format as claude-code)
-            import re
+    for turn in range(MAX_TURNS):
+        try:
+            r = requests.post(
+                "http://localhost:11434/api/chat",
+                json={
+                    "model": model,
+                    "messages": messages,
+                    "stream": False,
+                    "options": {"num_ctx": 4096},
+                },
+                timeout=120,
+            )
+            reply = r.json().get("message", {}).get("content", "")
+        except requests.ConnectionError:
+            yield {
+                "type": "error",
+                "content": "Ollama not reachable at localhost:11434. Install: https://ollama.com/download",
+            }
+            return
+        except Exception as e:
+            yield {"type": "error", "content": str(e)}
+            return
 
-            tool_pattern = re.compile(r"```tool\s*\n(.*?)\n```", re.DOTALL)
-            for match in tool_pattern.finditer(reply):
-                try:
-                    call = json.loads(match.group(1).strip())
-                    tool_name = call.get("tool", "")
-                    tool_args = call.get("args", {})
-                    tool_args.setdefault("device", session.device)
-                    result = execute_tool(tool_name, tool_args)
-                    yield {"type": "tool_call", "name": tool_name, "args": tool_args}
-                    yield {"type": "tool_result", "name": tool_name, "result": result[:500]}
-                except Exception:
-                    pass
-    except Exception as e:
-        yield {"type": "error", "content": str(e)}
+        if not reply:
+            break
+
+        session.messages.append(ChatMessage(role="assistant", content=reply))
+        yield {"type": "text", "content": reply}
+        messages.append({"role": "assistant", "content": reply})
+
+        # Parse and execute tool calls
+        tool_calls = _parse_tool_calls(reply)
+        if not tool_calls:
+            break  # No tools requested — done
+
+        tool_results = []
+        for call in tool_calls:
+            tool_name = call.get("tool", "")
+            tool_args = call.get("args", {})
+            tool_args.setdefault("device", session.device)
+
+            session.messages.append(ChatMessage(role="tool_call", tool_name=tool_name, tool_args=tool_args, content=""))
+            yield {"type": "tool_call", "name": tool_name, "args": tool_args}
+
+            try:
+                result = execute_tool(tool_name, tool_args)
+                session.messages.append(ChatMessage(role="tool_result", content=result[:500], tool_name=tool_name))
+                yield {"type": "tool_result", "name": tool_name, "result": result[:500]}
+                tool_results.append(f"[{tool_name}] {result[:800]}")
+            except Exception as e:
+                err = f"Tool error: {e}"
+                session.messages.append(ChatMessage(role="tool_result", content=err, tool_name=tool_name))
+                yield {"type": "tool_result", "name": tool_name, "result": err}
+                tool_results.append(f"[{tool_name}] ERROR: {err}")
+
+        # Feed tool results back for next turn
+        messages.append({"role": "user", "content": "Tool results:\n" + "\n".join(tool_results)})
 
     yield {"type": "done"}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "ghost-in-the-droid"
 version = "1.0.0"
 description = "Give any AI agent an Android body. Open-source phone automation via ADB — tap, swipe, type, run skills, scale across devices."
+readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "MIT"}
 keywords = ["android", "adb", "automation", "ghost", "agent", "mcp", "fastapi", "phone-farm"]
@@ -29,7 +30,14 @@ dependencies = [
     "pyyaml>=6.0",
     "psutil>=5.9",
     "openai>=1.0",
+    "mcp>=1.20",
 ]
+
+[project.urls]
+Homepage = "https://ghostinthedroid.com"
+Repository = "https://github.com/ghost-in-the-droid/android-agent"
+Documentation = "https://ghostinthedroid.com/getting-started/installation/"
+Issues = "https://github.com/ghost-in-the-droid/android-agent/issues"
 
 [project.optional-dependencies]
 llm = ["anthropic>=0.30"]
@@ -40,6 +48,7 @@ all = ["ghost-in-the-droid[llm,analytics,ocr,test]"]
 
 [project.scripts]
 android-agent = "gitd.cli:main"
+android-agent-mcp = "gitd.mcp_server:main"
 
 [tool.setuptools.packages.find]
 include = ["gitd*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ghost-in-the-droid"
-version = "1.0.0"
+version = "1.1.0"
 description = "Give any AI agent an Android body. Open-source phone automation via ADB — tap, swipe, type, run skills, scale across devices."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/install-mcp.sh
+++ b/scripts/install-mcp.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Ghost in the Droid — MCP Server Installer
+# Gives any AI agent 35 Android automation tools.
+#
+# Usage:
+#   bash <(curl -sSL https://raw.githubusercontent.com/ghost-in-the-droid/android-agent/main/scripts/install-mcp.sh)
+#
+# What it does:
+#   1. Clones the repo (or updates if already cloned)
+#   2. Creates a Python venv and installs dependencies
+#   3. Registers the MCP server with your AI client
+#
+set -euo pipefail
+
+REPO="https://github.com/ghost-in-the-droid/android-agent.git"
+DIR="$HOME/ghost-in-the-droid"
+
+echo "👻 Ghost in the Droid — MCP Installer"
+echo ""
+
+# ── Prerequisites ──────────────────────────────────────────────────────────
+
+check() { command -v "$1" &>/dev/null; }
+
+if ! check python3; then echo "❌ python3 not found. Install Python 3.10+."; exit 1; fi
+if ! check adb; then echo "⚠️  adb not found. Install Android platform-tools for device control."; fi
+if ! check git; then echo "❌ git not found."; exit 1; fi
+
+# ── Clone / Update ─────────────────────────────────────────────────────────
+
+if [ -d "$DIR" ]; then
+    echo "📂 Found $DIR — pulling latest..."
+    cd "$DIR" && git pull --quiet
+else
+    echo "📥 Cloning to $DIR..."
+    git clone --quiet "$REPO" "$DIR"
+    cd "$DIR"
+fi
+
+# ── Python Venv + Install ──────────────────────────────────────────────────
+
+if [ ! -d ".venv" ]; then
+    echo "🐍 Creating Python venv..."
+    python3 -m venv .venv
+fi
+
+echo "📦 Installing dependencies..."
+.venv/bin/pip install -q -e ".[all]"
+
+# Verify MCP server loads
+TOOL_COUNT=$(.venv/bin/python -c "from gitd.mcp_server import mcp; print(len(mcp._tool_manager.list_tools()))" 2>/dev/null || echo "0")
+if [ "$TOOL_COUNT" = "0" ]; then
+    echo "❌ MCP server failed to load. Check Python 3.10+ and try again."
+    exit 1
+fi
+
+echo "✅ MCP server ready — $TOOL_COUNT tools"
+
+# ── Register with AI Client ────────────────────────────────────────────────
+
+MCP_CMD="$DIR/.venv/bin/python"
+MCP_ARGS="-m gitd.mcp_server"
+
+if check claude; then
+    echo ""
+    echo "🔌 Registering with Claude Code..."
+    claude mcp add android-agent -- "$MCP_CMD" $MCP_ARGS 2>/dev/null && \
+        echo "✅ Claude Code: android-agent MCP registered" || \
+        echo "⚠️  claude mcp add failed — add manually (see below)"
+fi
+
+# ── Done ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "👻 Ghost in the Droid — $TOOL_COUNT MCP tools installed"
+echo ""
+echo "If auto-registration didn't work, add manually:"
+echo ""
+echo "  Claude Code:"
+echo "    claude mcp add android-agent -- $MCP_CMD $MCP_ARGS"
+echo ""
+echo "  Claude Desktop / Cursor / Windsurf — add to config:"
+echo "    {\"mcpServers\":{\"android-agent\":{\"command\":\"$MCP_CMD\",\"args\":[\"-m\",\"gitd.mcp_server\"]}}}"
+echo ""
+echo "  VS Code Copilot (.vscode/mcp.json):"
+echo "    {\"servers\":{\"android-agent\":{\"command\":\"$MCP_CMD\",\"args\":[\"-m\",\"gitd.mcp_server\"]}}}"
+echo ""
+echo "Start the dashboard:  cd $DIR && .venv/bin/python run.py"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -683,6 +683,32 @@
 		</div>
 	</section>
 
+	<!-- MCP INSTALL — one-liner for AI agents -->
+	<section style="position:relative;z-index:1;padding:3rem 0 1rem">
+		<div class="container">
+			<div style="max-width:720px;margin:0 auto;text-align:center">
+				<h2 style="font-size:1.4rem;font-weight:700;color:var(--text-primary);margin-bottom:0.5rem">Give your AI agent an Android body</h2>
+				<p style="color:var(--text-secondary);font-size:0.95rem;margin-bottom:1.5rem">35 MCP tools — tap, swipe, type, screenshot, OCR, launch apps, run skills. Works with Claude, Cursor, VS Code Copilot, Windsurf.</p>
+				<div class="terminal" style="text-align:left;margin-bottom:1rem">
+					<div class="terminal-header">
+						<span class="terminal-dot r"></span>
+						<span class="terminal-dot y"></span>
+						<span class="terminal-dot g"></span>
+						<span class="terminal-title">install</span>
+					</div>
+					<div class="terminal-body" style="font-size:0.85rem;line-height:1.8">
+						<span class="t-cm"># Add to Claude Code / Codex (one command)</span><br/>
+						<span class="t-fn">claude</span> mcp add android-agent <span class="t-op">--</span> uvx <span class="t-op">--from</span> ghost-in-the-droid android-agent-mcp<br/>
+						<br/>
+						<span class="t-cm"># Or any MCP client config (Cursor, VS Code, Windsurf, Claude Desktop)</span><br/>
+						<span class="t-op">{</span><span class="t-str">"command"</span><span class="t-op">:</span> <span class="t-str">"uvx"</span><span class="t-op">,</span> <span class="t-str">"args"</span><span class="t-op">:</span> <span class="t-op">[</span><span class="t-str">"--from"</span><span class="t-op">,</span> <span class="t-str">"ghost-in-the-droid"</span><span class="t-op">,</span> <span class="t-str">"android-agent-mcp"</span><span class="t-op">]}</span><br/>
+					</div>
+				</div>
+				<p style="color:#555;font-size:0.8rem">Plug in a phone with USB debugging, run the install, and your AI agent can control it immediately.</p>
+			</div>
+		</div>
+	</section>
+
 	<!-- DEMO VIDEOS -->
 	<section class="demo-section" style="position:relative;z-index:1">
 		<div class="container">

--- a/tests/test_ollama.py
+++ b/tests/test_ollama.py
@@ -1,0 +1,66 @@
+"""Tests for Ollama tool parsing and provider config."""
+
+from gitd.services.agent_chat import PROVIDERS, _parse_tool_calls
+
+
+def test_providers_ollama_has_models():
+    """Ollama provider should have a pre-filled model list."""
+    ollama = PROVIDERS["ollama"]
+    assert len(ollama["models"]) >= 5
+    assert "llama3.2:3b" in ollama["models"]
+    assert "gemma3:4b" in ollama["models"]
+
+
+def test_parse_tool_calls_basic():
+    text = '''I'll take a screenshot.
+```tool
+{"tool": "screenshot", "args": {"device": "emulator-5554"}}
+```'''
+    calls = _parse_tool_calls(text)
+    assert len(calls) == 1
+    assert calls[0]["tool"] == "screenshot"
+    assert calls[0]["args"]["device"] == "emulator-5554"
+
+
+def test_parse_tool_calls_multiple():
+    text = '''Let me check the screen and tap.
+```tool
+{"tool": "get_screen_tree", "args": {"device": "emulator-5554"}}
+```
+Now I'll tap.
+```tool
+{"tool": "tap", "args": {"device": "emulator-5554", "x": 540, "y": 1200}}
+```'''
+    calls = _parse_tool_calls(text)
+    assert len(calls) == 2
+    assert calls[0]["tool"] == "get_screen_tree"
+    assert calls[1]["tool"] == "tap"
+    assert calls[1]["args"]["x"] == 540
+
+
+def test_parse_tool_calls_doubled_braces():
+    """Some models (gemma3) wrap JSON in {{ ... }} — should handle gracefully."""
+    text = '```tool\n{{"tool": "tap", "args": {{"x": 100, "y": 200}}}}\n```'
+    calls = _parse_tool_calls(text)
+    assert len(calls) == 1
+    assert calls[0]["tool"] == "tap"
+    assert calls[0]["args"]["x"] == 100
+
+
+def test_parse_tool_calls_no_tools():
+    text = "I don't need any tools for this. The answer is 42."
+    calls = _parse_tool_calls(text)
+    assert len(calls) == 0
+
+
+def test_parse_tool_calls_invalid_json():
+    text = '```tool\n{not valid json}\n```'
+    calls = _parse_tool_calls(text)
+    assert len(calls) == 0
+
+
+def test_parse_tool_calls_missing_tool_key():
+    """Valid JSON but missing 'tool' key should be ignored."""
+    text = '```tool\n{"action": "screenshot", "args": {}}\n```'
+    calls = _parse_tool_calls(text)
+    assert len(calls) == 0


### PR DESCRIPTION
## What's new in v1.1.0

### Added
- **Ollama support** — multi-turn tool-using loop for local models (zero API keys). 6 pre-filled models: `llama3.2:3b`, `llama3.2:1b`, `gemma3:4b`, `qwen3:4b`, `phi4-mini:3.8b`, `mistral:7b`.
- **`_parse_tool_calls()`** — robust tool-call extractor handling LLM JSON quirks (doubled braces, trailing commas).
- **Ollama unload button** — free GPU memory between chats.
- **Emulator support (full stack)** — FastAPI router, Pool management, 4 Vue components, 21 REST endpoints.
- **Mac / Apple Silicon support** — HVF hardware acceleration, arm64-v8a auto-detection, Homebrew SDK path detection.
- **MCP distribution** — `.mcp.json` ships with the repo; 35 tools available on first clone.
- **PyPI package** — `uvx --from ghost-in-the-droid android-agent-mcp`.
- **CI/CD release pipeline** — push a `v*` tag → auto-publish to PyPI.

### Changed
- **Flask → FastAPI** — emulator router fully migrated to `APIRouter` + Pydantic models.
- **README & SETUP.md** — MCP install docs, emulator install docs, multi-client snippets.

### Fixed
- `pyproject.toml` — `dependencies` was mis-nested under `[project.urls]`.
- Import sort in `gitd/app.py` (ruff I001).

## Release process

After merge, tag `v1.1.0` to trigger PyPI publish. See `docs/RELEASE.md` for full release flow.

## Test plan
- [x] All CI checks pass on private mirror
- [x] Smoke-tested Ollama provider with local model
- [x] Emulator boots on Apple Silicon, snapshots work
- [ ] PyPI publish succeeds after tag (automated via `.github/workflows/publish.yml`)