### PR TITLE
Release v1.2.0 — Ghost Bench + Ollama discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) · Versioning: 
 
 ## [Unreleased]
 
+## [1.2.0] — 2026-04-17
+
+### Added
+- **Ghost Bench** — in-dashboard benchmark system with 14 built-in tasks (settings + navigation). Runner with SSE live streaming. New `Benchmarks` tab in the dashboard. Foundation for Phase 2 (real AndroidWorld integration).
+- **7 benchmark API endpoints** (`/api/benchmarks/*`) — list suites, start run, stream events, past runs, stop.
+- **Live Ollama model discovery** — new `GET /api/agent-chat/providers` endpoint queries `localhost:11434/api/tags` so the dropdown shows actually-installed models, not a hardcoded list.
+- **Background Ollama model pull** — endpoint to pull new models without blocking the UI, with live status tracking.
+
+### Changed
+- Frontend model selector fetches providers on mount instead of relying on hardcoded constants.
+- Better errors when Ollama isn't running or a requested model isn't installed.
+
+### Fixed
+- Confusing "connection error" when user selected a model not installed locally — now says "model X not found, pull it first" with a pull button.
+
 ## [1.1.0] — 2026-04-16
 
 ### Added
@@ -40,6 +55,7 @@ Initial open-source release of Ghost in the Droid.
 - Skill Hub (registry of reusable skills)
 - Agent Chat (LLM-driven device control via Claude / Claude Code / OpenRouter / Ollama)
 
-[Unreleased]: https://github.com/ghost-in-the-droid/android-agent/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/ghost-in-the-droid/android-agent/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/ghost-in-the-droid/android-agent/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/ghost-in-the-droid/android-agent/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/ghost-in-the-droid/android-agent/releases/tag/v1.0.0

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -9,6 +9,7 @@ import SkillCreatorView from '@/views/SkillCreatorView.vue'
 import ExplorerView from '@/views/ExplorerView.vue'
 import ToolsHubView from '@/views/ToolsHubView.vue'
 import EmulatorTab from '@/components/emulator/EmulatorTab.vue'
+import BenchmarkTab from '@/components/benchmark/BenchmarkTab.vue'
 
 const coreTabs = [
   { id: 'phone', label: '👻 Phone Agent' },
@@ -20,6 +21,7 @@ const coreTabs = [
   { id: 'bot', label: '▶️ Manual Run' },
   { id: 'tests', label: '🧪 Tests' },
   { id: 'emulators', label: '🖥️ Emulators' },
+  { id: 'benchmarks', label: '📊 Benchmarks' },
 ]
 
 const premiumTabs = ref<{id: string, label: string, component?: string}[]>([])
@@ -138,6 +140,7 @@ async function restartServer() {
       <BotView v-else-if="activeTab === 'bot'" />
       <TestsView v-else-if="activeTab === 'tests'" />
       <EmulatorTab v-else-if="activeTab === 'emulators'" />
+      <BenchmarkTab v-else-if="activeTab === 'benchmarks'" />
       <!-- Premium tabs: rendered as iframes from premium frontend server -->
       <iframe
         v-else-if="premiumTabs.some(t => t.id === activeTab)"

--- a/frontend/src/components/benchmark/BenchmarkTab.vue
+++ b/frontend/src/components/benchmark/BenchmarkTab.vue
@@ -1,0 +1,326 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref, computed } from 'vue'
+import { useBenchmarkStore } from '@/stores/benchmarks'
+
+const store = useBenchmarkStore()
+const activeSubTab = ref<'tasks' | 'runs'>('tasks')
+const toast = ref<{ msg: string; type: 'ok' | 'err' } | null>(null)
+const expandedLog = ref<string | null>(null)
+const liveLog = ref<Array<Record<string, any>>>([])
+const liveRunId = ref<string | null>(null)
+let liveEventSource: EventSource | null = null
+
+const selectedTasks = ref<Set<string>>(new Set())
+const runSuite = ref('ghost_bench')
+const runProvider = ref('ollama')
+const runModel = ref('gemma3:4b')
+const runDevice = ref('emulator-5554')
+const selectAll = ref(false)
+
+const PROVIDERS = [
+  { id: 'claude-code', label: 'Claude Code', models: ['sonnet', 'opus', 'haiku'] },
+  { id: 'anthropic', label: 'Claude API', models: ['claude-sonnet-4-20250514', 'claude-opus-4-20250514'] },
+  { id: 'openrouter', label: 'OpenRouter', models: ['anthropic/claude-sonnet-4', 'google/gemini-2.5-pro'] },
+  { id: 'ollama', label: 'Ollama (local)', models: ['llama3.2:3b', 'gemma3:4b', 'qwen3:4b', 'phi4-mini:3.8b', 'mistral:7b'] },
+]
+
+const currentModels = computed(() => PROVIDERS.find(p => p.id === runProvider.value)?.models || [])
+
+function onProviderChange() {
+  const p = PROVIDERS.find(p => p.id === runProvider.value)
+  if (p?.models.length) runModel.value = p.models[0]
+}
+
+// Also try to fetch live Ollama models
+async function fetchOllamaModels() {
+  try {
+    const resp = await fetch('/api/agent-chat/providers')
+    if (resp.ok) {
+      const providers = await resp.json()
+      const ollama = providers.find((p: any) => p.id === 'ollama')
+      if (ollama?.models?.length) {
+        const idx = PROVIDERS.findIndex(p => p.id === 'ollama')
+        if (idx >= 0) PROVIDERS[idx].models = ollama.models
+      }
+    }
+  } catch {}
+}
+
+const streamUrl = computed(() =>
+  runDevice.value ? `/api/phone/stream?device=${encodeURIComponent(runDevice.value)}&fps=3` : ''
+)
+
+let pollTimer: ReturnType<typeof setInterval> | null = null
+
+function showToast(msg: string, type: 'ok' | 'err' = 'ok') {
+  toast.value = { msg, type }
+  setTimeout(() => { toast.value = null }, 4000)
+}
+
+function toggleSelectAll() {
+  if (selectAll.value) store.tasks.forEach(t => selectedTasks.value.add(t.id))
+  else selectedTasks.value.clear()
+}
+
+function toggleTask(id: string) {
+  if (selectedTasks.value.has(id)) selectedTasks.value.delete(id)
+  else selectedTasks.value.add(id)
+}
+
+async function startRun() {
+  const ids = selectedTasks.value.size > 0 ? [...selectedTasks.value] : null
+  try {
+    const result = await store.startRun(runSuite.value, ids, runModel.value, runDevice.value, runProvider.value)
+    showToast(`Benchmark started: ${ids?.length || 'all'} tasks`)
+    activeSubTab.value = 'runs'
+
+    if (result.run_id) {
+      liveLog.value = []
+      liveRunId.value = result.run_id
+      if (liveEventSource) liveEventSource.close()
+      liveEventSource = new EventSource(`/api/benchmarks/runs/${result.run_id}/events`)
+      liveEventSource.onmessage = (e) => {
+        try {
+          const ev = JSON.parse(e.data)
+          liveLog.value.push(ev)
+          if (liveLog.value.length > 200) liveLog.value = liveLog.value.slice(-200)
+          if (ev.type === 'task_result' || ev.type === 'run_done') store.fetchRuns()
+          if (ev.type === 'run_done') {
+            liveEventSource?.close()
+            liveEventSource = null
+            liveRunId.value = null
+          }
+        } catch {}
+      }
+      liveEventSource.onerror = () => {
+        liveEventSource?.close()
+        liveEventSource = null
+        liveRunId.value = null
+      }
+    }
+  } catch (e: any) {
+    showToast(e.message, 'err')
+  }
+}
+
+async function handleStop(id: string) {
+  try { await store.stopRun(id); showToast('Run stopped') }
+  catch (e: any) { showToast(e.message, 'err') }
+}
+
+const activeRun = computed(() => store.runs.find(r => r.status === 'running'))
+
+onMounted(async () => {
+  await Promise.all([store.fetchSuites(), store.fetchTasks(), store.fetchRuns()])
+  fetchOllamaModels()
+  pollTimer = setInterval(() => {
+    if (activeSubTab.value === 'runs' || activeRun.value) store.fetchRuns()
+  }, 5000)
+})
+
+onUnmounted(() => {
+  if (pollTimer) clearInterval(pollTimer)
+  if (liveEventSource) { liveEventSource.close(); liveEventSource = null }
+})
+</script>
+
+<template>
+  <div>
+    <Transition name="fade">
+      <div v-if="toast" class="fixed top-4 right-4 z-50 px-4 py-2 rounded-lg text-sm font-medium shadow-lg"
+        :style="{ background: toast.type === 'ok' ? '#065f46' : '#7f1d1d', color: toast.type === 'ok' ? '#6ee7b7' : '#fca5a5', border: `1px solid ${toast.type === 'ok' ? '#059669' : '#dc2626'}` }">
+        {{ toast.msg }}
+      </div>
+    </Transition>
+
+    <div style="display: grid; grid-template-columns: 1fr 25%; gap: 16px; min-height: 600px">
+      <!-- LEFT: Content -->
+      <div>
+        <div class="flex gap-2 mb-4 items-center">
+          <button class="px-4 py-1.5 text-sm font-semibold rounded-lg transition-colors"
+            :class="activeSubTab === 'tasks' ? 'text-indigo-400 bg-indigo-500/10' : 'text-slate-500 hover:text-slate-300'"
+            @click="activeSubTab = 'tasks'">Tasks</button>
+          <button class="px-4 py-1.5 text-sm font-semibold rounded-lg transition-colors"
+            :class="activeSubTab === 'runs' ? 'text-indigo-400 bg-indigo-500/10' : 'text-slate-500 hover:text-slate-300'"
+            @click="activeSubTab = 'runs'; store.fetchRuns()">Runs</button>
+          <span v-if="activeRun" class="ml-auto text-xs px-3 py-1 rounded-full bg-yellow-500/15 text-yellow-400 animate-pulse">
+            Running: {{ activeRun.current_task }} ({{ activeRun.results?.length || 0 }}/{{ activeRun.total_tasks }})
+          </span>
+        </div>
+
+        <!-- Tasks -->
+        <div v-show="activeSubTab === 'tasks'" class="space-y-4">
+          <div class="card px-4 py-3 flex items-center gap-3 flex-wrap">
+            <span class="text-xs font-semibold" style="color: var(--text-2)">Run Config</span>
+            <select v-model="runProvider" @change="onProviderChange" class="text-xs px-2 py-1 rounded" style="background: var(--bg-deep); border: 1px solid var(--border); color: var(--text-2)">
+              <option v-for="p in PROVIDERS" :key="p.id" :value="p.id">{{ p.label }}</option>
+            </select>
+            <select v-model="runModel" class="text-xs px-2 py-1 rounded" style="background: var(--bg-deep); border: 1px solid var(--border); color: var(--text-2); max-width: 180px">
+              <option v-for="m in currentModels" :key="m" :value="m">{{ m }}</option>
+            </select>
+            <input v-model="runDevice" class="text-xs px-2 py-1 rounded" style="background: var(--bg-deep); border: 1px solid var(--border); color: var(--text-2); width: 140px" placeholder="device serial" />
+            <button @click="startRun" class="ml-auto px-4 py-1.5 text-sm font-semibold rounded-lg" style="background: #059669; color: white">
+              Run {{ selectedTasks.size || 'All' }} Tasks
+            </button>
+          </div>
+
+          <div class="card" style="min-height: 200px">
+            <div class="flex items-center justify-between mb-3">
+              <h2 class="text-base font-semibold" style="color: var(--text-1)">Ghost Bench</h2>
+              <span class="text-xs" style="color: var(--text-4)">{{ store.tasks.length }} tasks</span>
+            </div>
+            <div class="overflow-x-auto">
+              <table class="w-full text-sm">
+                <thead>
+                  <tr class="text-left text-xs uppercase" style="color: var(--text-4)">
+                    <th class="pb-2 pr-2 w-8"><input type="checkbox" v-model="selectAll" @change="toggleSelectAll" /></th>
+                    <th class="pb-2 pr-2">Task</th>
+                    <th class="pb-2 pr-2">Goal</th>
+                    <th class="pb-2 pr-2">Category</th>
+                    <th class="pb-2 pr-2">Steps</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="task in store.tasks" :key="task.id" class="border-t" style="border-color: var(--border)"
+                    :class="{ 'bg-indigo-500/5': selectedTasks.has(task.id) }">
+                    <td class="py-2 pr-2"><input type="checkbox" :checked="selectedTasks.has(task.id)" @change="toggleTask(task.id)" /></td>
+                    <td class="py-2 pr-2 font-mono text-xs" style="color: var(--text-2)">{{ task.id }}</td>
+                    <td class="py-2 pr-2 truncate" style="color: var(--text-1); max-width: 280px" :title="task.goal">{{ task.goal }}</td>
+                    <td class="py-2 pr-2 text-xs" style="color: var(--text-3)">{{ task.category }}</td>
+                    <td class="py-2 pr-2 text-xs" style="color: var(--text-3)">{{ task.max_steps }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+
+        <!-- Runs -->
+        <div v-show="activeSubTab === 'runs'" class="space-y-4">
+          <div v-if="!store.runs.length" class="card px-4 py-8 text-center" style="color: var(--text-3)">
+            No runs yet. Go to Tasks to start one.
+          </div>
+
+          <div v-for="run in store.runs" :key="run.id" class="card px-4 py-3">
+            <div class="flex items-center gap-3 mb-3">
+              <span class="font-mono text-xs px-2 py-0.5 rounded" style="background: var(--bg-deep); color: var(--text-3)">{{ run.id }}</span>
+              <span class="text-sm font-semibold" style="color: var(--text-1)">{{ run.provider }}/{{ run.model }}</span>
+              <span class="text-xs" style="color: var(--text-4)">{{ run.device }}</span>
+              <span class="text-xs px-2 py-0.5 rounded-full font-semibold"
+                :class="{
+                  'bg-green-500/15 text-green-400': run.status === 'completed',
+                  'bg-yellow-500/15 text-yellow-400': run.status === 'running',
+                  'bg-slate-500/15 text-slate-400': run.status === 'stopped',
+                }">{{ run.status }}</span>
+              <button v-if="run.status === 'running'" @click="handleStop(run.id)"
+                class="ml-auto text-xs px-3 py-1 rounded" style="border: 1px solid #ef4444; color: #ef4444">Stop</button>
+            </div>
+
+            <div class="grid grid-cols-4 gap-3 mb-3">
+              <div class="text-center">
+                <div class="text-lg font-bold" :style="{ color: run.success_rate > 0.5 ? '#34d399' : run.success_rate > 0 ? '#fbbf24' : '#94a3b8' }">
+                  {{ (run.success_rate * 100).toFixed(0) }}%
+                </div>
+                <div class="text-xs" style="color: var(--text-4)">Success</div>
+              </div>
+              <div class="text-center">
+                <div class="text-lg font-bold" style="color: var(--text-2)">{{ run.passed }}/{{ run.total_tasks }}</div>
+                <div class="text-xs" style="color: var(--text-4)">Passed</div>
+              </div>
+              <div class="text-center">
+                <div class="text-lg font-bold" style="color: var(--text-2)">{{ run.total_time_s?.toFixed(0) || 0 }}s</div>
+                <div class="text-xs" style="color: var(--text-4)">Total</div>
+              </div>
+              <div class="text-center">
+                <div class="text-lg font-bold" style="color: var(--text-2)">{{ run.total_tasks > 0 ? (run.total_time_s / run.total_tasks).toFixed(0) : 0 }}s</div>
+                <div class="text-xs" style="color: var(--text-4)">Avg/Task</div>
+              </div>
+            </div>
+
+            <div v-if="run.results?.length">
+              <div v-for="r in run.results" :key="r.task_id" class="border-t" style="border-color: var(--border)">
+                <div class="flex items-center gap-3 py-2 cursor-pointer hover:bg-white/[0.02] px-1 rounded"
+                  @click="expandedLog = expandedLog === r.task_id ? null : r.task_id">
+                  <span class="text-xs" style="color: var(--text-4)">{{ expandedLog === r.task_id ? '▼' : '▶' }}</span>
+                  <span class="font-mono text-xs" style="color: var(--text-2); min-width: 160px">{{ r.task_id }}</span>
+                  <span class="text-xs font-semibold" :style="{ color: r.score > 0 ? '#34d399' : '#ef4444', minWidth: '36px' }">
+                    {{ r.score > 0 ? 'PASS' : 'FAIL' }}
+                  </span>
+                  <span class="text-xs" style="color: var(--text-3)">{{ r.steps }} steps</span>
+                  <span class="text-xs" style="color: var(--text-3)">{{ r.time_s?.toFixed(0) }}s</span>
+                  <span class="text-xs truncate" style="color: var(--text-4); max-width: 200px">{{ r.reason }}</span>
+                </div>
+                <div v-if="expandedLog === r.task_id && r.agent_log?.length" class="mb-3 ml-4 p-3 rounded-lg"
+                  style="background: var(--bg-deep); border: 1px solid var(--border); max-height: 400px; overflow-y: auto">
+                  <div style="display: flex; flex-direction: column; gap: 4px">
+                    <template v-for="(ev, j) in r.agent_log" :key="j">
+                      <div v-if="ev.type === 'text'" style="background: #1a1f2e; color: var(--text-1); padding: 6px 10px; border-radius: 8px; font-size: 11px; line-height: 1.5; white-space: pre-wrap; word-break: break-word">{{ ev.content }}</div>
+                      <div v-else-if="ev.type === 'tool_call'" style="font-size: 10px; color: #38bdf8; padding: 2px 8px; background: #0ea5e908; border-radius: 10px; border: 1px solid #0ea5e922; width: fit-content">🔧 {{ ev.name }}({{ JSON.stringify(ev.args || {}).slice(0, 100) }})</div>
+                      <div v-else-if="ev.type === 'tool_result'" style="font-size: 9px; font-family: monospace; color: #64748b; padding: 3px 8px; max-height: 80px; overflow: hidden; border-left: 2px solid #1e293b; margin-left: 8px; white-space: pre-wrap; word-break: break-all">↳ {{ ev.result?.slice(0, 300) || ev.name }}</div>
+                      <div v-else-if="ev.type === 'error'" style="font-size: 10px; color: #f87171; padding: 4px 8px; background: #ef444411; border-radius: 6px; border-left: 2px solid #ef4444">{{ ev.content }}</div>
+                    </template>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div v-if="run.status === 'running' && run.total_tasks > 0" class="mt-2">
+              <div class="w-full h-1.5 rounded-full" style="background: var(--bg-deep)">
+                <div class="h-1.5 rounded-full transition-all" style="background: #059669"
+                  :style="{ width: `${((run.results?.length || 0) / run.total_tasks) * 100}%` }"></div>
+              </div>
+              <div class="text-xs mt-1" style="color: var(--text-4)">{{ run.current_task }}...</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- RIGHT: Device + Live Log -->
+      <div style="position: sticky; top: 12px; height: fit-content; display: flex; flex-direction: column; gap: 8px; max-height: calc(100vh - 80px); overflow: hidden">
+        <div class="card p-2" style="flex-shrink: 0">
+          <div class="flex items-center justify-between mb-2 px-1">
+            <span class="text-xs font-semibold" style="color: var(--text-2)">Device</span>
+            <span class="text-xs" style="color: var(--text-4)">{{ runDevice }}</span>
+          </div>
+          <img v-if="streamUrl" :src="streamUrl" style="width: 100%; border-radius: 8px; background: #000; aspect-ratio: 9/16" alt="Device" />
+          <div v-else class="flex items-center justify-center" style="aspect-ratio: 9/16; background: #0a0e17; border-radius: 8px">
+            <span class="text-xs" style="color: var(--text-4)">No device</span>
+          </div>
+        </div>
+
+        <div class="card p-2" style="flex: 1; min-height: 150px; overflow: hidden; display: flex; flex-direction: column">
+          <div class="flex items-center justify-between mb-2 px-1">
+            <span class="text-xs font-semibold" style="color: var(--text-2)">{{ liveRunId ? 'Live Log' : 'Agent Log' }}</span>
+            <span v-if="liveRunId" class="w-2 h-2 rounded-full bg-green-400 animate-pulse"></span>
+          </div>
+          <div style="flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: 3px; padding-right: 4px">
+            <div v-if="!liveLog.length" class="text-xs text-center py-4" style="color: var(--text-4)">
+              Start a run to see live agent activity.
+            </div>
+            <template v-for="(ev, i) in liveLog" :key="i">
+              <div v-if="ev.type === 'task_start'" style="font-size: 10px; font-weight: 600; color: #fbbf24; padding: 4px 6px; background: #fbbf2410; border-radius: 6px; border-left: 2px solid #fbbf24">Task: {{ ev.goal }}</div>
+              <div v-else-if="ev.type === 'init'" style="font-size: 9px; color: #64748b; padding: 1px 6px">init: {{ ev.desc }}</div>
+              <div v-else-if="ev.type === 'agent' && ev.content" style="font-size: 10px; color: var(--text-1); padding: 4px 6px; background: #1a1f2e; border-radius: 6px; line-height: 1.4; white-space: pre-wrap; word-break: break-word; max-height: 80px; overflow: hidden">{{ ev.content.slice(0, 300) }}</div>
+              <div v-else-if="ev.type === 'agent' && ev.name && !ev.result" style="font-size: 9px; color: #38bdf8; padding: 2px 6px; background: #0ea5e908; border-radius: 8px; border: 1px solid #0ea5e922; width: fit-content">🔧 {{ ev.name }}</div>
+              <div v-else-if="ev.type === 'agent' && ev.result" style="font-size: 8px; font-family: monospace; color: #475569; padding: 1px 6px; border-left: 2px solid #1e293b; margin-left: 6px; max-height: 40px; overflow: hidden; word-break: break-all">↳ {{ ev.result?.slice(0, 150) }}</div>
+              <div v-else-if="ev.type === 'task_result'" style="font-size: 10px; font-weight: 600; padding: 3px 6px; border-radius: 6px"
+                :style="{ color: ev.score > 0 ? '#34d399' : '#ef4444', background: ev.score > 0 ? '#34d39910' : '#ef444410', borderLeft: `2px solid ${ev.score > 0 ? '#34d399' : '#ef4444'}` }">
+                {{ ev.score > 0 ? 'PASS' : 'FAIL' }} — {{ ev.reason }}
+              </div>
+              <div v-else-if="ev.type === 'run_done'" style="font-size: 10px; font-weight: 600; color: #a78bfa; padding: 4px 6px; background: #a78bfa10; border-radius: 6px; text-align: center">Benchmark complete</div>
+            </template>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="store.error" class="mt-4 card px-4 py-3" style="border-color: #ef4444">
+      <div class="text-xs" style="color: #ef4444">{{ store.error }}</div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.fade-enter-active, .fade-leave-active { transition: opacity 0.3s; }
+.fade-enter-from, .fade-leave-to { opacity: 0; }
+</style>

--- a/frontend/src/stores/benchmarks.ts
+++ b/frontend/src/stores/benchmarks.ts
@@ -1,0 +1,104 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { api } from '@/composables/useApi'
+
+export interface BenchmarkTask {
+  id: string
+  goal: string
+  app: string
+  category: string
+  complexity: number
+  max_steps: number
+}
+
+export interface BenchmarkSuite {
+  id: string
+  name: string
+  description: string
+}
+
+export interface TaskResult {
+  task_id: string
+  goal: string
+  model: string
+  device: string
+  score: number
+  reason: string
+  steps: number
+  time_s: number
+  error: string
+  agent_log: Array<{ type: string; content?: string; name?: string; args?: any; result?: string }>
+}
+
+export interface BenchmarkRunSummary {
+  id: string
+  suite: string
+  model: string
+  provider: string
+  device: string
+  status: 'pending' | 'running' | 'completed' | 'stopped'
+  success_rate: number
+  total_tasks: number
+  passed: number
+  total_time_s: number
+  started_at: number
+  finished_at: number
+  current_task: string
+  results: TaskResult[]
+}
+
+export const useBenchmarkStore = defineStore('benchmarks', () => {
+  const suites = ref<BenchmarkSuite[]>([])
+  const tasks = ref<BenchmarkTask[]>([])
+  const runs = ref<BenchmarkRunSummary[]>([])
+  const error = ref<string | null>(null)
+
+  async function fetchSuites() {
+    try {
+      suites.value = await api<BenchmarkSuite[]>('/api/benchmarks/suites')
+    } catch (e: any) {
+      error.value = e.message
+    }
+  }
+
+  async function fetchTasks(suite = 'ghost_bench', category?: string) {
+    try {
+      const params = new URLSearchParams({ suite })
+      if (category) params.set('category', category)
+      tasks.value = await api<BenchmarkTask[]>(`/api/benchmarks/tasks?${params}`)
+    } catch (e: any) {
+      error.value = e.message
+    }
+  }
+
+  async function fetchRuns() {
+    try {
+      runs.value = await api<BenchmarkRunSummary[]>('/api/benchmarks/runs')
+    } catch (e: any) {
+      error.value = e.message
+    }
+  }
+
+  async function startRun(
+    suite: string, taskIds: string[] | null, model: string, device: string, provider: string
+  ) {
+    error.value = null
+    const result = await api<{ ok: boolean; run_id: string; message: string }>('/api/benchmarks/runs', {
+      method: 'POST',
+      body: JSON.stringify({ suite, tasks: taskIds, provider, model, device }),
+    })
+    await fetchRuns()
+    return result
+  }
+
+  async function stopRun(runId: string) {
+    await api(`/api/benchmarks/runs/${runId}/stop`, { method: 'POST' })
+    await fetchRuns()
+  }
+
+  async function getRun(runId: string) {
+    return api<BenchmarkRunSummary>(`/api/benchmarks/runs/${runId}`)
+  }
+
+  return { suites, tasks, runs, error, fetchSuites, fetchTasks, fetchRuns, startRun, stopRun, getRun }
+})

--- a/frontend/src/views/PhoneAdminView.vue
+++ b/frontend/src/views/PhoneAdminView.vue
@@ -409,6 +409,14 @@ function startStream() {
   streaming.value = true
   if (singleStreamMode.value === 'rtc') {
     rtcStart(selectedDevice.value)
+    // Auto-fallback: if RTC doesn't connect within 5s, switch to MJPEG
+    setTimeout(() => {
+      if (streaming.value && singleStreamMode.value === 'rtc' && rtcStatus[selectedDevice.value] !== 'Streaming') {
+        console.log('RTC timeout — falling back to MJPEG')
+        singleStreamMode.value = 'mjpeg'
+        singleMjpegUrl.value = `/api/phone/stream?device=${encodeURIComponent(selectedDevice.value)}&fps=5`
+      }
+    }, 5000)
   } else {
     singleMjpegUrl.value = `/api/phone/stream?device=${encodeURIComponent(selectedDevice.value)}&fps=5`
   }
@@ -534,26 +542,107 @@ if (!(window as any).marked) {
 }
 const chatProvider = ref(localStorage.getItem('agent_provider') || 'claude-code')
 const chatModel = ref(localStorage.getItem('agent_model') || 'sonnet')
-const CHAT_PROVIDERS = [
+const CHAT_PROVIDERS = ref([
   { id: 'claude-code', label: 'Claude Code (free)', models: ['sonnet', 'opus', 'haiku'] },
   { id: 'anthropic', label: 'Claude API', models: ['claude-sonnet-4-20250514', 'claude-opus-4-20250514'] },
   { id: 'openrouter', label: 'OpenRouter', models: ['anthropic/claude-sonnet-4', 'google/gemini-2.5-pro'] },
-  { id: 'ollama', label: 'Ollama (local)', models: ['llama3.2:3b', 'llama3.2:1b', 'gemma3:4b', 'qwen3:4b', 'phi4-mini:3.8b', 'mistral:7b'] },
-]
-const chatConversations = ref<{id: string; title: string; provider: string; model: string; message_count: number; updated_at: string}[]>([])
+  { id: 'ollama', label: 'Ollama (local)', models: [] },
+])
 
-async function ollamaUnload() {
+async function fetchProviders() {
   try {
-    await fetch('http://localhost:11434/api/generate', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ model: chatModel.value, keep_alive: 0 }),
+    const resp = await fetch('/api/agent-chat/providers')
+    if (resp.ok) CHAT_PROVIDERS.value = await resp.json()
+  } catch {}
+}
+
+// Ollama model status
+const ollamaModels = ref<Array<{name: string; status: string; vram_gb: number; size_gb: number; parameter_size: string}>>([])
+const ollamaLoading = ref('')  // model name currently loading
+
+async function fetchOllamaStatus() {
+  if (chatProvider.value !== 'ollama') return
+  try {
+    const resp = await fetch('/api/agent-chat/ollama/status')
+    if (resp.ok) {
+      const data = await resp.json()
+      if (data.ok) ollamaModels.value = data.models
+    }
+  } catch {}
+}
+
+function ollamaModelStatus(name: string): string {
+  if (ollamaLoading.value === name) return 'loading'
+  const m = ollamaModels.value.find(m => m.name === name)
+  return m?.status || 'unknown'
+}
+
+function ollamaModelVram(name: string): number {
+  const m = ollamaModels.value.find(m => m.name === name)
+  return m?.vram_gb || 0
+}
+
+async function ollamaLoad(model: string) {
+  ollamaLoading.value = model
+  try {
+    const resp = await fetch('/api/agent-chat/ollama/load', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model }),
     })
-    chatMessages.value.push({ role: 'system', content: `Unloaded ${chatModel.value} from memory.` })
+    const data = await resp.json()
+    if (!data.ok) chatMessages.value.push({ role: 'system', content: `Load failed: ${data.error}` })
+  } catch (e: any) {
+    chatMessages.value.push({ role: 'system', content: `Load failed: ${e.message}` })
+  }
+  ollamaLoading.value = ''
+  fetchOllamaStatus()
+}
+
+async function ollamaUnload(model?: string) {
+  const m = model || chatModel.value
+  try {
+    const resp = await fetch('/api/agent-chat/ollama/unload', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: m }),
+    })
+    const data = await resp.json()
+    if (data.ok) chatMessages.value.push({ role: 'system', content: `Unloaded ${m} from VRAM.` })
+    else chatMessages.value.push({ role: 'system', content: `Unload failed: ${data.error}` })
   } catch (e: any) {
     chatMessages.value.push({ role: 'system', content: `Failed to unload: ${e.message}` })
   }
+  fetchOllamaStatus()
 }
+
+const ollamaPullName = ref('')
+const ollamaPulling = ref(false)
+
+async function ollamaPull() {
+  const model = ollamaPullName.value.trim()
+  if (!model) return
+  ollamaPulling.value = true
+  chatMessages.value.push({ role: 'system', content: `Pulling ${model}...` })
+  try {
+    const resp = await fetch('/api/agent-chat/ollama/pull', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model }),
+    })
+    const data = await resp.json()
+    if (data.ok) {
+      chatMessages.value.push({ role: 'system', content: `${model} pulled successfully.` })
+      ollamaPullName.value = ''
+      fetchProviders()
+      fetchOllamaStatus()
+    } else {
+      chatMessages.value.push({ role: 'system', content: `Pull failed: ${data.error}` })
+    }
+  } catch (e: any) {
+    chatMessages.value.push({ role: 'system', content: `Pull failed: ${e.message}` })
+  }
+  ollamaPulling.value = false
+}
+
+const chatConversations = ref<{id: string; title: string; provider: string; model: string; message_count: number; updated_at: string}[]>([])
 
 async function loadConversations() {
   if (!selectedDevice.value) return
@@ -589,9 +678,10 @@ async function deleteConversation(cid: string) {
 
 function onProviderChange() {
   localStorage.setItem('agent_provider', chatProvider.value)
-  const p = CHAT_PROVIDERS.find(p => p.id === chatProvider.value)
+  const p = CHAT_PROVIDERS.value.find(p => p.id === chatProvider.value)
   if (p?.models.length) { chatModel.value = p.models[0]; localStorage.setItem('agent_model', chatModel.value) }
   chatSessionId.value = '' // reset session on provider change
+  if (chatProvider.value === 'ollama') fetchOllamaStatus()
 }
 function onModelChange() { localStorage.setItem('agent_model', chatModel.value); chatSessionId.value = '' }
 
@@ -766,6 +856,8 @@ onMounted(async () => {
   await loadDevices()
   loadAllHealth()
   loadConversations()
+  fetchProviders()
+  fetchOllamaStatus()
   logTimer = window.setInterval(pollLogs, 3000)
   multiLogTimer = window.setInterval(pollMultiLogs, 4000)
   pollMultiLogs()
@@ -816,9 +908,36 @@ onUnmounted(() => {
             style="font-size: 10px; padding: 2px 6px; background: var(--bg-deep); border: 1px solid var(--border); border-radius: 4px; color: var(--text-3); max-width: 140px">
             <option v-for="m in (CHAT_PROVIDERS.find(p => p.id === chatProvider)?.models || [])" :key="m" :value="m">{{ m }}</option>
           </select>
-          <button v-if="chatProvider === 'ollama'" @click="ollamaUnload"
-            style="font-size: 9px; padding: 2px 8px; background: #1a1f2e; border: 1px solid #ef4444; border-radius: 4px; color: #ef4444; cursor: pointer"
-            title="Unload model from GPU memory">Unload</button>
+          <!-- Ollama model status + load/unload -->
+          <template v-if="chatProvider === 'ollama'">
+            <span v-if="ollamaModelStatus(chatModel) === 'loaded'"
+              style="font-size: 8px; padding: 1px 6px; border-radius: 10px; background: #05966920; color: #34d399; border: 1px solid #05966940; white-space: nowrap"
+              :title="`${ollamaModelVram(chatModel)} GB VRAM`">
+              ● {{ ollamaModelVram(chatModel) }}GB
+            </span>
+            <span v-else-if="ollamaModelStatus(chatModel) === 'loading'"
+              style="font-size: 8px; padding: 1px 6px; border-radius: 10px; background: #f59e0b20; color: #fbbf24; border: 1px solid #f59e0b40; white-space: nowrap; animation: pulse 1.5s infinite">
+              ◌ loading...
+            </span>
+            <span v-else
+              style="font-size: 8px; padding: 1px 6px; border-radius: 10px; background: #64748b15; color: #64748b; border: 1px solid #64748b30; white-space: nowrap">
+              ○ idle
+            </span>
+            <button v-if="ollamaModelStatus(chatModel) === 'loaded'" @click="ollamaUnload()"
+              style="font-size: 8px; padding: 1px 6px; background: #1a1f2e; border: 1px solid #ef4444; border-radius: 4px; color: #ef4444; cursor: pointer"
+              title="Free VRAM">unload</button>
+            <button v-else-if="ollamaModelStatus(chatModel) !== 'loading'" @click="ollamaLoad(chatModel)"
+              style="font-size: 8px; padding: 1px 6px; background: #1a1f2e; border: 1px solid #059669; border-radius: 4px; color: #34d399; cursor: pointer"
+              title="Load into VRAM">load</button>
+            <span style="display:inline-flex;align-items:center;gap:2px;margin-left:4px">
+              <input v-model="ollamaPullName" placeholder="pull model..."
+                @keyup.enter="ollamaPull" :disabled="ollamaPulling"
+                style="font-size:8px;padding:1px 4px;width:90px;background:var(--bg-deep);border:1px solid var(--border);border-radius:3px;color:var(--text-3)" />
+              <button @click="ollamaPull" :disabled="ollamaPulling || !ollamaPullName.trim()"
+                style="font-size:8px;padding:1px 5px;background:#1a1f2e;border:1px solid var(--border);border-radius:3px;color:var(--text-3);cursor:pointer"
+                :style="ollamaPulling ? {opacity:0.5} : {}">{{ ollamaPulling ? '...' : '↓' }}</button>
+            </span>
+          </template>
           <span style="margin-left: auto; display: flex; align-items: center; gap: 6px">
             <button @click="chatVerbose = !chatVerbose"
               style="font-size: 9px; padding: 2px 6px; border-radius: 4px; cursor: pointer; border: 1px solid #2a3044"
@@ -900,7 +1019,13 @@ onUnmounted(() => {
             </option>
           </select>
           <button v-if="!streaming" class="ctrl-btn ctrl-btn--webrtc" style="font-size:9px;padding:3px 8px" @click="singleStreamMode = 'rtc'; startStream()">&#x26A1; Stream</button>
-          <button v-else class="ctrl-btn ctrl-btn--stop" style="font-size:9px;padding:3px 8px" @click="stopStream">&#x23F9; Stop</button>
+          <span v-if="streaming" style="font-size:8px;padding:1px 6px;border-radius:10px;white-space:nowrap"
+            :style="singleStreamMode === 'rtc'
+              ? { background: '#22c55e20', color: '#4ade80', border: '1px solid #22c55e40' }
+              : { background: '#6366f120', color: '#a5b4fc', border: '1px solid #6366f140' }">
+            {{ singleStreamMode === 'rtc' ? '⚡ WebRTC' : '📷 MJPEG' }}
+          </span>
+          <button v-if="streaming" class="ctrl-btn ctrl-btn--stop" style="font-size:9px;padding:3px 8px" @click="stopStream">&#x23F9; Stop</button>
           <button class="ctrl-btn" style="font-size:9px;padding:3px 6px" @click="toggleOverlay(selectedDevice)"
             :style="{ background: overlayOn[selectedDevice] ? '#fbbf24' : '', color: overlayOn[selectedDevice] ? '#000' : '#fbbf24' }">&#x1F522;</button>
         </div>

--- a/gitd/app.py
+++ b/gitd/app.py
@@ -10,6 +10,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from gitd.models.base import Base, engine
 from gitd.routers.agent_chat import router as agent_chat_router
+from gitd.routers.benchmarks import router as benchmarks_router
 from gitd.routers.bot import router as bot_router
 from gitd.routers.creator import router as creator_router
 from gitd.routers.emulators import pool_router as emulator_pool_router
@@ -63,6 +64,7 @@ TAGS_METADATA = [
     {"name": "tools", "description": "Utility tools hub"},
     {"name": "misc", "description": "Health, logs, server management"},
     {"name": "emulators", "description": "Emulator lifecycle, AVDs, snapshots, pool management"},
+    {"name": "benchmarks", "description": "Benchmark runner — task suites, live progress, results"},
 ]
 
 
@@ -111,6 +113,7 @@ def create_app() -> FastAPI:
     app.include_router(tests_router)
     app.include_router(emulators_router)
     app.include_router(emulator_pool_router)
+    app.include_router(benchmarks_router)
 
     # Plugin hook: load premium features if installed
     try:

--- a/gitd/benchmarks/__init__.py
+++ b/gitd/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+# Benchmark module — run standardized tasks, evaluate agent performance.

--- a/gitd/benchmarks/base.py
+++ b/gitd/benchmarks/base.py
@@ -1,0 +1,52 @@
+"""Base types for benchmark suites — shared across ghost_bench and future androidworld."""
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class Task:
+    """A single benchmark task."""
+
+    id: str
+    goal: str
+    app: str
+    category: str
+    complexity: float = 1.0
+    init: dict = field(default_factory=dict)
+    eval: dict = field(default_factory=dict)
+    teardown: dict | None = None
+
+    @property
+    def max_steps(self) -> int:
+        return int(self.complexity * 10)
+
+
+@dataclass
+class TaskResult:
+    """Result of running a single task."""
+
+    task_id: str
+    goal: str
+    model: str
+    device: str
+    score: float = 0.0
+    reason: str = ""
+    steps: int = 0
+    time_s: float = 0.0
+    agent_log: list = field(default_factory=list)
+    error: str = ""
+
+
+def load_tasks_from_dir(task_data_dir: Path, category: str | None = None) -> list[Task]:
+    """Load tasks from all JSON files in a directory."""
+    tasks = []
+    if not task_data_dir.exists():
+        return tasks
+    for f in sorted(task_data_dir.glob("*.json")):
+        for raw in json.loads(f.read_text()):
+            task = Task(**raw)
+            if category is None or task.category == category:
+                tasks.append(task)
+    return tasks

--- a/gitd/benchmarks/ghost_bench/__init__.py
+++ b/gitd/benchmarks/ghost_bench/__init__.py
@@ -1,0 +1,1 @@
+# Ghost Bench — lightweight built-in benchmark suite. No external deps.

--- a/gitd/benchmarks/ghost_bench/evaluators.py
+++ b/gitd/benchmarks/ghost_bench/evaluators.py
@@ -1,0 +1,57 @@
+"""Evaluators — run ADB commands to check if a task succeeded."""
+
+import subprocess
+
+from gitd.benchmarks.base import Task
+
+
+def _adb(serial: str, *args: str, timeout: int = 10) -> str:
+    cmd = ["adb", "-s", serial, "shell", *args]
+    r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    return r.stdout.strip()
+
+
+def initialize_task(task: Task, serial: str) -> str:
+    """Set up preconditions. Returns description of what was done."""
+    if not task.init or not task.init.get("cmd"):
+        return "no init needed"
+    _adb(serial, *task.init["cmd"].split())
+    return task.init.get("desc", task.init["cmd"])
+
+
+def evaluate_task(task: Task, serial: str) -> tuple[float, str]:
+    """Check if a task succeeded. Returns (score 0.0-1.0, reason)."""
+    ev = task.eval
+    if not ev or not ev.get("cmd"):
+        return 0.0, "no evaluator defined"
+
+    result = _adb(serial, *ev["cmd"].split())
+
+    if "expect" in ev:
+        expected = str(ev["expect"])
+        if result == expected:
+            return 1.0, f"got '{result}' (expected '{expected}')"
+        return 0.0, f"got '{result}' (expected '{expected}')"
+
+    if "expect_in" in ev:
+        if result in ev["expect_in"]:
+            return 1.0, f"got '{result}' (in {ev['expect_in']})"
+        return 0.0, f"got '{result}' (expected one of {ev['expect_in']})"
+
+    if "expect_contains" in ev:
+        needle = ev["expect_contains"]
+        if needle.lower() in result.lower():
+            return 1.0, f"found '{needle}' in output"
+        return 0.0, f"'{needle}' not found in output (got: {result[:200]})"
+
+    return 0.0, "unknown evaluator type"
+
+
+def teardown_task(task: Task, serial: str) -> None:
+    if task.teardown and task.teardown.get("cmd"):
+        _adb(serial, *task.teardown["cmd"].split())
+
+
+def reset_device(serial: str) -> None:
+    _adb(serial, "input", "keyevent", "KEYCODE_HOME")
+    _adb(serial, "input", "keyevent", "KEYCODE_HOME")

--- a/gitd/benchmarks/ghost_bench/task_data/navigation.json
+++ b/gitd/benchmarks/ghost_bench/task_data/navigation.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": "OpenAppSettings",
+    "goal": "Open the Settings app.",
+    "app": "com.android.settings",
+    "category": "navigation",
+    "complexity": 1,
+    "init": {"cmd": "input keyevent KEYCODE_HOME", "desc": "Go home"},
+    "eval": {"cmd": "dumpsys activity activities | grep mResumedActivity", "expect_contains": "com.android.settings"}
+  },
+  {
+    "id": "OpenAppContacts",
+    "goal": "Open the Contacts app.",
+    "app": "com.google.android.contacts",
+    "category": "navigation",
+    "complexity": 1,
+    "init": {"cmd": "input keyevent KEYCODE_HOME", "desc": "Go home"},
+    "eval": {"cmd": "dumpsys activity activities | grep mResumedActivity", "expect_contains": "contacts"}
+  },
+  {
+    "id": "OpenAppClock",
+    "goal": "Open the Clock app.",
+    "app": "com.google.android.deskclock",
+    "category": "navigation",
+    "complexity": 1,
+    "init": {"cmd": "input keyevent KEYCODE_HOME", "desc": "Go home"},
+    "eval": {"cmd": "dumpsys activity activities | grep mResumedActivity", "expect_contains": "deskclock"}
+  },
+  {
+    "id": "OpenAppCamera",
+    "goal": "Open the Camera app.",
+    "app": "com.android.camera2",
+    "category": "navigation",
+    "complexity": 1,
+    "init": {"cmd": "input keyevent KEYCODE_HOME", "desc": "Go home"},
+    "eval": {"cmd": "dumpsys activity activities | grep mResumedActivity", "expect_contains": "camera"}
+  },
+  {
+    "id": "OpenAppChrome",
+    "goal": "Open Chrome browser.",
+    "app": "com.android.chrome",
+    "category": "navigation",
+    "complexity": 1,
+    "init": {"cmd": "input keyevent KEYCODE_HOME", "desc": "Go home"},
+    "eval": {"cmd": "dumpsys activity activities | grep mResumedActivity", "expect_contains": "chrome"}
+  },
+  {
+    "id": "OpenAppCalculator",
+    "goal": "Open the Calculator app.",
+    "app": "com.google.android.calculator",
+    "category": "navigation",
+    "complexity": 1,
+    "init": {"cmd": "input keyevent KEYCODE_HOME", "desc": "Go home"},
+    "eval": {"cmd": "dumpsys activity activities | grep mResumedActivity", "expect_contains": "calculator"}
+  }
+]

--- a/gitd/benchmarks/ghost_bench/task_data/settings.json
+++ b/gitd/benchmarks/ghost_bench/task_data/settings.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "SystemWifiTurnOn",
+    "goal": "Turn wifi on.",
+    "app": "com.android.settings",
+    "category": "settings",
+    "complexity": 1,
+    "init": {"cmd": "svc wifi disable", "desc": "Disable WiFi"},
+    "eval": {"cmd": "settings get global wifi_on", "expect_in": ["1", "2"]}
+  },
+  {
+    "id": "SystemWifiTurnOff",
+    "goal": "Turn wifi off.",
+    "app": "com.android.settings",
+    "category": "settings",
+    "complexity": 1,
+    "init": {"cmd": "svc wifi enable", "desc": "Enable WiFi"},
+    "eval": {"cmd": "settings get global wifi_on", "expect": "0"}
+  },
+  {
+    "id": "SystemBluetoothTurnOn",
+    "goal": "Turn bluetooth on.",
+    "app": "com.android.settings",
+    "category": "settings",
+    "complexity": 1,
+    "init": {"cmd": "svc bluetooth disable", "desc": "Disable Bluetooth"},
+    "eval": {"cmd": "settings get global bluetooth_on", "expect": "1"}
+  },
+  {
+    "id": "SystemBluetoothTurnOff",
+    "goal": "Turn bluetooth off.",
+    "app": "com.android.settings",
+    "category": "settings",
+    "complexity": 1,
+    "init": {"cmd": "svc bluetooth enable", "desc": "Enable Bluetooth"},
+    "eval": {"cmd": "settings get global bluetooth_on", "expect": "0"}
+  },
+  {
+    "id": "SystemBrightnessMax",
+    "goal": "Set screen brightness to maximum.",
+    "app": "com.android.settings",
+    "category": "settings",
+    "complexity": 1,
+    "init": {"cmd": "settings put system screen_brightness 1", "desc": "Set brightness to min"},
+    "eval": {"cmd": "settings get system screen_brightness", "expect": "255"}
+  },
+  {
+    "id": "SystemBrightnessMin",
+    "goal": "Set screen brightness to minimum.",
+    "app": "com.android.settings",
+    "category": "settings",
+    "complexity": 1,
+    "init": {"cmd": "settings put system screen_brightness 255", "desc": "Set brightness to max"},
+    "eval": {"cmd": "settings get system screen_brightness", "expect": "1"}
+  },
+  {
+    "id": "SystemAirplaneModeOn",
+    "goal": "Turn on airplane mode.",
+    "app": "com.android.settings",
+    "category": "settings",
+    "complexity": 1.5,
+    "init": {"cmd": "settings put global airplane_mode_on 0", "desc": "Disable airplane mode"},
+    "eval": {"cmd": "settings get global airplane_mode_on", "expect": "1"}
+  },
+  {
+    "id": "SystemAirplaneModeOff",
+    "goal": "Turn off airplane mode.",
+    "app": "com.android.settings",
+    "category": "settings",
+    "complexity": 1.5,
+    "init": {"cmd": "settings put global airplane_mode_on 1", "desc": "Enable airplane mode"},
+    "eval": {"cmd": "settings get global airplane_mode_on", "expect": "0"}
+  }
+]

--- a/gitd/benchmarks/ghost_bench/tasks.py
+++ b/gitd/benchmarks/ghost_bench/tasks.py
@@ -1,0 +1,23 @@
+"""Ghost Bench task loading — reads task definitions from task_data/*.json."""
+
+from pathlib import Path
+
+from gitd.benchmarks.base import Task, load_tasks_from_dir
+
+TASK_DATA_DIR = Path(__file__).parent / "task_data"
+SUITE_NAME = "ghost_bench"
+
+
+def load_tasks(category: str | None = None) -> list[Task]:
+    return load_tasks_from_dir(TASK_DATA_DIR, category)
+
+
+def get_task(task_id: str) -> Task | None:
+    for task in load_tasks():
+        if task.id == task_id:
+            return task
+    return None
+
+
+def list_task_ids() -> list[str]:
+    return [t.id for t in load_tasks()]

--- a/gitd/benchmarks/results/.gitignore
+++ b/gitd/benchmarks/results/.gitignore
@@ -1,0 +1,2 @@
+*.json
+!.gitignore

--- a/gitd/benchmarks/runner.py
+++ b/gitd/benchmarks/runner.py
@@ -1,0 +1,251 @@
+"""Benchmark runner — orchestrates tasks through an agent and evaluates results."""
+
+import json
+import logging
+import queue
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+import requests
+
+from gitd.benchmarks.base import Task, TaskResult
+
+log = logging.getLogger(__name__)
+
+RESULTS_DIR = Path(__file__).parent / "results"
+RESULTS_DIR.mkdir(exist_ok=True)
+
+# ── Event pub/sub for live SSE streaming ─────────────────────────────────
+
+_event_queues: dict[str, list[queue.Queue]] = {}
+
+
+def subscribe(run_id: str) -> queue.Queue:
+    q: queue.Queue = queue.Queue(maxsize=500)
+    _event_queues.setdefault(run_id, []).append(q)
+    return q
+
+
+def unsubscribe(run_id: str, q: queue.Queue) -> None:
+    if run_id in _event_queues:
+        _event_queues[run_id] = [x for x in _event_queues[run_id] if x is not q]
+
+
+def _emit(run_id: str, event: dict) -> None:
+    for q in _event_queues.get(run_id, []):
+        try:
+            q.put_nowait(event)
+        except queue.Full:
+            pass
+
+
+# ── Run data structures ──────────────────────────────────────────────────
+
+
+@dataclass
+class BenchmarkRun:
+    id: str
+    suite: str
+    model: str
+    provider: str
+    device: str
+    status: str = "running"
+    results: list[TaskResult] = field(default_factory=list)
+    started_at: float = 0.0
+    finished_at: float = 0.0
+    current_task: str = ""
+
+    @property
+    def success_rate(self) -> float:
+        if not self.results:
+            return 0.0
+        return sum(r.score for r in self.results) / len(self.results)
+
+    @property
+    def total_time(self) -> float:
+        return sum(r.time_s for r in self.results)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "suite": self.suite,
+            "model": self.model,
+            "provider": self.provider,
+            "device": self.device,
+            "status": self.status,
+            "success_rate": round(self.success_rate, 3),
+            "total_tasks": len(self.results),
+            "passed": sum(1 for r in self.results if r.score > 0),
+            "total_time_s": round(self.total_time, 1),
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "current_task": self.current_task,
+            "results": [asdict(r) for r in self.results],
+        }
+
+    def save(self) -> None:
+        path = RESULTS_DIR / f"{self.id}.json"
+        path.write_text(json.dumps(self.to_dict(), indent=2))
+
+
+# ── Active runs registry ─────────────────────────────────────────────────
+
+_active_runs: dict[str, BenchmarkRun] = {}
+
+
+def list_runs() -> list[dict]:
+    seen = set()
+    runs = []
+    for run in _active_runs.values():
+        runs.append(run.to_dict())
+        seen.add(run.id)
+    for f in sorted(RESULTS_DIR.glob("*.json"), reverse=True):
+        try:
+            data = json.loads(f.read_text())
+            if data["id"] not in seen:
+                runs.append(data)
+        except Exception:
+            pass
+    return runs
+
+
+def get_run(run_id: str) -> dict | None:
+    if run_id in _active_runs:
+        return _active_runs[run_id].to_dict()
+    path = RESULTS_DIR / f"{run_id}.json"
+    if path.exists():
+        return json.loads(path.read_text())
+    return None
+
+
+def stop_run(run_id: str) -> bool:
+    if run_id in _active_runs:
+        _active_runs[run_id].status = "stopped"
+        return True
+    return False
+
+
+# ── Main runner ──────────────────────────────────────────────────────────
+
+
+def run_benchmark(
+    tasks: list[Task],
+    model: str,
+    device: str,
+    provider: str = "ollama",
+    suite: str = "ghost_bench",
+    api_base: str = "http://localhost:5055",
+    run_id: str = "",
+) -> BenchmarkRun:
+    """Run benchmark tasks sequentially. Blocking — run in a thread."""
+    from gitd.benchmarks.ghost_bench.evaluators import (
+        evaluate_task,
+        initialize_task,
+        reset_device,
+        teardown_task,
+    )
+
+    if not run_id:
+        run_id = str(uuid.uuid4())[:8]
+
+    run = BenchmarkRun(
+        id=run_id,
+        suite=suite,
+        model=model,
+        provider=provider,
+        device=device,
+        started_at=time.time(),
+    )
+    _active_runs[run_id] = run
+    _event_queues.setdefault(run_id, [])
+
+    for task in tasks:
+        if run.status == "stopped":
+            break
+
+        run.current_task = task.id
+        t0 = time.time()
+        _emit(run_id, {"type": "task_start", "task_id": task.id, "goal": task.goal})
+
+        try:
+            reset_device(device)
+            time.sleep(1)
+
+            init_desc = initialize_task(task, device)
+            _emit(run_id, {"type": "init", "task_id": task.id, "desc": init_desc})
+            time.sleep(1)
+
+            agent_log = _run_agent(task, model, device, provider, api_base, run_id)
+
+            time.sleep(1)
+            score, reason = evaluate_task(task, device)
+            _emit(run_id, {"type": "task_result", "task_id": task.id, "score": score, "reason": reason})
+
+            elapsed = time.time() - t0
+            result = TaskResult(
+                task_id=task.id,
+                goal=task.goal,
+                model=model,
+                device=device,
+                score=score,
+                reason=reason,
+                steps=len([e for e in agent_log if e.get("type") == "tool_call"]),
+                time_s=round(elapsed, 1),
+                agent_log=agent_log,
+            )
+            teardown_task(task, device)
+
+        except Exception as e:
+            elapsed = time.time() - t0
+            result = TaskResult(
+                task_id=task.id,
+                goal=task.goal,
+                model=model,
+                device=device,
+                reason=f"error: {e}",
+                time_s=round(elapsed, 1),
+                error=str(e),
+            )
+            log.exception("Benchmark task %s failed", task.id)
+
+        run.results.append(result)
+        run.save()
+
+    run.status = "completed" if run.status != "stopped" else "stopped"
+    run.finished_at = time.time()
+    run.current_task = ""
+    run.save()
+    _emit(run_id, {"type": "run_done", "status": run.status, "success_rate": run.success_rate})
+    _active_runs.pop(run_id, None)
+    _event_queues.pop(run_id, None)
+    return run
+
+
+def _run_agent(
+    task: Task, model: str, device: str, provider: str, api_base: str, run_id: str
+) -> list[dict]:
+    """Send task goal to agent chat endpoint and collect SSE events."""
+    events: list[dict] = []
+    try:
+        resp = requests.post(
+            f"{api_base}/api/agent-chat/message",
+            json={"content": task.goal, "device": device, "provider": provider, "model": model},
+            timeout=300,
+            stream=True,
+        )
+        for line in resp.iter_lines():
+            if not line:
+                continue
+            text = line.decode()
+            if text.startswith("data: "):
+                try:
+                    ev = json.loads(text[6:])
+                    events.append(ev)
+                    _emit(run_id, {"type": "agent", "task_id": task.id, **ev})
+                except json.JSONDecodeError:
+                    pass
+    except Exception as e:
+        events.append({"type": "error", "content": str(e)})
+    return events

--- a/gitd/config.py
+++ b/gitd/config.py
@@ -26,6 +26,9 @@ class Settings(BaseSettings):
     anthropic_api_key: str = ""
     openrouter_api_key: str = ""
 
+    # ── Ollama ──────────────────────────────────────────────────────────────
+    ollama_base_url: str = "http://localhost:11434"
+
     model_config = {
         "env_file": ".env",
         "env_file_encoding": "utf-8",

--- a/gitd/routers/agent_chat.py
+++ b/gitd/routers/agent_chat.py
@@ -1,12 +1,29 @@
 """Agent Chat routes — interactive natural language phone control."""
 
 import json
+import logging
+import threading
 from typing import Optional
 
+import requests
 from fastapi import APIRouter, Body, HTTPException, Query
+from pydantic import BaseModel
 from starlette.responses import StreamingResponse
 
+from gitd.config import settings
+
+log = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/api/agent-chat", tags=["agent-chat"])
+
+OLLAMA_URL = settings.ollama_base_url
+
+
+# ── Request models ──────────────────────────────────────────────────────────
+
+
+class OllamaModelRequest(BaseModel):
+    model: str
 
 
 @router.post("/session", summary="Create Agent Chat Session")
@@ -184,3 +201,121 @@ def delete_conversation_endpoint(cid: str):
 
     delete_conversation(cid)
     return {"ok": True}
+
+
+@router.get("/providers", summary="List Chat Providers")
+def list_providers():
+    """Return available providers with models. Ollama models are discovered live."""
+    from gitd.services.agent_chat import get_providers
+
+    return get_providers()
+
+
+# ── Ollama model management ──────────────────────────────────────────────
+
+# Track background pull operations
+_pull_status: dict[str, dict] = {}  # model -> {"status": "pulling"|"done"|"error", "error": "..."}
+
+
+def _ollama_request(method: str, path: str, **kwargs) -> requests.Response:
+    """Make a request to the Ollama API. Raises on connection failure."""
+    url = f"{OLLAMA_URL}{path}"
+    try:
+        return requests.request(method, url, **kwargs)
+    except requests.ConnectionError:
+        raise HTTPException(status_code=503, detail="Ollama not reachable. Start it: ollama serve")
+
+
+@router.get("/ollama/status", summary="Ollama Model Status")
+def ollama_status():
+    """Return all installed Ollama models with loaded/unloaded status and VRAM usage."""
+    try:
+        tags = _ollama_request("GET", "/api/tags", timeout=3).json()
+        ps = _ollama_request("GET", "/api/ps", timeout=3).json()
+    except HTTPException:
+        return {"ok": False, "error": "Ollama not running", "models": []}
+
+    loaded = {m["name"]: m for m in ps.get("models", [])}
+    models = []
+    for m in tags.get("models", []):
+        name = m["name"]
+        lm = loaded.get(name)
+        models.append(
+            {
+                "name": name,
+                "size_gb": round(m.get("size", 0) / 1e9, 1),
+                "parameter_size": m.get("details", {}).get("parameter_size", ""),
+                "family": m.get("details", {}).get("family", ""),
+                "quantization": m.get("details", {}).get("quantization_level", ""),
+                "status": "loaded" if lm else "unloaded",
+                "vram_gb": round(lm["size_vram"] / 1e9, 1) if lm else 0,
+                "expires_at": lm.get("expires_at", "") if lm else "",
+            }
+        )
+    return {"ok": True, "models": models}
+
+
+@router.post("/ollama/load", summary="Load Ollama Model")
+def ollama_load(req: OllamaModelRequest):
+    """Load a model into VRAM. Sends an empty generate to warm up."""
+    r = _ollama_request(
+        "POST",
+        "/api/generate",
+        json={"model": req.model, "prompt": "", "keep_alive": "10m"},
+        timeout=120,
+    )
+    if r.status_code != 200:
+        error = r.json().get("error", r.text[:200])
+        if "not found" in error.lower():
+            return {"ok": False, "error": f"Model not found. Run: ollama pull {req.model}"}
+        return {"ok": False, "error": error}
+    return {"ok": True, "model": req.model, "status": "loaded"}
+
+
+@router.post("/ollama/pull", summary="Pull Ollama Model")
+def ollama_pull(req: OllamaModelRequest):
+    """Pull (download) a model from the Ollama registry. Non-blocking — runs in background."""
+    if req.model in _pull_status and _pull_status[req.model].get("status") == "pulling":
+        return {"ok": True, "model": req.model, "status": "already_pulling"}
+
+    _pull_status[req.model] = {"status": "pulling"}
+
+    def _do_pull():
+        try:
+            r = requests.post(
+                f"{OLLAMA_URL}/api/pull",
+                json={"name": req.model, "stream": False},
+                timeout=1800,
+            )
+            if r.status_code == 200:
+                _pull_status[req.model] = {"status": "done"}
+                log.info("Pulled Ollama model: %s", req.model)
+            else:
+                _pull_status[req.model] = {"status": "error", "error": r.json().get("error", "unknown")}
+        except Exception as e:
+            _pull_status[req.model] = {"status": "error", "error": str(e)}
+
+    threading.Thread(target=_do_pull, daemon=True).start()
+    return {"ok": True, "model": req.model, "status": "pulling"}
+
+
+@router.get("/ollama/pull/{model:path}", summary="Check Pull Status")
+def ollama_pull_status(model: str):
+    """Check the status of a background model pull."""
+    status = _pull_status.get(model, {"status": "unknown"})
+    return {"model": model, **status}
+
+
+@router.post("/ollama/unload", summary="Unload Ollama Model")
+def ollama_unload(req: OllamaModelRequest):
+    """Unload a model from VRAM (keep_alive=0)."""
+    try:
+        _ollama_request(
+            "POST",
+            "/api/generate",
+            json={"model": req.model, "keep_alive": 0},
+            timeout=10,
+        )
+    except HTTPException:
+        return {"ok": False, "error": "Ollama not running"}
+    return {"ok": True, "model": req.model, "status": "unloaded"}

--- a/gitd/routers/benchmarks.py
+++ b/gitd/routers/benchmarks.py
@@ -1,0 +1,163 @@
+"""Benchmark API — run task suites through the agent, track results."""
+
+import json
+import logging
+import threading
+import uuid
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from starlette.responses import StreamingResponse
+
+from gitd.benchmarks.runner import get_run, list_runs, run_benchmark, stop_run, subscribe, unsubscribe
+
+log = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/benchmarks", tags=["benchmarks"])
+
+
+# ── Request/Response models ──────────────────────────────────────────────
+
+
+class RunRequest(BaseModel):
+    suite: str = "ghost_bench"
+    tasks: Optional[list[str]] = None  # None = all tasks in the suite
+    provider: str = "ollama"
+    model: str = "gemma3:4b"
+    device: str = "emulator-5554"
+
+
+class RunResponse(BaseModel):
+    ok: bool
+    run_id: str
+    message: str
+
+
+# ── Suites ───────────────────────────────────────────────────────────────
+
+
+SUITES = {
+    "ghost_bench": {
+        "name": "Ghost Bench",
+        "description": "Built-in lightweight benchmark — settings toggles, app navigation",
+        "module": "gitd.benchmarks.ghost_bench.tasks",
+    },
+}
+
+
+@router.get("/suites", summary="List Benchmark Suites")
+def api_list_suites():
+    return [{"id": k, "name": v["name"], "description": v["description"]} for k, v in SUITES.items()]
+
+
+# ── Tasks ────────────────────────────────────────────────────────────────
+
+
+def _get_suite_tasks(suite: str):
+    """Import and return tasks for a suite."""
+    if suite not in SUITES:
+        raise HTTPException(status_code=404, detail=f"Unknown suite: {suite}")
+    import importlib
+
+    mod = importlib.import_module(SUITES[suite]["module"])
+    return mod.load_tasks, mod.get_task, mod.list_task_ids
+
+
+@router.get("/tasks", summary="List Tasks in a Suite")
+def api_list_tasks(suite: str = "ghost_bench", category: Optional[str] = None):
+    load_tasks, _, _ = _get_suite_tasks(suite)
+    tasks = load_tasks(category)
+    return [
+        {
+            "id": t.id,
+            "goal": t.goal,
+            "app": t.app,
+            "category": t.category,
+            "complexity": t.complexity,
+            "max_steps": t.max_steps,
+        }
+        for t in tasks
+    ]
+
+
+# ── Runs ─────────────────────────────────────────────────────────────────
+
+
+@router.post("/runs", summary="Start Benchmark Run", response_model=RunResponse)
+def api_start_run(req: RunRequest):
+    load_tasks, get_task, list_task_ids = _get_suite_tasks(req.suite)
+
+    if req.tasks:
+        tasks = [get_task(tid) for tid in req.tasks]
+        tasks = [t for t in tasks if t is not None]
+        if not tasks:
+            raise HTTPException(status_code=400, detail="No valid task IDs provided")
+    else:
+        tasks = load_tasks()
+
+    run_id = str(uuid.uuid4())[:8]
+
+    def _run():
+        run_benchmark(
+            tasks,
+            req.model,
+            req.device,
+            provider=req.provider,
+            suite=req.suite,
+            run_id=run_id,
+        )
+
+    threading.Thread(target=_run, daemon=True).start()
+    log.info("Started benchmark %s: %d tasks, %s/%s on %s", run_id, len(tasks), req.provider, req.model, req.device)
+
+    return RunResponse(
+        ok=True,
+        run_id=run_id,
+        message=f"Started {len(tasks)} tasks with {req.provider}/{req.model}",
+    )
+
+
+@router.get("/runs", summary="List Benchmark Runs")
+def api_list_runs():
+    return list_runs()
+
+
+@router.get("/runs/{run_id}", summary="Get Run Details")
+def api_get_run(run_id: str):
+    run = get_run(run_id)
+    if not run:
+        raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
+    return run
+
+
+@router.post("/runs/{run_id}/stop", summary="Stop Running Benchmark")
+def api_stop_run(run_id: str):
+    ok = stop_run(run_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Run not found or already completed")
+    return {"ok": True}
+
+
+@router.get("/runs/{run_id}/events", summary="Stream Live Events (SSE)")
+def api_stream_events(run_id: str):
+    """Server-Sent Events stream of live benchmark progress."""
+    q = subscribe(run_id)
+
+    def event_generator():
+        try:
+            while True:
+                try:
+                    event = q.get(timeout=30)
+                    yield f"data: {json.dumps(event)}\n\n"
+                    if event.get("type") == "run_done":
+                        break
+                except Exception:
+                    yield ": keepalive\n\n"
+        finally:
+            unsubscribe(run_id, q)
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )

--- a/gitd/routers/streaming.py
+++ b/gitd/routers/streaming.py
@@ -35,7 +35,7 @@ def _stable_ws_port(serial: str) -> int:
 
 
 @router.get("/api/phone/stream", summary="Stream Phone Screen MJPEG")
-def phone_stream(device: str = "", fps: int = 30, quality: int = 8, mode: str = "portal"):
+def phone_stream(device: str = "", fps: int = 30, quality: int = 8, mode: str = "screencap"):
     """Stream phone screen via MJPEG."""
     fps = max(1, min(fps, 60))
     quality = max(1, min(quality, 31))

--- a/gitd/services/agent_chat.py
+++ b/gitd/services/agent_chat.py
@@ -310,6 +310,25 @@ def delete_conversation(conversation_id: str):
     _sessions.pop(conversation_id, None)
 
 
+def get_providers() -> list[dict]:
+    """Return providers with models. Ollama models are discovered live from the local server."""
+    import requests
+
+    result = []
+    for pid, info in PROVIDERS.items():
+        models = list(info["models"])
+        if pid == "ollama":
+            try:
+                r = requests.get("http://localhost:11434/api/tags", timeout=3)
+                installed = [m["name"] for m in r.json().get("models", [])]
+                if installed:
+                    models = installed
+            except Exception:
+                pass  # Ollama not running — return defaults
+        result.append({"id": pid, "label": info["label"], "models": models})
+    return result
+
+
 def chat_turn(session: ChatSession, user_message: str):
     """Run one agent turn. Yields SSE event dicts."""
     provider = session.provider
@@ -726,11 +745,22 @@ def _chat_ollama(session: ChatSession, user_message: str):
                 },
                 timeout=120,
             )
-            reply = r.json().get("message", {}).get("content", "")
+            data = r.json()
+            if r.status_code != 200:
+                error = data.get("error", r.text[:200])
+                if "not found" in error.lower():
+                    yield {
+                        "type": "error",
+                        "content": f"Model '{model}' not found. Pull it first: ollama pull {model}",
+                    }
+                else:
+                    yield {"type": "error", "content": f"Ollama error: {error}"}
+                return
+            reply = data.get("message", {}).get("content", "")
         except requests.ConnectionError:
             yield {
                 "type": "error",
-                "content": "Ollama not reachable at localhost:11434. Install: https://ollama.com/download",
+                "content": "Ollama not reachable at localhost:11434. Start it: ollama serve",
             }
             return
         except Exception as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ghost-in-the-droid"
-version = "1.1.0"
+version = "1.2.0"
 description = "Give any AI agent an Android body. Open-source phone automation via ADB — tap, swipe, type, run skills, scale across devices."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,0 +1,61 @@
+"""Tests for benchmark infrastructure."""
+
+from gitd.benchmarks.base import Task, TaskResult, load_tasks_from_dir
+from gitd.benchmarks.ghost_bench.tasks import TASK_DATA_DIR, get_task, list_task_ids, load_tasks
+
+
+def test_load_tasks():
+    tasks = load_tasks()
+    assert len(tasks) >= 10
+    assert all(isinstance(t, Task) for t in tasks)
+
+
+def test_load_tasks_by_category():
+    settings = load_tasks("settings")
+    nav = load_tasks("navigation")
+    assert all(t.category == "settings" for t in settings)
+    assert all(t.category == "navigation" for t in nav)
+    assert len(settings) + len(nav) == len(load_tasks())
+
+
+def test_get_task():
+    task = get_task("SystemWifiTurnOn")
+    assert task is not None
+    assert task.goal == "Turn wifi on."
+    assert task.app == "com.android.settings"
+    assert task.init["cmd"] == "svc wifi disable"
+
+
+def test_get_task_not_found():
+    assert get_task("NonExistent") is None
+
+
+def test_list_task_ids():
+    ids = list_task_ids()
+    assert "SystemWifiTurnOn" in ids
+    assert "OpenAppSettings" in ids
+
+
+def test_task_max_steps():
+    task = get_task("SystemAirplaneModeOn")
+    assert task is not None
+    assert task.complexity == 1.5
+    assert task.max_steps == 15
+
+
+def test_task_result_defaults():
+    result = TaskResult(task_id="test", goal="test goal", model="m", device="d")
+    assert result.score == 0.0
+    assert result.error == ""
+    assert result.agent_log == []
+
+
+def test_load_tasks_from_dir():
+    tasks = load_tasks_from_dir(TASK_DATA_DIR)
+    assert len(tasks) == len(load_tasks())
+
+
+def test_all_tasks_have_eval():
+    for task in load_tasks():
+        assert task.eval, f"Task {task.id} missing eval"
+        assert task.eval.get("cmd"), f"Task {task.id} eval missing cmd"


### PR DESCRIPTION
## What's new in v1.2.0

### 📊 Ghost Bench
In-dashboard benchmark system with 14 built-in tasks (settings + navigation). Runner with SSE live streaming. New `Benchmarks` tab in the dashboard. This is Phase 1 of the AndroidWorld benchmark integration — Phase 2 will wrap the real `google-research/android_world` package.

7 API endpoints: `GET /api/benchmarks/suites`, `/tasks`, `/runs`, `/runs/{id}`, `/runs/{id}/events` (SSE live stream), `POST /runs`, `/runs/{id}/stop`.

### 🦙 Ollama improvements
- **Live model discovery** — dropdown shows actually-installed models via `GET /api/agent-chat/providers` querying `localhost:11434/api/tags`
- **Background model pull** — pull new models without blocking the UI
- Helpful errors when Ollama isn't running or a requested model isn't installed

## 📦 Install

```bash
pip install ghost-in-the-droid==1.2.0
# or
uvx --from ghost-in-the-droid==1.2.0 android-agent-mcp
```

## Test plan
- [x] CI green
- [x] 14 benchmark tasks runnable on real device
- [x] Ollama discovery works with custom installed models