### PR TITLE
Release v1.2.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Verify package
+        run: |
+          pip install dist/*.whl
+          android-agent --help
+          python -c "from gitd.mcp_server import main; print('MCP entry point OK')"
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_PROJECT_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -27,9 +27,8 @@ reference/
 *.swp
 *.swo
 
-# Claude / MCP config
+# Claude session data (not the MCP config — that ships with the repo)
 .claude/
-.mcp.json
 
 # OS
 .DS_Store

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "android-agent": {
+      "command": ".venv/bin/python",
+      "args": ["-m", "gitd.mcp_server"]
+    }
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) · Versioning: 
 
 ## [Unreleased]
 
+## [1.2.0] — 2026-04-17
+
+### Added
+- **Ghost Bench** — in-dashboard benchmark system with 14 built-in tasks (settings + navigation). Runner with SSE live streaming. New `Benchmarks` tab in the dashboard. Foundation for Phase 2 (real AndroidWorld integration).
+- **7 benchmark API endpoints** (`/api/benchmarks/*`) — list suites, start run, stream events, past runs, stop.
+- **Live Ollama model discovery** — new `GET /api/agent-chat/providers` endpoint queries `localhost:11434/api/tags` so the dropdown shows actually-installed models, not a hardcoded list.
+- **Background Ollama model pull** — endpoint to pull new models without blocking the UI, with live status tracking.
+
+### Changed
+- Frontend model selector fetches providers on mount instead of relying on hardcoded constants.
+- Better errors when Ollama isn't running or a requested model isn't installed.
+
+### Fixed
+- Confusing "connection error" when user selected a model not installed locally — now says "model X not found, pull it first" with a pull button.
+
 ## [1.1.0] — 2026-04-16
 
 ### Added
@@ -40,6 +55,7 @@ Initial open-source release of Ghost in the Droid.
 - Skill Hub (registry of reusable skills)
 - Agent Chat (LLM-driven device control via Claude / Claude Code / OpenRouter / Ollama)
 
-[Unreleased]: https://github.com/ghost-in-the-droid/android-agent/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/ghost-in-the-droid/android-agent/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/ghost-in-the-droid/android-agent/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/ghost-in-the-droid/android-agent/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/ghost-in-the-droid/android-agent/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to Ghost in the Droid are documented here.
+
+Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) · Versioning: [Semantic](https://semver.org/)
+
+## [Unreleased]
+
+## [1.1.0] — 2026-04-16
+
+### Added
+- **Ollama support** — multi-turn tool-using loop for local models. Zero API keys needed. Pre-filled dropdown: `llama3.2:3b`, `llama3.2:1b`, `gemma3:4b`, `qwen3:4b`, `phi4-mini:3.8b`, `mistral:7b`.
+- **`_parse_tool_calls()`** — robust tool-call extractor handling common LLM JSON quirks (doubled braces from gemma/qwen, trailing commas, etc.).
+- **Ollama unload button** — free GPU memory between chats.
+- **Emulator support (full stack)** — FastAPI router, Pool management, 4 Vue components, 21 REST endpoints. See `gitd/services/emulator_service.py`.
+- **Mac / Apple Silicon support** — HVF hardware acceleration, arm64-v8a auto-detection, Homebrew SDK path detection.
+- **MCP distribution** — `.mcp.json` ships with the repo; 35 tools available on first clone.
+- **PyPI package** — `uvx --from ghost-in-the-droid android-agent-mcp` runs the MCP server without cloning.
+- **CI/CD release pipeline** — push a `v*` tag → auto-publish to PyPI.
+
+### Changed
+- **Flask → FastAPI** — emulator router fully migrated to `APIRouter` + Pydantic models.
+- **README & SETUP.md** — MCP install docs, emulator install docs, multi-client install snippets (Claude Code, Claude Desktop, Cursor, VS Code Copilot, Windsurf).
+
+### Fixed
+- `pyproject.toml` — `dependencies` was mis-nested under `[project.urls]`.
+- Import sort in `gitd/app.py` (ruff I001).
+
+## [1.0.0] — 2026-04-08
+
+Initial open-source release of Ghost in the Droid.
+
+### Added
+- FastAPI backend (`gitd/` package), Vue 3 frontend
+- Skills framework (Action / Workflow / Skill with YAML element locators)
+- ADB automation primitives (`Device` class: tap, swipe, type, XML dump, screen classification)
+- Portal companion APK for on-device streaming & notifications
+- MCP server with 35 tools for Android control
+- WebRTC screen streaming
+- Skill Hub (registry of reusable skills)
+- Agent Chat (LLM-driven device control via Claude / Claude Code / OpenRouter / Ollama)
+
+[Unreleased]: https://github.com/ghost-in-the-droid/android-agent/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/ghost-in-the-droid/android-agent/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/ghost-in-the-droid/android-agent/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ Copy `.env.example` to `.env` (if provided) or create a `.env` file in the proje
 | `OPENROUTER_API_KEY` | OpenRouter LLM provider |
 | `DEFAULT_DEVICE` | ADB serial (auto-detected if empty) |
 
+**No API keys needed for local models:** Select Ollama in the Phone Agent tab — runs entirely on your machine with [Ollama](https://ollama.com). Install, pull a model, go:
+
+```bash
+brew install ollama       # or curl -fsSL https://ollama.com/install.sh | sh
+ollama serve &
+ollama pull llama3.2:3b   # 2GB, fast, good tool-use
+```
+
 ---
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -165,7 +165,79 @@ API domains: phone, streaming, skills, creator, explorer, agent-chat, bot, sched
 | Tools | Utility tools hub |
 | Manual Run | Start/stop bot jobs, queue management, logs |
 | Tests | Per-device test runner with screen recording playback |
-| Emulators | Headless emulator management (coming soon) |
+| Emulators | Create, boot, snapshot, and manage Android emulators |
+
+---
+
+## MCP Server — Give Any AI Agent an Android Body
+
+The project ships an [MCP](https://modelcontextprotocol.io) server with 35 tools for Android control. Any MCP-compatible AI client (Claude Code, Claude Desktop, Cursor, VS Code Copilot, Windsurf) can use them.
+
+### Install
+
+One command — works with Claude Code, Codex, Cursor, VS Code Copilot, Windsurf:
+
+```bash
+claude mcp add android-agent -- uvx --from ghost-in-the-droid android-agent-mcp
+```
+
+That's it. `uvx` installs the package, creates an isolated env, and runs the MCP server. No clone, no venv, no manual setup.
+
+**Other clients** — same command, different registration:
+
+```bash
+# Codex (OpenAI)
+codex mcp add android-agent -- uvx --from ghost-in-the-droid android-agent-mcp
+```
+
+**Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+```json
+{
+  "mcpServers": {
+    "android-agent": {
+      "command": "uvx",
+      "args": ["--from", "ghost-in-the-droid", "android-agent-mcp"]
+    }
+  }
+}
+```
+
+**VS Code Copilot** (`.vscode/mcp.json`):
+```json
+{
+  "servers": {
+    "android-agent": {
+      "command": "uvx",
+      "args": ["--from", "ghost-in-the-droid", "android-agent-mcp"]
+    }
+  }
+}
+```
+
+**Cursor** (`.cursor/mcp.json`) / **Windsurf** (`~/.codeium/windsurf/mcp_config.json`):
+```json
+{
+  "mcpServers": {
+    "android-agent": {
+      "command": "uvx",
+      "args": ["--from", "ghost-in-the-droid", "android-agent-mcp"]
+    }
+  }
+}
+```
+
+**For contributors** who clone the repo: the `.mcp.json` is already there — 35 tools available on first `claude` launch.
+
+### Available tools
+
+| Category | Tools |
+|----------|-------|
+| Screen | `screenshot`, `get_elements`, `get_screen_tree`, `get_screen_xml`, `screenshot_annotated`, `screenshot_cropped` |
+| Interaction | `tap`, `tap_element`, `swipe`, `long_press`, `type_text`, `type_unicode`, `press_back`, `press_home`, `press_key` |
+| Apps | `launch_app`, `search_apps`, `list_apps`, `launch_intent` |
+| Context | `get_phone_state`, `classify_screen`, `find_on_screen`, `ocr_screen`, `ocr_region` |
+| Device | `list_devices`, `clipboard_get`, `clipboard_set`, `get_notifications`, `open_notifications`, `toggle_overlay` |
+| Skills | `list_skills`, `run_workflow`, `run_action`, `create_skill`, `explore_app` |
 
 ---
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,217 @@
+# Release Process
+
+How we cut a new release of Ghost in the Droid and publish it to GitHub + PyPI.
+
+---
+
+## Versioning — Semantic (SemVer)
+
+`MAJOR.MINOR.PATCH`
+
+- **MAJOR** — breaking changes (DB schema incompatible, API removed, skill framework rewrite)
+- **MINOR** — new features, backwards compatible (new provider, new skill, new tab)
+- **PATCH** — bug fixes only, no new features
+
+Examples: `1.0.0 → 1.1.0` (Ollama added), `1.1.0 → 1.1.1` (fix parse bug), `1.1.0 → 2.0.0` (skills YAML format changes).
+
+---
+
+## Repo Flow
+
+```
+   private-mirror (work here)
+        │
+        │ open PR against private-mirror/main
+        ▼
+   private-mirror/main  ← first merge here; CI runs
+        │
+        │ sync main → feature branch on public
+        ▼
+   public/android-agent (release target)
+        │
+        │ tag vX.Y.Z on public main
+        ▼
+   [publish.yml fires]
+        │
+        ├─► PyPI: ghost-in-the-droid==X.Y.Z
+        │
+        └─► GitHub Release: v X.Y.Z with notes
+```
+
+**Never push directly to public `main`.** Always go through private mirror PR → public PR → tag.
+
+---
+
+## Release Checklist
+
+### 1. Land all features on private mirror `main`
+
+- All PRs merged, CI green
+- Manual smoke test: `python3 run.py` starts, dashboard loads, one end-to-end flow works (e.g. take screenshot on a real device)
+
+### 2. Bump version + update changelog
+
+On private-mirror `main`:
+
+```bash
+# Update pyproject.toml
+sed -i 's/^version = "1.0.0"/version = "1.1.0"/' pyproject.toml
+
+# Move [Unreleased] → [1.1.0] — YYYY-MM-DD in CHANGELOG.md
+# Add the compare link at the bottom
+```
+
+Commit message: `Bump version to X.Y.Z`
+
+### 3. Create release PR on public repo
+
+```bash
+# Push private mirror/main as a feature branch on public
+git remote add public https://github.com/ghost-in-the-droid/android-agent.git
+git fetch public main
+git push public origin/main:refs/heads/release/vX.Y.Z
+
+# Open PR
+gh pr create --repo ghost-in-the-droid/android-agent \
+  --base main --head release/vX.Y.Z \
+  --title "Release vX.Y.Z" \
+  --body-file CHANGELOG_SECTION.md
+```
+
+Wait for CI to pass on public. Review. Merge.
+
+### 4. Tag the release
+
+```bash
+# On the merged public main
+git checkout main && git pull public main
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
+git push public vX.Y.Z
+```
+
+This triggers `.github/workflows/publish.yml`:
+- Builds the package (`python -m build`)
+- Verifies entry points (`android-agent --help`, MCP import)
+- Publishes to PyPI via `PYPI_PROJECT_TOKEN`
+
+### 5. Create GitHub Release
+
+```bash
+gh release create vX.Y.Z \
+  --repo ghost-in-the-droid/android-agent \
+  --title "vX.Y.Z" \
+  --notes-file CHANGELOG_SECTION.md \
+  --latest
+```
+
+(Or via the GitHub UI: Releases → Draft a new release → pick tag `vX.Y.Z` → paste changelog section.)
+
+### 6. Verify
+
+```bash
+# Clean environment
+uvx --from ghost-in-the-droid==X.Y.Z android-agent-mcp --help
+
+# PyPI page
+open https://pypi.org/project/ghost-in-the-droid/X.Y.Z/
+
+# GitHub release page
+open https://github.com/ghost-in-the-droid/android-agent/releases/tag/vX.Y.Z
+```
+
+---
+
+## What's Automated vs Manual
+
+| Step | Automated | Manual |
+|------|-----------|--------|
+| CI (lint, test, type-check, frontend build) | ✅ on every PR | — |
+| PyPI publish | ✅ on `v*` tag push | push the tag |
+| Package verification (install + entry points) | ✅ in publish.yml | — |
+| GitHub Release | ⚠️ partial (can be scripted below) | click "Publish release" |
+| CHANGELOG.md | ❌ | write release notes |
+| Version bump | ❌ | `sed` command |
+| Private → Public sync | ❌ | push branch + PR |
+
+---
+
+## GitHub Secrets (already configured)
+
+| Secret | Where used | Purpose |
+|--------|-----------|---------|
+| `PYPI_PROJECT_TOKEN` | `publish.yml` | PyPI upload (project-scoped token) |
+| `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY` | `ci.yml` | Integration tests (optional) |
+
+---
+
+## Automation Roadmap
+
+Full automation would reduce manual steps to: **write CHANGELOG entry → click a button**.
+
+### Phase 1 (easy wins)
+- [ ] Add a `release.sh` script that does: version bump + CHANGELOG stamp (move `[Unreleased]` → `[X.Y.Z]` with today's date) + commit + tag + push
+- [ ] Add auto-create GitHub Release in `publish.yml` (use `softprops/action-gh-release@v2` after PyPI upload, pulls notes from CHANGELOG.md section)
+- [ ] Pre-commit hook that runs `ruff check` + secret-scan (detect-secrets or gitleaks) on every commit
+
+### Phase 2 (medium effort)
+- [ ] `release-please` bot — reads conventional commits, auto-generates changelog + opens release PR on every merge to main
+- [ ] Branch protection on public `main`: require PR, require CI green, require 1 review, no force push
+- [ ] Dependabot for pip + npm
+
+### Phase 3 (nice to have)
+- [ ] Trusted Publishing to PyPI (OIDC, no stored token)
+- [ ] Sigstore attestations on releases (supply chain security)
+- [ ] Multi-package support if we split `gitd` into `gitd-core` + `gitd-cli` + `gitd-mcp`
+- [ ] Matrix CI: Python 3.10/3.11/3.12 × ubuntu/macos × latest/minimum deps
+
+---
+
+## Hotfix Process
+
+For urgent fixes on a released version:
+
+```bash
+# Branch from the tag
+git checkout -b hotfix/1.1.1 v1.1.0
+
+# Apply fix, commit
+...
+
+# Bump PATCH version, update CHANGELOG
+sed -i 's/version = "1.1.0"/version = "1.1.1"/' pyproject.toml
+
+# Push, PR to private-mirror/main, then public/main, then tag v1.1.1
+```
+
+Same flow as a regular release, just smaller scope.
+
+---
+
+## Rollback
+
+If a release is broken:
+
+**PyPI** — you can't delete a version, but you can yank it (prevents installs without explicit pin):
+
+```bash
+pip install twine
+twine upload --repository pypi dist/* --skip-existing
+# Go to https://pypi.org/manage/project/ghost-in-the-droid/ → Yank
+```
+
+**GitHub Release** — delete via UI or `gh release delete vX.Y.Z --yes`.
+
+**Tag** — `git push --delete public vX.Y.Z` (leaves PyPI version yanked).
+
+Then cut a new PATCH release with the fix.
+
+---
+
+## Release Cadence
+
+No fixed cadence. Release whenever:
+- A meaningful feature lands (MINOR)
+- A user-visible bug is fixed (PATCH)
+- Accumulated ~2-4 PRs on main
+
+Don't batch fixes if they're blocking users. Don't release daily — cut noise.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -162,10 +162,52 @@ DEVICE=SERIAL python3 -m pytest tests/ -v
 
 ---
 
+## MCP Server (AI Agent Tools)
+
+The project includes an MCP server that exposes 35 Android automation tools to any AI client. If you cloned this repo, the `.mcp.json` is already configured.
+
+**Claude Code / Codex** (if not using the repo's `.mcp.json`):
+```bash
+claude mcp add android-agent -- uvx --from ghost-in-the-droid android-agent-mcp
+codex mcp add android-agent -- uvx --from ghost-in-the-droid android-agent-mcp
+```
+
+**Claude Desktop / Cursor / VS Code / Windsurf** — see the [MCP section in README.md](../README.md#mcp-server--give-any-ai-agent-an-android-body) for config snippets.
+
+Verify it works:
+```bash
+# List available tools
+python3 -c "from gitd.mcp_server import mcp; print(len(mcp._tool_manager.list_tools()), 'tools')"
+```
+
+---
+
+## Emulators (Optional)
+
+Run Android emulators alongside physical devices. Requires Android SDK:
+
+```bash
+# macOS (Homebrew)
+brew install --cask android-commandlinetools
+sdkmanager "platform-tools" "emulator"
+sdkmanager "system-images;android-35;google_apis_playstore;arm64-v8a"
+
+# Create an AVD
+echo "no" | avdmanager create avd -n test_api35 \
+  -k "system-images;android-35;google_apis_playstore;arm64-v8a" -d medium_phone
+
+# Or use the API/dashboard after starting the server
+```
+
+The Emulators tab in the dashboard handles creation, boot, snapshots, and pool management.
+
+---
+
 ## Next Steps
 
-1. Open `http://localhost:6175` and explore the 9-tab dashboard
+1. Open `http://localhost:6175` and explore the dashboard
 2. Navigate to **Phone Agent** to verify your device appears
-3. Try **Multi Device > Start All (MJPEG)** to see your phone screen
+3. Try the live MJPEG stream to see your phone screen
 4. Browse **Skill Hub** to see installed skills and run them
-5. Read [ARCHITECTURE.md](ARCHITECTURE.md) for how the system fits together
+5. Open Claude Code in this project — the MCP tools are ready to use
+6. Read [ARCHITECTURE.md](ARCHITECTURE.md) for how the system fits together

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -101,7 +101,7 @@ API docs auto-generated at http://localhost:5055/docs
 
 ## Environment Variables
 
-Core ADB automation works without any API keys. AI features need keys in `.env`:
+Core ADB automation works without any API keys. For AI-powered phone control, either use Ollama (free, local, no keys) or add API keys in `.env`:
 
 | Variable | Purpose | Required? |
 |----------|---------|-----------|
@@ -109,6 +109,29 @@ Core ADB automation works without any API keys. AI features need keys in `.env`:
 | `OPENAI_API_KEY` | LLM features (Skill Creator, Content Agent) | For AI features |
 | `ANTHROPIC_API_KEY` | Alternative LLM provider | Optional |
 | `OPENROUTER_API_KEY` | LLM routing (content planning) | For content pipeline |
+
+---
+
+## Ollama (Local LLM — No API Keys)
+
+Run a tool-using Android agent entirely on your machine:
+
+```bash
+# Install Ollama
+brew install ollama       # macOS
+# or: curl -fsSL https://ollama.com/install.sh | sh  # Linux
+
+# Start server + pull a model
+ollama serve &
+ollama pull llama3.2:3b   # 2GB, fast, good tool-use
+
+# Other good options:
+# ollama pull gemma3:4b    # Google, multilingual
+# ollama pull qwen3:4b     # strong reasoning
+# ollama pull phi4-mini:3.8b  # Microsoft, efficient
+```
+
+In the dashboard: Phone Agent tab > Provider: Ollama > pick a model > chat. The agent can see the screen, tap elements, type, navigate — multi-turn with tool execution.
 
 ---
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -137,15 +137,7 @@ async function restartServer() {
       <ToolsHubView v-else-if="activeTab === 'tools'" />
       <BotView v-else-if="activeTab === 'bot'" />
       <TestsView v-else-if="activeTab === 'tests'" />
-      <div v-else-if="activeTab === 'emulators'">
-        <div style="display:flex;flex-direction:column;align-items:center;justify-content:center;padding:5rem 2rem;text-align:center">
-          <img src="/mascot/27-idle.png" alt="Ghost sleeping" style="width:120px;height:120px;object-fit:contain;margin-bottom:1.5rem;opacity:0.8" />
-          <h2 style="font-size:1.5rem;font-weight:700;color:var(--text-1);margin-bottom:0.5rem">The ghost is sleeping on this one.</h2>
-          <p style="color:var(--text-3);max-width:400px;font-size:0.9rem;line-height:1.6">
-            Headless emulator management is under active development. Spin up, control, and schedule jobs on virtual devices — no hardware required.
-          </p>
-        </div>
-      </div>
+      <EmulatorTab v-else-if="activeTab === 'emulators'" />
       <!-- Premium tabs: rendered as iframes from premium frontend server -->
       <iframe
         v-else-if="premiumTabs.some(t => t.id === activeTab)"

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -9,6 +9,7 @@ import SkillCreatorView from '@/views/SkillCreatorView.vue'
 import ExplorerView from '@/views/ExplorerView.vue'
 import ToolsHubView from '@/views/ToolsHubView.vue'
 import EmulatorTab from '@/components/emulator/EmulatorTab.vue'
+import BenchmarkTab from '@/components/benchmark/BenchmarkTab.vue'
 
 const coreTabs = [
   { id: 'phone', label: '👻 Phone Agent' },
@@ -20,6 +21,7 @@ const coreTabs = [
   { id: 'bot', label: '▶️ Manual Run' },
   { id: 'tests', label: '🧪 Tests' },
   { id: 'emulators', label: '🖥️ Emulators' },
+  { id: 'benchmarks', label: '📊 Benchmarks' },
 ]
 
 const premiumTabs = ref<{id: string, label: string, component?: string}[]>([])
@@ -138,6 +140,7 @@ async function restartServer() {
       <BotView v-else-if="activeTab === 'bot'" />
       <TestsView v-else-if="activeTab === 'tests'" />
       <EmulatorTab v-else-if="activeTab === 'emulators'" />
+      <BenchmarkTab v-else-if="activeTab === 'benchmarks'" />
       <!-- Premium tabs: rendered as iframes from premium frontend server -->
       <iframe
         v-else-if="premiumTabs.some(t => t.id === activeTab)"

--- a/frontend/src/components/benchmark/BenchmarkTab.vue
+++ b/frontend/src/components/benchmark/BenchmarkTab.vue
@@ -1,0 +1,326 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref, computed } from 'vue'
+import { useBenchmarkStore } from '@/stores/benchmarks'
+
+const store = useBenchmarkStore()
+const activeSubTab = ref<'tasks' | 'runs'>('tasks')
+const toast = ref<{ msg: string; type: 'ok' | 'err' } | null>(null)
+const expandedLog = ref<string | null>(null)
+const liveLog = ref<Array<Record<string, any>>>([])
+const liveRunId = ref<string | null>(null)
+let liveEventSource: EventSource | null = null
+
+const selectedTasks = ref<Set<string>>(new Set())
+const runSuite = ref('ghost_bench')
+const runProvider = ref('ollama')
+const runModel = ref('gemma3:4b')
+const runDevice = ref('emulator-5554')
+const selectAll = ref(false)
+
+const PROVIDERS = [
+  { id: 'claude-code', label: 'Claude Code', models: ['sonnet', 'opus', 'haiku'] },
+  { id: 'anthropic', label: 'Claude API', models: ['claude-sonnet-4-20250514', 'claude-opus-4-20250514'] },
+  { id: 'openrouter', label: 'OpenRouter', models: ['anthropic/claude-sonnet-4', 'google/gemini-2.5-pro'] },
+  { id: 'ollama', label: 'Ollama (local)', models: ['llama3.2:3b', 'gemma3:4b', 'qwen3:4b', 'phi4-mini:3.8b', 'mistral:7b'] },
+]
+
+const currentModels = computed(() => PROVIDERS.find(p => p.id === runProvider.value)?.models || [])
+
+function onProviderChange() {
+  const p = PROVIDERS.find(p => p.id === runProvider.value)
+  if (p?.models.length) runModel.value = p.models[0]
+}
+
+// Also try to fetch live Ollama models
+async function fetchOllamaModels() {
+  try {
+    const resp = await fetch('/api/agent-chat/providers')
+    if (resp.ok) {
+      const providers = await resp.json()
+      const ollama = providers.find((p: any) => p.id === 'ollama')
+      if (ollama?.models?.length) {
+        const idx = PROVIDERS.findIndex(p => p.id === 'ollama')
+        if (idx >= 0) PROVIDERS[idx].models = ollama.models
+      }
+    }
+  } catch {}
+}
+
+const streamUrl = computed(() =>
+  runDevice.value ? `/api/phone/stream?device=${encodeURIComponent(runDevice.value)}&fps=3` : ''
+)
+
+let pollTimer: ReturnType<typeof setInterval> | null = null
+
+function showToast(msg: string, type: 'ok' | 'err' = 'ok') {
+  toast.value = { msg, type }
+  setTimeout(() => { toast.value = null }, 4000)
+}
+
+function toggleSelectAll() {
+  if (selectAll.value) store.tasks.forEach(t => selectedTasks.value.add(t.id))
+  else selectedTasks.value.clear()
+}
+
+function toggleTask(id: string) {
+  if (selectedTasks.value.has(id)) selectedTasks.value.delete(id)
+  else selectedTasks.value.add(id)
+}
+
+async function startRun() {
+  const ids = selectedTasks.value.size > 0 ? [...selectedTasks.value] : null
+  try {
+    const result = await store.startRun(runSuite.value, ids, runModel.value, runDevice.value, runProvider.value)
+    showToast(`Benchmark started: ${ids?.length || 'all'} tasks`)
+    activeSubTab.value = 'runs'
+
+    if (result.run_id) {
+      liveLog.value = []
+      liveRunId.value = result.run_id
+      if (liveEventSource) liveEventSource.close()
+      liveEventSource = new EventSource(`/api/benchmarks/runs/${result.run_id}/events`)
+      liveEventSource.onmessage = (e) => {
+        try {
+          const ev = JSON.parse(e.data)
+          liveLog.value.push(ev)
+          if (liveLog.value.length > 200) liveLog.value = liveLog.value.slice(-200)
+          if (ev.type === 'task_result' || ev.type === 'run_done') store.fetchRuns()
+          if (ev.type === 'run_done') {
+            liveEventSource?.close()
+            liveEventSource = null
+            liveRunId.value = null
+          }
+        } catch {}
+      }
+      liveEventSource.onerror = () => {
+        liveEventSource?.close()
+        liveEventSource = null
+        liveRunId.value = null
+      }
+    }
+  } catch (e: any) {
+    showToast(e.message, 'err')
+  }
+}
+
+async function handleStop(id: string) {
+  try { await store.stopRun(id); showToast('Run stopped') }
+  catch (e: any) { showToast(e.message, 'err') }
+}
+
+const activeRun = computed(() => store.runs.find(r => r.status === 'running'))
+
+onMounted(async () => {
+  await Promise.all([store.fetchSuites(), store.fetchTasks(), store.fetchRuns()])
+  fetchOllamaModels()
+  pollTimer = setInterval(() => {
+    if (activeSubTab.value === 'runs' || activeRun.value) store.fetchRuns()
+  }, 5000)
+})
+
+onUnmounted(() => {
+  if (pollTimer) clearInterval(pollTimer)
+  if (liveEventSource) { liveEventSource.close(); liveEventSource = null }
+})
+</script>
+
+<template>
+  <div>
+    <Transition name="fade">
+      <div v-if="toast" class="fixed top-4 right-4 z-50 px-4 py-2 rounded-lg text-sm font-medium shadow-lg"
+        :style="{ background: toast.type === 'ok' ? '#065f46' : '#7f1d1d', color: toast.type === 'ok' ? '#6ee7b7' : '#fca5a5', border: `1px solid ${toast.type === 'ok' ? '#059669' : '#dc2626'}` }">
+        {{ toast.msg }}
+      </div>
+    </Transition>
+
+    <div style="display: grid; grid-template-columns: 1fr 25%; gap: 16px; min-height: 600px">
+      <!-- LEFT: Content -->
+      <div>
+        <div class="flex gap-2 mb-4 items-center">
+          <button class="px-4 py-1.5 text-sm font-semibold rounded-lg transition-colors"
+            :class="activeSubTab === 'tasks' ? 'text-indigo-400 bg-indigo-500/10' : 'text-slate-500 hover:text-slate-300'"
+            @click="activeSubTab = 'tasks'">Tasks</button>
+          <button class="px-4 py-1.5 text-sm font-semibold rounded-lg transition-colors"
+            :class="activeSubTab === 'runs' ? 'text-indigo-400 bg-indigo-500/10' : 'text-slate-500 hover:text-slate-300'"
+            @click="activeSubTab = 'runs'; store.fetchRuns()">Runs</button>
+          <span v-if="activeRun" class="ml-auto text-xs px-3 py-1 rounded-full bg-yellow-500/15 text-yellow-400 animate-pulse">
+            Running: {{ activeRun.current_task }} ({{ activeRun.results?.length || 0 }}/{{ activeRun.total_tasks }})
+          </span>
+        </div>
+
+        <!-- Tasks -->
+        <div v-show="activeSubTab === 'tasks'" class="space-y-4">
+          <div class="card px-4 py-3 flex items-center gap-3 flex-wrap">
+            <span class="text-xs font-semibold" style="color: var(--text-2)">Run Config</span>
+            <select v-model="runProvider" @change="onProviderChange" class="text-xs px-2 py-1 rounded" style="background: var(--bg-deep); border: 1px solid var(--border); color: var(--text-2)">
+              <option v-for="p in PROVIDERS" :key="p.id" :value="p.id">{{ p.label }}</option>
+            </select>
+            <select v-model="runModel" class="text-xs px-2 py-1 rounded" style="background: var(--bg-deep); border: 1px solid var(--border); color: var(--text-2); max-width: 180px">
+              <option v-for="m in currentModels" :key="m" :value="m">{{ m }}</option>
+            </select>
+            <input v-model="runDevice" class="text-xs px-2 py-1 rounded" style="background: var(--bg-deep); border: 1px solid var(--border); color: var(--text-2); width: 140px" placeholder="device serial" />
+            <button @click="startRun" class="ml-auto px-4 py-1.5 text-sm font-semibold rounded-lg" style="background: #059669; color: white">
+              Run {{ selectedTasks.size || 'All' }} Tasks
+            </button>
+          </div>
+
+          <div class="card" style="min-height: 200px">
+            <div class="flex items-center justify-between mb-3">
+              <h2 class="text-base font-semibold" style="color: var(--text-1)">Ghost Bench</h2>
+              <span class="text-xs" style="color: var(--text-4)">{{ store.tasks.length }} tasks</span>
+            </div>
+            <div class="overflow-x-auto">
+              <table class="w-full text-sm">
+                <thead>
+                  <tr class="text-left text-xs uppercase" style="color: var(--text-4)">
+                    <th class="pb-2 pr-2 w-8"><input type="checkbox" v-model="selectAll" @change="toggleSelectAll" /></th>
+                    <th class="pb-2 pr-2">Task</th>
+                    <th class="pb-2 pr-2">Goal</th>
+                    <th class="pb-2 pr-2">Category</th>
+                    <th class="pb-2 pr-2">Steps</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="task in store.tasks" :key="task.id" class="border-t" style="border-color: var(--border)"
+                    :class="{ 'bg-indigo-500/5': selectedTasks.has(task.id) }">
+                    <td class="py-2 pr-2"><input type="checkbox" :checked="selectedTasks.has(task.id)" @change="toggleTask(task.id)" /></td>
+                    <td class="py-2 pr-2 font-mono text-xs" style="color: var(--text-2)">{{ task.id }}</td>
+                    <td class="py-2 pr-2 truncate" style="color: var(--text-1); max-width: 280px" :title="task.goal">{{ task.goal }}</td>
+                    <td class="py-2 pr-2 text-xs" style="color: var(--text-3)">{{ task.category }}</td>
+                    <td class="py-2 pr-2 text-xs" style="color: var(--text-3)">{{ task.max_steps }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+
+        <!-- Runs -->
+        <div v-show="activeSubTab === 'runs'" class="space-y-4">
+          <div v-if="!store.runs.length" class="card px-4 py-8 text-center" style="color: var(--text-3)">
+            No runs yet. Go to Tasks to start one.
+          </div>
+
+          <div v-for="run in store.runs" :key="run.id" class="card px-4 py-3">
+            <div class="flex items-center gap-3 mb-3">
+              <span class="font-mono text-xs px-2 py-0.5 rounded" style="background: var(--bg-deep); color: var(--text-3)">{{ run.id }}</span>
+              <span class="text-sm font-semibold" style="color: var(--text-1)">{{ run.provider }}/{{ run.model }}</span>
+              <span class="text-xs" style="color: var(--text-4)">{{ run.device }}</span>
+              <span class="text-xs px-2 py-0.5 rounded-full font-semibold"
+                :class="{
+                  'bg-green-500/15 text-green-400': run.status === 'completed',
+                  'bg-yellow-500/15 text-yellow-400': run.status === 'running',
+                  'bg-slate-500/15 text-slate-400': run.status === 'stopped',
+                }">{{ run.status }}</span>
+              <button v-if="run.status === 'running'" @click="handleStop(run.id)"
+                class="ml-auto text-xs px-3 py-1 rounded" style="border: 1px solid #ef4444; color: #ef4444">Stop</button>
+            </div>
+
+            <div class="grid grid-cols-4 gap-3 mb-3">
+              <div class="text-center">
+                <div class="text-lg font-bold" :style="{ color: run.success_rate > 0.5 ? '#34d399' : run.success_rate > 0 ? '#fbbf24' : '#94a3b8' }">
+                  {{ (run.success_rate * 100).toFixed(0) }}%
+                </div>
+                <div class="text-xs" style="color: var(--text-4)">Success</div>
+              </div>
+              <div class="text-center">
+                <div class="text-lg font-bold" style="color: var(--text-2)">{{ run.passed }}/{{ run.total_tasks }}</div>
+                <div class="text-xs" style="color: var(--text-4)">Passed</div>
+              </div>
+              <div class="text-center">
+                <div class="text-lg font-bold" style="color: var(--text-2)">{{ run.total_time_s?.toFixed(0) || 0 }}s</div>
+                <div class="text-xs" style="color: var(--text-4)">Total</div>
+              </div>
+              <div class="text-center">
+                <div class="text-lg font-bold" style="color: var(--text-2)">{{ run.total_tasks > 0 ? (run.total_time_s / run.total_tasks).toFixed(0) : 0 }}s</div>
+                <div class="text-xs" style="color: var(--text-4)">Avg/Task</div>
+              </div>
+            </div>
+
+            <div v-if="run.results?.length">
+              <div v-for="r in run.results" :key="r.task_id" class="border-t" style="border-color: var(--border)">
+                <div class="flex items-center gap-3 py-2 cursor-pointer hover:bg-white/[0.02] px-1 rounded"
+                  @click="expandedLog = expandedLog === r.task_id ? null : r.task_id">
+                  <span class="text-xs" style="color: var(--text-4)">{{ expandedLog === r.task_id ? '▼' : '▶' }}</span>
+                  <span class="font-mono text-xs" style="color: var(--text-2); min-width: 160px">{{ r.task_id }}</span>
+                  <span class="text-xs font-semibold" :style="{ color: r.score > 0 ? '#34d399' : '#ef4444', minWidth: '36px' }">
+                    {{ r.score > 0 ? 'PASS' : 'FAIL' }}
+                  </span>
+                  <span class="text-xs" style="color: var(--text-3)">{{ r.steps }} steps</span>
+                  <span class="text-xs" style="color: var(--text-3)">{{ r.time_s?.toFixed(0) }}s</span>
+                  <span class="text-xs truncate" style="color: var(--text-4); max-width: 200px">{{ r.reason }}</span>
+                </div>
+                <div v-if="expandedLog === r.task_id && r.agent_log?.length" class="mb-3 ml-4 p-3 rounded-lg"
+                  style="background: var(--bg-deep); border: 1px solid var(--border); max-height: 400px; overflow-y: auto">
+                  <div style="display: flex; flex-direction: column; gap: 4px">
+                    <template v-for="(ev, j) in r.agent_log" :key="j">
+                      <div v-if="ev.type === 'text'" style="background: #1a1f2e; color: var(--text-1); padding: 6px 10px; border-radius: 8px; font-size: 11px; line-height: 1.5; white-space: pre-wrap; word-break: break-word">{{ ev.content }}</div>
+                      <div v-else-if="ev.type === 'tool_call'" style="font-size: 10px; color: #38bdf8; padding: 2px 8px; background: #0ea5e908; border-radius: 10px; border: 1px solid #0ea5e922; width: fit-content">🔧 {{ ev.name }}({{ JSON.stringify(ev.args || {}).slice(0, 100) }})</div>
+                      <div v-else-if="ev.type === 'tool_result'" style="font-size: 9px; font-family: monospace; color: #64748b; padding: 3px 8px; max-height: 80px; overflow: hidden; border-left: 2px solid #1e293b; margin-left: 8px; white-space: pre-wrap; word-break: break-all">↳ {{ ev.result?.slice(0, 300) || ev.name }}</div>
+                      <div v-else-if="ev.type === 'error'" style="font-size: 10px; color: #f87171; padding: 4px 8px; background: #ef444411; border-radius: 6px; border-left: 2px solid #ef4444">{{ ev.content }}</div>
+                    </template>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div v-if="run.status === 'running' && run.total_tasks > 0" class="mt-2">
+              <div class="w-full h-1.5 rounded-full" style="background: var(--bg-deep)">
+                <div class="h-1.5 rounded-full transition-all" style="background: #059669"
+                  :style="{ width: `${((run.results?.length || 0) / run.total_tasks) * 100}%` }"></div>
+              </div>
+              <div class="text-xs mt-1" style="color: var(--text-4)">{{ run.current_task }}...</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- RIGHT: Device + Live Log -->
+      <div style="position: sticky; top: 12px; height: fit-content; display: flex; flex-direction: column; gap: 8px; max-height: calc(100vh - 80px); overflow: hidden">
+        <div class="card p-2" style="flex-shrink: 0">
+          <div class="flex items-center justify-between mb-2 px-1">
+            <span class="text-xs font-semibold" style="color: var(--text-2)">Device</span>
+            <span class="text-xs" style="color: var(--text-4)">{{ runDevice }}</span>
+          </div>
+          <img v-if="streamUrl" :src="streamUrl" style="width: 100%; border-radius: 8px; background: #000; aspect-ratio: 9/16" alt="Device" />
+          <div v-else class="flex items-center justify-center" style="aspect-ratio: 9/16; background: #0a0e17; border-radius: 8px">
+            <span class="text-xs" style="color: var(--text-4)">No device</span>
+          </div>
+        </div>
+
+        <div class="card p-2" style="flex: 1; min-height: 150px; overflow: hidden; display: flex; flex-direction: column">
+          <div class="flex items-center justify-between mb-2 px-1">
+            <span class="text-xs font-semibold" style="color: var(--text-2)">{{ liveRunId ? 'Live Log' : 'Agent Log' }}</span>
+            <span v-if="liveRunId" class="w-2 h-2 rounded-full bg-green-400 animate-pulse"></span>
+          </div>
+          <div style="flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: 3px; padding-right: 4px">
+            <div v-if="!liveLog.length" class="text-xs text-center py-4" style="color: var(--text-4)">
+              Start a run to see live agent activity.
+            </div>
+            <template v-for="(ev, i) in liveLog" :key="i">
+              <div v-if="ev.type === 'task_start'" style="font-size: 10px; font-weight: 600; color: #fbbf24; padding: 4px 6px; background: #fbbf2410; border-radius: 6px; border-left: 2px solid #fbbf24">Task: {{ ev.goal }}</div>
+              <div v-else-if="ev.type === 'init'" style="font-size: 9px; color: #64748b; padding: 1px 6px">init: {{ ev.desc }}</div>
+              <div v-else-if="ev.type === 'agent' && ev.content" style="font-size: 10px; color: var(--text-1); padding: 4px 6px; background: #1a1f2e; border-radius: 6px; line-height: 1.4; white-space: pre-wrap; word-break: break-word; max-height: 80px; overflow: hidden">{{ ev.content.slice(0, 300) }}</div>
+              <div v-else-if="ev.type === 'agent' && ev.name && !ev.result" style="font-size: 9px; color: #38bdf8; padding: 2px 6px; background: #0ea5e908; border-radius: 8px; border: 1px solid #0ea5e922; width: fit-content">🔧 {{ ev.name }}</div>
+              <div v-else-if="ev.type === 'agent' && ev.result" style="font-size: 8px; font-family: monospace; color: #475569; padding: 1px 6px; border-left: 2px solid #1e293b; margin-left: 6px; max-height: 40px; overflow: hidden; word-break: break-all">↳ {{ ev.result?.slice(0, 150) }}</div>
+              <div v-else-if="ev.type === 'task_result'" style="font-size: 10px; font-weight: 600; padding: 3px 6px; border-radius: 6px"
+                :style="{ color: ev.score > 0 ? '#34d399' : '#ef4444', background: ev.score > 0 ? '#34d39910' : '#ef444410', borderLeft: `2px solid ${ev.score > 0 ? '#34d399' : '#ef4444'}` }">
+                {{ ev.score > 0 ? 'PASS' : 'FAIL' }} — {{ ev.reason }}
+              </div>
+              <div v-else-if="ev.type === 'run_done'" style="font-size: 10px; font-weight: 600; color: #a78bfa; padding: 4px 6px; background: #a78bfa10; border-radius: 6px; text-align: center">Benchmark complete</div>
+            </template>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="store.error" class="mt-4 card px-4 py-3" style="border-color: #ef4444">
+      <div class="text-xs" style="color: #ef4444">{{ store.error }}</div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.fade-enter-active, .fade-leave-active { transition: opacity 0.3s; }
+.fade-enter-from, .fade-leave-to { opacity: 0; }
+</style>

--- a/frontend/src/components/emulator/EmulatorTab.vue
+++ b/frontend/src/components/emulator/EmulatorTab.vue
@@ -140,13 +140,13 @@ onUnmounted(() => {
     </div>
 
     <div
-      v-if="store.prerequisites && !store.prerequisites.kvm"
+      v-if="store.prerequisites && !store.prerequisites.hw_accel"
       class="card mb-4 px-4 py-3"
       style="border-color: #f59e0b; background: #f59e0b10"
     >
-      <div class="text-sm font-semibold" style="color: #f59e0b">KVM Not Available</div>
+      <div class="text-sm font-semibold" style="color: #f59e0b">Hardware Acceleration Not Available</div>
       <div class="text-xs mt-1" style="color: var(--text-3)">
-        /dev/kvm not found. Emulators will run without hardware acceleration (very slow).
+        {{ store.prerequisites.hw_accel_type }} not available. Emulators will run without hardware acceleration (very slow).
       </div>
     </div>
 

--- a/frontend/src/stores/benchmarks.ts
+++ b/frontend/src/stores/benchmarks.ts
@@ -1,0 +1,104 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { api } from '@/composables/useApi'
+
+export interface BenchmarkTask {
+  id: string
+  goal: string
+  app: string
+  category: string
+  complexity: number
+  max_steps: number
+}
+
+export interface BenchmarkSuite {
+  id: string
+  name: string
+  description: string
+}
+
+export interface TaskResult {
+  task_id: string
+  goal: string
+  model: string
+  device: string
+  score: number
+  reason: string
+  steps: number
+  time_s: number
+  error: string
+  agent_log: Array<{ type: string; content?: string; name?: string; args?: any; result?: string }>
+}
+
+export interface BenchmarkRunSummary {
+  id: string
+  suite: string
+  model: string
+  provider: string
+  device: string
+  status: 'pending' | 'running' | 'completed' | 'stopped'
+  success_rate: number
+  total_tasks: number
+  passed: number
+  total_time_s: number
+  started_at: number
+  finished_at: number
+  current_task: string
+  results: TaskResult[]
+}
+
+export const useBenchmarkStore = defineStore('benchmarks', () => {
+  const suites = ref<BenchmarkSuite[]>([])
+  const tasks = ref<BenchmarkTask[]>([])
+  const runs = ref<BenchmarkRunSummary[]>([])
+  const error = ref<string | null>(null)
+
+  async function fetchSuites() {
+    try {
+      suites.value = await api<BenchmarkSuite[]>('/api/benchmarks/suites')
+    } catch (e: any) {
+      error.value = e.message
+    }
+  }
+
+  async function fetchTasks(suite = 'ghost_bench', category?: string) {
+    try {
+      const params = new URLSearchParams({ suite })
+      if (category) params.set('category', category)
+      tasks.value = await api<BenchmarkTask[]>(`/api/benchmarks/tasks?${params}`)
+    } catch (e: any) {
+      error.value = e.message
+    }
+  }
+
+  async function fetchRuns() {
+    try {
+      runs.value = await api<BenchmarkRunSummary[]>('/api/benchmarks/runs')
+    } catch (e: any) {
+      error.value = e.message
+    }
+  }
+
+  async function startRun(
+    suite: string, taskIds: string[] | null, model: string, device: string, provider: string
+  ) {
+    error.value = null
+    const result = await api<{ ok: boolean; run_id: string; message: string }>('/api/benchmarks/runs', {
+      method: 'POST',
+      body: JSON.stringify({ suite, tasks: taskIds, provider, model, device }),
+    })
+    await fetchRuns()
+    return result
+  }
+
+  async function stopRun(runId: string) {
+    await api(`/api/benchmarks/runs/${runId}/stop`, { method: 'POST' })
+    await fetchRuns()
+  }
+
+  async function getRun(runId: string) {
+    return api<BenchmarkRunSummary>(`/api/benchmarks/runs/${runId}`)
+  }
+
+  return { suites, tasks, runs, error, fetchSuites, fetchTasks, fetchRuns, startRun, stopRun, getRun }
+})

--- a/frontend/src/stores/emulators.ts
+++ b/frontend/src/stores/emulators.ts
@@ -26,7 +26,10 @@ export interface Prerequisites {
   emulator_binary: boolean
   adb_binary: boolean
   cmdline_tools: boolean
-  kvm: boolean
+  hw_accel: boolean
+  hw_accel_type: 'HVF' | 'KVM'
+  platform: string
+  arch: string
   avd_home: string
 }
 

--- a/frontend/src/views/PhoneAdminView.vue
+++ b/frontend/src/views/PhoneAdminView.vue
@@ -538,9 +538,22 @@ const CHAT_PROVIDERS = [
   { id: 'claude-code', label: 'Claude Code (free)', models: ['sonnet', 'opus', 'haiku'] },
   { id: 'anthropic', label: 'Claude API', models: ['claude-sonnet-4-20250514', 'claude-opus-4-20250514'] },
   { id: 'openrouter', label: 'OpenRouter', models: ['anthropic/claude-sonnet-4', 'google/gemini-2.5-pro'] },
-  { id: 'ollama', label: 'Ollama', models: [] },
+  { id: 'ollama', label: 'Ollama (local)', models: ['llama3.2:3b', 'llama3.2:1b', 'gemma3:4b', 'qwen3:4b', 'phi4-mini:3.8b', 'mistral:7b'] },
 ]
 const chatConversations = ref<{id: string; title: string; provider: string; model: string; message_count: number; updated_at: string}[]>([])
+
+async function ollamaUnload() {
+  try {
+    await fetch('http://localhost:11434/api/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: chatModel.value, keep_alive: 0 }),
+    })
+    chatMessages.value.push({ role: 'system', content: `Unloaded ${chatModel.value} from memory.` })
+  } catch (e: any) {
+    chatMessages.value.push({ role: 'system', content: `Failed to unload: ${e.message}` })
+  }
+}
 
 async function loadConversations() {
   if (!selectedDevice.value) return
@@ -803,6 +816,9 @@ onUnmounted(() => {
             style="font-size: 10px; padding: 2px 6px; background: var(--bg-deep); border: 1px solid var(--border); border-radius: 4px; color: var(--text-3); max-width: 140px">
             <option v-for="m in (CHAT_PROVIDERS.find(p => p.id === chatProvider)?.models || [])" :key="m" :value="m">{{ m }}</option>
           </select>
+          <button v-if="chatProvider === 'ollama'" @click="ollamaUnload"
+            style="font-size: 9px; padding: 2px 8px; background: #1a1f2e; border: 1px solid #ef4444; border-radius: 4px; color: #ef4444; cursor: pointer"
+            title="Unload model from GPU memory">Unload</button>
           <span style="margin-left: auto; display: flex; align-items: center; gap: 6px">
             <button @click="chatVerbose = !chatVerbose"
               style="font-size: 9px; padding: 2px 6px; border-radius: 4px; cursor: pointer; border: 1px solid #2a3044"

--- a/frontend/src/views/PhoneAdminView.vue
+++ b/frontend/src/views/PhoneAdminView.vue
@@ -409,6 +409,14 @@ function startStream() {
   streaming.value = true
   if (singleStreamMode.value === 'rtc') {
     rtcStart(selectedDevice.value)
+    // Auto-fallback: if RTC doesn't connect within 5s, switch to MJPEG
+    setTimeout(() => {
+      if (streaming.value && singleStreamMode.value === 'rtc' && rtcStatus[selectedDevice.value] !== 'Streaming') {
+        console.log('RTC timeout — falling back to MJPEG')
+        singleStreamMode.value = 'mjpeg'
+        singleMjpegUrl.value = `/api/phone/stream?device=${encodeURIComponent(selectedDevice.value)}&fps=5`
+      }
+    }, 5000)
   } else {
     singleMjpegUrl.value = `/api/phone/stream?device=${encodeURIComponent(selectedDevice.value)}&fps=5`
   }
@@ -534,26 +542,107 @@ if (!(window as any).marked) {
 }
 const chatProvider = ref(localStorage.getItem('agent_provider') || 'claude-code')
 const chatModel = ref(localStorage.getItem('agent_model') || 'sonnet')
-const CHAT_PROVIDERS = [
+const CHAT_PROVIDERS = ref([
   { id: 'claude-code', label: 'Claude Code (free)', models: ['sonnet', 'opus', 'haiku'] },
   { id: 'anthropic', label: 'Claude API', models: ['claude-sonnet-4-20250514', 'claude-opus-4-20250514'] },
   { id: 'openrouter', label: 'OpenRouter', models: ['anthropic/claude-sonnet-4', 'google/gemini-2.5-pro'] },
-  { id: 'ollama', label: 'Ollama (local)', models: ['llama3.2:3b', 'llama3.2:1b', 'gemma3:4b', 'qwen3:4b', 'phi4-mini:3.8b', 'mistral:7b'] },
-]
-const chatConversations = ref<{id: string; title: string; provider: string; model: string; message_count: number; updated_at: string}[]>([])
+  { id: 'ollama', label: 'Ollama (local)', models: [] },
+])
 
-async function ollamaUnload() {
+async function fetchProviders() {
   try {
-    await fetch('http://localhost:11434/api/generate', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ model: chatModel.value, keep_alive: 0 }),
+    const resp = await fetch('/api/agent-chat/providers')
+    if (resp.ok) CHAT_PROVIDERS.value = await resp.json()
+  } catch {}
+}
+
+// Ollama model status
+const ollamaModels = ref<Array<{name: string; status: string; vram_gb: number; size_gb: number; parameter_size: string}>>([])
+const ollamaLoading = ref('')  // model name currently loading
+
+async function fetchOllamaStatus() {
+  if (chatProvider.value !== 'ollama') return
+  try {
+    const resp = await fetch('/api/agent-chat/ollama/status')
+    if (resp.ok) {
+      const data = await resp.json()
+      if (data.ok) ollamaModels.value = data.models
+    }
+  } catch {}
+}
+
+function ollamaModelStatus(name: string): string {
+  if (ollamaLoading.value === name) return 'loading'
+  const m = ollamaModels.value.find(m => m.name === name)
+  return m?.status || 'unknown'
+}
+
+function ollamaModelVram(name: string): number {
+  const m = ollamaModels.value.find(m => m.name === name)
+  return m?.vram_gb || 0
+}
+
+async function ollamaLoad(model: string) {
+  ollamaLoading.value = model
+  try {
+    const resp = await fetch('/api/agent-chat/ollama/load', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model }),
     })
-    chatMessages.value.push({ role: 'system', content: `Unloaded ${chatModel.value} from memory.` })
+    const data = await resp.json()
+    if (!data.ok) chatMessages.value.push({ role: 'system', content: `Load failed: ${data.error}` })
+  } catch (e: any) {
+    chatMessages.value.push({ role: 'system', content: `Load failed: ${e.message}` })
+  }
+  ollamaLoading.value = ''
+  fetchOllamaStatus()
+}
+
+async function ollamaUnload(model?: string) {
+  const m = model || chatModel.value
+  try {
+    const resp = await fetch('/api/agent-chat/ollama/unload', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: m }),
+    })
+    const data = await resp.json()
+    if (data.ok) chatMessages.value.push({ role: 'system', content: `Unloaded ${m} from VRAM.` })
+    else chatMessages.value.push({ role: 'system', content: `Unload failed: ${data.error}` })
   } catch (e: any) {
     chatMessages.value.push({ role: 'system', content: `Failed to unload: ${e.message}` })
   }
+  fetchOllamaStatus()
 }
+
+const ollamaPullName = ref('')
+const ollamaPulling = ref(false)
+
+async function ollamaPull() {
+  const model = ollamaPullName.value.trim()
+  if (!model) return
+  ollamaPulling.value = true
+  chatMessages.value.push({ role: 'system', content: `Pulling ${model}...` })
+  try {
+    const resp = await fetch('/api/agent-chat/ollama/pull', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model }),
+    })
+    const data = await resp.json()
+    if (data.ok) {
+      chatMessages.value.push({ role: 'system', content: `${model} pulled successfully.` })
+      ollamaPullName.value = ''
+      fetchProviders()
+      fetchOllamaStatus()
+    } else {
+      chatMessages.value.push({ role: 'system', content: `Pull failed: ${data.error}` })
+    }
+  } catch (e: any) {
+    chatMessages.value.push({ role: 'system', content: `Pull failed: ${e.message}` })
+  }
+  ollamaPulling.value = false
+}
+
+const chatConversations = ref<{id: string; title: string; provider: string; model: string; message_count: number; updated_at: string}[]>([])
 
 async function loadConversations() {
   if (!selectedDevice.value) return
@@ -589,9 +678,10 @@ async function deleteConversation(cid: string) {
 
 function onProviderChange() {
   localStorage.setItem('agent_provider', chatProvider.value)
-  const p = CHAT_PROVIDERS.find(p => p.id === chatProvider.value)
+  const p = CHAT_PROVIDERS.value.find(p => p.id === chatProvider.value)
   if (p?.models.length) { chatModel.value = p.models[0]; localStorage.setItem('agent_model', chatModel.value) }
   chatSessionId.value = '' // reset session on provider change
+  if (chatProvider.value === 'ollama') fetchOllamaStatus()
 }
 function onModelChange() { localStorage.setItem('agent_model', chatModel.value); chatSessionId.value = '' }
 
@@ -766,6 +856,8 @@ onMounted(async () => {
   await loadDevices()
   loadAllHealth()
   loadConversations()
+  fetchProviders()
+  fetchOllamaStatus()
   logTimer = window.setInterval(pollLogs, 3000)
   multiLogTimer = window.setInterval(pollMultiLogs, 4000)
   pollMultiLogs()
@@ -816,9 +908,36 @@ onUnmounted(() => {
             style="font-size: 10px; padding: 2px 6px; background: var(--bg-deep); border: 1px solid var(--border); border-radius: 4px; color: var(--text-3); max-width: 140px">
             <option v-for="m in (CHAT_PROVIDERS.find(p => p.id === chatProvider)?.models || [])" :key="m" :value="m">{{ m }}</option>
           </select>
-          <button v-if="chatProvider === 'ollama'" @click="ollamaUnload"
-            style="font-size: 9px; padding: 2px 8px; background: #1a1f2e; border: 1px solid #ef4444; border-radius: 4px; color: #ef4444; cursor: pointer"
-            title="Unload model from GPU memory">Unload</button>
+          <!-- Ollama model status + load/unload -->
+          <template v-if="chatProvider === 'ollama'">
+            <span v-if="ollamaModelStatus(chatModel) === 'loaded'"
+              style="font-size: 8px; padding: 1px 6px; border-radius: 10px; background: #05966920; color: #34d399; border: 1px solid #05966940; white-space: nowrap"
+              :title="`${ollamaModelVram(chatModel)} GB VRAM`">
+              ● {{ ollamaModelVram(chatModel) }}GB
+            </span>
+            <span v-else-if="ollamaModelStatus(chatModel) === 'loading'"
+              style="font-size: 8px; padding: 1px 6px; border-radius: 10px; background: #f59e0b20; color: #fbbf24; border: 1px solid #f59e0b40; white-space: nowrap; animation: pulse 1.5s infinite">
+              ◌ loading...
+            </span>
+            <span v-else
+              style="font-size: 8px; padding: 1px 6px; border-radius: 10px; background: #64748b15; color: #64748b; border: 1px solid #64748b30; white-space: nowrap">
+              ○ idle
+            </span>
+            <button v-if="ollamaModelStatus(chatModel) === 'loaded'" @click="ollamaUnload()"
+              style="font-size: 8px; padding: 1px 6px; background: #1a1f2e; border: 1px solid #ef4444; border-radius: 4px; color: #ef4444; cursor: pointer"
+              title="Free VRAM">unload</button>
+            <button v-else-if="ollamaModelStatus(chatModel) !== 'loading'" @click="ollamaLoad(chatModel)"
+              style="font-size: 8px; padding: 1px 6px; background: #1a1f2e; border: 1px solid #059669; border-radius: 4px; color: #34d399; cursor: pointer"
+              title="Load into VRAM">load</button>
+            <span style="display:inline-flex;align-items:center;gap:2px;margin-left:4px">
+              <input v-model="ollamaPullName" placeholder="pull model..."
+                @keyup.enter="ollamaPull" :disabled="ollamaPulling"
+                style="font-size:8px;padding:1px 4px;width:90px;background:var(--bg-deep);border:1px solid var(--border);border-radius:3px;color:var(--text-3)" />
+              <button @click="ollamaPull" :disabled="ollamaPulling || !ollamaPullName.trim()"
+                style="font-size:8px;padding:1px 5px;background:#1a1f2e;border:1px solid var(--border);border-radius:3px;color:var(--text-3);cursor:pointer"
+                :style="ollamaPulling ? {opacity:0.5} : {}">{{ ollamaPulling ? '...' : '↓' }}</button>
+            </span>
+          </template>
           <span style="margin-left: auto; display: flex; align-items: center; gap: 6px">
             <button @click="chatVerbose = !chatVerbose"
               style="font-size: 9px; padding: 2px 6px; border-radius: 4px; cursor: pointer; border: 1px solid #2a3044"
@@ -900,7 +1019,13 @@ onUnmounted(() => {
             </option>
           </select>
           <button v-if="!streaming" class="ctrl-btn ctrl-btn--webrtc" style="font-size:9px;padding:3px 8px" @click="singleStreamMode = 'rtc'; startStream()">&#x26A1; Stream</button>
-          <button v-else class="ctrl-btn ctrl-btn--stop" style="font-size:9px;padding:3px 8px" @click="stopStream">&#x23F9; Stop</button>
+          <span v-if="streaming" style="font-size:8px;padding:1px 6px;border-radius:10px;white-space:nowrap"
+            :style="singleStreamMode === 'rtc'
+              ? { background: '#22c55e20', color: '#4ade80', border: '1px solid #22c55e40' }
+              : { background: '#6366f120', color: '#a5b4fc', border: '1px solid #6366f140' }">
+            {{ singleStreamMode === 'rtc' ? '⚡ WebRTC' : '📷 MJPEG' }}
+          </span>
+          <button v-if="streaming" class="ctrl-btn ctrl-btn--stop" style="font-size:9px;padding:3px 8px" @click="stopStream">&#x23F9; Stop</button>
           <button class="ctrl-btn" style="font-size:9px;padding:3px 6px" @click="toggleOverlay(selectedDevice)"
             :style="{ background: overlayOn[selectedDevice] ? '#fbbf24' : '', color: overlayOn[selectedDevice] ? '#000' : '#fbbf24' }">&#x1F522;</button>
         </div>

--- a/gitd/app.py
+++ b/gitd/app.py
@@ -10,6 +10,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from gitd.models.base import Base, engine
 from gitd.routers.agent_chat import router as agent_chat_router
+from gitd.routers.benchmarks import router as benchmarks_router
 from gitd.routers.bot import router as bot_router
 from gitd.routers.creator import router as creator_router
 from gitd.routers.emulators import pool_router as emulator_pool_router
@@ -63,6 +64,7 @@ TAGS_METADATA = [
     {"name": "tools", "description": "Utility tools hub"},
     {"name": "misc", "description": "Health, logs, server management"},
     {"name": "emulators", "description": "Emulator lifecycle, AVDs, snapshots, pool management"},
+    {"name": "benchmarks", "description": "Benchmark runner — task suites, live progress, results"},
 ]
 
 
@@ -111,6 +113,7 @@ def create_app() -> FastAPI:
     app.include_router(tests_router)
     app.include_router(emulators_router)
     app.include_router(emulator_pool_router)
+    app.include_router(benchmarks_router)
 
     # Plugin hook: load premium features if installed
     try:

--- a/gitd/app.py
+++ b/gitd/app.py
@@ -12,6 +12,8 @@ from gitd.models.base import Base, engine
 from gitd.routers.agent_chat import router as agent_chat_router
 from gitd.routers.bot import router as bot_router
 from gitd.routers.creator import router as creator_router
+from gitd.routers.emulators import pool_router as emulator_pool_router
+from gitd.routers.emulators import router as emulators_router
 from gitd.routers.explorer import router as explorer_router
 from gitd.routers.misc import router as misc_router
 from gitd.routers.phone import router as phone_router
@@ -60,6 +62,7 @@ TAGS_METADATA = [
     {"name": "stats", "description": "Dashboard stats"},
     {"name": "tools", "description": "Utility tools hub"},
     {"name": "misc", "description": "Health, logs, server management"},
+    {"name": "emulators", "description": "Emulator lifecycle, AVDs, snapshots, pool management"},
 ]
 
 
@@ -106,6 +109,8 @@ def create_app() -> FastAPI:
     app.include_router(bot_router)
     app.include_router(scheduler_router)
     app.include_router(tests_router)
+    app.include_router(emulators_router)
+    app.include_router(emulator_pool_router)
 
     # Plugin hook: load premium features if installed
     try:

--- a/gitd/benchmarks/__init__.py
+++ b/gitd/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+# Benchmark module — run standardized tasks, evaluate agent performance.

--- a/gitd/benchmarks/base.py
+++ b/gitd/benchmarks/base.py
@@ -1,0 +1,52 @@
+"""Base types for benchmark suites — shared across ghost_bench and future androidworld."""
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class Task:
+    """A single benchmark task."""
+
+    id: str
+    goal: str
+    app: str
+    category: str
+    complexity: float = 1.0
+    init: dict = field(default_factory=dict)
+    eval: dict = field(default_factory=dict)
+    teardown: dict | None = None
+
+    @property
+    def max_steps(self) -> int:
+        return int(self.complexity * 10)
+
+
+@dataclass
+class TaskResult:
+    """Result of running a single task."""
+
+    task_id: str
+    goal: str
+    model: str
+    device: str
+    score: float = 0.0
+    reason: str = ""
+    steps: int = 0
+    time_s: float = 0.0
+    agent_log: list = field(default_factory=list)
+    error: str = ""
+
+
+def load_tasks_from_dir(task_data_dir: Path, category: str | None = None) -> list[Task]:
+    """Load tasks from all JSON files in a directory."""
+    tasks = []
+    if not task_data_dir.exists():
+        return tasks
+    for f in sorted(task_data_dir.glob("*.json")):
+        for raw in json.loads(f.read_text()):
+            task = Task(**raw)
+            if category is None or task.category == category:
+                tasks.append(task)
+    return tasks

--- a/gitd/benchmarks/ghost_bench/__init__.py
+++ b/gitd/benchmarks/ghost_bench/__init__.py
@@ -1,0 +1,1 @@
+# Ghost Bench — lightweight built-in benchmark suite. No external deps.

--- a/gitd/benchmarks/ghost_bench/evaluators.py
+++ b/gitd/benchmarks/ghost_bench/evaluators.py
@@ -1,0 +1,57 @@
+"""Evaluators — run ADB commands to check if a task succeeded."""
+
+import subprocess
+
+from gitd.benchmarks.base import Task
+
+
+def _adb(serial: str, *args: str, timeout: int = 10) -> str:
+    cmd = ["adb", "-s", serial, "shell", *args]
+    r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    return r.stdout.strip()
+
+
+def initialize_task(task: Task, serial: str) -> str:
+    """Set up preconditions. Returns description of what was done."""
+    if not task.init or not task.init.get("cmd"):
+        return "no init needed"
+    _adb(serial, *task.init["cmd"].split())
+    return task.init.get("desc", task.init["cmd"])
+
+
+def evaluate_task(task: Task, serial: str) -> tuple[float, str]:
+    """Check if a task succeeded. Returns (score 0.0-1.0, reason)."""
+    ev = task.eval
+    if not ev or not ev.get("cmd"):
+        return 0.0, "no evaluator defined"
+
+    result = _adb(serial, *ev["cmd"].split())
+
+    if "expect" in ev:
+        expected = str(ev["expect"])
+        if result == expected:
+            return 1.0, f"got '{result}' (expected '{expected}')"
+        return 0.0, f"got '{result}' (expected '{expected}')"
+
+    if "expect_in" in ev:
+        if result in ev["expect_in"]:
+            return 1.0, f"got '{result}' (in {ev['expect_in']})"
+        return 0.0, f"got '{result}' (expected one of {ev['expect_in']})"
+
+    if "expect_contains" in ev:
+        needle = ev["expect_contains"]
+        if needle.lower() in result.lower():
+            return 1.0, f"found '{needle}' in output"
+        return 0.0, f"'{needle}' not found in output (got: {result[:200]})"
+
+    return 0.0, "unknown evaluator type"
+
+
+def teardown_task(task: Task, serial: str) -> None:
+    if task.teardown and task.teardown.get("cmd"):
+        _adb(serial, *task.teardown["cmd"].split())
+
+
+def reset_device(serial: str) -> None:
+    _adb(serial, "input", "keyevent", "KEYCODE_HOME")
+    _adb(serial, "input", "keyevent", "KEYCODE_HOME")

--- a/gitd/benchmarks/ghost_bench/task_data/navigation.json
+++ b/gitd/benchmarks/ghost_bench/task_data/navigation.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": "OpenAppSettings",
+    "goal": "Open the Settings app.",
+    "app": "com.android.settings",
+    "category": "navigation",
+    "complexity": 1,
+    "init": {"cmd": "input keyevent KEYCODE_HOME", "desc": "Go home"},
+    "eval": {"cmd": "dumpsys activity activities | grep mResumedActivity", "expect_contains": "com.android.settings"}
+  },
+  {
+    "id": "OpenAppContacts",
+    "goal": "Open the Contacts app.",
+    "app": "com.google.android.contacts",
+    "category": "navigation",
+    "complexity": 1,
+    "init": {"cmd": "input keyevent KEYCODE_HOME", "desc": "Go home"},
+    "eval": {"cmd": "dumpsys activity activities | grep mResumedActivity", "expect_contains": "contacts"}
+  },
+  {
+    "id": "OpenAppClock",
+    "goal": "Open the Clock app.",
+    "app": "com.google.android.deskclock",
+    "category": "navigation",
+    "complexity": 1,
+    "init": {"cmd": "input keyevent KEYCODE_HOME", "desc": "Go home"},
+    "eval": {"cmd": "dumpsys activity activities | grep mResumedActivity", "expect_contains": "deskclock"}
+  },
+  {
+    "id": "OpenAppCamera",
+    "goal": "Open the Camera app.",
+    "app": "com.android.camera2",
+    "category": "navigation",
+    "complexity": 1,
+    "init": {"cmd": "input keyevent KEYCODE_HOME", "desc": "Go home"},
+    "eval": {"cmd": "dumpsys activity activities | grep mResumedActivity", "expect_contains": "camera"}
+  },
+  {
+    "id": "OpenAppChrome",
+    "goal": "Open Chrome browser.",
+    "app": "com.android.chrome",
+    "category": "navigation",
+    "complexity": 1,
+    "init": {"cmd": "input keyevent KEYCODE_HOME", "desc": "Go home"},
+    "eval": {"cmd": "dumpsys activity activities | grep mResumedActivity", "expect_contains": "chrome"}
+  },
+  {
+    "id": "OpenAppCalculator",
+    "goal": "Open the Calculator app.",
+    "app": "com.google.android.calculator",
+    "category": "navigation",
+    "complexity": 1,
+    "init": {"cmd": "input keyevent KEYCODE_HOME", "desc": "Go home"},
+    "eval": {"cmd": "dumpsys activity activities | grep mResumedActivity", "expect_contains": "calculator"}
+  }
+]

--- a/gitd/benchmarks/ghost_bench/task_data/settings.json
+++ b/gitd/benchmarks/ghost_bench/task_data/settings.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "SystemWifiTurnOn",
+    "goal": "Turn wifi on.",
+    "app": "com.android.settings",
+    "category": "settings",
+    "complexity": 1,
+    "init": {"cmd": "svc wifi disable", "desc": "Disable WiFi"},
+    "eval": {"cmd": "settings get global wifi_on", "expect_in": ["1", "2"]}
+  },
+  {
+    "id": "SystemWifiTurnOff",
+    "goal": "Turn wifi off.",
+    "app": "com.android.settings",
+    "category": "settings",
+    "complexity": 1,
+    "init": {"cmd": "svc wifi enable", "desc": "Enable WiFi"},
+    "eval": {"cmd": "settings get global wifi_on", "expect": "0"}
+  },
+  {
+    "id": "SystemBluetoothTurnOn",
+    "goal": "Turn bluetooth on.",
+    "app": "com.android.settings",
+    "category": "settings",
+    "complexity": 1,
+    "init": {"cmd": "svc bluetooth disable", "desc": "Disable Bluetooth"},
+    "eval": {"cmd": "settings get global bluetooth_on", "expect": "1"}
+  },
+  {
+    "id": "SystemBluetoothTurnOff",
+    "goal": "Turn bluetooth off.",
+    "app": "com.android.settings",
+    "category": "settings",
+    "complexity": 1,
+    "init": {"cmd": "svc bluetooth enable", "desc": "Enable Bluetooth"},
+    "eval": {"cmd": "settings get global bluetooth_on", "expect": "0"}
+  },
+  {
+    "id": "SystemBrightnessMax",
+    "goal": "Set screen brightness to maximum.",
+    "app": "com.android.settings",
+    "category": "settings",
+    "complexity": 1,
+    "init": {"cmd": "settings put system screen_brightness 1", "desc": "Set brightness to min"},
+    "eval": {"cmd": "settings get system screen_brightness", "expect": "255"}
+  },
+  {
+    "id": "SystemBrightnessMin",
+    "goal": "Set screen brightness to minimum.",
+    "app": "com.android.settings",
+    "category": "settings",
+    "complexity": 1,
+    "init": {"cmd": "settings put system screen_brightness 255", "desc": "Set brightness to max"},
+    "eval": {"cmd": "settings get system screen_brightness", "expect": "1"}
+  },
+  {
+    "id": "SystemAirplaneModeOn",
+    "goal": "Turn on airplane mode.",
+    "app": "com.android.settings",
+    "category": "settings",
+    "complexity": 1.5,
+    "init": {"cmd": "settings put global airplane_mode_on 0", "desc": "Disable airplane mode"},
+    "eval": {"cmd": "settings get global airplane_mode_on", "expect": "1"}
+  },
+  {
+    "id": "SystemAirplaneModeOff",
+    "goal": "Turn off airplane mode.",
+    "app": "com.android.settings",
+    "category": "settings",
+    "complexity": 1.5,
+    "init": {"cmd": "settings put global airplane_mode_on 1", "desc": "Enable airplane mode"},
+    "eval": {"cmd": "settings get global airplane_mode_on", "expect": "0"}
+  }
+]

--- a/gitd/benchmarks/ghost_bench/tasks.py
+++ b/gitd/benchmarks/ghost_bench/tasks.py
@@ -1,0 +1,23 @@
+"""Ghost Bench task loading — reads task definitions from task_data/*.json."""
+
+from pathlib import Path
+
+from gitd.benchmarks.base import Task, load_tasks_from_dir
+
+TASK_DATA_DIR = Path(__file__).parent / "task_data"
+SUITE_NAME = "ghost_bench"
+
+
+def load_tasks(category: str | None = None) -> list[Task]:
+    return load_tasks_from_dir(TASK_DATA_DIR, category)
+
+
+def get_task(task_id: str) -> Task | None:
+    for task in load_tasks():
+        if task.id == task_id:
+            return task
+    return None
+
+
+def list_task_ids() -> list[str]:
+    return [t.id for t in load_tasks()]

--- a/gitd/benchmarks/results/.gitignore
+++ b/gitd/benchmarks/results/.gitignore
@@ -1,0 +1,2 @@
+*.json
+!.gitignore

--- a/gitd/benchmarks/runner.py
+++ b/gitd/benchmarks/runner.py
@@ -1,0 +1,251 @@
+"""Benchmark runner — orchestrates tasks through an agent and evaluates results."""
+
+import json
+import logging
+import queue
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+import requests
+
+from gitd.benchmarks.base import Task, TaskResult
+
+log = logging.getLogger(__name__)
+
+RESULTS_DIR = Path(__file__).parent / "results"
+RESULTS_DIR.mkdir(exist_ok=True)
+
+# ── Event pub/sub for live SSE streaming ─────────────────────────────────
+
+_event_queues: dict[str, list[queue.Queue]] = {}
+
+
+def subscribe(run_id: str) -> queue.Queue:
+    q: queue.Queue = queue.Queue(maxsize=500)
+    _event_queues.setdefault(run_id, []).append(q)
+    return q
+
+
+def unsubscribe(run_id: str, q: queue.Queue) -> None:
+    if run_id in _event_queues:
+        _event_queues[run_id] = [x for x in _event_queues[run_id] if x is not q]
+
+
+def _emit(run_id: str, event: dict) -> None:
+    for q in _event_queues.get(run_id, []):
+        try:
+            q.put_nowait(event)
+        except queue.Full:
+            pass
+
+
+# ── Run data structures ──────────────────────────────────────────────────
+
+
+@dataclass
+class BenchmarkRun:
+    id: str
+    suite: str
+    model: str
+    provider: str
+    device: str
+    status: str = "running"
+    results: list[TaskResult] = field(default_factory=list)
+    started_at: float = 0.0
+    finished_at: float = 0.0
+    current_task: str = ""
+
+    @property
+    def success_rate(self) -> float:
+        if not self.results:
+            return 0.0
+        return sum(r.score for r in self.results) / len(self.results)
+
+    @property
+    def total_time(self) -> float:
+        return sum(r.time_s for r in self.results)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "suite": self.suite,
+            "model": self.model,
+            "provider": self.provider,
+            "device": self.device,
+            "status": self.status,
+            "success_rate": round(self.success_rate, 3),
+            "total_tasks": len(self.results),
+            "passed": sum(1 for r in self.results if r.score > 0),
+            "total_time_s": round(self.total_time, 1),
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "current_task": self.current_task,
+            "results": [asdict(r) for r in self.results],
+        }
+
+    def save(self) -> None:
+        path = RESULTS_DIR / f"{self.id}.json"
+        path.write_text(json.dumps(self.to_dict(), indent=2))
+
+
+# ── Active runs registry ─────────────────────────────────────────────────
+
+_active_runs: dict[str, BenchmarkRun] = {}
+
+
+def list_runs() -> list[dict]:
+    seen = set()
+    runs = []
+    for run in _active_runs.values():
+        runs.append(run.to_dict())
+        seen.add(run.id)
+    for f in sorted(RESULTS_DIR.glob("*.json"), reverse=True):
+        try:
+            data = json.loads(f.read_text())
+            if data["id"] not in seen:
+                runs.append(data)
+        except Exception:
+            pass
+    return runs
+
+
+def get_run(run_id: str) -> dict | None:
+    if run_id in _active_runs:
+        return _active_runs[run_id].to_dict()
+    path = RESULTS_DIR / f"{run_id}.json"
+    if path.exists():
+        return json.loads(path.read_text())
+    return None
+
+
+def stop_run(run_id: str) -> bool:
+    if run_id in _active_runs:
+        _active_runs[run_id].status = "stopped"
+        return True
+    return False
+
+
+# ── Main runner ──────────────────────────────────────────────────────────
+
+
+def run_benchmark(
+    tasks: list[Task],
+    model: str,
+    device: str,
+    provider: str = "ollama",
+    suite: str = "ghost_bench",
+    api_base: str = "http://localhost:5055",
+    run_id: str = "",
+) -> BenchmarkRun:
+    """Run benchmark tasks sequentially. Blocking — run in a thread."""
+    from gitd.benchmarks.ghost_bench.evaluators import (
+        evaluate_task,
+        initialize_task,
+        reset_device,
+        teardown_task,
+    )
+
+    if not run_id:
+        run_id = str(uuid.uuid4())[:8]
+
+    run = BenchmarkRun(
+        id=run_id,
+        suite=suite,
+        model=model,
+        provider=provider,
+        device=device,
+        started_at=time.time(),
+    )
+    _active_runs[run_id] = run
+    _event_queues.setdefault(run_id, [])
+
+    for task in tasks:
+        if run.status == "stopped":
+            break
+
+        run.current_task = task.id
+        t0 = time.time()
+        _emit(run_id, {"type": "task_start", "task_id": task.id, "goal": task.goal})
+
+        try:
+            reset_device(device)
+            time.sleep(1)
+
+            init_desc = initialize_task(task, device)
+            _emit(run_id, {"type": "init", "task_id": task.id, "desc": init_desc})
+            time.sleep(1)
+
+            agent_log = _run_agent(task, model, device, provider, api_base, run_id)
+
+            time.sleep(1)
+            score, reason = evaluate_task(task, device)
+            _emit(run_id, {"type": "task_result", "task_id": task.id, "score": score, "reason": reason})
+
+            elapsed = time.time() - t0
+            result = TaskResult(
+                task_id=task.id,
+                goal=task.goal,
+                model=model,
+                device=device,
+                score=score,
+                reason=reason,
+                steps=len([e for e in agent_log if e.get("type") == "tool_call"]),
+                time_s=round(elapsed, 1),
+                agent_log=agent_log,
+            )
+            teardown_task(task, device)
+
+        except Exception as e:
+            elapsed = time.time() - t0
+            result = TaskResult(
+                task_id=task.id,
+                goal=task.goal,
+                model=model,
+                device=device,
+                reason=f"error: {e}",
+                time_s=round(elapsed, 1),
+                error=str(e),
+            )
+            log.exception("Benchmark task %s failed", task.id)
+
+        run.results.append(result)
+        run.save()
+
+    run.status = "completed" if run.status != "stopped" else "stopped"
+    run.finished_at = time.time()
+    run.current_task = ""
+    run.save()
+    _emit(run_id, {"type": "run_done", "status": run.status, "success_rate": run.success_rate})
+    _active_runs.pop(run_id, None)
+    _event_queues.pop(run_id, None)
+    return run
+
+
+def _run_agent(
+    task: Task, model: str, device: str, provider: str, api_base: str, run_id: str
+) -> list[dict]:
+    """Send task goal to agent chat endpoint and collect SSE events."""
+    events: list[dict] = []
+    try:
+        resp = requests.post(
+            f"{api_base}/api/agent-chat/message",
+            json={"content": task.goal, "device": device, "provider": provider, "model": model},
+            timeout=300,
+            stream=True,
+        )
+        for line in resp.iter_lines():
+            if not line:
+                continue
+            text = line.decode()
+            if text.startswith("data: "):
+                try:
+                    ev = json.loads(text[6:])
+                    events.append(ev)
+                    _emit(run_id, {"type": "agent", "task_id": task.id, **ev})
+                except json.JSONDecodeError:
+                    pass
+    except Exception as e:
+        events.append({"type": "error", "content": str(e)})
+    return events

--- a/gitd/config.py
+++ b/gitd/config.py
@@ -26,6 +26,9 @@ class Settings(BaseSettings):
     anthropic_api_key: str = ""
     openrouter_api_key: str = ""
 
+    # ── Ollama ──────────────────────────────────────────────────────────────
+    ollama_base_url: str = "http://localhost:11434"
+
     model_config = {
         "env_file": ".env",
         "env_file_encoding": "utf-8",

--- a/gitd/mcp_server.py
+++ b/gitd/mcp_server.py
@@ -552,5 +552,9 @@ def create_skill(name: str, app_package: str, steps: str) -> str:
     return f"Skill '{name}' created at skills/{name}/ with {len(parsed_steps)} steps"
 
 
-if __name__ == "__main__":
+def main():
     mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/gitd/routers/agent_chat.py
+++ b/gitd/routers/agent_chat.py
@@ -1,12 +1,29 @@
 """Agent Chat routes — interactive natural language phone control."""
 
 import json
+import logging
+import threading
 from typing import Optional
 
+import requests
 from fastapi import APIRouter, Body, HTTPException, Query
+from pydantic import BaseModel
 from starlette.responses import StreamingResponse
 
+from gitd.config import settings
+
+log = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/api/agent-chat", tags=["agent-chat"])
+
+OLLAMA_URL = settings.ollama_base_url
+
+
+# ── Request models ──────────────────────────────────────────────────────────
+
+
+class OllamaModelRequest(BaseModel):
+    model: str
 
 
 @router.post("/session", summary="Create Agent Chat Session")
@@ -184,3 +201,121 @@ def delete_conversation_endpoint(cid: str):
 
     delete_conversation(cid)
     return {"ok": True}
+
+
+@router.get("/providers", summary="List Chat Providers")
+def list_providers():
+    """Return available providers with models. Ollama models are discovered live."""
+    from gitd.services.agent_chat import get_providers
+
+    return get_providers()
+
+
+# ── Ollama model management ──────────────────────────────────────────────
+
+# Track background pull operations
+_pull_status: dict[str, dict] = {}  # model -> {"status": "pulling"|"done"|"error", "error": "..."}
+
+
+def _ollama_request(method: str, path: str, **kwargs) -> requests.Response:
+    """Make a request to the Ollama API. Raises on connection failure."""
+    url = f"{OLLAMA_URL}{path}"
+    try:
+        return requests.request(method, url, **kwargs)
+    except requests.ConnectionError:
+        raise HTTPException(status_code=503, detail="Ollama not reachable. Start it: ollama serve")
+
+
+@router.get("/ollama/status", summary="Ollama Model Status")
+def ollama_status():
+    """Return all installed Ollama models with loaded/unloaded status and VRAM usage."""
+    try:
+        tags = _ollama_request("GET", "/api/tags", timeout=3).json()
+        ps = _ollama_request("GET", "/api/ps", timeout=3).json()
+    except HTTPException:
+        return {"ok": False, "error": "Ollama not running", "models": []}
+
+    loaded = {m["name"]: m for m in ps.get("models", [])}
+    models = []
+    for m in tags.get("models", []):
+        name = m["name"]
+        lm = loaded.get(name)
+        models.append(
+            {
+                "name": name,
+                "size_gb": round(m.get("size", 0) / 1e9, 1),
+                "parameter_size": m.get("details", {}).get("parameter_size", ""),
+                "family": m.get("details", {}).get("family", ""),
+                "quantization": m.get("details", {}).get("quantization_level", ""),
+                "status": "loaded" if lm else "unloaded",
+                "vram_gb": round(lm["size_vram"] / 1e9, 1) if lm else 0,
+                "expires_at": lm.get("expires_at", "") if lm else "",
+            }
+        )
+    return {"ok": True, "models": models}
+
+
+@router.post("/ollama/load", summary="Load Ollama Model")
+def ollama_load(req: OllamaModelRequest):
+    """Load a model into VRAM. Sends an empty generate to warm up."""
+    r = _ollama_request(
+        "POST",
+        "/api/generate",
+        json={"model": req.model, "prompt": "", "keep_alive": "10m"},
+        timeout=120,
+    )
+    if r.status_code != 200:
+        error = r.json().get("error", r.text[:200])
+        if "not found" in error.lower():
+            return {"ok": False, "error": f"Model not found. Run: ollama pull {req.model}"}
+        return {"ok": False, "error": error}
+    return {"ok": True, "model": req.model, "status": "loaded"}
+
+
+@router.post("/ollama/pull", summary="Pull Ollama Model")
+def ollama_pull(req: OllamaModelRequest):
+    """Pull (download) a model from the Ollama registry. Non-blocking — runs in background."""
+    if req.model in _pull_status and _pull_status[req.model].get("status") == "pulling":
+        return {"ok": True, "model": req.model, "status": "already_pulling"}
+
+    _pull_status[req.model] = {"status": "pulling"}
+
+    def _do_pull():
+        try:
+            r = requests.post(
+                f"{OLLAMA_URL}/api/pull",
+                json={"name": req.model, "stream": False},
+                timeout=1800,
+            )
+            if r.status_code == 200:
+                _pull_status[req.model] = {"status": "done"}
+                log.info("Pulled Ollama model: %s", req.model)
+            else:
+                _pull_status[req.model] = {"status": "error", "error": r.json().get("error", "unknown")}
+        except Exception as e:
+            _pull_status[req.model] = {"status": "error", "error": str(e)}
+
+    threading.Thread(target=_do_pull, daemon=True).start()
+    return {"ok": True, "model": req.model, "status": "pulling"}
+
+
+@router.get("/ollama/pull/{model:path}", summary="Check Pull Status")
+def ollama_pull_status(model: str):
+    """Check the status of a background model pull."""
+    status = _pull_status.get(model, {"status": "unknown"})
+    return {"model": model, **status}
+
+
+@router.post("/ollama/unload", summary="Unload Ollama Model")
+def ollama_unload(req: OllamaModelRequest):
+    """Unload a model from VRAM (keep_alive=0)."""
+    try:
+        _ollama_request(
+            "POST",
+            "/api/generate",
+            json={"model": req.model, "keep_alive": 0},
+            timeout=10,
+        )
+    except HTTPException:
+        return {"ok": False, "error": "Ollama not running"}
+    return {"ok": True, "model": req.model, "status": "unloaded"}

--- a/gitd/routers/benchmarks.py
+++ b/gitd/routers/benchmarks.py
@@ -1,0 +1,163 @@
+"""Benchmark API — run task suites through the agent, track results."""
+
+import json
+import logging
+import threading
+import uuid
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from starlette.responses import StreamingResponse
+
+from gitd.benchmarks.runner import get_run, list_runs, run_benchmark, stop_run, subscribe, unsubscribe
+
+log = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/benchmarks", tags=["benchmarks"])
+
+
+# ── Request/Response models ──────────────────────────────────────────────
+
+
+class RunRequest(BaseModel):
+    suite: str = "ghost_bench"
+    tasks: Optional[list[str]] = None  # None = all tasks in the suite
+    provider: str = "ollama"
+    model: str = "gemma3:4b"
+    device: str = "emulator-5554"
+
+
+class RunResponse(BaseModel):
+    ok: bool
+    run_id: str
+    message: str
+
+
+# ── Suites ───────────────────────────────────────────────────────────────
+
+
+SUITES = {
+    "ghost_bench": {
+        "name": "Ghost Bench",
+        "description": "Built-in lightweight benchmark — settings toggles, app navigation",
+        "module": "gitd.benchmarks.ghost_bench.tasks",
+    },
+}
+
+
+@router.get("/suites", summary="List Benchmark Suites")
+def api_list_suites():
+    return [{"id": k, "name": v["name"], "description": v["description"]} for k, v in SUITES.items()]
+
+
+# ── Tasks ────────────────────────────────────────────────────────────────
+
+
+def _get_suite_tasks(suite: str):
+    """Import and return tasks for a suite."""
+    if suite not in SUITES:
+        raise HTTPException(status_code=404, detail=f"Unknown suite: {suite}")
+    import importlib
+
+    mod = importlib.import_module(SUITES[suite]["module"])
+    return mod.load_tasks, mod.get_task, mod.list_task_ids
+
+
+@router.get("/tasks", summary="List Tasks in a Suite")
+def api_list_tasks(suite: str = "ghost_bench", category: Optional[str] = None):
+    load_tasks, _, _ = _get_suite_tasks(suite)
+    tasks = load_tasks(category)
+    return [
+        {
+            "id": t.id,
+            "goal": t.goal,
+            "app": t.app,
+            "category": t.category,
+            "complexity": t.complexity,
+            "max_steps": t.max_steps,
+        }
+        for t in tasks
+    ]
+
+
+# ── Runs ─────────────────────────────────────────────────────────────────
+
+
+@router.post("/runs", summary="Start Benchmark Run", response_model=RunResponse)
+def api_start_run(req: RunRequest):
+    load_tasks, get_task, list_task_ids = _get_suite_tasks(req.suite)
+
+    if req.tasks:
+        tasks = [get_task(tid) for tid in req.tasks]
+        tasks = [t for t in tasks if t is not None]
+        if not tasks:
+            raise HTTPException(status_code=400, detail="No valid task IDs provided")
+    else:
+        tasks = load_tasks()
+
+    run_id = str(uuid.uuid4())[:8]
+
+    def _run():
+        run_benchmark(
+            tasks,
+            req.model,
+            req.device,
+            provider=req.provider,
+            suite=req.suite,
+            run_id=run_id,
+        )
+
+    threading.Thread(target=_run, daemon=True).start()
+    log.info("Started benchmark %s: %d tasks, %s/%s on %s", run_id, len(tasks), req.provider, req.model, req.device)
+
+    return RunResponse(
+        ok=True,
+        run_id=run_id,
+        message=f"Started {len(tasks)} tasks with {req.provider}/{req.model}",
+    )
+
+
+@router.get("/runs", summary="List Benchmark Runs")
+def api_list_runs():
+    return list_runs()
+
+
+@router.get("/runs/{run_id}", summary="Get Run Details")
+def api_get_run(run_id: str):
+    run = get_run(run_id)
+    if not run:
+        raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
+    return run
+
+
+@router.post("/runs/{run_id}/stop", summary="Stop Running Benchmark")
+def api_stop_run(run_id: str):
+    ok = stop_run(run_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Run not found or already completed")
+    return {"ok": True}
+
+
+@router.get("/runs/{run_id}/events", summary="Stream Live Events (SSE)")
+def api_stream_events(run_id: str):
+    """Server-Sent Events stream of live benchmark progress."""
+    q = subscribe(run_id)
+
+    def event_generator():
+        try:
+            while True:
+                try:
+                    event = q.get(timeout=30)
+                    yield f"data: {json.dumps(event)}\n\n"
+                    if event.get("type") == "run_done":
+                        break
+                except Exception:
+                    yield ": keepalive\n\n"
+        finally:
+            unsubscribe(run_id, q)
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )

--- a/gitd/routers/emulators.py
+++ b/gitd/routers/emulators.py
@@ -1,11 +1,14 @@
 """
-Emulator management API — Flask Blueprint.
+Emulator management API — FastAPI Router.
 
 All emulator lifecycle operations: list, create, delete, start, stop,
 setup, install APK, snapshots, system images, pool management.
 """
 
-from flask import Blueprint, jsonify, request
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
 
 from gitd.services.emulator_service import (
     EmulatorConfig,
@@ -13,246 +16,265 @@ from gitd.services.emulator_service import (
     get_pool,
 )
 
-bp = Blueprint("emulators", __name__, url_prefix="/api/emulators")
-pool_bp = Blueprint("emulator_pool", __name__, url_prefix="/api/emulator-pool")
+router = APIRouter(prefix="/api/emulators", tags=["emulators"])
+pool_router = APIRouter(prefix="/api/emulator-pool", tags=["emulators"])
 
 
-# ── Prerequisites ────────────────────────────────────────────────────────────
+# ── Request models ──────────────────────────────────────────────────────────
 
 
-@bp.route("/prerequisites", methods=["GET"])
+class CreateAVDRequest(BaseModel):
+    name: str
+    api_level: int = 35
+    target: str = "google_apis_playstore"
+    arch: str = ""
+    device_profile: str = "medium_phone"
+    ram_mb: int = 2048
+    disk_mb: int = 6144
+    resolution: str = "1080x2400"
+    dpi: int = 420
+    gpu: str = "auto"
+    cores: int = 2
+    headless: bool = False
+    snapshot: bool = True
+
+
+class StartRequest(BaseModel):
+    headless: bool = False
+    gpu: str = "auto"
+    cold_boot: bool = False
+    extra_args: Optional[list[str]] = None
+
+
+class StopBySerialRequest(BaseModel):
+    serial: str
+
+
+class ApkRequest(BaseModel):
+    apk_path: str
+
+
+class SnapshotRequest(BaseModel):
+    snapshot_name: str = "automation_ready"
+
+
+class ImageInstallRequest(BaseModel):
+    api_level: int
+    target: str = "google_apis_playstore"
+    arch: str = ""
+
+
+class PoolScaleUpRequest(BaseModel):
+    count: int = 1
+    config: Optional[dict] = None
+
+
+class PoolScaleDownRequest(BaseModel):
+    count: Optional[int] = None
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _find_running_serial(name: str) -> str:
+    """Find the serial for a running emulator by AVD name. Raises 404 if not running."""
+    mgr = get_manager()
+    for info in mgr.list_running():
+        if info["name"] == name:
+            return info["serial"]
+    raise HTTPException(status_code=404, detail=f'Emulator "{name}" is not running')
+
+
+# ── Prerequisites ───────────────────────────────────────────────────────────
+
+
+@router.get("/prerequisites", summary="Check SDK Prerequisites")
 def prerequisites():
-    """Check SDK tool availability."""
+    """Check SDK tool availability and hardware acceleration."""
     mgr = get_manager()
-    return jsonify(mgr.check_prerequisites())
+    return mgr.check_prerequisites()
 
 
-# ── AVD CRUD ─────────────────────────────────────────────────────────────────
+# ── AVD CRUD ────────────────────────────────────────────────────────────────
 
 
-@bp.route("", methods=["GET"])
+@router.get("", summary="List All AVDs")
 def list_avds():
-    """List all AVDs (created + running status)."""
+    """List all AVDs with running status annotation."""
     mgr = get_manager()
-    return jsonify(mgr.list_avds())
+    return mgr.list_avds()
 
 
-@bp.route("", methods=["POST"])
-def create_avd():
-    """Create a new AVD.
-    Body: {name, api_level?, target?, device_profile?, ram_mb?, disk_mb?,
-           resolution?, dpi?, gpu?, cores?, headless?, snapshot?}
-    """
-    data = request.json or {}
-    name = data.get("name")
-    if not name:
-        return jsonify({"ok": False, "error": "name is required"}), 400
-
+@router.post("", summary="Create AVD", status_code=201)
+def create_avd(req: CreateAVDRequest):
+    """Create a new Android Virtual Device."""
     config = EmulatorConfig(
-        name=name,
-        api_level=data.get("api_level", 35),
-        target=data.get("target", "google_apis_playstore"),
-        arch=data.get("arch", "x86_64"),
-        device_profile=data.get("device_profile", "medium_phone"),
-        ram_mb=data.get("ram_mb", 2048),
-        disk_mb=data.get("disk_mb", 6144),
-        resolution=data.get("resolution", "1080x2400"),
-        dpi=data.get("dpi", 420),
-        gpu=data.get("gpu", "auto"),
-        cores=data.get("cores", 2),
-        headless=data.get("headless", False),
-        snapshot=data.get("snapshot", True),
+        name=req.name,
+        api_level=req.api_level,
+        target=req.target,
+        arch=req.arch,
+        device_profile=req.device_profile,
+        ram_mb=req.ram_mb,
+        disk_mb=req.disk_mb,
+        resolution=req.resolution,
+        dpi=req.dpi,
+        gpu=req.gpu,
+        cores=req.cores,
+        headless=req.headless,
+        snapshot=req.snapshot,
     )
     mgr = get_manager()
     result = mgr.create(config)
-    status_code = 201 if result.get("ok") else 400
-    return jsonify(result), status_code
+    if not result.get("ok"):
+        raise HTTPException(status_code=400, detail=result.get("error", "Create failed"))
+    return result
 
 
-@bp.route("/<name>", methods=["DELETE"])
-def delete_avd(name):
-    """Delete an AVD."""
+@router.delete("/{name}", summary="Delete AVD")
+def delete_avd(name: str):
+    """Delete an AVD and all its data."""
     mgr = get_manager()
     result = mgr.delete(name)
-    status_code = 200 if result.get("ok") else 404
-    return jsonify(result), status_code
+    if not result.get("ok"):
+        raise HTTPException(status_code=404, detail=result.get("error", "Not found"))
+    return result
 
 
-# ── Lifecycle ────────────────────────────────────────────────────────────────
+# ── Lifecycle ───────────────────────────────────────────────────────────────
 
 
-@bp.route("/<name>/start", methods=["POST"])
-def start_emulator(name):
-    """Start an emulator.
-    Body: {headless?: bool, gpu?: str, cold_boot?: bool, extra_args?: list}
-    """
-    data = request.json or {}
+@router.post("/{name}/start", summary="Start Emulator")
+def start_emulator(name: str, req: StartRequest = StartRequest()):
+    """Boot an emulator by AVD name."""
     mgr = get_manager()
     result = mgr.start(
         name,
-        headless=data.get("headless", False),
-        gpu=data.get("gpu", "auto"),
-        cold_boot=data.get("cold_boot", False),
-        extra_args=data.get("extra_args"),
+        headless=req.headless,
+        gpu=req.gpu,
+        cold_boot=req.cold_boot,
+        extra_args=req.extra_args,
     )
-    status_code = 200 if result.get("ok") else 400
-    return jsonify(result), status_code
+    if not result.get("ok"):
+        raise HTTPException(status_code=400, detail=result.get("error", "Start failed"))
+    return result
 
 
-@bp.route("/<name>/stop", methods=["POST"])
-def stop_emulator(name):
-    """Stop an emulator by AVD name — finds its serial first."""
+@router.post("/{name}/stop", summary="Stop Emulator by Name")
+def stop_emulator(name: str):
+    """Stop a running emulator by AVD name."""
+    serial = _find_running_serial(name)
     mgr = get_manager()
-    for info in mgr.list_running():
-        if info["name"] == name:
-            result = mgr.stop(info["serial"])
-            return jsonify(result)
-    return jsonify({"ok": False, "error": f'Emulator "{name}" is not running'}), 404
+    return mgr.stop(serial)
 
 
-@bp.route("/stop-by-serial", methods=["POST"])
-def stop_by_serial():
-    """Stop an emulator by serial. Body: {serial}"""
-    data = request.json or {}
-    serial = data.get("serial")
-    if not serial:
-        return jsonify({"ok": False, "error": "serial is required"}), 400
+@router.post("/stop-by-serial", summary="Stop Emulator by Serial")
+def stop_by_serial(req: StopBySerialRequest):
+    """Stop a running emulator by ADB serial."""
     mgr = get_manager()
-    result = mgr.stop(serial)
-    return jsonify(result)
+    return mgr.stop(req.serial)
 
 
-@bp.route("/running", methods=["GET"])
+@router.get("/running", summary="List Running Emulators")
 def list_running():
     """List running emulators with serials and AVD names."""
     mgr = get_manager()
-    return jsonify(mgr.list_running())
+    return mgr.list_running()
 
 
-@bp.route("/<name>/boot-status", methods=["GET"])
-def boot_status(name):
-    """Check if an emulator has booted. Finds serial by name."""
+@router.get("/{name}/boot-status", summary="Check Boot Status")
+def boot_status(name: str):
+    """Check if a named emulator has finished booting."""
+    serial = _find_running_serial(name)
     mgr = get_manager()
-    for info in mgr.list_running():
-        if info["name"] == name:
-            return jsonify(mgr.get_boot_status(info["serial"]))
-    return jsonify({"booted": False, "error": f'Emulator "{name}" is not running'}), 404
+    return mgr.get_boot_status(serial)
 
 
-# ── Setup & Apps ─────────────────────────────────────────────────────────────
+# ── Setup & Apps ────────────────────────────────────────────────────────────
 
 
-@bp.route("/<name>/setup", methods=["POST"])
-def setup_emulator(name):
-    """Run automation setup (disable animations, max timeout, etc.)."""
+@router.post("/{name}/setup", summary="Setup for Automation")
+def setup_emulator(name: str):
+    """Disable animations, set max timeout, configure for automation."""
+    serial = _find_running_serial(name)
     mgr = get_manager()
-    for info in mgr.list_running():
-        if info["name"] == name:
-            result = mgr.setup_for_automation(info["serial"])
-            return jsonify(result)
-    return jsonify({"ok": False, "error": f'Emulator "{name}" is not running'}), 404
+    return mgr.setup_for_automation(serial)
 
 
-@bp.route("/<name>/install-apk", methods=["POST"])
-def install_apk(name):
-    """Install APK on emulator. Body: {apk_path}"""
-    data = request.json or {}
-    apk_path = data.get("apk_path")
-    if not apk_path:
-        return jsonify({"ok": False, "error": "apk_path is required"}), 400
+@router.post("/{name}/install-apk", summary="Install APK")
+def install_apk(name: str, req: ApkRequest):
+    """Install an APK file on a running emulator."""
+    serial = _find_running_serial(name)
     mgr = get_manager()
-    for info in mgr.list_running():
-        if info["name"] == name:
-            result = mgr.install_apk(info["serial"], apk_path)
-            return jsonify(result)
-    return jsonify({"ok": False, "error": f'Emulator "{name}" is not running'}), 404
+    return mgr.install_apk(serial, req.apk_path)
 
 
-# ── Snapshots ────────────────────────────────────────────────────────────────
+# ── Snapshots ───────────────────────────────────────────────────────────────
 
 
-@bp.route("/<name>/snapshot/save", methods=["POST"])
-def snapshot_save(name):
-    """Save emulator snapshot. Body: {snapshot_name?: str}"""
-    data = request.json or {}
-    snap_name = data.get("snapshot_name", "automation_ready")
+@router.post("/{name}/snapshot/save", summary="Save Snapshot")
+def snapshot_save(name: str, req: SnapshotRequest = SnapshotRequest()):
+    """Save emulator state to a named snapshot."""
+    serial = _find_running_serial(name)
     mgr = get_manager()
-    for info in mgr.list_running():
-        if info["name"] == name:
-            result = mgr.snapshot_save(info["serial"], snap_name)
-            return jsonify(result)
-    return jsonify({"ok": False, "error": f'Emulator "{name}" is not running'}), 404
+    return mgr.snapshot_save(serial, req.snapshot_name)
 
 
-@bp.route("/<name>/snapshot/load", methods=["POST"])
-def snapshot_load(name):
-    """Load emulator snapshot. Body: {snapshot_name?: str}"""
-    data = request.json or {}
-    snap_name = data.get("snapshot_name", "automation_ready")
+@router.post("/{name}/snapshot/load", summary="Load Snapshot")
+def snapshot_load(name: str, req: SnapshotRequest = SnapshotRequest()):
+    """Restore emulator state from a named snapshot."""
+    serial = _find_running_serial(name)
     mgr = get_manager()
-    for info in mgr.list_running():
-        if info["name"] == name:
-            result = mgr.snapshot_load(info["serial"], snap_name)
-            return jsonify(result)
-    return jsonify({"ok": False, "error": f'Emulator "{name}" is not running'}), 404
+    return mgr.snapshot_load(serial, req.snapshot_name)
 
 
-@bp.route("/<name>/snapshots", methods=["GET"])
-def list_snapshots(name):
-    """List snapshots for a running emulator."""
+@router.get("/{name}/snapshots", summary="List Snapshots")
+def list_snapshots(name: str):
+    """List available snapshots for a running emulator."""
+    serial = _find_running_serial(name)
     mgr = get_manager()
-    for info in mgr.list_running():
-        if info["name"] == name:
-            result = mgr.list_snapshots(info["serial"])
-            return jsonify(result)
-    return jsonify({"ok": False, "error": f'Emulator "{name}" is not running'}), 404
+    return mgr.list_snapshots(serial)
 
 
-# ── System Images ────────────────────────────────────────────────────────────
+# ── System Images ───────────────────────────────────────────────────────────
 
 
-@bp.route("/system-images", methods=["GET"])
+@router.get("/system-images", summary="List System Images")
 def list_system_images():
-    """List installed system images."""
+    """List installed Android system images."""
     mgr = get_manager()
-    return jsonify(mgr.list_system_images())
+    return mgr.list_system_images()
 
 
-@bp.route("/system-images/install", methods=["POST"])
-def install_system_image():
-    """Download a new system image. Body: {api_level, target?, arch?}"""
-    data = request.json or {}
-    api_level = data.get("api_level")
-    if not api_level:
-        return jsonify({"ok": False, "error": "api_level is required"}), 400
+@router.post("/system-images/install", summary="Install System Image")
+def install_system_image(req: ImageInstallRequest):
+    """Download and install a system image via sdkmanager."""
     mgr = get_manager()
     result = mgr.install_system_image(
-        api_level=int(api_level),
-        target=data.get("target", "google_apis_playstore"),
-        arch=data.get("arch", "x86_64"),
+        api_level=req.api_level,
+        target=req.target,
+        arch=req.arch or "",
     )
-    status_code = 200 if result.get("ok") else 400
-    return jsonify(result), status_code
+    if not result.get("ok"):
+        raise HTTPException(status_code=400, detail=result.get("error", "Install failed"))
+    return result
 
 
-# ── Emulator Pool ────────────────────────────────────────────────────────────
+# ── Emulator Pool ───────────────────────────────────────────────────────────
 
 
-@pool_bp.route("/status", methods=["GET"])
+@pool_router.get("/status", summary="Pool Status")
 def pool_status():
-    """Pool status (active, idle, busy counts + resources)."""
+    """Get pool status: active, idle, busy counts + resource usage."""
     pool = get_pool()
-    return jsonify(pool.status())
+    return pool.status()
 
 
-@pool_bp.route("/scale-up", methods=["POST"])
-def pool_scale_up():
-    """Start N emulators. Body: {count, config?: {api_level, ram_mb, ...}}"""
-    data = request.json or {}
-    count = data.get("count", 1)
-    cfg_data = data.get("config", {})
+@pool_router.post("/scale-up", summary="Scale Up Pool")
+def pool_scale_up(req: PoolScaleUpRequest):
+    """Start N emulators in the pool."""
+    cfg_data = req.config or {}
     config = EmulatorConfig(
-        name="_template",  # ignored — pool generates names
+        name="_template",
         api_level=cfg_data.get("api_level", 35),
         target=cfg_data.get("target", "google_apis_playstore"),
         ram_mb=cfg_data.get("ram_mb", 2048),
@@ -262,31 +284,28 @@ def pool_scale_up():
         headless=True,
     )
     pool = get_pool()
-    result = pool.scale_up(count, config)
-    status_code = 200 if result.get("ok") else 400
-    return jsonify(result), status_code
+    result = pool.scale_up(req.count, config)
+    if not result.get("ok"):
+        raise HTTPException(status_code=400, detail=result.get("error", "Scale up failed"))
+    return result
 
 
-@pool_bp.route("/scale-down", methods=["POST"])
-def pool_scale_down():
-    """Stop N idle emulators. Body: {count?: int} (null = all idle)"""
-    data = request.json or {}
-    count = data.get("count")
+@pool_router.post("/scale-down", summary="Scale Down Pool")
+def pool_scale_down(req: PoolScaleDownRequest = PoolScaleDownRequest()):
+    """Stop N idle emulators from the pool."""
     pool = get_pool()
-    result = pool.scale_down(count)
-    return jsonify(result)
+    return pool.scale_down(req.count)
 
 
-@pool_bp.route("/stop-all", methods=["POST"])
+@pool_router.post("/stop-all", summary="Stop All Pool Emulators")
 def pool_stop_all():
-    """Stop all pool emulators."""
+    """Stop every emulator managed by the pool."""
     pool = get_pool()
-    result = pool.stop_all()
-    return jsonify(result)
+    return pool.stop_all()
 
 
-@pool_bp.route("/resources", methods=["GET"])
+@pool_router.get("/resources", summary="System Resources")
 def pool_resources():
-    """System resource usage (CPU, RAM, disk)."""
+    """Get system resource usage (CPU, RAM, disk)."""
     pool = get_pool()
-    return jsonify(pool.resource_usage())
+    return pool.resource_usage()

--- a/gitd/routers/streaming.py
+++ b/gitd/routers/streaming.py
@@ -35,7 +35,7 @@ def _stable_ws_port(serial: str) -> int:
 
 
 @router.get("/api/phone/stream", summary="Stream Phone Screen MJPEG")
-def phone_stream(device: str = "", fps: int = 30, quality: int = 8, mode: str = "portal"):
+def phone_stream(device: str = "", fps: int = 30, quality: int = 8, mode: str = "screencap"):
     """Stream phone screen via MJPEG."""
     fps = max(1, min(fps, 60))
     quality = max(1, min(quality, 31))

--- a/gitd/services/_emulator_helpers.py
+++ b/gitd/services/_emulator_helpers.py
@@ -6,6 +6,7 @@ EmulatorConfig dataclass, and discovery/query functions.
 import configparser
 import logging
 import os
+import platform
 import shutil
 import subprocess
 import threading
@@ -19,7 +20,29 @@ logger = logging.getLogger(__name__)
 
 # ── SDK paths ────────────────────────────────────────────────────────────────
 
-SDK_ROOT = Path(os.environ.get("ANDROID_SDK_ROOT", os.environ.get("ANDROID_HOME", Path.home() / "Android" / "Sdk")))
+
+def _detect_sdk_root() -> Path:
+    """Auto-detect Android SDK root across platforms."""
+    for var in ("ANDROID_SDK_ROOT", "ANDROID_HOME"):
+        val = os.environ.get(var)
+        if val and Path(val).exists():
+            return Path(val)
+    # macOS: Homebrew commandline-tools
+    brew = Path("/opt/homebrew/share/android-commandlinetools")
+    if brew.exists():
+        return brew
+    # macOS: Android Studio default
+    mac_studio = Path.home() / "Library" / "Android" / "sdk"
+    if mac_studio.exists():
+        return mac_studio
+    # Linux default
+    linux = Path.home() / "Android" / "Sdk"
+    if linux.exists():
+        return linux
+    return brew if platform.system() == "Darwin" else linux
+
+
+SDK_ROOT = _detect_sdk_root()
 
 EMULATOR_BIN = SDK_ROOT / "emulator" / "emulator"
 ADB_BIN = shutil.which("adb") or str(SDK_ROOT / "platform-tools" / "adb")
@@ -48,8 +71,30 @@ def _adb(serial: str, *args, timeout: int = 30) -> str:
     return r.stdout.strip()
 
 
+def _safe_int(val: str, default: int = 0) -> int:
+    """Parse int from string, stripping size suffixes like 'M', 'G', '2G'."""
+    val = val.strip()
+    if not val:
+        return default
+    for suffix in ("MB", "GB", "KB", "M", "G", "K"):
+        if val.upper().endswith(suffix):
+            val = val[: -len(suffix)]
+            break
+    try:
+        return int(val)
+    except ValueError:
+        return default
+
+
 def is_emulator(serial: str) -> bool:
     return serial.startswith("emulator-")
+
+
+def default_arch() -> str:
+    """Return the correct emulator arch for this platform."""
+    if platform.machine().lower() in ("arm64", "aarch64"):
+        return "arm64-v8a"
+    return "x86_64"
 
 
 # ── Config dataclass ─────────────────────────────────────────────────────────
@@ -60,7 +105,7 @@ class EmulatorConfig:
     name: str
     api_level: int = 35
     target: str = "google_apis_playstore"  # google_apis | google_apis_playstore | default
-    arch: str = "x86_64"
+    arch: str = ""  # auto-detected if empty
     device_profile: str = "medium_phone"  # hardware profile name
     ram_mb: int = 2048
     disk_mb: int = 6144
@@ -70,6 +115,10 @@ class EmulatorConfig:
     cores: int = 2
     headless: bool = False
     snapshot: bool = True
+
+    def __post_init__(self):
+        if not self.arch:
+            self.arch = default_arch()
 
     def system_image_pkg(self) -> str:
         api = f"android-{self.api_level}"
@@ -87,13 +136,18 @@ class EmulatorConfig:
 
 def check_prerequisites() -> dict:
     """Check what SDK tools are available."""
+    is_mac = platform.system() == "Darwin"
+    hw_accel = True if is_mac else Path("/dev/kvm").exists()
     return {
         "sdk_root": str(SDK_ROOT),
         "sdk_exists": SDK_ROOT.exists(),
         "emulator_binary": EMULATOR_BIN.exists(),
         "adb_binary": shutil.which("adb") is not None or (SDK_ROOT / "platform-tools" / "adb").exists(),
         "cmdline_tools": _has_cmdline_tools(),
-        "kvm": Path("/dev/kvm").exists(),
+        "hw_accel": hw_accel,
+        "hw_accel_type": "HVF" if is_mac else "KVM",
+        "platform": platform.system(),
+        "arch": default_arch(),
         "avd_home": str(AVD_HOME),
     }
 
@@ -127,8 +181,10 @@ def list_system_images() -> list[dict]:
     return images
 
 
-def install_system_image(api_level: int, target: str = "google_apis_playstore", arch: str = "x86_64") -> dict:
+def install_system_image(api_level: int, target: str = "google_apis_playstore", arch: str = "") -> dict:
     """Download a system image via sdkmanager. Requires cmdline-tools."""
+    if not arch:
+        arch = default_arch()
     if not _has_cmdline_tools():
         return {
             "ok": False,
@@ -157,7 +213,6 @@ def list_avds(running_list: list[dict]) -> list[dict]:
     for ini_file in sorted(AVD_HOME.glob("*.ini")):
         if ini_file.suffix != ".ini":
             continue
-        # skip .avd directories, only process top-level .ini
         name_from_file = ini_file.stem
 
         cfg = configparser.ConfigParser()
@@ -171,7 +226,6 @@ def list_avds(running_list: list[dict]) -> list[dict]:
             "target": cfg.get("root", "target", fallback=""),
         }
 
-        # Read detailed config from the .avd/config.ini
         config_ini = avd_path / "config.ini" if avd_path else None
         if config_ini and config_ini.exists():
             lines = config_ini.read_text().splitlines()
@@ -189,16 +243,15 @@ def list_avds(running_list: list[dict]) -> list[dict]:
                     "target_flavor": kv.get("tag.display", ""),
                     "abi": kv.get("abi.type", ""),
                     "resolution": f"{kv.get('hw.lcd.width', '?')}x{kv.get('hw.lcd.height', '?')}",
-                    "dpi": int(kv.get("hw.lcd.density", 0)),
-                    "ram_mb": int(kv.get("hw.ramSize", 0)),
+                    "dpi": _safe_int(kv.get("hw.lcd.density", "0")),
+                    "ram_mb": _safe_int(kv.get("hw.ramSize", "0")),
                     "disk": kv.get("disk.dataPartition.size", ""),
                     "gpu_mode": kv.get("hw.gpu.mode", ""),
-                    "cores": int(kv.get("hw.cpu.ncore", 0)),
+                    "cores": _safe_int(kv.get("hw.cpu.ncore", "0")),
                     "playstore": kv.get("PlayStore.enabled", "false").lower() == "true",
                 }
             )
 
-        # Running status
         run_info = running.get(name_from_file)
         if run_info:
             adb_state = run_info.get("adb_state", "device")
@@ -215,14 +268,7 @@ def list_avds(running_list: list[dict]) -> list[dict]:
 
 
 def list_running(procs: dict, lock: threading.Lock) -> list[dict]:
-    """List running emulators with serials and AVD names.
-
-    Picks up both 'device' (fully booted) and 'offline' (booting) emulators.
-
-    Args:
-        procs: the EmulatorManager._procs dict (serial -> Popen).
-        lock: the EmulatorManager._lock.
-    """
+    """List running emulators with serials and AVD names."""
     try:
         r = _run([ADB_BIN, "devices"], timeout=10, check=False)
     except (subprocess.SubprocessError, OSError):
@@ -232,13 +278,11 @@ def list_running(procs: dict, lock: threading.Lock) -> list[dict]:
         parts = line.split()
         if len(parts) >= 2 and parts[0].startswith("emulator-") and parts[1] in ("device", "offline"):
             serial = parts[0]
-            adb_state = parts[1]  # 'device' or 'offline'
-            # get AVD name (only works if device is online)
+            adb_state = parts[1]
             avd_name = "unknown"
             if adb_state == "device":
                 name_out = _adb(serial, "emu", "avd", "name", timeout=5)
                 avd_name = name_out.splitlines()[0].strip() if name_out else "unknown"
-            # get pid from tracked procs or from system
             pid = None
             with lock:
                 proc = procs.get(serial)

--- a/gitd/services/agent_chat.py
+++ b/gitd/services/agent_chat.py
@@ -310,6 +310,25 @@ def delete_conversation(conversation_id: str):
     _sessions.pop(conversation_id, None)
 
 
+def get_providers() -> list[dict]:
+    """Return providers with models. Ollama models are discovered live from the local server."""
+    import requests
+
+    result = []
+    for pid, info in PROVIDERS.items():
+        models = list(info["models"])
+        if pid == "ollama":
+            try:
+                r = requests.get("http://localhost:11434/api/tags", timeout=3)
+                installed = [m["name"] for m in r.json().get("models", [])]
+                if installed:
+                    models = installed
+            except Exception:
+                pass  # Ollama not running — return defaults
+        result.append({"id": pid, "label": info["label"], "models": models})
+    return result
+
+
 def chat_turn(session: ChatSession, user_message: str):
     """Run one agent turn. Yields SSE event dicts."""
     provider = session.provider
@@ -726,11 +745,22 @@ def _chat_ollama(session: ChatSession, user_message: str):
                 },
                 timeout=120,
             )
-            reply = r.json().get("message", {}).get("content", "")
+            data = r.json()
+            if r.status_code != 200:
+                error = data.get("error", r.text[:200])
+                if "not found" in error.lower():
+                    yield {
+                        "type": "error",
+                        "content": f"Model '{model}' not found. Pull it first: ollama pull {model}",
+                    }
+                else:
+                    yield {"type": "error", "content": f"Ollama error: {error}"}
+                return
+            reply = data.get("message", {}).get("content", "")
         except requests.ConnectionError:
             yield {
                 "type": "error",
-                "content": "Ollama not reachable at localhost:11434. Install: https://ollama.com/download",
+                "content": "Ollama not reachable at localhost:11434. Start it: ollama serve",
             }
             return
         except Exception as e:

--- a/gitd/services/agent_chat.py
+++ b/gitd/services/agent_chat.py
@@ -60,7 +60,17 @@ PROVIDERS = {
     "claude-code": {"label": "Claude Code (free)", "models": ["sonnet", "opus", "haiku"]},
     "anthropic": {"label": "Claude API", "models": ["claude-sonnet-4-20250514", "claude-opus-4-20250514"]},
     "openrouter": {"label": "OpenRouter", "models": ["anthropic/claude-sonnet-4", "google/gemini-2.5-pro"]},
-    "ollama": {"label": "Ollama (local)", "models": []},
+    "ollama": {
+        "label": "Ollama (local)",
+        "models": [
+            "llama3.2:3b",
+            "llama3.2:1b",
+            "gemma3:4b",
+            "qwen3:4b",
+            "phi4-mini:3.8b",
+            "mistral:7b",
+        ],
+    },
 }
 
 
@@ -645,12 +655,43 @@ def _chat_openrouter(session: ChatSession, user_message: str):
 # ── Ollama ───────────────────────────────────────────────────────────────────
 
 
+def _parse_tool_calls(text: str) -> list[dict]:
+    """Extract tool calls from LLM output. Handles ```tool blocks and common LLM quirks."""
+    import re
+
+    calls = []
+    for match in re.finditer(r"```tool\s*\n?(.*?)\n?```", text, re.DOTALL):
+        raw = match.group(1).strip()
+        # Try parsing as-is first (valid JSON)
+        try:
+            call = json.loads(raw)
+            if isinstance(call, dict) and "tool" in call:
+                calls.append(call)
+                continue
+        except json.JSONDecodeError:
+            pass
+        # Fallback: some models wrap JSON in doubled braces {{ ... }}
+        fixed = raw
+        for _ in range(3):
+            fixed = re.sub(r"\{\{", "{", fixed)
+            fixed = re.sub(r"\}\}", "}", fixed)
+            try:
+                call = json.loads(fixed)
+                if isinstance(call, dict) and "tool" in call:
+                    calls.append(call)
+                    break
+            except json.JSONDecodeError:
+                continue
+    return calls
+
+
 def _chat_ollama(session: ChatSession, user_message: str):
-    """Use local Ollama model."""
+    """Use local Ollama model with multi-turn tool execution loop."""
     import requests
 
     session.messages.append(ChatMessage(role="user", content=user_message))
 
+    # Build screen context
     context = ""
     try:
         tree = get_screen_tree(session.device)
@@ -659,45 +700,77 @@ def _chat_ollama(session: ChatSession, user_message: str):
     except Exception:
         pass
 
-    tool_list = "\n".join(f"- {t['name']}: {t['description']}" for t in TOOLS)
+    # Build tool list with param names so the LLM knows what args to send
+    tool_list = "\n".join(
+        f"- {t['name']}: {t['description']}  params: {list(t.get('input_schema', {}).get('properties', {}).keys())}"
+        for t in TOOLS
+    )
     system = DEFAULT_SYSTEM.replace("{tool_list}", tool_list)
 
-    try:
-        r = requests.post(
-            "http://localhost:11434/api/chat",
-            json={
-                "model": session.model or "llama3",
-                "messages": [
-                    {"role": "system", "content": system},
-                    {"role": "user", "content": f"{context}Device: {session.device}\n\n{user_message}"},
-                ],
-                "stream": False,
-            },
-            timeout=120,
-        )
-        reply = r.json().get("message", {}).get("content", "")
+    messages = [
+        {"role": "system", "content": system},
+        {"role": "user", "content": f"{context}Device: {session.device}\n\n{user_message}"},
+    ]
 
-        if reply:
-            session.messages.append(ChatMessage(role="assistant", content=reply))
-            yield {"type": "text", "content": reply}
+    model = session.model or "llama3.2:3b"
 
-            # Parse tool calls from response (same format as claude-code)
-            import re
+    for turn in range(MAX_TURNS):
+        try:
+            r = requests.post(
+                "http://localhost:11434/api/chat",
+                json={
+                    "model": model,
+                    "messages": messages,
+                    "stream": False,
+                    "options": {"num_ctx": 4096},
+                },
+                timeout=120,
+            )
+            reply = r.json().get("message", {}).get("content", "")
+        except requests.ConnectionError:
+            yield {
+                "type": "error",
+                "content": "Ollama not reachable at localhost:11434. Install: https://ollama.com/download",
+            }
+            return
+        except Exception as e:
+            yield {"type": "error", "content": str(e)}
+            return
 
-            tool_pattern = re.compile(r"```tool\s*\n(.*?)\n```", re.DOTALL)
-            for match in tool_pattern.finditer(reply):
-                try:
-                    call = json.loads(match.group(1).strip())
-                    tool_name = call.get("tool", "")
-                    tool_args = call.get("args", {})
-                    tool_args.setdefault("device", session.device)
-                    result = execute_tool(tool_name, tool_args)
-                    yield {"type": "tool_call", "name": tool_name, "args": tool_args}
-                    yield {"type": "tool_result", "name": tool_name, "result": result[:500]}
-                except Exception:
-                    pass
-    except Exception as e:
-        yield {"type": "error", "content": str(e)}
+        if not reply:
+            break
+
+        session.messages.append(ChatMessage(role="assistant", content=reply))
+        yield {"type": "text", "content": reply}
+        messages.append({"role": "assistant", "content": reply})
+
+        # Parse and execute tool calls
+        tool_calls = _parse_tool_calls(reply)
+        if not tool_calls:
+            break  # No tools requested — done
+
+        tool_results = []
+        for call in tool_calls:
+            tool_name = call.get("tool", "")
+            tool_args = call.get("args", {})
+            tool_args.setdefault("device", session.device)
+
+            session.messages.append(ChatMessage(role="tool_call", tool_name=tool_name, tool_args=tool_args, content=""))
+            yield {"type": "tool_call", "name": tool_name, "args": tool_args}
+
+            try:
+                result = execute_tool(tool_name, tool_args)
+                session.messages.append(ChatMessage(role="tool_result", content=result[:500], tool_name=tool_name))
+                yield {"type": "tool_result", "name": tool_name, "result": result[:500]}
+                tool_results.append(f"[{tool_name}] {result[:800]}")
+            except Exception as e:
+                err = f"Tool error: {e}"
+                session.messages.append(ChatMessage(role="tool_result", content=err, tool_name=tool_name))
+                yield {"type": "tool_result", "name": tool_name, "result": err}
+                tool_results.append(f"[{tool_name}] ERROR: {err}")
+
+        # Feed tool results back for next turn
+        messages.append({"role": "user", "content": "Tool results:\n" + "\n".join(tool_results)})
 
     yield {"type": "done"}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ghost-in-the-droid"
-version = "1.1.0"
+version = "1.2.0"
 description = "Give any AI agent an Android body. Open-source phone automation via ADB — tap, swipe, type, run skills, scale across devices."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "ghost-in-the-droid"
 version = "1.0.0"
 description = "Give any AI agent an Android body. Open-source phone automation via ADB — tap, swipe, type, run skills, scale across devices."
+readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "MIT"}
 keywords = ["android", "adb", "automation", "ghost", "agent", "mcp", "fastapi", "phone-farm"]
@@ -29,7 +30,14 @@ dependencies = [
     "pyyaml>=6.0",
     "psutil>=5.9",
     "openai>=1.0",
+    "mcp>=1.20",
 ]
+
+[project.urls]
+Homepage = "https://ghostinthedroid.com"
+Repository = "https://github.com/ghost-in-the-droid/android-agent"
+Documentation = "https://ghostinthedroid.com/getting-started/installation/"
+Issues = "https://github.com/ghost-in-the-droid/android-agent/issues"
 
 [project.optional-dependencies]
 llm = ["anthropic>=0.30"]
@@ -40,6 +48,7 @@ all = ["ghost-in-the-droid[llm,analytics,ocr,test]"]
 
 [project.scripts]
 android-agent = "gitd.cli:main"
+android-agent-mcp = "gitd.mcp_server:main"
 
 [tool.setuptools.packages.find]
 include = ["gitd*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ghost-in-the-droid"
-version = "1.0.0"
+version = "1.1.0"
 description = "Give any AI agent an Android body. Open-source phone automation via ADB — tap, swipe, type, run skills, scale across devices."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/install-mcp.sh
+++ b/scripts/install-mcp.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Ghost in the Droid — MCP Server Installer
+# Gives any AI agent 35 Android automation tools.
+#
+# Usage:
+#   bash <(curl -sSL https://raw.githubusercontent.com/ghost-in-the-droid/android-agent/main/scripts/install-mcp.sh)
+#
+# What it does:
+#   1. Clones the repo (or updates if already cloned)
+#   2. Creates a Python venv and installs dependencies
+#   3. Registers the MCP server with your AI client
+#
+set -euo pipefail
+
+REPO="https://github.com/ghost-in-the-droid/android-agent.git"
+DIR="$HOME/ghost-in-the-droid"
+
+echo "👻 Ghost in the Droid — MCP Installer"
+echo ""
+
+# ── Prerequisites ──────────────────────────────────────────────────────────
+
+check() { command -v "$1" &>/dev/null; }
+
+if ! check python3; then echo "❌ python3 not found. Install Python 3.10+."; exit 1; fi
+if ! check adb; then echo "⚠️  adb not found. Install Android platform-tools for device control."; fi
+if ! check git; then echo "❌ git not found."; exit 1; fi
+
+# ── Clone / Update ─────────────────────────────────────────────────────────
+
+if [ -d "$DIR" ]; then
+    echo "📂 Found $DIR — pulling latest..."
+    cd "$DIR" && git pull --quiet
+else
+    echo "📥 Cloning to $DIR..."
+    git clone --quiet "$REPO" "$DIR"
+    cd "$DIR"
+fi
+
+# ── Python Venv + Install ──────────────────────────────────────────────────
+
+if [ ! -d ".venv" ]; then
+    echo "🐍 Creating Python venv..."
+    python3 -m venv .venv
+fi
+
+echo "📦 Installing dependencies..."
+.venv/bin/pip install -q -e ".[all]"
+
+# Verify MCP server loads
+TOOL_COUNT=$(.venv/bin/python -c "from gitd.mcp_server import mcp; print(len(mcp._tool_manager.list_tools()))" 2>/dev/null || echo "0")
+if [ "$TOOL_COUNT" = "0" ]; then
+    echo "❌ MCP server failed to load. Check Python 3.10+ and try again."
+    exit 1
+fi
+
+echo "✅ MCP server ready — $TOOL_COUNT tools"
+
+# ── Register with AI Client ────────────────────────────────────────────────
+
+MCP_CMD="$DIR/.venv/bin/python"
+MCP_ARGS="-m gitd.mcp_server"
+
+if check claude; then
+    echo ""
+    echo "🔌 Registering with Claude Code..."
+    claude mcp add android-agent -- "$MCP_CMD" $MCP_ARGS 2>/dev/null && \
+        echo "✅ Claude Code: android-agent MCP registered" || \
+        echo "⚠️  claude mcp add failed — add manually (see below)"
+fi
+
+# ── Done ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "👻 Ghost in the Droid — $TOOL_COUNT MCP tools installed"
+echo ""
+echo "If auto-registration didn't work, add manually:"
+echo ""
+echo "  Claude Code:"
+echo "    claude mcp add android-agent -- $MCP_CMD $MCP_ARGS"
+echo ""
+echo "  Claude Desktop / Cursor / Windsurf — add to config:"
+echo "    {\"mcpServers\":{\"android-agent\":{\"command\":\"$MCP_CMD\",\"args\":[\"-m\",\"gitd.mcp_server\"]}}}"
+echo ""
+echo "  VS Code Copilot (.vscode/mcp.json):"
+echo "    {\"servers\":{\"android-agent\":{\"command\":\"$MCP_CMD\",\"args\":[\"-m\",\"gitd.mcp_server\"]}}}"
+echo ""
+echo "Start the dashboard:  cd $DIR && .venv/bin/python run.py"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -683,6 +683,32 @@
 		</div>
 	</section>
 
+	<!-- MCP INSTALL — one-liner for AI agents -->
+	<section style="position:relative;z-index:1;padding:3rem 0 1rem">
+		<div class="container">
+			<div style="max-width:720px;margin:0 auto;text-align:center">
+				<h2 style="font-size:1.4rem;font-weight:700;color:var(--text-primary);margin-bottom:0.5rem">Give your AI agent an Android body</h2>
+				<p style="color:var(--text-secondary);font-size:0.95rem;margin-bottom:1.5rem">35 MCP tools — tap, swipe, type, screenshot, OCR, launch apps, run skills. Works with Claude, Cursor, VS Code Copilot, Windsurf.</p>
+				<div class="terminal" style="text-align:left;margin-bottom:1rem">
+					<div class="terminal-header">
+						<span class="terminal-dot r"></span>
+						<span class="terminal-dot y"></span>
+						<span class="terminal-dot g"></span>
+						<span class="terminal-title">install</span>
+					</div>
+					<div class="terminal-body" style="font-size:0.85rem;line-height:1.8">
+						<span class="t-cm"># Add to Claude Code / Codex (one command)</span><br/>
+						<span class="t-fn">claude</span> mcp add android-agent <span class="t-op">--</span> uvx <span class="t-op">--from</span> ghost-in-the-droid android-agent-mcp<br/>
+						<br/>
+						<span class="t-cm"># Or any MCP client config (Cursor, VS Code, Windsurf, Claude Desktop)</span><br/>
+						<span class="t-op">{</span><span class="t-str">"command"</span><span class="t-op">:</span> <span class="t-str">"uvx"</span><span class="t-op">,</span> <span class="t-str">"args"</span><span class="t-op">:</span> <span class="t-op">[</span><span class="t-str">"--from"</span><span class="t-op">,</span> <span class="t-str">"ghost-in-the-droid"</span><span class="t-op">,</span> <span class="t-str">"android-agent-mcp"</span><span class="t-op">]}</span><br/>
+					</div>
+				</div>
+				<p style="color:#555;font-size:0.8rem">Plug in a phone with USB debugging, run the install, and your AI agent can control it immediately.</p>
+			</div>
+		</div>
+	</section>
+
 	<!-- DEMO VIDEOS -->
 	<section class="demo-section" style="position:relative;z-index:1">
 		<div class="container">

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,0 +1,61 @@
+"""Tests for benchmark infrastructure."""
+
+from gitd.benchmarks.base import Task, TaskResult, load_tasks_from_dir
+from gitd.benchmarks.ghost_bench.tasks import TASK_DATA_DIR, get_task, list_task_ids, load_tasks
+
+
+def test_load_tasks():
+    tasks = load_tasks()
+    assert len(tasks) >= 10
+    assert all(isinstance(t, Task) for t in tasks)
+
+
+def test_load_tasks_by_category():
+    settings = load_tasks("settings")
+    nav = load_tasks("navigation")
+    assert all(t.category == "settings" for t in settings)
+    assert all(t.category == "navigation" for t in nav)
+    assert len(settings) + len(nav) == len(load_tasks())
+
+
+def test_get_task():
+    task = get_task("SystemWifiTurnOn")
+    assert task is not None
+    assert task.goal == "Turn wifi on."
+    assert task.app == "com.android.settings"
+    assert task.init["cmd"] == "svc wifi disable"
+
+
+def test_get_task_not_found():
+    assert get_task("NonExistent") is None
+
+
+def test_list_task_ids():
+    ids = list_task_ids()
+    assert "SystemWifiTurnOn" in ids
+    assert "OpenAppSettings" in ids
+
+
+def test_task_max_steps():
+    task = get_task("SystemAirplaneModeOn")
+    assert task is not None
+    assert task.complexity == 1.5
+    assert task.max_steps == 15
+
+
+def test_task_result_defaults():
+    result = TaskResult(task_id="test", goal="test goal", model="m", device="d")
+    assert result.score == 0.0
+    assert result.error == ""
+    assert result.agent_log == []
+
+
+def test_load_tasks_from_dir():
+    tasks = load_tasks_from_dir(TASK_DATA_DIR)
+    assert len(tasks) == len(load_tasks())
+
+
+def test_all_tasks_have_eval():
+    for task in load_tasks():
+        assert task.eval, f"Task {task.id} missing eval"
+        assert task.eval.get("cmd"), f"Task {task.id} eval missing cmd"

--- a/tests/test_ollama.py
+++ b/tests/test_ollama.py
@@ -1,0 +1,66 @@
+"""Tests for Ollama tool parsing and provider config."""
+
+from gitd.services.agent_chat import PROVIDERS, _parse_tool_calls
+
+
+def test_providers_ollama_has_models():
+    """Ollama provider should have a pre-filled model list."""
+    ollama = PROVIDERS["ollama"]
+    assert len(ollama["models"]) >= 5
+    assert "llama3.2:3b" in ollama["models"]
+    assert "gemma3:4b" in ollama["models"]
+
+
+def test_parse_tool_calls_basic():
+    text = '''I'll take a screenshot.
+```tool
+{"tool": "screenshot", "args": {"device": "emulator-5554"}}
+```'''
+    calls = _parse_tool_calls(text)
+    assert len(calls) == 1
+    assert calls[0]["tool"] == "screenshot"
+    assert calls[0]["args"]["device"] == "emulator-5554"
+
+
+def test_parse_tool_calls_multiple():
+    text = '''Let me check the screen and tap.
+```tool
+{"tool": "get_screen_tree", "args": {"device": "emulator-5554"}}
+```
+Now I'll tap.
+```tool
+{"tool": "tap", "args": {"device": "emulator-5554", "x": 540, "y": 1200}}
+```'''
+    calls = _parse_tool_calls(text)
+    assert len(calls) == 2
+    assert calls[0]["tool"] == "get_screen_tree"
+    assert calls[1]["tool"] == "tap"
+    assert calls[1]["args"]["x"] == 540
+
+
+def test_parse_tool_calls_doubled_braces():
+    """Some models (gemma3) wrap JSON in {{ ... }} — should handle gracefully."""
+    text = '```tool\n{{"tool": "tap", "args": {{"x": 100, "y": 200}}}}\n```'
+    calls = _parse_tool_calls(text)
+    assert len(calls) == 1
+    assert calls[0]["tool"] == "tap"
+    assert calls[0]["args"]["x"] == 100
+
+
+def test_parse_tool_calls_no_tools():
+    text = "I don't need any tools for this. The answer is 42."
+    calls = _parse_tool_calls(text)
+    assert len(calls) == 0
+
+
+def test_parse_tool_calls_invalid_json():
+    text = '```tool\n{not valid json}\n```'
+    calls = _parse_tool_calls(text)
+    assert len(calls) == 0
+
+
+def test_parse_tool_calls_missing_tool_key():
+    """Valid JSON but missing 'tool' key should be ignored."""
+    text = '```tool\n{"action": "screenshot", "args": {}}\n```'
+    calls = _parse_tool_calls(text)
+    assert len(calls) == 0


### PR DESCRIPTION
## What's new in v1.2.0

### Added
- **Ghost Bench** — in-dashboard benchmark system with 14 built-in tasks (settings + navigation). Runner with SSE live streaming. New `Benchmarks` tab in the dashboard. Foundation for Phase 2 (real AndroidWorld integration).
- **7 benchmark API endpoints** (`/api/benchmarks/*`) — list suites, start run, stream events, past runs, stop.
- **Live Ollama model discovery** — `GET /api/agent-chat/providers` queries `localhost:11434/api/tags` so the dropdown shows actually-installed models.
- **Background Ollama model pull** — pull new models without blocking the UI, with live status tracking.

### Changed
- Frontend model selector fetches providers on mount instead of hardcoded constants.
- Better errors when Ollama isn't running or a model isn't installed.

### Fixed
- Confusing "connection error" when user selected a non-installed model → now says "model not found, pull it first".

## Release process

Tag `v1.2.0` after merge → auto-publish to PyPI via `.github/workflows/publish.yml`.

## Test plan
- [x] CI green on private mirror
- [x] 14 benchmark tasks runnable on real device
- [x] Ollama discovery tested with custom model set