### PR TITLE
feat: on-device Gemma provider + stop-button fix + tracing + vLLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,11 @@ DEFAULT_DEVICE=
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 OPENROUTER_API_KEY=
+
+# Observability — Langfuse (optional; leave empty to disable)
+# Self-hosted: docker compose -f docker-compose.langfuse.yml up -d, then
+#   open http://localhost:3000 → sign up → create project → paste keys.
+# Cloud: sign up at https://cloud.langfuse.com (free tier).
+LANGFUSE_PUBLIC_KEY=
+LANGFUSE_SECRET_KEY=
+LANGFUSE_HOST=http://localhost:3000

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Verify package
+        run: |
+          pip install dist/*.whl
+          android-agent --help
+          python -c "from gitd.mcp_server import main; print('MCP entry point OK')"
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_PROJECT_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -27,9 +27,8 @@ reference/
 *.swp
 *.swo
 
-# Claude / MCP config
+# Claude session data (not the MCP config — that ships with the repo)
 .claude/
-.mcp.json
 
 # OS
 .DS_Store

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "android-agent": {
+      "command": ".venv/bin/python",
+      "args": ["-m", "gitd.mcp_server"]
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,3 @@
 {
-  "mcpServers": {
-    "android-agent": {
-      "command": ".venv/bin/python",
-      "args": ["-m", "gitd.mcp_server"]
-    }
-  }
+  "mcpServers": {}
 }

--- a/.playwright-mcp/console-2026-04-30T09-59-45-363Z.log
+++ b/.playwright-mcp/console-2026-04-30T09-59-45-363Z.log
@@ -1,0 +1,14 @@
+[    1366ms] [WARNING] Manifest: property 'start_url' ignored, should be same origin as document. @ https://www.redditstatic.com/desktop2x/img/favicon/manifest.json:0
+[    1366ms] [WARNING] Manifest: property 'scope' ignored. Start url should be within scope of scope URL. @ https://www.redditstatic.com/desktop2x/img/favicon/manifest.json:0
+[    1366ms] [WARNING] Manifest: property 'url' ignored, should be within scope of the manifest. @ https://www.redditstatic.com/desktop2x/img/favicon/manifest.json:0
+[    1366ms] [WARNING] Manifest: property 'url' of 'shortcut' not present. @ https://www.redditstatic.com/desktop2x/img/favicon/manifest.json:0
+[    1366ms] [WARNING] Manifest: property 'url' ignored, should be within scope of the manifest. @ https://www.redditstatic.com/desktop2x/img/favicon/manifest.json:0
+[    1366ms] [WARNING] Manifest: property 'url' of 'shortcut' not present. @ https://www.redditstatic.com/desktop2x/img/favicon/manifest.json:0
+[    1366ms] [WARNING] Manifest: property 'url' ignored, should be within scope of the manifest. @ https://www.redditstatic.com/desktop2x/img/favicon/manifest.json:0
+[    1366ms] [WARNING] Manifest: property 'url' of 'shortcut' not present. @ https://www.redditstatic.com/desktop2x/img/favicon/manifest.json:0
+[    1366ms] [WARNING] Manifest: property 'url' ignored, should be within scope of the manifest. @ https://www.redditstatic.com/desktop2x/img/favicon/manifest.json:0
+[    1366ms] [WARNING] Manifest: property 'url' of 'shortcut' not present. @ https://www.redditstatic.com/desktop2x/img/favicon/manifest.json:0
+[    1366ms] [WARNING] Manifest: property 'url' ignored, should be within scope of the manifest. @ https://www.redditstatic.com/desktop2x/img/favicon/manifest.json:0
+[    1366ms] [WARNING] Manifest: property 'url' of 'shortcut' not present. @ https://www.redditstatic.com/desktop2x/img/favicon/manifest.json:0
+[    1366ms] [WARNING] Manifest: property 'url' ignored, should be within scope of the manifest. @ https://www.redditstatic.com/desktop2x/img/favicon/manifest.json:0
+[    1366ms] [WARNING] Manifest: property 'url' of 'shortcut' not present. @ https://www.redditstatic.com/desktop2x/img/favicon/manifest.json:0

--- a/.playwright-mcp/page-2026-04-30T09-59-41-729Z.yml
+++ b/.playwright-mcp/page-2026-04-30T09-59-41-729Z.yml
@@ -1,0 +1,26 @@
+- generic [active] [ref=e1]:
+  - link [ref=e3] [cursor=pointer]:
+    - /url: https://www.reddit.com
+    - img [ref=e4]
+  - generic [ref=e5]:
+    - img [ref=e6]
+    - heading "Prove your humanity" [level=1] [ref=e8]
+    - paragraph [ref=e9]: We’re committed to safety and security. But not for bots. Complete the challenge below and let us know you’re a real person.
+    - iframe [ref=e14]:
+      - generic [ref=f1e2]:
+        - generic [ref=f1e3]:
+          - checkbox "I'm not a robot" [ref=f1e7]
+          - generic [ref=f1e11]: I'm not a robot
+        - generic [ref=f1e15]: reCAPTCHA
+  - generic [ref=e15]:
+    - link "Reddit, Inc. © \"2026\". All rights reserved." [ref=e16] [cursor=pointer]:
+      - /url: https://www.redditinc.com/
+    - generic [ref=e17]:
+      - link "User Agreement" [ref=e18] [cursor=pointer]:
+        - /url: https://www.reddit.com/help/useragreement
+      - link "Privacy Policy" [ref=e19] [cursor=pointer]:
+        - /url: https://www.reddit.com/help/privacypolicy
+      - link "Content Policy" [ref=e20] [cursor=pointer]:
+        - /url: https://www.reddit.com/help/contentpolicy
+      - link "Help" [ref=e21] [cursor=pointer]:
+        - /url: https://support.reddithelp.com/hc/en-us

--- a/.playwright-mcp/page-2026-04-30T09-59-46-769Z.yml
+++ b/.playwright-mcp/page-2026-04-30T09-59-46-769Z.yml
@@ -1,0 +1,1436 @@
+- generic [active] [ref=e1]:
+  - banner [ref=e2]:
+    - link "jump to content" [ref=e3] [cursor=pointer]:
+      - /url: "#content"
+    - generic [ref=e5]:
+      - generic [ref=e7] [cursor=pointer]: my subreddits
+      - generic [ref=e8]:
+        - list [ref=e9]:
+          - listitem [ref=e10]:
+            - link "popular" [ref=e11] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/popular/
+          - listitem [ref=e12]:
+            - text: "-"
+            - link "all" [ref=e13] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/all/
+          - listitem [ref=e14]:
+            - text: "-"
+            - link "users" [ref=e15] [cursor=pointer]:
+              - /url: https://old.reddit.com/users/
+        - text: "|"
+        - list [ref=e16]:
+          - listitem [ref=e17]:
+            - link "AskReddit" [ref=e18] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/AskReddit/
+          - listitem [ref=e19]:
+            - text: "-"
+            - link "pics" [ref=e20] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/pics/
+          - listitem [ref=e21]:
+            - text: "-"
+            - link "funny" [ref=e22] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/funny/
+          - listitem [ref=e23]:
+            - text: "-"
+            - link "movies" [ref=e24] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/movies/
+          - listitem [ref=e25]:
+            - text: "-"
+            - link "gaming" [ref=e26] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/gaming/
+          - listitem [ref=e27]:
+            - text: "-"
+            - link "worldnews" [ref=e28] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/worldnews/
+          - listitem [ref=e29]:
+            - text: "-"
+            - link "news" [ref=e30] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/news/
+          - listitem [ref=e31]:
+            - text: "-"
+            - link "todayilearned" [ref=e32] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/todayilearned/
+          - listitem [ref=e33]:
+            - text: "-"
+            - link "nottheonion" [ref=e34] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/nottheonion/
+          - listitem [ref=e35]:
+            - text: "-"
+            - link "explainlikeimfive" [ref=e36] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/explainlikeimfive/
+          - listitem [ref=e37]:
+            - text: "-"
+            - link "mildlyinteresting" [ref=e38] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/mildlyinteresting/
+          - listitem [ref=e39]:
+            - text: "-"
+            - link "DIY" [ref=e40] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/DIY/
+          - listitem [ref=e41]:
+            - text: "-"
+            - link "videos" [ref=e42] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/videos/
+          - listitem [ref=e43]:
+            - text: "-"
+            - link "OldSchoolCool" [ref=e44] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/OldSchoolCool/
+          - listitem [ref=e45]:
+            - text: "-"
+            - link "TwoXChromosomes" [ref=e46] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/TwoXChromosomes/
+          - listitem [ref=e47]:
+            - text: "-"
+            - link "tifu" [ref=e48] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/tifu/
+          - listitem [ref=e49]:
+            - text: "-"
+            - link "Music" [ref=e50] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/Music/
+          - listitem [ref=e51]:
+            - text: "-"
+            - link "books" [ref=e52] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/books/
+          - listitem [ref=e53]:
+            - text: "-"
+            - link "LifeProTips" [ref=e54] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/LifeProTips/
+          - listitem [ref=e55]:
+            - text: "-"
+            - link "dataisbeautiful" [ref=e56] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/dataisbeautiful/
+          - listitem [ref=e57]:
+            - text: "-"
+            - link "aww" [ref=e58] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/aww/
+          - listitem [ref=e59]:
+            - text: "-"
+            - link "science" [ref=e60] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/science/
+          - listitem [ref=e61]:
+            - text: "-"
+            - link "space" [ref=e62] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/space/
+          - listitem [ref=e63]:
+            - text: "-"
+            - link "Showerthoughts" [ref=e64] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/Showerthoughts/
+          - listitem [ref=e65]:
+            - text: "-"
+            - link "askscience" [ref=e66] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/askscience/
+          - listitem [ref=e67]:
+            - text: "-"
+            - link "Jokes" [ref=e68] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/Jokes/
+          - listitem [ref=e69]:
+            - text: "-"
+            - link "Art" [ref=e70] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/Art/
+          - listitem [ref=e71]:
+            - text: "-"
+            - link "IAmA" [ref=e72] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/IAmA/
+          - listitem [ref=e73]:
+            - text: "-"
+            - link "Futurology" [ref=e74] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/Futurology/
+          - listitem [ref=e75]:
+            - text: "-"
+            - link "sports" [ref=e76] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/sports/
+          - listitem [ref=e77]:
+            - text: "-"
+            - link "UpliftingNews" [ref=e78] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/UpliftingNews/
+          - listitem [ref=e79]:
+            - text: "-"
+            - link "food" [ref=e80] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/food/
+          - listitem [ref=e81]:
+            - text: "-"
+            - link "nosleep" [ref=e82] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/nosleep/
+          - listitem [ref=e83]:
+            - text: "-"
+            - link "creepy" [ref=e84] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/creepy/
+          - listitem [ref=e85]:
+            - text: "-"
+            - link "history" [ref=e86] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/history/
+          - listitem [ref=e87]:
+            - text: "-"
+            - link "gifs" [ref=e88] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/gifs/
+          - listitem [ref=e89]:
+            - text: "-"
+            - link "InternetIsBeautiful" [ref=e90] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/InternetIsBeautiful/
+          - listitem [ref=e91]:
+            - text: "-"
+            - link "GetMotivated" [ref=e92] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/GetMotivated/
+          - listitem [ref=e93]:
+            - text: "-"
+            - link "gadgets" [ref=e94] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/gadgets/
+          - listitem [ref=e95]:
+            - text: "-"
+            - link "announcements" [ref=e96] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/announcements/
+          - listitem [ref=e97]:
+            - text: "-"
+            - link "WritingPrompts" [ref=e98] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/WritingPrompts/
+          - listitem [ref=e99]:
+            - text: "-"
+            - link "philosophy" [ref=e100] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/philosophy/
+          - listitem [ref=e101]:
+            - text: "-"
+            - link "Documentaries" [ref=e102] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/Documentaries/
+          - listitem [ref=e103]:
+            - text: "-"
+            - link "EarthPorn" [ref=e104] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/EarthPorn/
+          - listitem [ref=e105]:
+            - text: "-"
+            - link "photoshopbattles" [ref=e106] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/photoshopbattles/
+          - listitem [ref=e107]:
+            - text: "-"
+            - link "listentothis" [ref=e108] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/listentothis/
+          - listitem [ref=e109]:
+            - text: "-"
+            - link "blog" [ref=e110] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/blog/
+      - link "more »" [ref=e111] [cursor=pointer]:
+        - /url: https://old.reddit.com/subreddits/
+    - generic [ref=e112]:
+      - link "reddit.com" [ref=e113] [cursor=pointer]:
+        - /url: /
+      - list [ref=e114]:
+        - listitem [ref=e115]:
+          - link "hot" [ref=e116] [cursor=pointer]:
+            - /url: https://old.reddit.com/
+        - listitem [ref=e117]:
+          - link "new" [ref=e118] [cursor=pointer]:
+            - /url: https://old.reddit.com/new/
+        - listitem [ref=e119]:
+          - link "rising" [ref=e120] [cursor=pointer]:
+            - /url: https://old.reddit.com/rising/
+        - listitem [ref=e121]:
+          - link "controversial" [ref=e122] [cursor=pointer]:
+            - /url: https://old.reddit.com/controversial/
+        - listitem [ref=e123]:
+          - link "top" [ref=e124] [cursor=pointer]:
+            - /url: https://old.reddit.com/top/
+        - listitem [ref=e125]:
+          - link "wiki" [ref=e126] [cursor=pointer]:
+            - /url: https://old.reddit.com/wiki/
+    - generic [ref=e127]:
+      - generic [ref=e128]:
+        - text: Want to join?
+        - link "Log in" [ref=e129] [cursor=pointer]:
+          - /url: https://www.reddit.com/login
+        - text: or
+        - link "sign up" [ref=e130] [cursor=pointer]:
+          - /url: https://www.reddit.com/login
+        - text: in seconds.
+      - list
+  - generic [ref=e131]:
+    - search [ref=e133]:
+      - textbox "search" [ref=e134]
+      - button "Submit" [ref=e135] [cursor=pointer]
+    - link "Submit a new link" [ref=e139] [cursor=pointer]:
+      - /url: https://old.reddit.com/submit
+    - link "Submit a new text post" [ref=e144] [cursor=pointer]:
+      - /url: https://old.reddit.com/submit?selftext=true
+  - main [ref=e146]:
+    - generic [ref=e147]:
+      - link "Welcome to Reddit, the front page of the internet. Become a Redditor and join one of thousands of communities." [ref=e148] [cursor=pointer]:
+        - /url: /login
+        - heading "Welcome to Reddit," [level=2] [ref=e149]
+        - paragraph [ref=e150]: the front page of the internet.
+        - generic [ref=e151]:
+          - generic [ref=e152]: Become a Redditor
+          - paragraph [ref=e153]: and join one of thousands of communities.
+      - link "×" [ref=e154] [cursor=pointer]:
+        - /url: "#"
+    - generic [ref=e156]:
+      - text: "popular in:"
+      - generic [ref=e157]: Thailand
+    - generic [ref=e158]:
+      - generic [ref=e159]:
+        - paragraph
+        - generic [ref=e160]: "1"
+        - generic [ref=e161]:
+          - button "upvote" [ref=e162] [cursor=pointer]
+          - generic "80" [ref=e163]
+          - button "downvote" [ref=e164] [cursor=pointer]
+        - link [ref=e165] [cursor=pointer]:
+          - /url: https://i.redd.it/7094u8wf9ayg1.jpeg
+        - generic [ref=e167]:
+          - paragraph [ref=e168]:
+            - link "PU VS PU" [ref=e169] [cursor=pointer]:
+              - /url: https://i.redd.it/7094u8wf9ayg1.jpeg
+            - generic [ref=e170]:
+              - text: (
+              - link "i.redd.it" [ref=e171] [cursor=pointer]:
+                - /url: /domain/i.redd.it/
+              - text: )
+          - paragraph [ref=e173]:
+            - text: submitted
+            - time [ref=e174]: 2 hours ago
+            - text: by
+            - link "MiserableCell9552" [ref=e175] [cursor=pointer]:
+              - /url: https://old.reddit.com/user/MiserableCell9552
+            - text: to
+            - link "r/oksahaipunyaon" [ref=e176] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/oksahaipunyaon/
+          - list [ref=e177]:
+            - listitem [ref=e178]:
+              - link "11 comments" [ref=e179] [cursor=pointer]:
+                - /url: https://old.reddit.com/r/oksahaipunyaon/comments/1szpg0s/pu_vs_pu/
+            - listitem [ref=e180]:
+              - link "share" [ref=e181] [cursor=pointer]:
+                - /url: "javascript: void 0;"
+            - listitem [ref=e182]:
+              - link "save" [ref=e183] [cursor=pointer]:
+                - /url: "#"
+            - listitem [ref=e184]:
+              - link "hide" [ref=e187] [cursor=pointer]:
+                - /url: javascript:void(0)
+            - listitem [ref=e188]:
+              - link "report" [ref=e189] [cursor=pointer]:
+                - /url: javascript:void(0)
+      - generic [ref=e190]:
+        - paragraph
+        - generic [ref=e191]: "2"
+        - generic [ref=e192]:
+          - button "upvote" [ref=e193] [cursor=pointer]
+          - generic "241" [ref=e194]
+          - button "downvote" [ref=e195] [cursor=pointer]
+        - link [ref=e196] [cursor=pointer]:
+          - /url: https://www.reddit.com/gallery/1szk352
+        - generic [ref=e198]:
+          - paragraph [ref=e199]:
+            - link "Tourist found with 30 turtles taped to herself, arrested at Suvarnabhumi airport" [ref=e200] [cursor=pointer]:
+              - /url: https://www.reddit.com/gallery/1szk352
+            - generic "News" [ref=e201]
+            - generic [ref=e202]:
+              - text: (
+              - link "old.reddit.com" [ref=e203] [cursor=pointer]:
+                - /url: /domain/old.reddit.com/
+              - text: )
+          - paragraph [ref=e205]:
+            - text: submitted
+            - time [ref=e206]: 6 hours ago
+            - text: by
+            - link "tuktukson" [ref=e207] [cursor=pointer]:
+              - /url: https://old.reddit.com/user/tuktukson
+            - text: to
+            - link "r/Thailand" [ref=e208] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/Thailand/
+          - list [ref=e209]:
+            - listitem [ref=e210]:
+              - link "68 comments" [ref=e211] [cursor=pointer]:
+                - /url: https://old.reddit.com/r/Thailand/comments/1szk352/tourist_found_with_30_turtles_taped_to_herself/
+            - listitem [ref=e212]:
+              - link "share" [ref=e213] [cursor=pointer]:
+                - /url: "javascript: void 0;"
+            - listitem [ref=e214]:
+              - link "save" [ref=e215] [cursor=pointer]:
+                - /url: "#"
+            - listitem [ref=e216]:
+              - link "hide" [ref=e219] [cursor=pointer]:
+                - /url: javascript:void(0)
+            - listitem [ref=e220]:
+              - link "report" [ref=e221] [cursor=pointer]:
+                - /url: javascript:void(0)
+      - generic [ref=e222]:
+        - paragraph
+        - generic [ref=e223]: "3"
+        - generic [ref=e224]:
+          - button "upvote" [ref=e225] [cursor=pointer]
+          - generic "1115" [ref=e226]
+          - button "downvote" [ref=e227] [cursor=pointer]
+        - link [ref=e228] [cursor=pointer]:
+          - /url: https://www.reddit.com/gallery/1szm6su
+        - generic [ref=e230]:
+          - paragraph [ref=e231]:
+            - link "All Season 3 Character Reveal (En & JP VA's included)" [ref=e232] [cursor=pointer]:
+              - /url: https://www.reddit.com/gallery/1szm6su
+            - generic "Official" [ref=e233]
+            - generic [ref=e234]:
+              - text: (
+              - link "old.reddit.com" [ref=e235] [cursor=pointer]:
+                - /url: /domain/old.reddit.com/
+              - text: )
+          - paragraph [ref=e237]:
+            - text: submitted
+            - time [ref=e238]: 5 hours ago
+            - text: by
+            - link "StarBurstero" [ref=e239] [cursor=pointer]:
+              - /url: https://old.reddit.com/user/StarBurstero
+            - text: to
+            - link "r/Zenlesszonezeroleaks_" [ref=e240] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/Zenlesszonezeroleaks_/
+          - list [ref=e241]:
+            - listitem [ref=e242]:
+              - link "392 comments" [ref=e243] [cursor=pointer]:
+                - /url: https://old.reddit.com/r/Zenlesszonezeroleaks_/comments/1szm6su/all_season_3_character_reveal_en_jp_vas_included/
+            - listitem [ref=e244]:
+              - link "share" [ref=e245] [cursor=pointer]:
+                - /url: "javascript: void 0;"
+            - listitem [ref=e246]:
+              - link "save" [ref=e247] [cursor=pointer]:
+                - /url: "#"
+            - listitem [ref=e248]:
+              - link "hide" [ref=e251] [cursor=pointer]:
+                - /url: javascript:void(0)
+            - listitem [ref=e252]:
+              - link "report" [ref=e253] [cursor=pointer]:
+                - /url: javascript:void(0)
+      - generic [ref=e254]:
+        - paragraph
+        - generic [ref=e255]: "4"
+        - generic [ref=e256]:
+          - button "upvote" [ref=e257] [cursor=pointer]
+          - generic "2017" [ref=e258]
+          - button "downvote" [ref=e259] [cursor=pointer]
+        - link "0:33" [ref=e260] [cursor=pointer]:
+          - /url: https://v.redd.it/ypm4u1aaa9yg1
+          - generic [ref=e261]: 0:33
+        - generic [ref=e263]:
+          - paragraph [ref=e264]:
+            - link "[ZZZ - 3.0 BETA] Norma Animations Via Mero" [ref=e265] [cursor=pointer]:
+              - /url: https://v.redd.it/ypm4u1aaa9yg1
+            - generic "Reliable" [ref=e266]
+            - generic [ref=e267]:
+              - text: (
+              - link "v.redd.it" [ref=e268] [cursor=pointer]:
+                - /url: /domain/v.redd.it/
+              - text: )
+          - paragraph [ref=e270]:
+            - text: submitted
+            - time [ref=e271]: 5 hours ago
+            - text: by
+            - link "joshxleon" [ref=e272] [cursor=pointer]:
+              - /url: https://old.reddit.com/user/joshxleon
+            - text: to
+            - link "r/Zenlesszonezeroleaks_" [ref=e273] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/Zenlesszonezeroleaks_/
+          - list [ref=e274]:
+            - listitem [ref=e275]:
+              - link "247 comments" [ref=e276] [cursor=pointer]:
+                - /url: https://old.reddit.com/r/Zenlesszonezeroleaks_/comments/1szlvcf/zzz_30_beta_norma_animations_via_mero/
+            - listitem [ref=e277]:
+              - link "share" [ref=e278] [cursor=pointer]:
+                - /url: "javascript: void 0;"
+            - listitem [ref=e279]:
+              - link "save" [ref=e280] [cursor=pointer]:
+                - /url: "#"
+            - listitem [ref=e281]:
+              - link "hide" [ref=e284] [cursor=pointer]:
+                - /url: javascript:void(0)
+            - listitem [ref=e285]:
+              - link "report" [ref=e286] [cursor=pointer]:
+                - /url: javascript:void(0)
+      - generic [ref=e287]:
+        - paragraph
+        - generic [ref=e288]: "5"
+        - generic [ref=e289]:
+          - button "upvote" [ref=e290] [cursor=pointer]
+          - generic "1757" [ref=e291]
+          - button "downvote" [ref=e292] [cursor=pointer]
+        - link [ref=e293] [cursor=pointer]:
+          - /url: https://i.redd.it/o6tsuvr3a9yg1.png
+        - generic [ref=e295]:
+          - paragraph [ref=e296]:
+            - link "They took my goat's design out back and shot it" [ref=e297] [cursor=pointer]:
+              - /url: https://i.redd.it/o6tsuvr3a9yg1.png
+            - generic "Discussions & Questions" [ref=e298]
+            - generic [ref=e299]:
+              - text: (
+              - link "i.redd.it" [ref=e300] [cursor=pointer]:
+                - /url: /domain/i.redd.it/
+              - text: )
+          - paragraph [ref=e302]:
+            - text: submitted
+            - time [ref=e303]: 5 hours ago
+            - text: by
+            - link "WhenBuffalosfly" [ref=e304] [cursor=pointer]:
+              - /url: https://old.reddit.com/user/WhenBuffalosfly
+            - text: to
+            - link "r/ZZZ_Discussion" [ref=e305] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/ZZZ_Discussion/
+          - list [ref=e306]:
+            - listitem [ref=e307]:
+              - link "391 comments" [ref=e308] [cursor=pointer]:
+                - /url: https://old.reddit.com/r/ZZZ_Discussion/comments/1szlw54/they_took_my_goats_design_out_back_and_shot_it/
+            - listitem [ref=e309]:
+              - link "share" [ref=e310] [cursor=pointer]:
+                - /url: "javascript: void 0;"
+            - listitem [ref=e311]:
+              - link "save" [ref=e312] [cursor=pointer]:
+                - /url: "#"
+            - listitem [ref=e313]:
+              - link "hide" [ref=e316] [cursor=pointer]:
+                - /url: javascript:void(0)
+            - listitem [ref=e317]:
+              - link "report" [ref=e318] [cursor=pointer]:
+                - /url: javascript:void(0)
+      - generic [ref=e319]:
+        - paragraph
+        - generic [ref=e320]: "6"
+        - generic [ref=e321]:
+          - button "upvote" [ref=e322] [cursor=pointer]
+          - generic "105" [ref=e323]
+          - button "downvote" [ref=e324] [cursor=pointer]
+        - link [ref=e325] [cursor=pointer]:
+          - /url: https://v.redd.it/xy5s67pt9ayg1
+        - generic [ref=e327]:
+          - paragraph [ref=e328]:
+            - link "Maya Bay, Koh Phi Phi" [ref=e329] [cursor=pointer]:
+              - /url: https://v.redd.it/xy5s67pt9ayg1
+            - generic "Phuket/Krabi/South" [ref=e330]
+            - generic [ref=e331]:
+              - text: (
+              - link "v.redd.it" [ref=e332] [cursor=pointer]:
+                - /url: /domain/v.redd.it/
+              - text: )
+          - paragraph [ref=e334]:
+            - text: submitted
+            - time [ref=e335]: 2 hours ago
+            - text: by
+            - link "TheRealCockzilla" [ref=e336] [cursor=pointer]:
+              - /url: https://old.reddit.com/user/TheRealCockzilla
+            - text: to
+            - link "r/ThailandTourism" [ref=e337] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/ThailandTourism/
+          - list [ref=e338]:
+            - listitem [ref=e339]:
+              - link "98 comments" [ref=e340] [cursor=pointer]:
+                - /url: https://old.reddit.com/r/ThailandTourism/comments/1szphui/maya_bay_koh_phi_phi/
+            - listitem [ref=e341]:
+              - link "share" [ref=e342] [cursor=pointer]:
+                - /url: "javascript: void 0;"
+            - listitem [ref=e343]:
+              - link "save" [ref=e344] [cursor=pointer]:
+                - /url: "#"
+            - listitem [ref=e345]:
+              - link "hide" [ref=e348] [cursor=pointer]:
+                - /url: javascript:void(0)
+            - listitem [ref=e349]:
+              - link "report" [ref=e350] [cursor=pointer]:
+                - /url: javascript:void(0)
+      - generic [ref=e351]:
+        - paragraph
+        - generic [ref=e352]: "7"
+        - generic [ref=e353]:
+          - button "upvote" [ref=e354] [cursor=pointer]
+          - generic "14096" [ref=e355]: 14.1k
+          - button "downvote" [ref=e356] [cursor=pointer]
+        - link "0:20" [ref=e357] [cursor=pointer]:
+          - /url: https://v.redd.it/k3nj7ky8g9yg1
+          - generic [ref=e358]: 0:20
+        - generic [ref=e360]:
+          - paragraph [ref=e361]:
+            - link "Adding color to rice" [ref=e362] [cursor=pointer]:
+              - /url: https://v.redd.it/k3nj7ky8g9yg1
+            - generic [ref=e363]:
+              - text: (
+              - link "v.redd.it" [ref=e364] [cursor=pointer]:
+                - /url: /domain/v.redd.it/
+              - text: )
+          - paragraph [ref=e366]:
+            - text: submitted
+            - time [ref=e367]: 4 hours ago
+            - text: by
+            - link "BreakfastTop6899" [ref=e368] [cursor=pointer]:
+              - /url: https://old.reddit.com/user/BreakfastTop6899
+            - text: to
+            - link "r/oddlysatisfying" [ref=e369] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/oddlysatisfying/
+          - list [ref=e370]:
+            - listitem [ref=e371]:
+              - link "311 comments" [ref=e372] [cursor=pointer]:
+                - /url: https://old.reddit.com/r/oddlysatisfying/comments/1szmifu/adding_color_to_rice/
+            - listitem [ref=e373]:
+              - link "share" [ref=e374] [cursor=pointer]:
+                - /url: "javascript: void 0;"
+            - listitem [ref=e375]:
+              - link "save" [ref=e376] [cursor=pointer]:
+                - /url: "#"
+            - listitem [ref=e377]:
+              - link "hide" [ref=e380] [cursor=pointer]:
+                - /url: javascript:void(0)
+            - listitem [ref=e381]:
+              - link "report" [ref=e382] [cursor=pointer]:
+                - /url: javascript:void(0)
+      - generic [ref=e383]:
+        - paragraph
+        - generic [ref=e384]: "8"
+        - generic [ref=e385]:
+          - button "upvote" [ref=e386] [cursor=pointer]
+          - generic [ref=e387]: •
+          - button "downvote" [ref=e388] [cursor=pointer]
+        - link [ref=e389] [cursor=pointer]:
+          - /url: https://i.redd.it/q8qqu4gahayg1.jpeg
+        - generic [ref=e391]:
+          - paragraph [ref=e392]:
+            - link "Is it just me or the anatomy is awful." [ref=e393] [cursor=pointer]:
+              - /url: https://i.redd.it/q8qqu4gahayg1.jpeg
+            - generic "Discussion" [ref=e394]
+            - generic [ref=e395]:
+              - text: (
+              - link "i.redd.it" [ref=e396] [cursor=pointer]:
+                - /url: /domain/i.redd.it/
+              - text: )
+          - paragraph [ref=e398]:
+            - text: submitted
+            - time [ref=e399]: 1 hour ago
+            - text: by
+            - link "LittleWeirdPerson28" [ref=e400] [cursor=pointer]:
+              - /url: https://old.reddit.com/user/LittleWeirdPerson28
+            - text: to
+            - link "r/fivenightsatfreddys" [ref=e401] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/fivenightsatfreddys/
+          - list [ref=e402]:
+            - listitem [ref=e403]:
+              - link "43 comments" [ref=e404] [cursor=pointer]:
+                - /url: https://old.reddit.com/r/fivenightsatfreddys/comments/1szq6zb/is_it_just_me_or_the_anatomy_is_awful/
+            - listitem [ref=e405]:
+              - link "share" [ref=e406] [cursor=pointer]:
+                - /url: "javascript: void 0;"
+            - listitem [ref=e407]:
+              - link "save" [ref=e408] [cursor=pointer]:
+                - /url: "#"
+            - listitem [ref=e409]:
+              - link "hide" [ref=e412] [cursor=pointer]:
+                - /url: javascript:void(0)
+            - listitem [ref=e413]:
+              - link "report" [ref=e414] [cursor=pointer]:
+                - /url: javascript:void(0)
+      - generic [ref=e415]:
+        - paragraph
+        - generic [ref=e416]: "9"
+        - generic [ref=e417]:
+          - button "upvote" [ref=e418] [cursor=pointer]
+          - generic "4507" [ref=e419]
+          - button "downvote" [ref=e420] [cursor=pointer]
+        - link [ref=e421] [cursor=pointer]:
+          - /url: /r/AskReddit/comments/1szbpra/who_is_the_nastiest_celebrity_that_you_met_in/
+        - generic [ref=e423]:
+          - paragraph [ref=e424]:
+            - link "Who is the nastiest Celebrity that you met in Real life?" [ref=e425] [cursor=pointer]:
+              - /url: /r/AskReddit/comments/1szbpra/who_is_the_nastiest_celebrity_that_you_met_in/
+            - generic [ref=e426]:
+              - text: (
+              - link "self.AskReddit" [ref=e427] [cursor=pointer]:
+                - /url: /r/AskReddit/
+              - text: )
+          - paragraph [ref=e428]:
+            - text: submitted
+            - time [ref=e429]: 12 hours ago
+            - text: by
+            - link "Scunnard1839" [ref=e430] [cursor=pointer]:
+              - /url: https://old.reddit.com/user/Scunnard1839
+            - text: to
+            - link "r/AskReddit" [ref=e431] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/AskReddit/
+          - list [ref=e432]:
+            - listitem [ref=e433]:
+              - link "8255 comments" [ref=e434] [cursor=pointer]:
+                - /url: https://old.reddit.com/r/AskReddit/comments/1szbpra/who_is_the_nastiest_celebrity_that_you_met_in/
+            - listitem [ref=e435]:
+              - link "share" [ref=e436] [cursor=pointer]:
+                - /url: "javascript: void 0;"
+            - listitem [ref=e437]:
+              - link "save" [ref=e438] [cursor=pointer]:
+                - /url: "#"
+            - listitem [ref=e439]:
+              - link "hide" [ref=e442] [cursor=pointer]:
+                - /url: javascript:void(0)
+            - listitem [ref=e443]:
+              - link "report" [ref=e444] [cursor=pointer]:
+                - /url: javascript:void(0)
+      - generic [ref=e445]:
+        - paragraph
+        - generic [ref=e446]: "10"
+        - generic [ref=e447]:
+          - button "upvote" [ref=e448] [cursor=pointer]
+          - generic "6001" [ref=e449]
+          - button "downvote" [ref=e450] [cursor=pointer]
+        - link [ref=e451] [cursor=pointer]:
+          - /url: https://www.reddit.com/gallery/1szhfc3
+        - generic [ref=e453]:
+          - paragraph [ref=e454]:
+            - link "i love when shows randomly include rotoscoped scenes" [ref=e455] [cursor=pointer]:
+              - /url: https://www.reddit.com/gallery/1szhfc3
+            - generic [ref=e456]:
+              - text: (
+              - link "old.reddit.com" [ref=e457] [cursor=pointer]:
+                - /url: /domain/old.reddit.com/
+              - text: )
+          - paragraph [ref=e459]:
+            - text: submitted
+            - time [ref=e460]: 8 hours ago
+            - text: by
+            - link "Secure_Reply_1086" [ref=e461] [cursor=pointer]:
+              - /url: https://old.reddit.com/user/Secure_Reply_1086
+            - text: to
+            - link "r/lovethissmug" [ref=e462] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/lovethissmug/
+          - list [ref=e463]:
+            - listitem [ref=e464]:
+              - link "163 comments" [ref=e465] [cursor=pointer]:
+                - /url: https://old.reddit.com/r/lovethissmug/comments/1szhfc3/i_love_when_shows_randomly_include_rotoscoped/
+            - listitem [ref=e466]:
+              - link "share" [ref=e467] [cursor=pointer]:
+                - /url: "javascript: void 0;"
+            - listitem [ref=e468]:
+              - link "save" [ref=e469] [cursor=pointer]:
+                - /url: "#"
+            - listitem [ref=e470]:
+              - link "hide" [ref=e473] [cursor=pointer]:
+                - /url: javascript:void(0)
+            - listitem [ref=e474]:
+              - link "report" [ref=e475] [cursor=pointer]:
+                - /url: javascript:void(0)
+      - generic [ref=e476]:
+        - paragraph
+        - generic [ref=e477]: "11"
+        - generic [ref=e478]:
+          - button "upvote" [ref=e479] [cursor=pointer]
+          - generic "29870" [ref=e480]: 29.9k
+          - button "downvote" [ref=e481] [cursor=pointer]
+        - link [ref=e482] [cursor=pointer]:
+          - /url: https://www.reddit.com/gallery/1sznyef
+        - generic [ref=e484]:
+          - paragraph [ref=e485]:
+            - link "[OC] New Banksy artwork, A man blinded by his flag" [ref=e486] [cursor=pointer]:
+              - /url: https://www.reddit.com/gallery/1sznyef
+            - generic "Arts/Crafts" [ref=e487]
+            - generic [ref=e488]:
+              - text: (
+              - link "old.reddit.com" [ref=e489] [cursor=pointer]:
+                - /url: /domain/old.reddit.com/
+              - text: )
+          - paragraph [ref=e491]:
+            - text: submitted
+            - time [ref=e492]: 3 hours ago
+            - text: by
+            - link "hakh-ti-cxamen" [ref=e493] [cursor=pointer]:
+              - /url: https://old.reddit.com/user/hakh-ti-cxamen
+            - text: to
+            - link "r/pics" [ref=e494] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/pics/
+          - list [ref=e495]:
+            - listitem [ref=e496]:
+              - link "606 comments" [ref=e497] [cursor=pointer]:
+                - /url: https://old.reddit.com/r/pics/comments/1sznyef/oc_new_banksy_artwork_a_man_blinded_by_his_flag/
+            - listitem [ref=e498]:
+              - link "share" [ref=e499] [cursor=pointer]:
+                - /url: "javascript: void 0;"
+            - listitem [ref=e500]:
+              - link "save" [ref=e501] [cursor=pointer]:
+                - /url: "#"
+            - listitem [ref=e502]:
+              - link "hide" [ref=e505] [cursor=pointer]:
+                - /url: javascript:void(0)
+            - listitem [ref=e506]:
+              - link "report" [ref=e507] [cursor=pointer]:
+                - /url: javascript:void(0)
+      - generic [ref=e508]:
+        - paragraph
+        - generic [ref=e509]: "12"
+        - generic [ref=e510]:
+          - button "upvote" [ref=e511] [cursor=pointer]
+          - generic "12007" [ref=e512]: 12.0k
+          - button "downvote" [ref=e513] [cursor=pointer]
+        - link [ref=e514] [cursor=pointer]:
+          - /url: https://i.redd.it/yu345t8nq8yg1.jpeg
+        - generic [ref=e516]:
+          - paragraph [ref=e517]:
+            - link "Improvements" [ref=e518] [cursor=pointer]:
+              - /url: https://i.redd.it/yu345t8nq8yg1.jpeg
+            - generic [ref=e519]:
+              - text: (
+              - link "i.redd.it" [ref=e520] [cursor=pointer]:
+                - /url: /domain/i.redd.it/
+              - text: )
+          - paragraph [ref=e522]:
+            - text: submitted
+            - time [ref=e523]: 7 hours ago
+            - text: by
+            - link "Delicious_Main_4360" [ref=e524] [cursor=pointer]:
+              - /url: https://old.reddit.com/user/Delicious_Main_4360
+            - generic [ref=e525]:
+              - text: "["
+              - link "🍰" [ref=e526] [cursor=pointer]:
+                - /url: /user/Delicious_Main_4360
+              - text: "]"
+            - text: to
+            - link "r/Animemes" [ref=e527] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/Animemes/
+          - list [ref=e528]:
+            - listitem [ref=e529]:
+              - link "129 comments" [ref=e530] [cursor=pointer]:
+                - /url: https://old.reddit.com/r/Animemes/comments/1szjlq2/improvements/
+            - listitem [ref=e531]:
+              - link "share" [ref=e532] [cursor=pointer]:
+                - /url: "javascript: void 0;"
+            - listitem [ref=e533]:
+              - link "save" [ref=e534] [cursor=pointer]:
+                - /url: "#"
+            - listitem [ref=e535]:
+              - link "hide" [ref=e538] [cursor=pointer]:
+                - /url: javascript:void(0)
+            - listitem [ref=e539]:
+              - link "report" [ref=e540] [cursor=pointer]:
+                - /url: javascript:void(0)
+      - generic [ref=e541]:
+        - paragraph
+        - generic [ref=e542]: "13"
+        - generic [ref=e543]:
+          - button "upvote" [ref=e544] [cursor=pointer]
+          - generic "490" [ref=e545]
+          - button "downvote" [ref=e546] [cursor=pointer]
+        - link [ref=e547] [cursor=pointer]:
+          - /url: https://i.redd.it/din7jo0hy9yg1.png
+        - generic [ref=e549]:
+          - paragraph [ref=e550]:
+            - link "I like these guys!" [ref=e551] [cursor=pointer]:
+              - /url: https://i.redd.it/din7jo0hy9yg1.png
+            - generic "Game Content" [ref=e552]
+            - generic [ref=e553]:
+              - text: (
+              - link "i.redd.it" [ref=e554] [cursor=pointer]:
+                - /url: /domain/i.redd.it/
+              - text: )
+          - paragraph [ref=e556]:
+            - text: submitted
+            - time [ref=e557]: 3 hours ago
+            - text: by
+            - link "HauntedPutty" [ref=e558] [cursor=pointer]:
+              - /url: https://old.reddit.com/user/HauntedPutty
+            - text: to
+            - link "r/limbuscompany" [ref=e559] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/limbuscompany/
+          - list [ref=e560]:
+            - listitem [ref=e561]:
+              - link "27 comments" [ref=e562] [cursor=pointer]:
+                - /url: https://old.reddit.com/r/limbuscompany/comments/1szodzo/i_like_these_guys/
+            - listitem [ref=e563]:
+              - link "share" [ref=e564] [cursor=pointer]:
+                - /url: "javascript: void 0;"
+            - listitem [ref=e565]:
+              - link "save" [ref=e566] [cursor=pointer]:
+                - /url: "#"
+            - listitem [ref=e567]:
+              - link "hide" [ref=e570] [cursor=pointer]:
+                - /url: javascript:void(0)
+            - listitem [ref=e571]:
+              - link "report" [ref=e572] [cursor=pointer]:
+                - /url: javascript:void(0)
+      - generic [ref=e573]:
+        - paragraph
+        - generic [ref=e574]: "14"
+        - generic [ref=e575]:
+          - button "upvote" [ref=e576] [cursor=pointer]
+          - generic "2143" [ref=e577]
+          - button "downvote" [ref=e578] [cursor=pointer]
+        - link [ref=e579] [cursor=pointer]:
+          - /url: https://i.redd.it/fhs4d1c8e9yg1.jpeg
+        - generic [ref=e581]:
+          - paragraph [ref=e582]:
+            - link "T.M Opera O and the cardboard cutout of his anthropomorphized horse best friend" [ref=e583] [cursor=pointer]:
+              - /url: https://i.redd.it/fhs4d1c8e9yg1.jpeg
+            - generic "IRL Horses" [ref=e584]
+            - generic [ref=e585]:
+              - text: (
+              - link "i.redd.it" [ref=e586] [cursor=pointer]:
+                - /url: /domain/i.redd.it/
+              - text: )
+          - paragraph [ref=e588]:
+            - text: submitted
+            - time [ref=e589]: 5 hours ago
+            - text: by
+            - link "relentlesseht" [ref=e590] [cursor=pointer]:
+              - /url: https://old.reddit.com/user/relentlesseht
+            - text: to
+            - link "r/UmaMusume" [ref=e591] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/UmaMusume/
+          - list [ref=e592]:
+            - listitem [ref=e593]:
+              - link "45 comments" [ref=e594] [cursor=pointer]:
+                - /url: https://old.reddit.com/r/UmaMusume/comments/1szmaht/tm_opera_o_and_the_cardboard_cutout_of_his/
+            - listitem [ref=e595]:
+              - link "share" [ref=e596] [cursor=pointer]:
+                - /url: "javascript: void 0;"
+            - listitem [ref=e597]:
+              - link "save" [ref=e598] [cursor=pointer]:
+                - /url: "#"
+            - listitem [ref=e599]:
+              - link "hide" [ref=e602] [cursor=pointer]:
+                - /url: javascript:void(0)
+            - listitem [ref=e603]:
+              - link "report" [ref=e604] [cursor=pointer]:
+                - /url: javascript:void(0)
+      - generic [ref=e605]:
+        - paragraph
+        - generic [ref=e606]: "15"
+        - generic [ref=e607]:
+          - button "upvote" [ref=e608] [cursor=pointer]
+          - generic [ref=e609]: •
+          - button "downvote" [ref=e610] [cursor=pointer]
+        - link [ref=e611] [cursor=pointer]:
+          - /url: /r/ThailandTourism/comments/1szqjdh/how_can_i_have_a_westerner_girlfriend/
+        - generic [ref=e613]:
+          - paragraph [ref=e614]:
+            - link "How can I have a westerner girlfriend" [ref=e615] [cursor=pointer]:
+              - /url: /r/ThailandTourism/comments/1szqjdh/how_can_i_have_a_westerner_girlfriend/
+            - generic "Bangkok/Middle" [ref=e616]
+            - generic [ref=e617]:
+              - text: (
+              - link "self.ThailandTourism" [ref=e618] [cursor=pointer]:
+                - /url: /r/ThailandTourism/
+              - text: )
+          - paragraph [ref=e620]:
+            - text: submitted
+            - time [ref=e621]: 1 hour ago
+            - text: by
+            - link "hourza2545" [ref=e622] [cursor=pointer]:
+              - /url: https://old.reddit.com/user/hourza2545
+            - text: to
+            - link "r/ThailandTourism" [ref=e623] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/ThailandTourism/
+          - list [ref=e624]:
+            - listitem [ref=e625]:
+              - link "48 comments" [ref=e626] [cursor=pointer]:
+                - /url: https://old.reddit.com/r/ThailandTourism/comments/1szqjdh/how_can_i_have_a_westerner_girlfriend/
+            - listitem [ref=e627]:
+              - link "share" [ref=e628] [cursor=pointer]:
+                - /url: "javascript: void 0;"
+            - listitem [ref=e629]:
+              - link "save" [ref=e630] [cursor=pointer]:
+                - /url: "#"
+            - listitem [ref=e631]:
+              - link "hide" [ref=e634] [cursor=pointer]:
+                - /url: javascript:void(0)
+            - listitem [ref=e635]:
+              - link "report" [ref=e636] [cursor=pointer]:
+                - /url: javascript:void(0)
+      - generic [ref=e637]:
+        - paragraph
+        - generic [ref=e638]: "16"
+        - generic [ref=e639]:
+          - button "upvote" [ref=e640] [cursor=pointer]
+          - generic "224" [ref=e641]
+          - button "downvote" [ref=e642] [cursor=pointer]
+        - link [ref=e643] [cursor=pointer]:
+          - /url: https://youtu.be/ew9nVnCl8AY
+        - generic [ref=e645]:
+          - paragraph [ref=e646]:
+            - link "Season 3 Teaser - \"Before the Wind Rises\" | Zenless Zone Zero" [ref=e647] [cursor=pointer]:
+              - /url: https://youtu.be/ew9nVnCl8AY
+            - generic "(Global) News" [ref=e648]
+            - generic [ref=e649]:
+              - text: (
+              - link "youtu.be" [ref=e650] [cursor=pointer]:
+                - /url: /domain/youtu.be/
+              - text: )
+          - paragraph [ref=e652]:
+            - text: submitted
+            - time [ref=e653]: 3 hours ago
+            - text: by
+            - link "Bloodman" [ref=e654] [cursor=pointer]:
+              - /url: https://old.reddit.com/user/Bloodman
+            - text: to
+            - link "r/gachagaming" [ref=e655] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/gachagaming/
+          - list [ref=e656]:
+            - listitem [ref=e657]:
+              - link "382 comments" [ref=e658] [cursor=pointer]:
+                - /url: https://old.reddit.com/r/gachagaming/comments/1szo6pw/season_3_teaser_before_the_wind_rises_zenless/
+            - listitem [ref=e659]:
+              - link "share" [ref=e660] [cursor=pointer]:
+                - /url: "javascript: void 0;"
+            - listitem [ref=e661]:
+              - link "save" [ref=e662] [cursor=pointer]:
+                - /url: "#"
+            - listitem [ref=e663]:
+              - link "hide" [ref=e666] [cursor=pointer]:
+                - /url: javascript:void(0)
+            - listitem [ref=e667]:
+              - link "report" [ref=e668] [cursor=pointer]:
+                - /url: javascript:void(0)
+      - generic [ref=e669]:
+        - paragraph
+        - generic [ref=e670]: "17"
+        - generic [ref=e671]:
+          - button "upvote" [ref=e672] [cursor=pointer]
+          - generic "611" [ref=e673]
+          - button "downvote" [ref=e674] [cursor=pointer]
+        - link [ref=e675] [cursor=pointer]:
+          - /url: https://www.reddit.com/gallery/1szkdt2
+        - generic [ref=e677]:
+          - paragraph [ref=e678]:
+            - link "New Info about Ricardo and the Middle (Information from Uptie 3 Big Brother Heathcliff)" [ref=e679] [cursor=pointer]:
+              - /url: https://www.reddit.com/gallery/1szkdt2
+            - generic "Game Content" [ref=e680]
+            - generic [ref=e681]:
+              - text: (
+              - link "old.reddit.com" [ref=e682] [cursor=pointer]:
+                - /url: /domain/old.reddit.com/
+              - text: )
+          - paragraph [ref=e684]:
+            - text: submitted
+            - time [ref=e685]: 6 hours ago
+            - text: by
+            - link "Violeties" [ref=e686] [cursor=pointer]:
+              - /url: https://old.reddit.com/user/Violeties
+            - text: to
+            - link "r/limbuscompany" [ref=e687] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/limbuscompany/
+          - list [ref=e688]:
+            - listitem [ref=e689]:
+              - generic [ref=e690]: SPOILER
+            - listitem [ref=e691]:
+              - link "49 comments" [ref=e692] [cursor=pointer]:
+                - /url: https://old.reddit.com/r/limbuscompany/comments/1szkdt2/new_info_about_ricardo_and_the_middle_information/
+            - listitem [ref=e693]:
+              - link "share" [ref=e694] [cursor=pointer]:
+                - /url: "javascript: void 0;"
+            - listitem [ref=e695]:
+              - link "save" [ref=e696] [cursor=pointer]:
+                - /url: "#"
+            - listitem [ref=e697]:
+              - link "hide" [ref=e700] [cursor=pointer]:
+                - /url: javascript:void(0)
+            - listitem [ref=e701]:
+              - link "report" [ref=e702] [cursor=pointer]:
+                - /url: javascript:void(0)
+      - generic [ref=e703]:
+        - paragraph
+        - generic [ref=e704]: "18"
+        - generic [ref=e705]:
+          - button "upvote" [ref=e706] [cursor=pointer]
+          - generic "4240" [ref=e707]
+          - button "downvote" [ref=e708] [cursor=pointer]
+        - link [ref=e709] [cursor=pointer]:
+          - /url: https://www.reddit.com/gallery/1szg31g
+        - generic [ref=e711]:
+          - paragraph [ref=e712]:
+            - link "Justchads but humanization (by @kikikiko84)" [ref=e713] [cursor=pointer]:
+              - /url: https://www.reddit.com/gallery/1szg31g
+            - generic "Fan Content (Non-OP)" [ref=e714]
+            - generic [ref=e715]:
+              - text: (
+              - link "old.reddit.com" [ref=e716] [cursor=pointer]:
+                - /url: /domain/old.reddit.com/
+              - text: )
+          - paragraph [ref=e718]:
+            - text: submitted
+            - time [ref=e719]: 9 hours ago
+            - text: by
+            - link "ldg-9743" [ref=e720] [cursor=pointer]:
+              - /url: https://old.reddit.com/user/ldg-9743
+            - text: to
+            - link "r/Hololive" [ref=e721] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/Hololive/
+          - list [ref=e722]:
+            - listitem [ref=e723]:
+              - link "60 comments" [ref=e724] [cursor=pointer]:
+                - /url: https://old.reddit.com/r/Hololive/comments/1szg31g/justchads_but_humanization_by_kikikiko84/
+            - listitem [ref=e725]:
+              - link "share" [ref=e726] [cursor=pointer]:
+                - /url: "javascript: void 0;"
+            - listitem [ref=e727]:
+              - link "save" [ref=e728] [cursor=pointer]:
+                - /url: "#"
+            - listitem [ref=e729]:
+              - link "hide" [ref=e732] [cursor=pointer]:
+                - /url: javascript:void(0)
+            - listitem [ref=e733]:
+              - link "report" [ref=e734] [cursor=pointer]:
+                - /url: javascript:void(0)
+      - generic [ref=e735]:
+        - paragraph
+        - generic [ref=e736]: "19"
+        - generic [ref=e737]:
+          - button "upvote" [ref=e738] [cursor=pointer]
+          - generic "381" [ref=e739]
+          - button "downvote" [ref=e740] [cursor=pointer]
+        - link [ref=e741] [cursor=pointer]:
+          - /url: https://v.redd.it/4dyzcckbr9yg1
+        - generic [ref=e743]:
+          - paragraph [ref=e744]:
+            - link "Middle Heathcliff 5-30 Interaction" [ref=e745] [cursor=pointer]:
+              - /url: https://v.redd.it/4dyzcckbr9yg1
+            - generic "Game Content" [ref=e746]
+            - generic [ref=e747]:
+              - text: (
+              - link "v.redd.it" [ref=e748] [cursor=pointer]:
+                - /url: /domain/v.redd.it/
+              - text: )
+          - paragraph [ref=e750]:
+            - text: submitted
+            - time [ref=e751]: 3 hours ago
+            - text: by
+            - link "Timekilling_Time" [ref=e752] [cursor=pointer]:
+              - /url: https://old.reddit.com/user/Timekilling_Time
+            - text: to
+            - link "r/limbuscompany" [ref=e753] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/limbuscompany/
+          - list [ref=e754]:
+            - listitem [ref=e755]:
+              - generic [ref=e756]: SPOILER
+            - listitem [ref=e757]:
+              - link "52 comments" [ref=e758] [cursor=pointer]:
+                - /url: https://old.reddit.com/r/limbuscompany/comments/1sznoe1/middle_heathcliff_530_interaction/
+            - listitem [ref=e759]:
+              - link "share" [ref=e760] [cursor=pointer]:
+                - /url: "javascript: void 0;"
+            - listitem [ref=e761]:
+              - link "save" [ref=e762] [cursor=pointer]:
+                - /url: "#"
+            - listitem [ref=e763]:
+              - link "hide" [ref=e766] [cursor=pointer]:
+                - /url: javascript:void(0)
+            - listitem [ref=e767]:
+              - link "report" [ref=e768] [cursor=pointer]:
+                - /url: javascript:void(0)
+      - generic [ref=e769]:
+        - paragraph
+        - generic [ref=e770]: "20"
+        - generic [ref=e771]:
+          - button "upvote" [ref=e772] [cursor=pointer]
+          - generic "6201" [ref=e773]
+          - button "downvote" [ref=e774] [cursor=pointer]
+        - link [ref=e775] [cursor=pointer]:
+          - /url: https://i.redd.it/hqu9cbe0j8yg1.jpeg
+        - generic [ref=e777]:
+          - paragraph [ref=e778]:
+            - link "Nana thank you for your attention to this matter!" [ref=e779] [cursor=pointer]:
+              - /url: https://i.redd.it/hqu9cbe0j8yg1.jpeg
+            - generic "YOLO" [ref=e780]
+            - generic [ref=e781]:
+              - text: (
+              - link "i.redd.it" [ref=e782] [cursor=pointer]:
+                - /url: /domain/i.redd.it/
+              - text: )
+          - paragraph [ref=e784]:
+            - text: submitted
+            - time [ref=e785]: 7 hours ago
+            - text: by
+            - link "FunctionOk8962" [ref=e786] [cursor=pointer]:
+              - /url: https://old.reddit.com/user/FunctionOk8962
+            - text: to
+            - link "r/wallstreetbets" [ref=e787] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/wallstreetbets/
+          - list [ref=e788]:
+            - listitem [ref=e789]:
+              - link "590 comments" [ref=e790] [cursor=pointer]:
+                - /url: https://old.reddit.com/r/wallstreetbets/comments/1szioki/nana_thank_you_for_your_attention_to_this_matter/
+            - listitem [ref=e791]:
+              - link "share" [ref=e792] [cursor=pointer]:
+                - /url: "javascript: void 0;"
+            - listitem [ref=e793]:
+              - link "save" [ref=e794] [cursor=pointer]:
+                - /url: "#"
+            - listitem [ref=e795]:
+              - link "hide" [ref=e798] [cursor=pointer]:
+                - /url: javascript:void(0)
+            - listitem [ref=e799]:
+              - link "report" [ref=e800] [cursor=pointer]:
+                - /url: javascript:void(0)
+      - generic [ref=e801]:
+        - paragraph
+        - generic [ref=e802]: "21"
+        - generic [ref=e803]:
+          - button "upvote" [ref=e804] [cursor=pointer]
+          - generic "3808" [ref=e805]
+          - button "downvote" [ref=e806] [cursor=pointer]
+        - link "0:12" [ref=e807] [cursor=pointer]:
+          - /url: https://v.redd.it/xgi4wjdcz9yg1
+          - generic [ref=e808]: 0:12
+        - generic [ref=e810]:
+          - paragraph [ref=e811]:
+            - link "Residential apartment with Artificial Mountain for fengshui reason in Shanghai" [ref=e812] [cursor=pointer]:
+              - /url: https://v.redd.it/xgi4wjdcz9yg1
+            - generic "Video" [ref=e813]
+            - generic [ref=e814]:
+              - text: (
+              - link "v.redd.it" [ref=e815] [cursor=pointer]:
+                - /url: /domain/v.redd.it/
+              - text: )
+          - paragraph [ref=e817]:
+            - text: submitted
+            - time [ref=e818]: 3 hours ago
+            - text: by
+            - link "BumblebeeFantastic40" [ref=e819] [cursor=pointer]:
+              - /url: https://old.reddit.com/user/BumblebeeFantastic40
+            - text: to
+            - link "r/Damnthatsinteresting" [ref=e820] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/Damnthatsinteresting/
+          - list [ref=e821]:
+            - listitem [ref=e822]:
+              - link "186 comments" [ref=e823] [cursor=pointer]:
+                - /url: https://old.reddit.com/r/Damnthatsinteresting/comments/1szoggt/residential_apartment_with_artificial_mountain/
+            - listitem [ref=e824]:
+              - link "share" [ref=e825] [cursor=pointer]:
+                - /url: "javascript: void 0;"
+            - listitem [ref=e826]:
+              - link "save" [ref=e827] [cursor=pointer]:
+                - /url: "#"
+            - listitem [ref=e828]:
+              - link "hide" [ref=e831] [cursor=pointer]:
+                - /url: javascript:void(0)
+            - listitem [ref=e832]:
+              - link "report" [ref=e833] [cursor=pointer]:
+                - /url: javascript:void(0)
+      - generic [ref=e834]:
+        - paragraph
+        - generic [ref=e835]: "22"
+        - generic [ref=e836]:
+          - button "upvote" [ref=e837] [cursor=pointer]
+          - generic "2088" [ref=e838]
+          - button "downvote" [ref=e839] [cursor=pointer]
+        - link [ref=e840] [cursor=pointer]:
+          - /url: https://i.redd.it/v7xg5mm1u9yg1.png
+        - generic [ref=e842]:
+          - paragraph [ref=e843]:
+            - link "MyEthnicity starterpack" [ref=e844] [cursor=pointer]:
+              - /url: https://i.redd.it/v7xg5mm1u9yg1.png
+            - generic [ref=e845]:
+              - text: (
+              - link "i.redd.it" [ref=e846] [cursor=pointer]:
+                - /url: /domain/i.redd.it/
+              - text: )
+          - paragraph [ref=e848]:
+            - text: submitted
+            - time [ref=e849]: 3 hours ago
+            - text: by
+            - link "Impossible_Driver111" [ref=e850] [cursor=pointer]:
+              - /url: https://old.reddit.com/user/Impossible_Driver111
+            - text: to
+            - link "r/starterpacks" [ref=e851] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/starterpacks/
+          - list [ref=e852]:
+            - listitem [ref=e853]:
+              - link "260 comments" [ref=e854] [cursor=pointer]:
+                - /url: https://old.reddit.com/r/starterpacks/comments/1szny8w/myethnicity_starterpack/
+            - listitem [ref=e855]:
+              - link "share" [ref=e856] [cursor=pointer]:
+                - /url: "javascript: void 0;"
+            - listitem [ref=e857]:
+              - link "save" [ref=e858] [cursor=pointer]:
+                - /url: "#"
+            - listitem [ref=e859]:
+              - link "hide" [ref=e862] [cursor=pointer]:
+                - /url: javascript:void(0)
+            - listitem [ref=e863]:
+              - link "report" [ref=e864] [cursor=pointer]:
+                - /url: javascript:void(0)
+      - generic [ref=e865]:
+        - paragraph
+        - generic [ref=e866]: "23"
+        - generic [ref=e867]:
+          - button "upvote" [ref=e868] [cursor=pointer]
+          - generic "11191" [ref=e869]: 11.2k
+          - button "downvote" [ref=e870] [cursor=pointer]
+        - link [ref=e871] [cursor=pointer]:
+          - /url: https://i.redd.it/xsvj6kjl29yg1.jpeg
+        - generic [ref=e873]:
+          - paragraph [ref=e874]:
+            - link "Petah, why is this arm poor?" [ref=e875] [cursor=pointer]:
+              - /url: https://i.redd.it/xsvj6kjl29yg1.jpeg
+            - generic "Meme needing explanation" [ref=e876]
+            - generic [ref=e877]:
+              - text: (
+              - link "i.redd.it" [ref=e878] [cursor=pointer]:
+                - /url: /domain/i.redd.it/
+              - text: )
+          - paragraph [ref=e880]:
+            - text: submitted
+            - time [ref=e881]: 6 hours ago
+            - text: by
+            - link "AnnualZealousideal27" [ref=e882] [cursor=pointer]:
+              - /url: https://old.reddit.com/user/AnnualZealousideal27
+            - text: to
+            - link "r/PeterExplainsTheJoke" [ref=e883] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/PeterExplainsTheJoke/
+          - list [ref=e884]:
+            - listitem [ref=e885]:
+              - link "234 comments" [ref=e886] [cursor=pointer]:
+                - /url: https://old.reddit.com/r/PeterExplainsTheJoke/comments/1szl085/petah_why_is_this_arm_poor/
+            - listitem [ref=e887]:
+              - link "share" [ref=e888] [cursor=pointer]:
+                - /url: "javascript: void 0;"
+            - listitem [ref=e889]:
+              - link "save" [ref=e890] [cursor=pointer]:
+                - /url: "#"
+            - listitem [ref=e891]:
+              - link "hide" [ref=e894] [cursor=pointer]:
+                - /url: javascript:void(0)
+            - listitem [ref=e895]:
+              - link "report" [ref=e896] [cursor=pointer]:
+                - /url: javascript:void(0)
+      - generic [ref=e897]:
+        - paragraph
+        - generic [ref=e898]: "24"
+        - generic [ref=e899]:
+          - button "upvote" [ref=e900] [cursor=pointer]
+          - generic "1756" [ref=e901]
+          - button "downvote" [ref=e902] [cursor=pointer]
+        - link "0:33" [ref=e903] [cursor=pointer]:
+          - /url: https://v.redd.it/i8ioatrka9yg1
+          - generic [ref=e904]: 0:33
+        - generic [ref=e906]:
+          - paragraph [ref=e907]:
+            - link "[ZZZ - 3.0 BETA] Velina Animations Via Mero" [ref=e908] [cursor=pointer]:
+              - /url: https://v.redd.it/i8ioatrka9yg1
+            - generic "Reliable" [ref=e909]
+            - generic [ref=e910]:
+              - text: (
+              - link "v.redd.it" [ref=e911] [cursor=pointer]:
+                - /url: /domain/v.redd.it/
+              - text: )
+          - paragraph [ref=e913]:
+            - text: submitted
+            - time [ref=e914]: 5 hours ago
+            - text: by
+            - link "joshxleon" [ref=e915] [cursor=pointer]:
+              - /url: https://old.reddit.com/user/joshxleon
+            - text: to
+            - link "r/Zenlesszonezeroleaks_" [ref=e916] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/Zenlesszonezeroleaks_/
+          - list [ref=e917]:
+            - listitem [ref=e918]:
+              - link "194 comments" [ref=e919] [cursor=pointer]:
+                - /url: https://old.reddit.com/r/Zenlesszonezeroleaks_/comments/1szlwh6/zzz_30_beta_velina_animations_via_mero/
+            - listitem [ref=e920]:
+              - link "share" [ref=e921] [cursor=pointer]:
+                - /url: "javascript: void 0;"
+            - listitem [ref=e922]:
+              - link "save" [ref=e923] [cursor=pointer]:
+                - /url: "#"
+            - listitem [ref=e924]:
+              - link "hide" [ref=e927] [cursor=pointer]:
+                - /url: javascript:void(0)
+            - listitem [ref=e928]:
+              - link "report" [ref=e929] [cursor=pointer]:
+                - /url: javascript:void(0)
+      - generic [ref=e930]:
+        - paragraph
+        - generic [ref=e931]: "25"
+        - generic [ref=e932]:
+          - button "upvote" [ref=e933] [cursor=pointer]
+          - generic "2961" [ref=e934]
+          - button "downvote" [ref=e935] [cursor=pointer]
+        - link [ref=e936] [cursor=pointer]:
+          - /url: https://i.redd.it/rxunlhkoe8yg1.png
+        - generic [ref=e938]:
+          - paragraph [ref=e939]:
+            - link "Is this supposed to be a dig at Japanese declining birth rates?" [ref=e940] [cursor=pointer]:
+              - /url: https://i.redd.it/rxunlhkoe8yg1.png
+            - generic "Meme / Fluff" [ref=e941]
+            - generic [ref=e942]:
+              - text: (
+              - link "i.redd.it" [ref=e943] [cursor=pointer]:
+                - /url: /domain/i.redd.it/
+              - text: )
+          - paragraph [ref=e945]:
+            - text: submitted
+            - time [ref=e946]: 8 hours ago
+            - text: by
+            - link "Knight_Steve_" [ref=e947] [cursor=pointer]:
+              - /url: https://old.reddit.com/user/Knight_Steve_
+            - text: to
+            - link "r/HonkaiStarRail" [ref=e948] [cursor=pointer]:
+              - /url: https://old.reddit.com/r/HonkaiStarRail/
+          - list [ref=e949]:
+            - listitem [ref=e950]:
+              - link "136 comments" [ref=e951] [cursor=pointer]:
+                - /url: https://old.reddit.com/r/HonkaiStarRail/comments/1szi3x2/is_this_supposed_to_be_a_dig_at_japanese/
+            - listitem [ref=e952]:
+              - link "share" [ref=e953] [cursor=pointer]:
+                - /url: "javascript: void 0;"
+            - listitem [ref=e954]:
+              - link "save" [ref=e955] [cursor=pointer]:
+                - /url: "#"
+            - listitem [ref=e956]:
+              - link "hide" [ref=e959] [cursor=pointer]:
+                - /url: javascript:void(0)
+            - listitem [ref=e960]:
+              - link "report" [ref=e961] [cursor=pointer]:
+                - /url: javascript:void(0)
+      - generic [ref=e963]:
+        - text: "view more:"
+        - link "next ›" [ref=e965] [cursor=pointer]:
+          - /url: https://old.reddit.com/?count=25&after=t3_1szi3x2
+  - generic [ref=e966]:
+    - generic [ref=e967]:
+      - list [ref=e969]:
+        - listitem [ref=e970]: about
+        - listitem [ref=e971]:
+          - link "blog" [ref=e972] [cursor=pointer]:
+            - /url: https://redditblog.com
+        - listitem [ref=e973]:
+          - link "about" [ref=e974] [cursor=pointer]:
+            - /url: https://www.redditinc.com
+        - listitem [ref=e975]:
+          - link "advertising" [ref=e976] [cursor=pointer]:
+            - /url: https://www.redditinc.com/advertising
+        - listitem [ref=e977]:
+          - link "careers" [ref=e978] [cursor=pointer]:
+            - /url: https://www.redditinc.com/careers
+      - list [ref=e980]:
+        - listitem [ref=e981]: help
+        - listitem [ref=e982]:
+          - link "site rules" [ref=e983] [cursor=pointer]:
+            - /url: https://old.reddit.com/rules/
+        - listitem [ref=e984]:
+          - link "Reddit help center" [ref=e985] [cursor=pointer]:
+            - /url: https://www.reddithelp.com
+        - listitem [ref=e986]:
+          - link "reddiquette" [ref=e987] [cursor=pointer]:
+            - /url: https://old.reddit.com/wiki/reddiquette/
+        - listitem [ref=e988]:
+          - link "mod guidelines" [ref=e989] [cursor=pointer]:
+            - /url: https://old.reddit.com/help/healthycommunities/
+        - listitem [ref=e990]:
+          - link "contact us" [ref=e991] [cursor=pointer]:
+            - /url: https://old.reddit.com/contact/
+      - list [ref=e993]:
+        - listitem [ref=e994]: apps & tools
+        - listitem [ref=e995]:
+          - link "Reddit for iPhone" [ref=e996] [cursor=pointer]:
+            - /url: https://itunes.apple.com/us/app/reddit-the-official-app/id1064216828?mt=8
+        - listitem [ref=e997]:
+          - link "Reddit for Android" [ref=e998] [cursor=pointer]:
+            - /url: https://play.google.com/store/apps/details?id=com.reddit.frontpage
+        - listitem [ref=e999]:
+          - link "mobile website" [ref=e1000] [cursor=pointer]:
+            - /url: "#"
+      - list [ref=e1002]:
+        - listitem [ref=e1003]: <3
+        - listitem [ref=e1004]:
+          - link "reddit premium" [ref=e1005] [cursor=pointer]:
+            - /url: https://old.reddit.com/premium/
+    - paragraph [ref=e1006]:
+      - text: Use of this site constitutes acceptance of our
+      - link "User Agreement" [ref=e1007] [cursor=pointer]:
+        - /url: https://old.reddit.com/help/useragreement
+      - text: and
+      - link "Privacy Policy" [ref=e1008] [cursor=pointer]:
+        - /url: https://old.reddit.com/help/privacypolicy
+      - text: . © 2026 reddit inc. All rights reserved.
+    - paragraph [ref=e1009]: REDDIT and the ALIEN Logo are registered trademarks of reddit inc.
+  - img [ref=e1010]
+  - paragraph [ref=e1011]: π

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) · Versioning: 
 
 ## [Unreleased]
 
+## [1.2.0] — 2026-04-17
+
+### Added
+- **Ghost Bench** — in-dashboard benchmark system with 14 built-in tasks (settings + navigation). Runner with SSE live streaming. New `Benchmarks` tab in the dashboard. Foundation for Phase 2 (real AndroidWorld integration).
+- **7 benchmark API endpoints** (`/api/benchmarks/*`) — list suites, start run, stream events, past runs, stop.
+- **Live Ollama model discovery** — new `GET /api/agent-chat/providers` endpoint queries `localhost:11434/api/tags` so the dropdown shows actually-installed models, not a hardcoded list.
+- **Background Ollama model pull** — endpoint to pull new models without blocking the UI, with live status tracking.
+
+### Changed
+- Frontend model selector fetches providers on mount instead of relying on hardcoded constants.
+- Better errors when Ollama isn't running or a requested model isn't installed.
+
+### Fixed
+- Confusing "connection error" when user selected a model not installed locally — now says "model X not found, pull it first" with a pull button.
+
 ## [1.1.0] — 2026-04-16
 
 ### Added
@@ -40,6 +55,7 @@ Initial open-source release of Ghost in the Droid.
 - Skill Hub (registry of reusable skills)
 - Agent Chat (LLM-driven device control via Claude / Claude Code / OpenRouter / Ollama)
 
-[Unreleased]: https://github.com/ghost-in-the-droid/android-agent/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/ghost-in-the-droid/android-agent/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/ghost-in-the-droid/android-agent/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/ghost-in-the-droid/android-agent/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/ghost-in-the-droid/android-agent/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to Ghost in the Droid are documented here.
+
+Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) · Versioning: [Semantic](https://semver.org/)
+
+## [Unreleased]
+
+## [1.1.0] — 2026-04-16
+
+### Added
+- **Ollama support** — multi-turn tool-using loop for local models. Zero API keys needed. Pre-filled dropdown: `llama3.2:3b`, `llama3.2:1b`, `gemma3:4b`, `qwen3:4b`, `phi4-mini:3.8b`, `mistral:7b`.
+- **`_parse_tool_calls()`** — robust tool-call extractor handling common LLM JSON quirks (doubled braces from gemma/qwen, trailing commas, etc.).
+- **Ollama unload button** — free GPU memory between chats.
+- **Emulator support (full stack)** — FastAPI router, Pool management, 4 Vue components, 21 REST endpoints. See `gitd/services/emulator_service.py`.
+- **Mac / Apple Silicon support** — HVF hardware acceleration, arm64-v8a auto-detection, Homebrew SDK path detection.
+- **MCP distribution** — `.mcp.json` ships with the repo; 35 tools available on first clone.
+- **PyPI package** — `uvx --from ghost-in-the-droid android-agent-mcp` runs the MCP server without cloning.
+- **CI/CD release pipeline** — push a `v*` tag → auto-publish to PyPI.
+
+### Changed
+- **Flask → FastAPI** — emulator router fully migrated to `APIRouter` + Pydantic models.
+- **README & SETUP.md** — MCP install docs, emulator install docs, multi-client install snippets (Claude Code, Claude Desktop, Cursor, VS Code Copilot, Windsurf).
+
+### Fixed
+- `pyproject.toml` — `dependencies` was mis-nested under `[project.urls]`.
+- Import sort in `gitd/app.py` (ruff I001).
+
+## [1.0.0] — 2026-04-08
+
+Initial open-source release of Ghost in the Droid.
+
+### Added
+- FastAPI backend (`gitd/` package), Vue 3 frontend
+- Skills framework (Action / Workflow / Skill with YAML element locators)
+- ADB automation primitives (`Device` class: tap, swipe, type, XML dump, screen classification)
+- Portal companion APK for on-device streaming & notifications
+- MCP server with 35 tools for Android control
+- WebRTC screen streaming
+- Skill Hub (registry of reusable skills)
+- Agent Chat (LLM-driven device control via Claude / Claude Code / OpenRouter / Ollama)
+
+[Unreleased]: https://github.com/ghost-in-the-droid/android-agent/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/ghost-in-the-droid/android-agent/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/ghost-in-the-droid/android-agent/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ Copy `.env.example` to `.env` (if provided) or create a `.env` file in the proje
 | `OPENROUTER_API_KEY` | OpenRouter LLM provider |
 | `DEFAULT_DEVICE` | ADB serial (auto-detected if empty) |
 
+**No API keys needed for local models:** Select Ollama in the Phone Agent tab — runs entirely on your machine with [Ollama](https://ollama.com). Install, pull a model, go:
+
+```bash
+brew install ollama       # or curl -fsSL https://ollama.com/install.sh | sh
+ollama serve &
+ollama pull llama3.2:3b   # 2GB, fast, good tool-use
+```
+
 ---
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -165,7 +165,79 @@ API domains: phone, streaming, skills, creator, explorer, agent-chat, bot, sched
 | Tools | Utility tools hub |
 | Manual Run | Start/stop bot jobs, queue management, logs |
 | Tests | Per-device test runner with screen recording playback |
-| Emulators | Headless emulator management (coming soon) |
+| Emulators | Create, boot, snapshot, and manage Android emulators |
+
+---
+
+## MCP Server — Give Any AI Agent an Android Body
+
+The project ships an [MCP](https://modelcontextprotocol.io) server with 35 tools for Android control. Any MCP-compatible AI client (Claude Code, Claude Desktop, Cursor, VS Code Copilot, Windsurf) can use them.
+
+### Install
+
+One command — works with Claude Code, Codex, Cursor, VS Code Copilot, Windsurf:
+
+```bash
+claude mcp add android-agent -- uvx --from ghost-in-the-droid android-agent-mcp
+```
+
+That's it. `uvx` installs the package, creates an isolated env, and runs the MCP server. No clone, no venv, no manual setup.
+
+**Other clients** — same command, different registration:
+
+```bash
+# Codex (OpenAI)
+codex mcp add android-agent -- uvx --from ghost-in-the-droid android-agent-mcp
+```
+
+**Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+```json
+{
+  "mcpServers": {
+    "android-agent": {
+      "command": "uvx",
+      "args": ["--from", "ghost-in-the-droid", "android-agent-mcp"]
+    }
+  }
+}
+```
+
+**VS Code Copilot** (`.vscode/mcp.json`):
+```json
+{
+  "servers": {
+    "android-agent": {
+      "command": "uvx",
+      "args": ["--from", "ghost-in-the-droid", "android-agent-mcp"]
+    }
+  }
+}
+```
+
+**Cursor** (`.cursor/mcp.json`) / **Windsurf** (`~/.codeium/windsurf/mcp_config.json`):
+```json
+{
+  "mcpServers": {
+    "android-agent": {
+      "command": "uvx",
+      "args": ["--from", "ghost-in-the-droid", "android-agent-mcp"]
+    }
+  }
+}
+```
+
+**For contributors** who clone the repo: the `.mcp.json` is already there — 35 tools available on first `claude` launch.
+
+### Available tools
+
+| Category | Tools |
+|----------|-------|
+| Screen | `screenshot`, `get_elements`, `get_screen_tree`, `get_screen_xml`, `screenshot_annotated`, `screenshot_cropped` |
+| Interaction | `tap`, `tap_element`, `swipe`, `long_press`, `type_text`, `type_unicode`, `press_back`, `press_home`, `press_key` |
+| Apps | `launch_app`, `search_apps`, `list_apps`, `launch_intent` |
+| Context | `get_phone_state`, `classify_screen`, `find_on_screen`, `ocr_screen`, `ocr_region` |
+| Device | `list_devices`, `clipboard_get`, `clipboard_set`, `get_notifications`, `open_notifications`, `toggle_overlay` |
+| Skills | `list_skills`, `run_workflow`, `run_action`, `create_skill`, `explore_app` |
 
 ---
 

--- a/docker-compose.langfuse.yml
+++ b/docker-compose.langfuse.yml
@@ -1,0 +1,48 @@
+version: "3.9"
+
+# Langfuse self-hosted — run on the Mac. Web UI at http://localhost:3000
+#
+#   docker compose -f docker-compose.langfuse.yml up -d
+#   open http://localhost:3000
+#   → sign up (local-only, first user becomes admin)
+#   → create project → copy public/secret keys → paste into .env
+#
+# To let the phone (Chaquopy on-device provider) report to this same instance:
+#   adb -s <serial> reverse tcp:3000 tcp:3000
+# then on Android side LANGFUSE_HOST=http://127.0.0.1:3000 works as if local.
+
+services:
+  langfuse-db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: langfuse
+      POSTGRES_PASSWORD: langfuse
+      POSTGRES_DB: langfuse
+    volumes:
+      - langfuse_pg_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U langfuse"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  langfuse:
+    image: langfuse/langfuse:2  # pinned to v2 for single-container simplicity
+    restart: unless-stopped
+    depends_on:
+      langfuse-db:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://langfuse:langfuse@langfuse-db:5432/langfuse
+      NEXTAUTH_URL: http://localhost:3000
+      NEXTAUTH_SECRET: dev-secret-change-me-in-prod
+      SALT: dev-salt-change-me-in-prod
+      TELEMETRY_ENABLED: "false"
+      LANGFUSE_DEFAULT_PROJECT_ROLE: ADMIN
+      AUTH_DISABLE_SIGNUP: "false"
+    ports:
+      - "3000:3000"
+
+volumes:
+  langfuse_pg_data:

--- a/docs/LLAMA_CPP_INTEGRATION.md
+++ b/docs/LLAMA_CPP_INTEGRATION.md
@@ -1,0 +1,162 @@
+# llama.cpp Android — integration plan
+
+**Status:** Kotlin scaffolding is shipped; native lib not yet built into the APK.
+**Why:** Google's MediaPipe Android SDK doesn't ship a loadable Gemma 4 `.task`
+yet — only `-web.task` (browser-only) and `.litertlm` (new SDK not on Maven).
+llama.cpp main branch supports Gemma 4 in GGUF, so that's the path to true
+on-device Gemma 4.
+
+## What's already in place
+
+- `app/src/main/java/com/ghostinthedroid/app/ondevice/OnDeviceModel.kt` —
+  added `Runtime { MEDIAPIPE, LLAMA_CPP }` enum field on `OnDeviceModel`.
+- `LlamaCppLLM.kt` — singleton mirror of `OnDeviceLLM`'s API
+  (`init`, `ensureLoaded`, `generate`, `unload`). Native methods are declared
+  but unimplemented; calls return `[on-device error: llama.cpp not wired yet …]`
+  until the JNI lib lands.
+- `OnDeviceLLM.kt` — delegates to `LlamaCppLLM` when the model's `runtime ==
+  LLAMA_CPP`. So registering a GGUF-backed model in `OnDeviceModelRegistry`
+  with `runtime = Runtime.LLAMA_CPP` immediately routes through the new path.
+- `app/build.gradle.kts` — unchanged (no new gradle wiring yet, see step 3).
+
+This means the Kotlin compiler stays green, the existing MediaPipe path is
+untouched, and we have a single API for both backends.
+
+## What still needs to happen (~half day)
+
+### 1. Vendor llama.cpp source
+
+```bash
+cd ghost-app/app/src/main
+git submodule add https://github.com/ggerganov/llama.cpp cpp/llama.cpp
+git submodule update --init --recursive
+```
+
+llama.cpp itself is the source of truth — we don't fork. Pin to a tag
+(e.g. `b4500` or whatever the latest with Gemma 4 support is) so builds
+are reproducible.
+
+### 2. Tiny JNI bridge
+
+Write `app/src/main/cpp/llama_jni.cpp` (~100 lines). Skeleton:
+
+```cpp
+#include <jni.h>
+#include "llama.h"
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_com_ghostinthedroid_app_ondevice_LlamaCppLLM_nativeLoadModel(
+    JNIEnv* env, jobject /* this */, jstring path, jint maxTokens) {
+    const char* path_chars = env->GetStringUTFChars(path, nullptr);
+    llama_model_params model_params = llama_model_default_params();
+    llama_model* model = llama_load_model_from_file(path_chars, model_params);
+    env->ReleaseStringUTFChars(path, path_chars);
+    if (!model) return 0;
+
+    llama_context_params ctx_params = llama_context_default_params();
+    ctx_params.n_ctx = maxTokens;
+    llama_context* ctx = llama_new_context_with_model(model, ctx_params);
+    // pack {model, ctx} into a struct, return its pointer as jlong
+    auto* handle = new LlamaHandle{model, ctx};
+    return reinterpret_cast<jlong>(handle);
+}
+
+// nativeGenerate — tokenize prompt, sample tokens until <end_of_turn>, return string
+// nativeFreeModel — delete LlamaHandle
+```
+
+Match function names to the `external fun` declarations in `LlamaCppLLM.kt`
+(JNI auto-binds by `Java_<package>_<class>_<method>`).
+
+### 3. CMakeLists for the NDK build
+
+`app/src/main/cpp/CMakeLists.txt`:
+
+```cmake
+cmake_minimum_required(VERSION 3.22)
+project(llama_jni)
+
+# Tell llama.cpp we're targeting Android
+set(LLAMA_NATIVE OFF)
+set(GGML_OPENMP OFF)  # Android NDK doesn't ship openmp by default
+add_subdirectory(llama.cpp EXCLUDE_FROM_ALL)
+
+add_library(llama_jni SHARED llama_jni.cpp)
+target_link_libraries(llama_jni llama android log)
+```
+
+Wire from gradle:
+
+```kotlin
+// app/build.gradle.kts
+android {
+    defaultConfig {
+        externalNativeBuild {
+            cmake { arguments += listOf("-DGGML_OPENMP=OFF") }
+        }
+    }
+    externalNativeBuild {
+        cmake {
+            path = file("src/main/cpp/CMakeLists.txt")
+            version = "3.22.1"
+        }
+    }
+}
+```
+
+### 4. Register Gemma 4 entries in OnDeviceModelRegistry
+
+```kotlin
+OnDeviceModel(
+    id = "gemma-4-e2b",
+    displayName = "Gemma 4 E2B (Q4_K_M)",
+    downloadUrl = "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_K_M.gguf",
+    sizeBytes = 3_106_735_776L,
+    runtime = Runtime.LLAMA_CPP,
+    supportsImages = false,  // text-only via llama.cpp; mmproj support is separate
+    maxTokens = 4096,
+),
+OnDeviceModel(
+    id = "ghost-gemma",
+    displayName = "Ghost-Gemma E4B (fine-tune, Q4_K_M)",
+    downloadUrl = "https://huggingface.co/ghost-in-the-droid/ghost-gemma-E4B-GGUF/resolve/main/ghost-gemma-E4B-Q4_K_M.gguf",  // when published
+    sizeBytes = 5_335_289_888L,
+    runtime = Runtime.LLAMA_CPP,
+    maxTokens = 4096,
+),
+```
+
+These show up in the model picker automatically (no UI changes needed).
+
+### 5. Verify
+
+- `./gradlew :app:assembleDebug` — should compile native lib + APK
+- Install + open model picker → see Gemma 4 entries
+- Tap Download — file downloads via existing `ModelDownloader` (unchanged)
+- Send a chat with `provider=on-device, model=gemma-4-e2b` — routes through
+  `OnDeviceLLM.generate` → sees `runtime=LLAMA_CPP` → delegates to
+  `LlamaCppLLM.generate` → JNI → llama.cpp inference → response streams back
+  → trace shows in the in-app Traces tab with `provider=on-device, model=gemma-4-e2b`
+
+### 6. Optional polish
+
+- **Streaming**: llama.cpp emits tokens one at a time; expose a callback-based
+  `generate` that yields each token to the chat loop for real-time TTS.
+- **Vision via mmproj**: Gemma 4 multimodal needs the separate
+  `mmproj-gemma-4-E2B-it-bf16.gguf` file; llama.cpp loads it as a paired
+  encoder. Out of scope for v1.
+- **GPU offload**: phones with Adreno can run llama.cpp's Vulkan backend;
+  fall back to CPU otherwise.
+
+## Risks
+
+- **APK size**: vendored llama.cpp + the .so for arm64-v8a + x86_64 adds
+  ~30-40 MB to the APK. Acceptable for hackathon, can split-APK later.
+- **Build time**: first NDK build is ~5 min. Cached after. CI needs
+  `--no-daemon` flag to avoid stale cmake state.
+- **NDK version**: llama.cpp wants r25b+. Chaquopy uses r25c — overlap fine.
+
+## Reference
+
+- llama.cpp Android example (full working setup): https://github.com/ggerganov/llama.cpp/tree/master/examples/llama.android
+- Pattern we're following: `app/src/main/cpp/<jni source>` + cmake submodule.

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,0 +1,121 @@
+# Observability — Langfuse
+
+Trace every chat turn, tool call, and LLM generation. Two sources reporting to one Langfuse instance:
+
+- **Mac backend** — `claude-code`, `ollama`, `anthropic` providers.
+- **Android (Chaquopy)** — the `on-device` provider running Gemma via MediaPipe inside the app.
+
+## Where it runs
+
+Langfuse server **runs on the Mac**, not the phone. The phone is too constrained for Postgres + Next.js. Both sources emit HTTP events to the same Mac instance:
+
+```
+┌────────────────┐      ┌─────────────────────────────┐
+│  Phone         │──────▶ Mac:3000 (Langfuse UI + API) │
+│  Chaquopy      │      │   ↑                          │
+│  on-device LLM │      │   │                          │
+└────────────────┘      │   │                          │
+                        │  Mac backend (claude-code,   │
+                        │  ollama, anthropic) ─────────┤
+                        └─────────────────────────────┘
+```
+
+## Quickstart — self-hosted (recommended)
+
+```bash
+# 1. Start a docker daemon (OrbStack, Docker Desktop, or Colima).
+brew install --cask orbstack && open /Applications/OrbStack.app
+
+# 2. Boot Langfuse + Postgres
+docker compose -f docker-compose.langfuse.yml up -d
+
+# 3. First-time setup
+open http://localhost:3000
+# → sign up (first user becomes admin, this is local-only)
+# → create a project
+# → Settings → API Keys → Create — copy public + secret keys
+
+# 4. Paste into .env
+LANGFUSE_PUBLIC_KEY=pk-lf-xxxxxxxx
+LANGFUSE_SECRET_KEY=sk-lf-xxxxxxxx
+LANGFUSE_HOST=http://localhost:3000
+
+# 5. Restart the backend
+.venv/bin/python run.py
+```
+
+## Quickstart — cloud (zero infra)
+
+If you'd rather skip Docker:
+
+```
+LANGFUSE_PUBLIC_KEY=pk-lf-xxxxxxxx
+LANGFUSE_SECRET_KEY=sk-lf-xxxxxxxx
+LANGFUSE_HOST=https://cloud.langfuse.com
+```
+
+## Bringing it up after a reboot
+
+The Mac backend, the SSH tunnel to wherever Langfuse runs, and the ADB
+reverses don't auto-restart. After a Mac sleep/reboot or a USB
+disconnect/reconnect, anything in that chain may need re-establishing.
+
+If you're working in the **private `mono` repo**, there's a one-shot script
+that handles all three:
+
+```bash
+./scripts/phone-up.sh        # idempotent bring-up (backend + tunnel + reverses)
+./scripts/phone-status.sh    # read-only probe — pinpoints which layer is down
+./scripts/phone-down.sh      # symmetric teardown
+```
+
+See `mono/docs/PHONE_DEV_SETUP.md` for details. If you're working from the
+public repo only, the manual steps are below.
+
+## Letting the phone reach the Mac instance
+
+The on-device provider (`agent_chat_ondevice.py`) runs *inside the Android app* via Chaquopy. To make it report to the Mac's Langfuse:
+
+```bash
+# Option A: USB / wireless ADB — port-forward Mac:3000 onto phone:3000
+adb -s <serial> reverse tcp:3000 tcp:3000
+# Then on the phone, LANGFUSE_HOST=http://127.0.0.1:3000 just works.
+
+# Option B: Same LAN — find Mac's LAN IP
+ipconfig getifaddr en0
+# e.g. 10.0.0.5  →  set LANGFUSE_HOST=http://10.0.0.5:3000 in the app's prefs
+```
+
+For Chaquopy, env vars are seeded from Android's SharedPreferences in `app/src/main/python/_env.py` (or however you bootstrap them) — surface a simple settings field for the Langfuse host.
+
+## What gets traced
+
+Per chat turn (one trace):
+- **input** — user message
+- **metadata** — `provider`, `model`, `device`, `source: mac|android`, `duration_s`
+- **tags** — `[provider, source]` (filterable in UI)
+
+Per tool call (one span):
+- name `tool:<tool_name>` (e.g. `tool:get_screen_tree`, `tool:tap`)
+- input — tool args
+- output — tool result (truncated to 2000 chars)
+- level `ERROR` if the tool returned an error
+
+Per LLM call (one generation):
+- model name
+- input prompt
+- output text
+- token usage (input / output / total)
+- cost (USD) where the provider exposes it
+
+## Disabling
+
+Just leave `LANGFUSE_PUBLIC_KEY` empty. All helpers become no-ops with zero overhead — no client is constructed.
+
+## Files
+
+- `gitd/services/observability.py` — singleton client + helpers (`trace_chat_turn`, `span_tool_call`, `record_generation`, `record_tool_result`).
+- `gitd/services/agent_chat_claude_code.py` — wraps Mac-side claude-code provider.
+- `gitd/services/agent_chat_ondevice.py` — wraps Android-side Chaquopy provider.
+- `docker-compose.langfuse.yml` — Postgres + Langfuse v2 (single-container).
+- `.env.example` — credential template.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -2,6 +2,8 @@
 
 How we cut a new release of Ghost in the Droid and publish it to GitHub + PyPI.
 
+**TL;DR:** `./scripts/release.sh 1.3.0` → merge the PR it opens → `git tag v1.3.0 && git push public v1.3.0` → done. Workflows handle PyPI + GitHub Release + archive sync automatically.
+
 ---
 
 ## Versioning — Semantic (SemVer)
@@ -19,168 +21,143 @@ Examples: `1.0.0 → 1.1.0` (Ollama added), `1.1.0 → 1.1.1` (fix parse bug), `
 ## Repo Flow
 
 ```
-   private-mirror (work here)
+   private-mirror (dev target)
         │
-        │ open PR against private-mirror/main
+        │ feature PRs land on main
         ▼
-   private-mirror/main  ← first merge here; CI runs
+   private-mirror/main  ← release.sh runs here
         │
-        │ sync main → feature branch on public
+        │ script creates clean PR on public (rebuilt on public/main)
         ▼
-   public/android-agent (release target)
+   public/main ← merge PR
         │
-        │ tag vX.Y.Z on public main
+        │ push v* tag
         ▼
-   [publish.yml fires]
+   [publish.yml fires automatically]
         │
         ├─► PyPI: ghost-in-the-droid==X.Y.Z
-        │
-        └─► GitHub Release: v X.Y.Z with notes
+        ├─► GitHub Release v X.Y.Z with CHANGELOG notes
+        └─► Archive: mirror public/main + tag to android-agent-archive
 ```
 
-**Never push directly to public `main`.** Always go through private mirror PR → public PR → tag.
+**Never push directly to public `main`.** Always go through the release.sh flow.
 
 ---
 
-## Release Checklist
+## Quick Release (automated path)
 
-### 1. Land all features on private mirror `main`
-
-- All PRs merged, CI green
-- Manual smoke test: `python3 run.py` starts, dashboard loads, one end-to-end flow works (e.g. take screenshot on a real device)
-
-### 2. Bump version + update changelog
-
-On private-mirror `main`:
+### 1. Run the script on private-mirror/main
 
 ```bash
-# Update pyproject.toml
-sed -i 's/^version = "1.0.0"/version = "1.1.0"/' pyproject.toml
-
-# Move [Unreleased] → [1.1.0] — YYYY-MM-DD in CHANGELOG.md
-# Add the compare link at the bottom
+./scripts/release.sh 1.3.0
 ```
 
-Commit message: `Bump version to X.Y.Z`
+This does everything up to opening the public PR:
+- Pulls latest private-mirror/main
+- Bumps `pyproject.toml` version
+- Stamps CHANGELOG.md (moves `[Unreleased]` → dated section, updates compare links)
+- Commits + pushes to private-mirror/main
+- Creates `release/v1.3.0` branch on public (rebuilt on top of public/main — no history-divergence conflicts)
+- Opens PR on public with CHANGELOG notes as the body
 
-### 3. Create release PR on public repo
+### 2. Wait for CI + merge the public PR
+
+4 checks on public (lint, test, type-check, build-frontend) — all must pass.
+
+Use **Squash and merge** on the public repo.
+
+### 3. Tag
 
 ```bash
-# Push private mirror/main as a feature branch on public
-git remote add public https://github.com/ghost-in-the-droid/android-agent.git
-git fetch public main
-git push public origin/main:refs/heads/release/vX.Y.Z
-
-# Open PR
-gh pr create --repo ghost-in-the-droid/android-agent \
-  --base main --head release/vX.Y.Z \
-  --title "Release vX.Y.Z" \
-  --body-file CHANGELOG_SECTION.md
+git fetch public
+git checkout public/main
+git tag v1.3.0
+git push public v1.3.0
 ```
 
-Wait for CI to pass on public. Review. Merge.
+### 4. Automation takes over
 
-### 4. Tag the release
+The tag push triggers `.github/workflows/publish.yml` which:
+- Builds the package, verifies entry points
+- Publishes to PyPI (`PYPI_PROJECT_TOKEN`)
+- Creates the GitHub Release with notes pulled from CHANGELOG.md
+- Mirrors `public/main` + the tag to the archive repo (needs `ARCHIVE_PUSH_TOKEN` secret)
 
-```bash
-# On the merged public main
-git checkout main && git pull public main
-git tag -a vX.Y.Z -m "Release vX.Y.Z"
-git push public vX.Y.Z
-```
-
-This triggers `.github/workflows/publish.yml`:
-- Builds the package (`python -m build`)
-- Verifies entry points (`android-agent --help`, MCP import)
-- Publishes to PyPI via `PYPI_PROJECT_TOKEN`
-
-### 5. Create GitHub Release
+### 5. Verify
 
 ```bash
-gh release create vX.Y.Z \
-  --repo ghost-in-the-droid/android-agent \
-  --title "vX.Y.Z" \
-  --notes-file CHANGELOG_SECTION.md \
-  --latest
-```
-
-(Or via the GitHub UI: Releases → Draft a new release → pick tag `vX.Y.Z` → paste changelog section.)
-
-### 6. Verify
-
-```bash
-# Clean environment
-uvx --from ghost-in-the-droid==X.Y.Z android-agent-mcp --help
-
-# PyPI page
-open https://pypi.org/project/ghost-in-the-droid/X.Y.Z/
-
-# GitHub release page
-open https://github.com/ghost-in-the-droid/android-agent/releases/tag/vX.Y.Z
+pip install ghost-in-the-droid==1.3.0
+# GitHub release: https://github.com/ghost-in-the-droid/android-agent/releases/tag/v1.3.0
+# PyPI: https://pypi.org/project/ghost-in-the-droid/1.3.0/
 ```
 
 ---
 
-## What's Automated vs Manual
+## Manual Path (if the script fails)
+
+Everything release.sh does can be done by hand; see git history for worked examples (v1.0.0, v1.1.0, v1.2.0).
+
+The one thing that's easy to miss: when pushing private-mirror/main to public, history often diverges (private-mirror has non-squashed PR merges, public is squashed). Fix: rebuild a clean release branch on top of public/main:
+
+```bash
+git fetch public
+git checkout -B release/vX.Y.Z public/main
+# Apply cumulative diff from the last "Release" commit on main onto public/main:
+git diff <last-release-commit>..main | git apply --3way --index
+git commit -m "Release vX.Y.Z"
+git push public release/vX.Y.Z
+gh pr create --repo ghost-in-the-droid/android-agent --base main --head release/vX.Y.Z ...
+```
+
+The script automates this pattern.
+
+---
+
+## GitHub Secrets (one-time setup)
+
+| Secret | Repo | Purpose |
+|--------|------|---------|
+| `PYPI_PROJECT_TOKEN` | `android-agent` (public) | PyPI upload via `publish.yml` |
+| `ARCHIVE_PUSH_TOKEN` | `android-agent` (public) | Auto-mirror to archive repo. PAT with `repo` scope on `android-agent-archive`. |
+| `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY` | all repos | Integration tests (optional) |
+
+Set in **Settings → Secrets and variables → Actions** on each repo.
+
+---
+
+## What's Automated
 
 | Step | Automated | Manual |
 |------|-----------|--------|
-| CI (lint, test, type-check, frontend build) | ✅ on every PR | — |
-| PyPI publish | ✅ on `v*` tag push | push the tag |
-| Package verification (install + entry points) | ✅ in publish.yml | — |
-| GitHub Release | ⚠️ partial (can be scripted below) | click "Publish release" |
-| CHANGELOG.md | ❌ | write release notes |
-| Version bump | ❌ | `sed` command |
-| Private → Public sync | ❌ | push branch + PR |
+| CI (lint, test, type-check, frontend build) on every PR | ✅ | — |
+| Version bump + CHANGELOG stamp | ✅ (release.sh) | — |
+| Release PR on public | ✅ (release.sh) | — |
+| PyPI publish | ✅ (publish.yml on tag) | push the tag |
+| Package verification (install + entry points) | ✅ (publish.yml) | — |
+| GitHub Release creation | ✅ (publish.yml on tag) | — |
+| Archive mirror sync | ✅ (mirror-to-archive.yml on tag) | — |
 
 ---
 
-## GitHub Secrets (already configured)
+## Still Manual (see "Automation Roadmap" section)
 
-| Secret | Where used | Purpose |
-|--------|-----------|---------|
-| `PYPI_PROJECT_TOKEN` | `publish.yml` | PyPI upload (project-scoped token) |
-| `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY` | `ci.yml` | Integration tests (optional) |
-
----
-
-## Automation Roadmap
-
-Full automation would reduce manual steps to: **write CHANGELOG entry → click a button**.
-
-### Phase 1 (easy wins)
-- [ ] Add a `release.sh` script that does: version bump + CHANGELOG stamp (move `[Unreleased]` → `[X.Y.Z]` with today's date) + commit + tag + push
-- [ ] Add auto-create GitHub Release in `publish.yml` (use `softprops/action-gh-release@v2` after PyPI upload, pulls notes from CHANGELOG.md section)
-- [ ] Pre-commit hook that runs `ruff check` + secret-scan (detect-secrets or gitleaks) on every commit
-
-### Phase 2 (medium effort)
-- [ ] `release-please` bot — reads conventional commits, auto-generates changelog + opens release PR on every merge to main
-- [ ] Branch protection on public `main`: require PR, require CI green, require 1 review, no force push
-- [ ] Dependabot for pip + npm
-
-### Phase 3 (nice to have)
-- [ ] Trusted Publishing to PyPI (OIDC, no stored token)
-- [ ] Sigstore attestations on releases (supply chain security)
-- [ ] Multi-package support if we split `gitd` into `gitd-core` + `gitd-cli` + `gitd-mcp`
-- [ ] Matrix CI: Python 3.10/3.11/3.12 × ubuntu/macos × latest/minimum deps
+- CHANGELOG entry for each PR — currently human-written. Could be auto-generated from conventional-commit messages via `release-please` bot.
+- Merging release PRs on public — intentionally manual (human review gate before shipping).
+- Deciding when to cut a release — by user request, not time-based.
 
 ---
 
 ## Hotfix Process
 
-For urgent fixes on a released version:
+Urgent fix on a released version:
 
 ```bash
 # Branch from the tag
 git checkout -b hotfix/1.1.1 v1.1.0
-
-# Apply fix, commit
+# Apply fix
 ...
-
-# Bump PATCH version, update CHANGELOG
-sed -i 's/version = "1.1.0"/version = "1.1.1"/' pyproject.toml
-
-# Push, PR to private-mirror/main, then public/main, then tag v1.1.1
+# Use release.sh with the PATCH-bumped version
+./scripts/release.sh 1.1.1
 ```
 
 Same flow as a regular release, just smaller scope.
@@ -189,29 +166,17 @@ Same flow as a regular release, just smaller scope.
 
 ## Rollback
 
-If a release is broken:
+**PyPI** can't be deleted, only yanked:
+- Go to https://pypi.org/manage/project/ghost-in-the-droid/ → Yank
 
-**PyPI** — you can't delete a version, but you can yank it (prevents installs without explicit pin):
+**GitHub Release** — `gh release delete vX.Y.Z --yes`
 
-```bash
-pip install twine
-twine upload --repository pypi dist/* --skip-existing
-# Go to https://pypi.org/manage/project/ghost-in-the-droid/ → Yank
-```
-
-**GitHub Release** — delete via UI or `gh release delete vX.Y.Z --yes`.
-
-**Tag** — `git push --delete public vX.Y.Z` (leaves PyPI version yanked).
+**Tag** — `git push --delete public vX.Y.Z`
 
 Then cut a new PATCH release with the fix.
 
 ---
 
-## Release Cadence
+## Automation Roadmap
 
-No fixed cadence. Release whenever:
-- A meaningful feature lands (MINOR)
-- A user-visible bug is fixed (PATCH)
-- Accumulated ~2-4 PRs on main
-
-Don't batch fixes if they're blocking users. Don't release daily — cut noise.
+See [`mono/docs/refactor/release-automation-nbs.md`](https://github.com/ghost-in-the-droid/mono/blob/main/docs/refactor/release-automation-nbs.md) for the next-level automation plans that are deliberately not shipped yet (release-please bot, squash-merge enforcement, Trusted Publishing, public-first workflow).

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,217 @@
+# Release Process
+
+How we cut a new release of Ghost in the Droid and publish it to GitHub + PyPI.
+
+---
+
+## Versioning — Semantic (SemVer)
+
+`MAJOR.MINOR.PATCH`
+
+- **MAJOR** — breaking changes (DB schema incompatible, API removed, skill framework rewrite)
+- **MINOR** — new features, backwards compatible (new provider, new skill, new tab)
+- **PATCH** — bug fixes only, no new features
+
+Examples: `1.0.0 → 1.1.0` (Ollama added), `1.1.0 → 1.1.1` (fix parse bug), `1.1.0 → 2.0.0` (skills YAML format changes).
+
+---
+
+## Repo Flow
+
+```
+   private-mirror (work here)
+        │
+        │ open PR against private-mirror/main
+        ▼
+   private-mirror/main  ← first merge here; CI runs
+        │
+        │ sync main → feature branch on public
+        ▼
+   public/android-agent (release target)
+        │
+        │ tag vX.Y.Z on public main
+        ▼
+   [publish.yml fires]
+        │
+        ├─► PyPI: ghost-in-the-droid==X.Y.Z
+        │
+        └─► GitHub Release: v X.Y.Z with notes
+```
+
+**Never push directly to public `main`.** Always go through private mirror PR → public PR → tag.
+
+---
+
+## Release Checklist
+
+### 1. Land all features on private mirror `main`
+
+- All PRs merged, CI green
+- Manual smoke test: `python3 run.py` starts, dashboard loads, one end-to-end flow works (e.g. take screenshot on a real device)
+
+### 2. Bump version + update changelog
+
+On private-mirror `main`:
+
+```bash
+# Update pyproject.toml
+sed -i 's/^version = "1.0.0"/version = "1.1.0"/' pyproject.toml
+
+# Move [Unreleased] → [1.1.0] — YYYY-MM-DD in CHANGELOG.md
+# Add the compare link at the bottom
+```
+
+Commit message: `Bump version to X.Y.Z`
+
+### 3. Create release PR on public repo
+
+```bash
+# Push private mirror/main as a feature branch on public
+git remote add public https://github.com/ghost-in-the-droid/android-agent.git
+git fetch public main
+git push public origin/main:refs/heads/release/vX.Y.Z
+
+# Open PR
+gh pr create --repo ghost-in-the-droid/android-agent \
+  --base main --head release/vX.Y.Z \
+  --title "Release vX.Y.Z" \
+  --body-file CHANGELOG_SECTION.md
+```
+
+Wait for CI to pass on public. Review. Merge.
+
+### 4. Tag the release
+
+```bash
+# On the merged public main
+git checkout main && git pull public main
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
+git push public vX.Y.Z
+```
+
+This triggers `.github/workflows/publish.yml`:
+- Builds the package (`python -m build`)
+- Verifies entry points (`android-agent --help`, MCP import)
+- Publishes to PyPI via `PYPI_PROJECT_TOKEN`
+
+### 5. Create GitHub Release
+
+```bash
+gh release create vX.Y.Z \
+  --repo ghost-in-the-droid/android-agent \
+  --title "vX.Y.Z" \
+  --notes-file CHANGELOG_SECTION.md \
+  --latest
+```
+
+(Or via the GitHub UI: Releases → Draft a new release → pick tag `vX.Y.Z` → paste changelog section.)
+
+### 6. Verify
+
+```bash
+# Clean environment
+uvx --from ghost-in-the-droid==X.Y.Z android-agent-mcp --help
+
+# PyPI page
+open https://pypi.org/project/ghost-in-the-droid/X.Y.Z/
+
+# GitHub release page
+open https://github.com/ghost-in-the-droid/android-agent/releases/tag/vX.Y.Z
+```
+
+---
+
+## What's Automated vs Manual
+
+| Step | Automated | Manual |
+|------|-----------|--------|
+| CI (lint, test, type-check, frontend build) | ✅ on every PR | — |
+| PyPI publish | ✅ on `v*` tag push | push the tag |
+| Package verification (install + entry points) | ✅ in publish.yml | — |
+| GitHub Release | ⚠️ partial (can be scripted below) | click "Publish release" |
+| CHANGELOG.md | ❌ | write release notes |
+| Version bump | ❌ | `sed` command |
+| Private → Public sync | ❌ | push branch + PR |
+
+---
+
+## GitHub Secrets (already configured)
+
+| Secret | Where used | Purpose |
+|--------|-----------|---------|
+| `PYPI_PROJECT_TOKEN` | `publish.yml` | PyPI upload (project-scoped token) |
+| `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY` | `ci.yml` | Integration tests (optional) |
+
+---
+
+## Automation Roadmap
+
+Full automation would reduce manual steps to: **write CHANGELOG entry → click a button**.
+
+### Phase 1 (easy wins)
+- [ ] Add a `release.sh` script that does: version bump + CHANGELOG stamp (move `[Unreleased]` → `[X.Y.Z]` with today's date) + commit + tag + push
+- [ ] Add auto-create GitHub Release in `publish.yml` (use `softprops/action-gh-release@v2` after PyPI upload, pulls notes from CHANGELOG.md section)
+- [ ] Pre-commit hook that runs `ruff check` + secret-scan (detect-secrets or gitleaks) on every commit
+
+### Phase 2 (medium effort)
+- [ ] `release-please` bot — reads conventional commits, auto-generates changelog + opens release PR on every merge to main
+- [ ] Branch protection on public `main`: require PR, require CI green, require 1 review, no force push
+- [ ] Dependabot for pip + npm
+
+### Phase 3 (nice to have)
+- [ ] Trusted Publishing to PyPI (OIDC, no stored token)
+- [ ] Sigstore attestations on releases (supply chain security)
+- [ ] Multi-package support if we split `gitd` into `gitd-core` + `gitd-cli` + `gitd-mcp`
+- [ ] Matrix CI: Python 3.10/3.11/3.12 × ubuntu/macos × latest/minimum deps
+
+---
+
+## Hotfix Process
+
+For urgent fixes on a released version:
+
+```bash
+# Branch from the tag
+git checkout -b hotfix/1.1.1 v1.1.0
+
+# Apply fix, commit
+...
+
+# Bump PATCH version, update CHANGELOG
+sed -i 's/version = "1.1.0"/version = "1.1.1"/' pyproject.toml
+
+# Push, PR to private-mirror/main, then public/main, then tag v1.1.1
+```
+
+Same flow as a regular release, just smaller scope.
+
+---
+
+## Rollback
+
+If a release is broken:
+
+**PyPI** — you can't delete a version, but you can yank it (prevents installs without explicit pin):
+
+```bash
+pip install twine
+twine upload --repository pypi dist/* --skip-existing
+# Go to https://pypi.org/manage/project/ghost-in-the-droid/ → Yank
+```
+
+**GitHub Release** — delete via UI or `gh release delete vX.Y.Z --yes`.
+
+**Tag** — `git push --delete public vX.Y.Z` (leaves PyPI version yanked).
+
+Then cut a new PATCH release with the fix.
+
+---
+
+## Release Cadence
+
+No fixed cadence. Release whenever:
+- A meaningful feature lands (MINOR)
+- A user-visible bug is fixed (PATCH)
+- Accumulated ~2-4 PRs on main
+
+Don't batch fixes if they're blocking users. Don't release daily — cut noise.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -162,10 +162,52 @@ DEVICE=SERIAL python3 -m pytest tests/ -v
 
 ---
 
+## MCP Server (AI Agent Tools)
+
+The project includes an MCP server that exposes 35 Android automation tools to any AI client. If you cloned this repo, the `.mcp.json` is already configured.
+
+**Claude Code / Codex** (if not using the repo's `.mcp.json`):
+```bash
+claude mcp add android-agent -- uvx --from ghost-in-the-droid android-agent-mcp
+codex mcp add android-agent -- uvx --from ghost-in-the-droid android-agent-mcp
+```
+
+**Claude Desktop / Cursor / VS Code / Windsurf** — see the [MCP section in README.md](../README.md#mcp-server--give-any-ai-agent-an-android-body) for config snippets.
+
+Verify it works:
+```bash
+# List available tools
+python3 -c "from gitd.mcp_server import mcp; print(len(mcp._tool_manager.list_tools()), 'tools')"
+```
+
+---
+
+## Emulators (Optional)
+
+Run Android emulators alongside physical devices. Requires Android SDK:
+
+```bash
+# macOS (Homebrew)
+brew install --cask android-commandlinetools
+sdkmanager "platform-tools" "emulator"
+sdkmanager "system-images;android-35;google_apis_playstore;arm64-v8a"
+
+# Create an AVD
+echo "no" | avdmanager create avd -n test_api35 \
+  -k "system-images;android-35;google_apis_playstore;arm64-v8a" -d medium_phone
+
+# Or use the API/dashboard after starting the server
+```
+
+The Emulators tab in the dashboard handles creation, boot, snapshots, and pool management.
+
+---
+
 ## Next Steps
 
-1. Open `http://localhost:6175` and explore the 9-tab dashboard
+1. Open `http://localhost:6175` and explore the dashboard
 2. Navigate to **Phone Agent** to verify your device appears
-3. Try **Multi Device > Start All (MJPEG)** to see your phone screen
+3. Try the live MJPEG stream to see your phone screen
 4. Browse **Skill Hub** to see installed skills and run them
-5. Read [ARCHITECTURE.md](ARCHITECTURE.md) for how the system fits together
+5. Open Claude Code in this project — the MCP tools are ready to use
+6. Read [ARCHITECTURE.md](ARCHITECTURE.md) for how the system fits together

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -101,7 +101,7 @@ API docs auto-generated at http://localhost:5055/docs
 
 ## Environment Variables
 
-Core ADB automation works without any API keys. AI features need keys in `.env`:
+Core ADB automation works without any API keys. For AI-powered phone control, either use Ollama (free, local, no keys) or add API keys in `.env`:
 
 | Variable | Purpose | Required? |
 |----------|---------|-----------|
@@ -109,6 +109,29 @@ Core ADB automation works without any API keys. AI features need keys in `.env`:
 | `OPENAI_API_KEY` | LLM features (Skill Creator, Content Agent) | For AI features |
 | `ANTHROPIC_API_KEY` | Alternative LLM provider | Optional |
 | `OPENROUTER_API_KEY` | LLM routing (content planning) | For content pipeline |
+
+---
+
+## Ollama (Local LLM — No API Keys)
+
+Run a tool-using Android agent entirely on your machine:
+
+```bash
+# Install Ollama
+brew install ollama       # macOS
+# or: curl -fsSL https://ollama.com/install.sh | sh  # Linux
+
+# Start server + pull a model
+ollama serve &
+ollama pull llama3.2:3b   # 2GB, fast, good tool-use
+
+# Other good options:
+# ollama pull gemma3:4b    # Google, multilingual
+# ollama pull qwen3:4b     # strong reasoning
+# ollama pull phi4-mini:3.8b  # Microsoft, efficient
+```
+
+In the dashboard: Phone Agent tab > Provider: Ollama > pick a model > chat. The agent can see the screen, tap elements, type, navigate — multi-turn with tool execution.
 
 ---
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1,0 +1,141 @@
+# Agent Tools Reference
+
+The catalog of tools the LLM agent can call. Identical surface across both
+inference paths so prompts/skills behave the same regardless of where the
+model runs:
+
+- **MCP server** (`gitd/mcp_server.py`) — exposed to `claude-code` over MCP. The CLI auto-prefixes them as `mcp__android-agent__<tool>`.
+- **Local tool list** (`gitd/services/agent_tools.py` → `TOOLS`) — exposed to the on-device Gemma provider (`agent_chat_ondevice.py`) and any other in-process tool-using loop.
+
+Both paths execute the same underlying logic — for tools with non-trivial
+behavior (e.g. `web_search`) they share a service module so there's one
+implementation, not two drifts.
+
+## App lifecycle
+
+### `launch_app(device, package, fresh=false)`
+
+Launch an Android app by package name.
+
+| arg | type | required | default | notes |
+|---|---|---|---|---|
+| `device` | str | yes | — | ADB serial |
+| `package` | str | yes | — | e.g. `com.android.chrome` |
+| `fresh` | bool | no | `false` | If `true`, force-stop the app first (cold start). Use for benchmarks or when prior in-app state would interfere. If `false` (default), warm start — resumes wherever the user left off. |
+
+The LLM picks based on context: a benchmark task or "open Reddit fresh" → `fresh=true`. "Go back to Chrome" / general use → `fresh=false`.
+
+### `force_stop(device, package)`
+
+Kill an app outright. No relaunch.
+
+### `search_apps(device, query)` / `list_apps(device)` / `list_packages(device)`
+
+Find package names. Use `search_apps` first, fall back to `list_apps`.
+
+## Web
+
+### `web_search(device, query, engine="google")`
+
+Open a search results page in whatever browser is on the device. Faster than
+`launch_app(chrome) → tap_element(address bar) → type_text → press_enter`
+(four steps collapsed to one).
+
+| arg | type | required | default | notes |
+|---|---|---|---|---|
+| `device` | str | yes | — | ADB serial |
+| `query` | str | yes | — | Free-text. Don't pre-URL-encode — the tool handles it. |
+| `engine` | str | no | `"google"` | One of `google`, `ddg` / `duckduckgo`, `bing`, `brave`. |
+
+#### How fallback works
+
+Implemented in `gitd/services/web_search.py:open_search`:
+
+1. Build the search URL: e.g. `https://www.google.com/search?q=<urlencoded>`.
+2. One ADB call probes installed packages: `pm list packages` → set.
+3. Walk a priority list of browsers, skipping ones that aren't installed:
+
+   Chrome → Firefox → Samsung Internet → Edge → Brave → Opera → Opera GX → Vivaldi → DuckDuckGo Browser
+
+4. For the first hit, fire `am start -a android.intent.action.VIEW -d <url> -p <pkg>`. Parse stdout for `Error:` / `no activities found` to detect failure.
+5. If every priority browser failed (or none was installed), fire the same intent **without** `-p` and let Android resolve to whatever browser handles `VIEW`.
+6. As a true last resort (e.g. an extreme stripped-down vendor build with zero browsers): open `market://search?q=browser&c=apps` to nudge the user to install one, and return a clear failure string the agent can show.
+
+#### URL safety
+
+The URL is passed to `subprocess` as a single argument (list form), so
+`&` and `?` aren't interpreted by the shell. URL-encoding via
+`urllib.parse.quote` covers the rest.
+
+#### Examples
+
+```python
+web_search(device, "best gemma 4 benchmarks")            # → Chrome / Google
+web_search(device, "self-hosted langfuse", engine="ddg") # → Chrome / DuckDuckGo
+```
+
+Both work the same when the model is `claude-code` (MCP) or `on-device` Gemma.
+
+## Intents (escape hatch)
+
+### `launch_intent(device, action, data, package, extras)`
+
+Fire an arbitrary Android intent. Use when no dedicated tool fits.
+
+```text
+Open a URL:    action=android.intent.action.VIEW data=https://google.com
+Open Settings: package=com.android.settings
+Share text:    action=android.intent.action.SEND extras='{"android.intent.extra.TEXT": "hello"}'
+```
+
+## UI primitives
+
+| tool | purpose |
+|---|---|
+| `tap(device, x, y)` | Raw coordinate tap. |
+| `tap_element(device, idx)` | Tap by element index from `get_screen_tree`. Prefer this. |
+| `swipe(device, direction)` | `up` / `down` / `left` / `right`. |
+| `long_press(device, x, y, duration_ms=1000)` | Long-press for context menus. |
+| `type_text(device, text)` | Type into the focused field. |
+| `press_key(device, key)` | `BACK`, `HOME`, `ENTER`, etc. |
+
+## Observation
+
+| tool | purpose |
+|---|---|
+| `screenshot(device)` | Full PNG. Use when OCR / visual reasoning is needed. |
+| `get_screen_tree(device)` | XML accessibility tree, indexed for `tap_element`. Cheaper than screenshots. |
+| `get_phone_state(device)` | Foreground app, activity, keyboard state. The lightest "where am I?" probe. |
+| `find_on_screen(device, text)` | Locate visible text via XML first, OCR fallback. |
+
+## Notifications
+
+| tool | purpose |
+|---|---|
+| `get_notifications(device)` | JSON of active notifications. |
+| `open_notifications(device)` | Pull down the shade. |
+
+---
+
+## Adding a new tool
+
+The convention is:
+
+1. **Implementation** in a service module under `gitd/services/`. One module per
+   feature area (`web_search.py`, `device_context.py`, etc.).
+2. **MCP exposure** in `gitd/mcp_server.py` — a thin `@mcp.tool()` wrapper that
+   imports from the service module. Docstring is what claude-code sees.
+3. **Local tool list** in `gitd/services/agent_tools.py`:
+   - Add a dict to `TOOLS` (name, description, JSON-schema input).
+   - Add a branch in `execute_tool` that imports from the service module and
+     calls it.
+
+Sharing the service module guarantees both paths execute the *exact same*
+logic — there's no drift between "what claude does" and "what Gemma does."
+
+## Observability
+
+Every tool call becomes a `tool:<name>` span under the parent `chat:*` trace
+in Langfuse (see `docs/OBSERVABILITY.md`). Args land as `input`, return value
+as `output`, errors get `level=ERROR`. So if the agent picks the wrong tool
+for a job, you'll see it in the trace timeline.

--- a/docs/pr-drafts/PR-on-device-parser-and-providers.md
+++ b/docs/pr-drafts/PR-on-device-parser-and-providers.md
@@ -1,0 +1,138 @@
+# On-device parser + Gemma chat template + stop-fix + WIP vLLM provider
+
+Python-side companion to the app's `feature/llama-cpp-vulkan-adreno` PR.
+Everything here is provider/agent-loop work: tool-call parsing, prompt
+template, KV cache hashing, multi-turn coherence, and the stop button.
+
+## Companion PR
+
+- `ghost-app` → `feature/llama-cpp-vulkan-adreno` (the Kotlin / JNI / Gradle
+  side; carries this submodule bump)
+
+## Commits
+
+| Commit | What |
+|---|---|
+| `fe17427` | Gemma chat template (`<start_of_turn>` markers) + DeviceActions Python wiring + n_ctx=4096 |
+| `d869a6f` | Stream-side protocol: empty piece ≠ EOS (needed for JNI hold-back) |
+| `c1823b7` | Chat path loads disk-persist KV cache before generateStart |
+| `64769e9` | Rename `gemma-4-e2b-gguf` → `gemma-4-e2b-q4km-gguf` |
+| `2096c08` | **Stop button actually stops claude** (orphan subproc fix) |
+| `06fea2f` | WIP: vLLM provider for jsl-gpu via SSH tunnel + adb reverse |
+
+## The big-deal fixes
+
+### 1. Gemma chat template
+
+Was using a custom `[SYSTEM]/[USER]/[ASSISTANT]` scaffold the model had
+never seen in training. Gemma cheerfully echoed those markers back inside
+its own replies, then started hallucinating fake follow-up turns. Result:
+"`com.android.settings, com.android.settings, com.android.settings, ...`"
+× hundreds, eventual context overflow on turn 7.
+
+Switched to canonical `<start_of_turn>user / model / <end_of_turn>`.
+Single source of truth via `ondevice_stable_prefix(system, device)` so
+the warmup endpoint and the chat path can never drift apart. Multi-turn
+coherence holds for 6+ turns now (verified live on Snapdragon 888).
+
+### 2. Stop button propagates across the phone↔Mac boundary
+
+Phone's `_chat_claude_code_remote` is a proxy: phone hits its own
+`/api/agent-chat/message` → that hits Mac's same endpoint → Mac spawns
+`claude` CLI. Two separate session ids. When the user hit Stop on the
+phone, the phone-side stop fired against the phone's own session_id —
+but the claude subprocess lives on the Mac under a different session.
+Mac's `send_message` generator was blocked in `iter_lines()` waiting for
+claude's next chunk, so it didn't notice the broken pipe until claude
+had emitted 3-5 more tool calls. Multiple stops accumulated multiple
+runaway claudes fighting each other for phone control.
+
+Fix is layered:
+
+- Phone-side proxy captures Mac's session_id from the first SSE `session`
+  event and on `GeneratorExit` POSTs `/stop/{remote_sid}` to Mac before
+  the connection dies.
+- Mac-side `chat_claude_code` spawns claude with `start_new_session=True`
+  so it has its own pgid, then registers the `Popen` in `_active_procs`.
+- `stop_agent` does `killpg(SIGTERM)` → wait 2s → `killpg(SIGKILL)`,
+  wiping claude + node + MCP-tool children together. Nuclear pkill kept
+  as safety net.
+
+Verified live: Stop now halts within ~1 s instead of letting claude run
+wild for 30+ seconds.
+
+### 3. Chat path loads disk-persist KV cache
+
+Previously only the warmup endpoint loaded it. The chat path's
+`generateStart` saw an empty KV and paid a full cold prefill (~4 min on
+Q5_K_M) on every first chat call after a model switch. Now both callers
+share `_ensure_kv_warmed()` so the cache file lands the same way.
+
+### 4. Tool-call parser handles model slop
+
+Three layers, applied in order:
+
+1. `tool` / ` ```json ` fenced block parse
+2. Inline `{...}` scan with `_attempt_repairs` (doubled-brace collapse,
+   trailing-junk strip, balanced-brace truncation)
+3. **NEW**: global `{{ ` → `{` flatten + re-scan if both prior passes
+   missed (Gemma at temp 0 routinely emits inline doubled braces with
+   mismatched closing counts that the step-2 regex couldn't match)
+
+Plus action-schema (`{"action_type": "open_app", "app_name": "X"}`)
+translation for ghost-gemma-style trained outputs.
+
+### 5. launch_app: package verifier + Chaquopy bridge
+
+Was failing two ways on-phone:
+
+1. Model hallucinated package names (`com.reddit.android` when reality
+   was `com.reddit.frontpage`). `monkey` returns 0 for missing packages,
+   so the agent thought it succeeded.
+2. `monkey` and `am force-stop` both require permissions uid 10030 doesn't
+   have. Both fall back silently from host adb (uid 2000 shell) which
+   masked the bug during dev.
+
+Fix: verify the package exists first (returns "Did you mean: X?" hint),
+then call into `DeviceActions.launchApp()` via the Chaquopy `jclass`
+bridge — uses the app's own `Context.startActivity()` which doesn't
+need cross-user permissions. Falls back to the `am start` path when
+Chaquopy isn't available (host-side dev runs).
+
+## Numbers
+
+End-to-end first-turn UX, gemma-4-e2b-q4km-gguf on Snapdragon 888:
+
+| Phase | Tokens | ms |
+|---|---:|---:|
+| App cold launch → daemon ready | — | ~15 000 |
+| KV restore from disk (warmup-d5e... or warmup-c7b7...) | 1263 | 155 |
+| Prefill turn 1 (KV cache hit + user msg diff) | ~50 new | 6 000 – 13 000 |
+| Decode turn 1 | 30–90 | 7 000 – 22 000 |
+
+## Untested / WIP
+
+- **vLLM provider** (`06fea2f`): code-complete (full multi-turn loop,
+  OpenAI conversation-history wiring, tool dispatch, helpful error
+  messages) but never run against a live vLLM server. Doesn't affect
+  any existing provider. Verification path documented in the commit
+  message.
+
+## How to verify
+
+Without vLLM, on a real phone:
+
+```bash
+# Mac side
+cd android-agent && source .venv/bin/activate
+uvicorn gitd.app:app --port 15055 --host 127.0.0.1 &
+adb reverse tcp:15055 tcp:15055
+adb reverse tcp:3000 tcp:3000  # optional, for Langfuse tracing
+
+# Phone side — the bundled gitd is on localhost:5055 inside the app's process
+# Use the on-device picker → gemma-4-e2b-q4km-gguf
+# Tap a suggestion chip (e.g. Wi-Fi toggle)
+
+# Watch for:
+adb logcat | grep -F -e BENCH -e DeviceActions -e nativeLoadState
+```

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -137,15 +137,7 @@ async function restartServer() {
       <ToolsHubView v-else-if="activeTab === 'tools'" />
       <BotView v-else-if="activeTab === 'bot'" />
       <TestsView v-else-if="activeTab === 'tests'" />
-      <div v-else-if="activeTab === 'emulators'">
-        <div style="display:flex;flex-direction:column;align-items:center;justify-content:center;padding:5rem 2rem;text-align:center">
-          <img src="/mascot/27-idle.png" alt="Ghost sleeping" style="width:120px;height:120px;object-fit:contain;margin-bottom:1.5rem;opacity:0.8" />
-          <h2 style="font-size:1.5rem;font-weight:700;color:var(--text-1);margin-bottom:0.5rem">The ghost is sleeping on this one.</h2>
-          <p style="color:var(--text-3);max-width:400px;font-size:0.9rem;line-height:1.6">
-            Headless emulator management is under active development. Spin up, control, and schedule jobs on virtual devices — no hardware required.
-          </p>
-        </div>
-      </div>
+      <EmulatorTab v-else-if="activeTab === 'emulators'" />
       <!-- Premium tabs: rendered as iframes from premium frontend server -->
       <iframe
         v-else-if="premiumTabs.some(t => t.id === activeTab)"

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -9,6 +9,7 @@ import SkillCreatorView from '@/views/SkillCreatorView.vue'
 import ExplorerView from '@/views/ExplorerView.vue'
 import ToolsHubView from '@/views/ToolsHubView.vue'
 import EmulatorTab from '@/components/emulator/EmulatorTab.vue'
+import BenchmarkTab from '@/components/benchmark/BenchmarkTab.vue'
 
 const coreTabs = [
   { id: 'phone', label: '👻 Phone Agent' },
@@ -20,6 +21,7 @@ const coreTabs = [
   { id: 'bot', label: '▶️ Manual Run' },
   { id: 'tests', label: '🧪 Tests' },
   { id: 'emulators', label: '🖥️ Emulators' },
+  { id: 'benchmarks', label: '📊 Benchmarks' },
 ]
 
 const premiumTabs = ref<{id: string, label: string, component?: string}[]>([])
@@ -138,6 +140,7 @@ async function restartServer() {
       <BotView v-else-if="activeTab === 'bot'" />
       <TestsView v-else-if="activeTab === 'tests'" />
       <EmulatorTab v-else-if="activeTab === 'emulators'" />
+      <BenchmarkTab v-else-if="activeTab === 'benchmarks'" />
       <!-- Premium tabs: rendered as iframes from premium frontend server -->
       <iframe
         v-else-if="premiumTabs.some(t => t.id === activeTab)"

--- a/frontend/src/components/benchmark/BenchmarkTab.vue
+++ b/frontend/src/components/benchmark/BenchmarkTab.vue
@@ -1,0 +1,326 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref, computed } from 'vue'
+import { useBenchmarkStore } from '@/stores/benchmarks'
+
+const store = useBenchmarkStore()
+const activeSubTab = ref<'tasks' | 'runs'>('tasks')
+const toast = ref<{ msg: string; type: 'ok' | 'err' } | null>(null)
+const expandedLog = ref<string | null>(null)
+const liveLog = ref<Array<Record<string, any>>>([])
+const liveRunId = ref<string | null>(null)
+let liveEventSource: EventSource | null = null
+
+const selectedTasks = ref<Set<string>>(new Set())
+const runSuite = ref('ghost_bench')
+const runProvider = ref('ollama')
+const runModel = ref('gemma3:4b')
+const runDevice = ref('emulator-5554')
+const selectAll = ref(false)
+
+const PROVIDERS = [
+  { id: 'claude-code', label: 'Claude Code', models: ['sonnet', 'opus', 'haiku'] },
+  { id: 'anthropic', label: 'Claude API', models: ['claude-sonnet-4-20250514', 'claude-opus-4-20250514'] },
+  { id: 'openrouter', label: 'OpenRouter', models: ['anthropic/claude-sonnet-4', 'google/gemini-2.5-pro'] },
+  { id: 'ollama', label: 'Ollama (local)', models: ['llama3.2:3b', 'gemma3:4b', 'qwen3:4b', 'phi4-mini:3.8b', 'mistral:7b'] },
+]
+
+const currentModels = computed(() => PROVIDERS.find(p => p.id === runProvider.value)?.models || [])
+
+function onProviderChange() {
+  const p = PROVIDERS.find(p => p.id === runProvider.value)
+  if (p?.models.length) runModel.value = p.models[0]
+}
+
+// Also try to fetch live Ollama models
+async function fetchOllamaModels() {
+  try {
+    const resp = await fetch('/api/agent-chat/providers')
+    if (resp.ok) {
+      const providers = await resp.json()
+      const ollama = providers.find((p: any) => p.id === 'ollama')
+      if (ollama?.models?.length) {
+        const idx = PROVIDERS.findIndex(p => p.id === 'ollama')
+        if (idx >= 0) PROVIDERS[idx].models = ollama.models
+      }
+    }
+  } catch {}
+}
+
+const streamUrl = computed(() =>
+  runDevice.value ? `/api/phone/stream?device=${encodeURIComponent(runDevice.value)}&fps=3` : ''
+)
+
+let pollTimer: ReturnType<typeof setInterval> | null = null
+
+function showToast(msg: string, type: 'ok' | 'err' = 'ok') {
+  toast.value = { msg, type }
+  setTimeout(() => { toast.value = null }, 4000)
+}
+
+function toggleSelectAll() {
+  if (selectAll.value) store.tasks.forEach(t => selectedTasks.value.add(t.id))
+  else selectedTasks.value.clear()
+}
+
+function toggleTask(id: string) {
+  if (selectedTasks.value.has(id)) selectedTasks.value.delete(id)
+  else selectedTasks.value.add(id)
+}
+
+async function startRun() {
+  const ids = selectedTasks.value.size > 0 ? [...selectedTasks.value] : null
+  try {
+    const result = await store.startRun(runSuite.value, ids, runModel.value, runDevice.value, runProvider.value)
+    showToast(`Benchmark started: ${ids?.length || 'all'} tasks`)
+    activeSubTab.value = 'runs'
+
+    if (result.run_id) {
+      liveLog.value = []
+      liveRunId.value = result.run_id
+      if (liveEventSource) liveEventSource.close()
+      liveEventSource = new EventSource(`/api/benchmarks/runs/${result.run_id}/events`)
+      liveEventSource.onmessage = (e) => {
+        try {
+          const ev = JSON.parse(e.data)
+          liveLog.value.push(ev)
+          if (liveLog.value.length > 200) liveLog.value = liveLog.value.slice(-200)
+          if (ev.type === 'task_result' || ev.type === 'run_done') store.fetchRuns()
+          if (ev.type === 'run_done') {
+            liveEventSource?.close()
+            liveEventSource = null
+            liveRunId.value = null
+          }
+        } catch {}
+      }
+      liveEventSource.onerror = () => {
+        liveEventSource?.close()
+        liveEventSource = null
+        liveRunId.value = null
+      }
+    }
+  } catch (e: any) {
+    showToast(e.message, 'err')
+  }
+}
+
+async function handleStop(id: string) {
+  try { await store.stopRun(id); showToast('Run stopped') }
+  catch (e: any) { showToast(e.message, 'err') }
+}
+
+const activeRun = computed(() => store.runs.find(r => r.status === 'running'))
+
+onMounted(async () => {
+  await Promise.all([store.fetchSuites(), store.fetchTasks(), store.fetchRuns()])
+  fetchOllamaModels()
+  pollTimer = setInterval(() => {
+    if (activeSubTab.value === 'runs' || activeRun.value) store.fetchRuns()
+  }, 5000)
+})
+
+onUnmounted(() => {
+  if (pollTimer) clearInterval(pollTimer)
+  if (liveEventSource) { liveEventSource.close(); liveEventSource = null }
+})
+</script>
+
+<template>
+  <div>
+    <Transition name="fade">
+      <div v-if="toast" class="fixed top-4 right-4 z-50 px-4 py-2 rounded-lg text-sm font-medium shadow-lg"
+        :style="{ background: toast.type === 'ok' ? '#065f46' : '#7f1d1d', color: toast.type === 'ok' ? '#6ee7b7' : '#fca5a5', border: `1px solid ${toast.type === 'ok' ? '#059669' : '#dc2626'}` }">
+        {{ toast.msg }}
+      </div>
+    </Transition>
+
+    <div style="display: grid; grid-template-columns: 1fr 25%; gap: 16px; min-height: 600px">
+      <!-- LEFT: Content -->
+      <div>
+        <div class="flex gap-2 mb-4 items-center">
+          <button class="px-4 py-1.5 text-sm font-semibold rounded-lg transition-colors"
+            :class="activeSubTab === 'tasks' ? 'text-indigo-400 bg-indigo-500/10' : 'text-slate-500 hover:text-slate-300'"
+            @click="activeSubTab = 'tasks'">Tasks</button>
+          <button class="px-4 py-1.5 text-sm font-semibold rounded-lg transition-colors"
+            :class="activeSubTab === 'runs' ? 'text-indigo-400 bg-indigo-500/10' : 'text-slate-500 hover:text-slate-300'"
+            @click="activeSubTab = 'runs'; store.fetchRuns()">Runs</button>
+          <span v-if="activeRun" class="ml-auto text-xs px-3 py-1 rounded-full bg-yellow-500/15 text-yellow-400 animate-pulse">
+            Running: {{ activeRun.current_task }} ({{ activeRun.results?.length || 0 }}/{{ activeRun.total_tasks }})
+          </span>
+        </div>
+
+        <!-- Tasks -->
+        <div v-show="activeSubTab === 'tasks'" class="space-y-4">
+          <div class="card px-4 py-3 flex items-center gap-3 flex-wrap">
+            <span class="text-xs font-semibold" style="color: var(--text-2)">Run Config</span>
+            <select v-model="runProvider" @change="onProviderChange" class="text-xs px-2 py-1 rounded" style="background: var(--bg-deep); border: 1px solid var(--border); color: var(--text-2)">
+              <option v-for="p in PROVIDERS" :key="p.id" :value="p.id">{{ p.label }}</option>
+            </select>
+            <select v-model="runModel" class="text-xs px-2 py-1 rounded" style="background: var(--bg-deep); border: 1px solid var(--border); color: var(--text-2); max-width: 180px">
+              <option v-for="m in currentModels" :key="m" :value="m">{{ m }}</option>
+            </select>
+            <input v-model="runDevice" class="text-xs px-2 py-1 rounded" style="background: var(--bg-deep); border: 1px solid var(--border); color: var(--text-2); width: 140px" placeholder="device serial" />
+            <button @click="startRun" class="ml-auto px-4 py-1.5 text-sm font-semibold rounded-lg" style="background: #059669; color: white">
+              Run {{ selectedTasks.size || 'All' }} Tasks
+            </button>
+          </div>
+
+          <div class="card" style="min-height: 200px">
+            <div class="flex items-center justify-between mb-3">
+              <h2 class="text-base font-semibold" style="color: var(--text-1)">Ghost Bench</h2>
+              <span class="text-xs" style="color: var(--text-4)">{{ store.tasks.length }} tasks</span>
+            </div>
+            <div class="overflow-x-auto">
+              <table class="w-full text-sm">
+                <thead>
+                  <tr class="text-left text-xs uppercase" style="color: var(--text-4)">
+                    <th class="pb-2 pr-2 w-8"><input type="checkbox" v-model="selectAll" @change="toggleSelectAll" /></th>
+                    <th class="pb-2 pr-2">Task</th>
+                    <th class="pb-2 pr-2">Goal</th>
+                    <th class="pb-2 pr-2">Category</th>
+                    <th class="pb-2 pr-2">Steps</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="task in store.tasks" :key="task.id" class="border-t" style="border-color: var(--border)"
+                    :class="{ 'bg-indigo-500/5': selectedTasks.has(task.id) }">
+                    <td class="py-2 pr-2"><input type="checkbox" :checked="selectedTasks.has(task.id)" @change="toggleTask(task.id)" /></td>
+                    <td class="py-2 pr-2 font-mono text-xs" style="color: var(--text-2)">{{ task.id }}</td>
+                    <td class="py-2 pr-2 truncate" style="color: var(--text-1); max-width: 280px" :title="task.goal">{{ task.goal }}</td>
+                    <td class="py-2 pr-2 text-xs" style="color: var(--text-3)">{{ task.category }}</td>
+                    <td class="py-2 pr-2 text-xs" style="color: var(--text-3)">{{ task.max_steps }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+
+        <!-- Runs -->
+        <div v-show="activeSubTab === 'runs'" class="space-y-4">
+          <div v-if="!store.runs.length" class="card px-4 py-8 text-center" style="color: var(--text-3)">
+            No runs yet. Go to Tasks to start one.
+          </div>
+
+          <div v-for="run in store.runs" :key="run.id" class="card px-4 py-3">
+            <div class="flex items-center gap-3 mb-3">
+              <span class="font-mono text-xs px-2 py-0.5 rounded" style="background: var(--bg-deep); color: var(--text-3)">{{ run.id }}</span>
+              <span class="text-sm font-semibold" style="color: var(--text-1)">{{ run.provider }}/{{ run.model }}</span>
+              <span class="text-xs" style="color: var(--text-4)">{{ run.device }}</span>
+              <span class="text-xs px-2 py-0.5 rounded-full font-semibold"
+                :class="{
+                  'bg-green-500/15 text-green-400': run.status === 'completed',
+                  'bg-yellow-500/15 text-yellow-400': run.status === 'running',
+                  'bg-slate-500/15 text-slate-400': run.status === 'stopped',
+                }">{{ run.status }}</span>
+              <button v-if="run.status === 'running'" @click="handleStop(run.id)"
+                class="ml-auto text-xs px-3 py-1 rounded" style="border: 1px solid #ef4444; color: #ef4444">Stop</button>
+            </div>
+
+            <div class="grid grid-cols-4 gap-3 mb-3">
+              <div class="text-center">
+                <div class="text-lg font-bold" :style="{ color: run.success_rate > 0.5 ? '#34d399' : run.success_rate > 0 ? '#fbbf24' : '#94a3b8' }">
+                  {{ (run.success_rate * 100).toFixed(0) }}%
+                </div>
+                <div class="text-xs" style="color: var(--text-4)">Success</div>
+              </div>
+              <div class="text-center">
+                <div class="text-lg font-bold" style="color: var(--text-2)">{{ run.passed }}/{{ run.total_tasks }}</div>
+                <div class="text-xs" style="color: var(--text-4)">Passed</div>
+              </div>
+              <div class="text-center">
+                <div class="text-lg font-bold" style="color: var(--text-2)">{{ run.total_time_s?.toFixed(0) || 0 }}s</div>
+                <div class="text-xs" style="color: var(--text-4)">Total</div>
+              </div>
+              <div class="text-center">
+                <div class="text-lg font-bold" style="color: var(--text-2)">{{ run.total_tasks > 0 ? (run.total_time_s / run.total_tasks).toFixed(0) : 0 }}s</div>
+                <div class="text-xs" style="color: var(--text-4)">Avg/Task</div>
+              </div>
+            </div>
+
+            <div v-if="run.results?.length">
+              <div v-for="r in run.results" :key="r.task_id" class="border-t" style="border-color: var(--border)">
+                <div class="flex items-center gap-3 py-2 cursor-pointer hover:bg-white/[0.02] px-1 rounded"
+                  @click="expandedLog = expandedLog === r.task_id ? null : r.task_id">
+                  <span class="text-xs" style="color: var(--text-4)">{{ expandedLog === r.task_id ? '▼' : '▶' }}</span>
+                  <span class="font-mono text-xs" style="color: var(--text-2); min-width: 160px">{{ r.task_id }}</span>
+                  <span class="text-xs font-semibold" :style="{ color: r.score > 0 ? '#34d399' : '#ef4444', minWidth: '36px' }">
+                    {{ r.score > 0 ? 'PASS' : 'FAIL' }}
+                  </span>
+                  <span class="text-xs" style="color: var(--text-3)">{{ r.steps }} steps</span>
+                  <span class="text-xs" style="color: var(--text-3)">{{ r.time_s?.toFixed(0) }}s</span>
+                  <span class="text-xs truncate" style="color: var(--text-4); max-width: 200px">{{ r.reason }}</span>
+                </div>
+                <div v-if="expandedLog === r.task_id && r.agent_log?.length" class="mb-3 ml-4 p-3 rounded-lg"
+                  style="background: var(--bg-deep); border: 1px solid var(--border); max-height: 400px; overflow-y: auto">
+                  <div style="display: flex; flex-direction: column; gap: 4px">
+                    <template v-for="(ev, j) in r.agent_log" :key="j">
+                      <div v-if="ev.type === 'text'" style="background: #1a1f2e; color: var(--text-1); padding: 6px 10px; border-radius: 8px; font-size: 11px; line-height: 1.5; white-space: pre-wrap; word-break: break-word">{{ ev.content }}</div>
+                      <div v-else-if="ev.type === 'tool_call'" style="font-size: 10px; color: #38bdf8; padding: 2px 8px; background: #0ea5e908; border-radius: 10px; border: 1px solid #0ea5e922; width: fit-content">🔧 {{ ev.name }}({{ JSON.stringify(ev.args || {}).slice(0, 100) }})</div>
+                      <div v-else-if="ev.type === 'tool_result'" style="font-size: 9px; font-family: monospace; color: #64748b; padding: 3px 8px; max-height: 80px; overflow: hidden; border-left: 2px solid #1e293b; margin-left: 8px; white-space: pre-wrap; word-break: break-all">↳ {{ ev.result?.slice(0, 300) || ev.name }}</div>
+                      <div v-else-if="ev.type === 'error'" style="font-size: 10px; color: #f87171; padding: 4px 8px; background: #ef444411; border-radius: 6px; border-left: 2px solid #ef4444">{{ ev.content }}</div>
+                    </template>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div v-if="run.status === 'running' && run.total_tasks > 0" class="mt-2">
+              <div class="w-full h-1.5 rounded-full" style="background: var(--bg-deep)">
+                <div class="h-1.5 rounded-full transition-all" style="background: #059669"
+                  :style="{ width: `${((run.results?.length || 0) / run.total_tasks) * 100}%` }"></div>
+              </div>
+              <div class="text-xs mt-1" style="color: var(--text-4)">{{ run.current_task }}...</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- RIGHT: Device + Live Log -->
+      <div style="position: sticky; top: 12px; height: fit-content; display: flex; flex-direction: column; gap: 8px; max-height: calc(100vh - 80px); overflow: hidden">
+        <div class="card p-2" style="flex-shrink: 0">
+          <div class="flex items-center justify-between mb-2 px-1">
+            <span class="text-xs font-semibold" style="color: var(--text-2)">Device</span>
+            <span class="text-xs" style="color: var(--text-4)">{{ runDevice }}</span>
+          </div>
+          <img v-if="streamUrl" :src="streamUrl" style="width: 100%; border-radius: 8px; background: #000; aspect-ratio: 9/16" alt="Device" />
+          <div v-else class="flex items-center justify-center" style="aspect-ratio: 9/16; background: #0a0e17; border-radius: 8px">
+            <span class="text-xs" style="color: var(--text-4)">No device</span>
+          </div>
+        </div>
+
+        <div class="card p-2" style="flex: 1; min-height: 150px; overflow: hidden; display: flex; flex-direction: column">
+          <div class="flex items-center justify-between mb-2 px-1">
+            <span class="text-xs font-semibold" style="color: var(--text-2)">{{ liveRunId ? 'Live Log' : 'Agent Log' }}</span>
+            <span v-if="liveRunId" class="w-2 h-2 rounded-full bg-green-400 animate-pulse"></span>
+          </div>
+          <div style="flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: 3px; padding-right: 4px">
+            <div v-if="!liveLog.length" class="text-xs text-center py-4" style="color: var(--text-4)">
+              Start a run to see live agent activity.
+            </div>
+            <template v-for="(ev, i) in liveLog" :key="i">
+              <div v-if="ev.type === 'task_start'" style="font-size: 10px; font-weight: 600; color: #fbbf24; padding: 4px 6px; background: #fbbf2410; border-radius: 6px; border-left: 2px solid #fbbf24">Task: {{ ev.goal }}</div>
+              <div v-else-if="ev.type === 'init'" style="font-size: 9px; color: #64748b; padding: 1px 6px">init: {{ ev.desc }}</div>
+              <div v-else-if="ev.type === 'agent' && ev.content" style="font-size: 10px; color: var(--text-1); padding: 4px 6px; background: #1a1f2e; border-radius: 6px; line-height: 1.4; white-space: pre-wrap; word-break: break-word; max-height: 80px; overflow: hidden">{{ ev.content.slice(0, 300) }}</div>
+              <div v-else-if="ev.type === 'agent' && ev.name && !ev.result" style="font-size: 9px; color: #38bdf8; padding: 2px 6px; background: #0ea5e908; border-radius: 8px; border: 1px solid #0ea5e922; width: fit-content">🔧 {{ ev.name }}</div>
+              <div v-else-if="ev.type === 'agent' && ev.result" style="font-size: 8px; font-family: monospace; color: #475569; padding: 1px 6px; border-left: 2px solid #1e293b; margin-left: 6px; max-height: 40px; overflow: hidden; word-break: break-all">↳ {{ ev.result?.slice(0, 150) }}</div>
+              <div v-else-if="ev.type === 'task_result'" style="font-size: 10px; font-weight: 600; padding: 3px 6px; border-radius: 6px"
+                :style="{ color: ev.score > 0 ? '#34d399' : '#ef4444', background: ev.score > 0 ? '#34d39910' : '#ef444410', borderLeft: `2px solid ${ev.score > 0 ? '#34d399' : '#ef4444'}` }">
+                {{ ev.score > 0 ? 'PASS' : 'FAIL' }} — {{ ev.reason }}
+              </div>
+              <div v-else-if="ev.type === 'run_done'" style="font-size: 10px; font-weight: 600; color: #a78bfa; padding: 4px 6px; background: #a78bfa10; border-radius: 6px; text-align: center">Benchmark complete</div>
+            </template>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="store.error" class="mt-4 card px-4 py-3" style="border-color: #ef4444">
+      <div class="text-xs" style="color: #ef4444">{{ store.error }}</div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.fade-enter-active, .fade-leave-active { transition: opacity 0.3s; }
+.fade-enter-from, .fade-leave-to { opacity: 0; }
+</style>

--- a/frontend/src/components/emulator/EmulatorTab.vue
+++ b/frontend/src/components/emulator/EmulatorTab.vue
@@ -140,13 +140,13 @@ onUnmounted(() => {
     </div>
 
     <div
-      v-if="store.prerequisites && !store.prerequisites.kvm"
+      v-if="store.prerequisites && !store.prerequisites.hw_accel"
       class="card mb-4 px-4 py-3"
       style="border-color: #f59e0b; background: #f59e0b10"
     >
-      <div class="text-sm font-semibold" style="color: #f59e0b">KVM Not Available</div>
+      <div class="text-sm font-semibold" style="color: #f59e0b">Hardware Acceleration Not Available</div>
       <div class="text-xs mt-1" style="color: var(--text-3)">
-        /dev/kvm not found. Emulators will run without hardware acceleration (very slow).
+        {{ store.prerequisites.hw_accel_type }} not available. Emulators will run without hardware acceleration (very slow).
       </div>
     </div>
 

--- a/frontend/src/stores/benchmarks.ts
+++ b/frontend/src/stores/benchmarks.ts
@@ -1,0 +1,104 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { api } from '@/composables/useApi'
+
+export interface BenchmarkTask {
+  id: string
+  goal: string
+  app: string
+  category: string
+  complexity: number
+  max_steps: number
+}
+
+export interface BenchmarkSuite {
+  id: string
+  name: string
+  description: string
+}
+
+export interface TaskResult {
+  task_id: string
+  goal: string
+  model: string
+  device: string
+  score: number
+  reason: string
+  steps: number
+  time_s: number
+  error: string
+  agent_log: Array<{ type: string; content?: string; name?: string; args?: any; result?: string }>
+}
+
+export interface BenchmarkRunSummary {
+  id: string
+  suite: string
+  model: string
+  provider: string
+  device: string
+  status: 'pending' | 'running' | 'completed' | 'stopped'
+  success_rate: number
+  total_tasks: number
+  passed: number
+  total_time_s: number
+  started_at: number
+  finished_at: number
+  current_task: string
+  results: TaskResult[]
+}
+
+export const useBenchmarkStore = defineStore('benchmarks', () => {
+  const suites = ref<BenchmarkSuite[]>([])
+  const tasks = ref<BenchmarkTask[]>([])
+  const runs = ref<BenchmarkRunSummary[]>([])
+  const error = ref<string | null>(null)
+
+  async function fetchSuites() {
+    try {
+      suites.value = await api<BenchmarkSuite[]>('/api/benchmarks/suites')
+    } catch (e: any) {
+      error.value = e.message
+    }
+  }
+
+  async function fetchTasks(suite = 'ghost_bench', category?: string) {
+    try {
+      const params = new URLSearchParams({ suite })
+      if (category) params.set('category', category)
+      tasks.value = await api<BenchmarkTask[]>(`/api/benchmarks/tasks?${params}`)
+    } catch (e: any) {
+      error.value = e.message
+    }
+  }
+
+  async function fetchRuns() {
+    try {
+      runs.value = await api<BenchmarkRunSummary[]>('/api/benchmarks/runs')
+    } catch (e: any) {
+      error.value = e.message
+    }
+  }
+
+  async function startRun(
+    suite: string, taskIds: string[] | null, model: string, device: string, provider: string
+  ) {
+    error.value = null
+    const result = await api<{ ok: boolean; run_id: string; message: string }>('/api/benchmarks/runs', {
+      method: 'POST',
+      body: JSON.stringify({ suite, tasks: taskIds, provider, model, device }),
+    })
+    await fetchRuns()
+    return result
+  }
+
+  async function stopRun(runId: string) {
+    await api(`/api/benchmarks/runs/${runId}/stop`, { method: 'POST' })
+    await fetchRuns()
+  }
+
+  async function getRun(runId: string) {
+    return api<BenchmarkRunSummary>(`/api/benchmarks/runs/${runId}`)
+  }
+
+  return { suites, tasks, runs, error, fetchSuites, fetchTasks, fetchRuns, startRun, stopRun, getRun }
+})

--- a/frontend/src/stores/emulators.ts
+++ b/frontend/src/stores/emulators.ts
@@ -26,7 +26,10 @@ export interface Prerequisites {
   emulator_binary: boolean
   adb_binary: boolean
   cmdline_tools: boolean
-  kvm: boolean
+  hw_accel: boolean
+  hw_accel_type: 'HVF' | 'KVM'
+  platform: string
+  arch: string
   avd_home: string
 }
 

--- a/frontend/src/views/PhoneAdminView.vue
+++ b/frontend/src/views/PhoneAdminView.vue
@@ -538,9 +538,22 @@ const CHAT_PROVIDERS = [
   { id: 'claude-code', label: 'Claude Code (free)', models: ['sonnet', 'opus', 'haiku'] },
   { id: 'anthropic', label: 'Claude API', models: ['claude-sonnet-4-20250514', 'claude-opus-4-20250514'] },
   { id: 'openrouter', label: 'OpenRouter', models: ['anthropic/claude-sonnet-4', 'google/gemini-2.5-pro'] },
-  { id: 'ollama', label: 'Ollama', models: [] },
+  { id: 'ollama', label: 'Ollama (local)', models: ['llama3.2:3b', 'llama3.2:1b', 'gemma3:4b', 'qwen3:4b', 'phi4-mini:3.8b', 'mistral:7b'] },
 ]
 const chatConversations = ref<{id: string; title: string; provider: string; model: string; message_count: number; updated_at: string}[]>([])
+
+async function ollamaUnload() {
+  try {
+    await fetch('http://localhost:11434/api/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: chatModel.value, keep_alive: 0 }),
+    })
+    chatMessages.value.push({ role: 'system', content: `Unloaded ${chatModel.value} from memory.` })
+  } catch (e: any) {
+    chatMessages.value.push({ role: 'system', content: `Failed to unload: ${e.message}` })
+  }
+}
 
 async function loadConversations() {
   if (!selectedDevice.value) return
@@ -803,6 +816,9 @@ onUnmounted(() => {
             style="font-size: 10px; padding: 2px 6px; background: var(--bg-deep); border: 1px solid var(--border); border-radius: 4px; color: var(--text-3); max-width: 140px">
             <option v-for="m in (CHAT_PROVIDERS.find(p => p.id === chatProvider)?.models || [])" :key="m" :value="m">{{ m }}</option>
           </select>
+          <button v-if="chatProvider === 'ollama'" @click="ollamaUnload"
+            style="font-size: 9px; padding: 2px 8px; background: #1a1f2e; border: 1px solid #ef4444; border-radius: 4px; color: #ef4444; cursor: pointer"
+            title="Unload model from GPU memory">Unload</button>
           <span style="margin-left: auto; display: flex; align-items: center; gap: 6px">
             <button @click="chatVerbose = !chatVerbose"
               style="font-size: 9px; padding: 2px 6px; border-radius: 4px; cursor: pointer; border: 1px solid #2a3044"

--- a/frontend/src/views/PhoneAdminView.vue
+++ b/frontend/src/views/PhoneAdminView.vue
@@ -409,6 +409,14 @@ function startStream() {
   streaming.value = true
   if (singleStreamMode.value === 'rtc') {
     rtcStart(selectedDevice.value)
+    // Auto-fallback: if RTC doesn't connect within 5s, switch to MJPEG
+    setTimeout(() => {
+      if (streaming.value && singleStreamMode.value === 'rtc' && rtcStatus[selectedDevice.value] !== 'Streaming') {
+        console.log('RTC timeout — falling back to MJPEG')
+        singleStreamMode.value = 'mjpeg'
+        singleMjpegUrl.value = `/api/phone/stream?device=${encodeURIComponent(selectedDevice.value)}&fps=5`
+      }
+    }, 5000)
   } else {
     singleMjpegUrl.value = `/api/phone/stream?device=${encodeURIComponent(selectedDevice.value)}&fps=5`
   }
@@ -534,26 +542,107 @@ if (!(window as any).marked) {
 }
 const chatProvider = ref(localStorage.getItem('agent_provider') || 'claude-code')
 const chatModel = ref(localStorage.getItem('agent_model') || 'sonnet')
-const CHAT_PROVIDERS = [
+const CHAT_PROVIDERS = ref([
   { id: 'claude-code', label: 'Claude Code (free)', models: ['sonnet', 'opus', 'haiku'] },
   { id: 'anthropic', label: 'Claude API', models: ['claude-sonnet-4-20250514', 'claude-opus-4-20250514'] },
   { id: 'openrouter', label: 'OpenRouter', models: ['anthropic/claude-sonnet-4', 'google/gemini-2.5-pro'] },
-  { id: 'ollama', label: 'Ollama (local)', models: ['llama3.2:3b', 'llama3.2:1b', 'gemma3:4b', 'qwen3:4b', 'phi4-mini:3.8b', 'mistral:7b'] },
-]
-const chatConversations = ref<{id: string; title: string; provider: string; model: string; message_count: number; updated_at: string}[]>([])
+  { id: 'ollama', label: 'Ollama (local)', models: [] },
+])
 
-async function ollamaUnload() {
+async function fetchProviders() {
   try {
-    await fetch('http://localhost:11434/api/generate', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ model: chatModel.value, keep_alive: 0 }),
+    const resp = await fetch('/api/agent-chat/providers')
+    if (resp.ok) CHAT_PROVIDERS.value = await resp.json()
+  } catch {}
+}
+
+// Ollama model status
+const ollamaModels = ref<Array<{name: string; status: string; vram_gb: number; size_gb: number; parameter_size: string}>>([])
+const ollamaLoading = ref('')  // model name currently loading
+
+async function fetchOllamaStatus() {
+  if (chatProvider.value !== 'ollama') return
+  try {
+    const resp = await fetch('/api/agent-chat/ollama/status')
+    if (resp.ok) {
+      const data = await resp.json()
+      if (data.ok) ollamaModels.value = data.models
+    }
+  } catch {}
+}
+
+function ollamaModelStatus(name: string): string {
+  if (ollamaLoading.value === name) return 'loading'
+  const m = ollamaModels.value.find(m => m.name === name)
+  return m?.status || 'unknown'
+}
+
+function ollamaModelVram(name: string): number {
+  const m = ollamaModels.value.find(m => m.name === name)
+  return m?.vram_gb || 0
+}
+
+async function ollamaLoad(model: string) {
+  ollamaLoading.value = model
+  try {
+    const resp = await fetch('/api/agent-chat/ollama/load', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model }),
     })
-    chatMessages.value.push({ role: 'system', content: `Unloaded ${chatModel.value} from memory.` })
+    const data = await resp.json()
+    if (!data.ok) chatMessages.value.push({ role: 'system', content: `Load failed: ${data.error}` })
+  } catch (e: any) {
+    chatMessages.value.push({ role: 'system', content: `Load failed: ${e.message}` })
+  }
+  ollamaLoading.value = ''
+  fetchOllamaStatus()
+}
+
+async function ollamaUnload(model?: string) {
+  const m = model || chatModel.value
+  try {
+    const resp = await fetch('/api/agent-chat/ollama/unload', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: m }),
+    })
+    const data = await resp.json()
+    if (data.ok) chatMessages.value.push({ role: 'system', content: `Unloaded ${m} from VRAM.` })
+    else chatMessages.value.push({ role: 'system', content: `Unload failed: ${data.error}` })
   } catch (e: any) {
     chatMessages.value.push({ role: 'system', content: `Failed to unload: ${e.message}` })
   }
+  fetchOllamaStatus()
 }
+
+const ollamaPullName = ref('')
+const ollamaPulling = ref(false)
+
+async function ollamaPull() {
+  const model = ollamaPullName.value.trim()
+  if (!model) return
+  ollamaPulling.value = true
+  chatMessages.value.push({ role: 'system', content: `Pulling ${model}...` })
+  try {
+    const resp = await fetch('/api/agent-chat/ollama/pull', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model }),
+    })
+    const data = await resp.json()
+    if (data.ok) {
+      chatMessages.value.push({ role: 'system', content: `${model} pulled successfully.` })
+      ollamaPullName.value = ''
+      fetchProviders()
+      fetchOllamaStatus()
+    } else {
+      chatMessages.value.push({ role: 'system', content: `Pull failed: ${data.error}` })
+    }
+  } catch (e: any) {
+    chatMessages.value.push({ role: 'system', content: `Pull failed: ${e.message}` })
+  }
+  ollamaPulling.value = false
+}
+
+const chatConversations = ref<{id: string; title: string; provider: string; model: string; message_count: number; updated_at: string}[]>([])
 
 async function loadConversations() {
   if (!selectedDevice.value) return
@@ -589,9 +678,10 @@ async function deleteConversation(cid: string) {
 
 function onProviderChange() {
   localStorage.setItem('agent_provider', chatProvider.value)
-  const p = CHAT_PROVIDERS.find(p => p.id === chatProvider.value)
+  const p = CHAT_PROVIDERS.value.find(p => p.id === chatProvider.value)
   if (p?.models.length) { chatModel.value = p.models[0]; localStorage.setItem('agent_model', chatModel.value) }
   chatSessionId.value = '' // reset session on provider change
+  if (chatProvider.value === 'ollama') fetchOllamaStatus()
 }
 function onModelChange() { localStorage.setItem('agent_model', chatModel.value); chatSessionId.value = '' }
 
@@ -766,6 +856,8 @@ onMounted(async () => {
   await loadDevices()
   loadAllHealth()
   loadConversations()
+  fetchProviders()
+  fetchOllamaStatus()
   logTimer = window.setInterval(pollLogs, 3000)
   multiLogTimer = window.setInterval(pollMultiLogs, 4000)
   pollMultiLogs()
@@ -816,9 +908,36 @@ onUnmounted(() => {
             style="font-size: 10px; padding: 2px 6px; background: var(--bg-deep); border: 1px solid var(--border); border-radius: 4px; color: var(--text-3); max-width: 140px">
             <option v-for="m in (CHAT_PROVIDERS.find(p => p.id === chatProvider)?.models || [])" :key="m" :value="m">{{ m }}</option>
           </select>
-          <button v-if="chatProvider === 'ollama'" @click="ollamaUnload"
-            style="font-size: 9px; padding: 2px 8px; background: #1a1f2e; border: 1px solid #ef4444; border-radius: 4px; color: #ef4444; cursor: pointer"
-            title="Unload model from GPU memory">Unload</button>
+          <!-- Ollama model status + load/unload -->
+          <template v-if="chatProvider === 'ollama'">
+            <span v-if="ollamaModelStatus(chatModel) === 'loaded'"
+              style="font-size: 8px; padding: 1px 6px; border-radius: 10px; background: #05966920; color: #34d399; border: 1px solid #05966940; white-space: nowrap"
+              :title="`${ollamaModelVram(chatModel)} GB VRAM`">
+              ● {{ ollamaModelVram(chatModel) }}GB
+            </span>
+            <span v-else-if="ollamaModelStatus(chatModel) === 'loading'"
+              style="font-size: 8px; padding: 1px 6px; border-radius: 10px; background: #f59e0b20; color: #fbbf24; border: 1px solid #f59e0b40; white-space: nowrap; animation: pulse 1.5s infinite">
+              ◌ loading...
+            </span>
+            <span v-else
+              style="font-size: 8px; padding: 1px 6px; border-radius: 10px; background: #64748b15; color: #64748b; border: 1px solid #64748b30; white-space: nowrap">
+              ○ idle
+            </span>
+            <button v-if="ollamaModelStatus(chatModel) === 'loaded'" @click="ollamaUnload()"
+              style="font-size: 8px; padding: 1px 6px; background: #1a1f2e; border: 1px solid #ef4444; border-radius: 4px; color: #ef4444; cursor: pointer"
+              title="Free VRAM">unload</button>
+            <button v-else-if="ollamaModelStatus(chatModel) !== 'loading'" @click="ollamaLoad(chatModel)"
+              style="font-size: 8px; padding: 1px 6px; background: #1a1f2e; border: 1px solid #059669; border-radius: 4px; color: #34d399; cursor: pointer"
+              title="Load into VRAM">load</button>
+            <span style="display:inline-flex;align-items:center;gap:2px;margin-left:4px">
+              <input v-model="ollamaPullName" placeholder="pull model..."
+                @keyup.enter="ollamaPull" :disabled="ollamaPulling"
+                style="font-size:8px;padding:1px 4px;width:90px;background:var(--bg-deep);border:1px solid var(--border);border-radius:3px;color:var(--text-3)" />
+              <button @click="ollamaPull" :disabled="ollamaPulling || !ollamaPullName.trim()"
+                style="font-size:8px;padding:1px 5px;background:#1a1f2e;border:1px solid var(--border);border-radius:3px;color:var(--text-3);cursor:pointer"
+                :style="ollamaPulling ? {opacity:0.5} : {}">{{ ollamaPulling ? '...' : '↓' }}</button>
+            </span>
+          </template>
           <span style="margin-left: auto; display: flex; align-items: center; gap: 6px">
             <button @click="chatVerbose = !chatVerbose"
               style="font-size: 9px; padding: 2px 6px; border-radius: 4px; cursor: pointer; border: 1px solid #2a3044"
@@ -900,7 +1019,13 @@ onUnmounted(() => {
             </option>
           </select>
           <button v-if="!streaming" class="ctrl-btn ctrl-btn--webrtc" style="font-size:9px;padding:3px 8px" @click="singleStreamMode = 'rtc'; startStream()">&#x26A1; Stream</button>
-          <button v-else class="ctrl-btn ctrl-btn--stop" style="font-size:9px;padding:3px 8px" @click="stopStream">&#x23F9; Stop</button>
+          <span v-if="streaming" style="font-size:8px;padding:1px 6px;border-radius:10px;white-space:nowrap"
+            :style="singleStreamMode === 'rtc'
+              ? { background: '#22c55e20', color: '#4ade80', border: '1px solid #22c55e40' }
+              : { background: '#6366f120', color: '#a5b4fc', border: '1px solid #6366f140' }">
+            {{ singleStreamMode === 'rtc' ? '⚡ WebRTC' : '📷 MJPEG' }}
+          </span>
+          <button v-if="streaming" class="ctrl-btn ctrl-btn--stop" style="font-size:9px;padding:3px 8px" @click="stopStream">&#x23F9; Stop</button>
           <button class="ctrl-btn" style="font-size:9px;padding:3px 6px" @click="toggleOverlay(selectedDevice)"
             :style="{ background: overlayOn[selectedDevice] ? '#fbbf24' : '', color: overlayOn[selectedDevice] ? '#000' : '#fbbf24' }">&#x1F522;</button>
         </div>

--- a/gitd/app.py
+++ b/gitd/app.py
@@ -10,6 +10,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from gitd.models.base import Base, engine
 from gitd.routers.agent_chat import router as agent_chat_router
+from gitd.routers.benchmarks import router as benchmarks_router
 from gitd.routers.bot import router as bot_router
 from gitd.routers.creator import router as creator_router
 from gitd.routers.emulators import pool_router as emulator_pool_router
@@ -63,6 +64,7 @@ TAGS_METADATA = [
     {"name": "tools", "description": "Utility tools hub"},
     {"name": "misc", "description": "Health, logs, server management"},
     {"name": "emulators", "description": "Emulator lifecycle, AVDs, snapshots, pool management"},
+    {"name": "benchmarks", "description": "Benchmark runner — task suites, live progress, results"},
 ]
 
 
@@ -111,6 +113,7 @@ def create_app() -> FastAPI:
     app.include_router(tests_router)
     app.include_router(emulators_router)
     app.include_router(emulator_pool_router)
+    app.include_router(benchmarks_router)
 
     # Plugin hook: load premium features if installed
     try:

--- a/gitd/app.py
+++ b/gitd/app.py
@@ -12,6 +12,8 @@ from gitd.models.base import Base, engine
 from gitd.routers.agent_chat import router as agent_chat_router
 from gitd.routers.bot import router as bot_router
 from gitd.routers.creator import router as creator_router
+from gitd.routers.emulators import pool_router as emulator_pool_router
+from gitd.routers.emulators import router as emulators_router
 from gitd.routers.explorer import router as explorer_router
 from gitd.routers.misc import router as misc_router
 from gitd.routers.phone import router as phone_router
@@ -60,6 +62,7 @@ TAGS_METADATA = [
     {"name": "stats", "description": "Dashboard stats"},
     {"name": "tools", "description": "Utility tools hub"},
     {"name": "misc", "description": "Health, logs, server management"},
+    {"name": "emulators", "description": "Emulator lifecycle, AVDs, snapshots, pool management"},
 ]
 
 
@@ -106,6 +109,8 @@ def create_app() -> FastAPI:
     app.include_router(bot_router)
     app.include_router(scheduler_router)
     app.include_router(tests_router)
+    app.include_router(emulators_router)
+    app.include_router(emulator_pool_router)
 
     # Plugin hook: load premium features if installed
     try:

--- a/gitd/app.py
+++ b/gitd/app.py
@@ -19,6 +19,7 @@ from gitd.routers.explorer import router as explorer_router
 from gitd.routers.misc import router as misc_router
 from gitd.routers.phone import router as phone_router
 from gitd.routers.scheduler import router as scheduler_router
+from gitd.routers.traces import router as traces_router
 from gitd.routers.skills import router as skills_router
 from gitd.routers.streaming import router as streaming_router
 from gitd.routers.streaming_viewers import router as streaming_viewers_router
@@ -114,6 +115,7 @@ def create_app() -> FastAPI:
     app.include_router(emulators_router)
     app.include_router(emulator_pool_router)
     app.include_router(benchmarks_router)
+    app.include_router(traces_router)
 
     # Plugin hook: load premium features if installed
     try:

--- a/gitd/benchmarks/__init__.py
+++ b/gitd/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+# Benchmark module — run standardized tasks, evaluate agent performance.

--- a/gitd/benchmarks/base.py
+++ b/gitd/benchmarks/base.py
@@ -1,0 +1,52 @@
+"""Base types for benchmark suites — shared across ghost_bench and future androidworld."""
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class Task:
+    """A single benchmark task."""
+
+    id: str
+    goal: str
+    app: str
+    category: str
+    complexity: float = 1.0
+    init: dict = field(default_factory=dict)
+    eval: dict = field(default_factory=dict)
+    teardown: dict | None = None
+
+    @property
+    def max_steps(self) -> int:
+        return int(self.complexity * 10)
+
+
+@dataclass
+class TaskResult:
+    """Result of running a single task."""
+
+    task_id: str
+    goal: str
+    model: str
+    device: str
+    score: float = 0.0
+    reason: str = ""
+    steps: int = 0
+    time_s: float = 0.0
+    agent_log: list = field(default_factory=list)
+    error: str = ""
+
+
+def load_tasks_from_dir(task_data_dir: Path, category: str | None = None) -> list[Task]:
+    """Load tasks from all JSON files in a directory."""
+    tasks = []
+    if not task_data_dir.exists():
+        return tasks
+    for f in sorted(task_data_dir.glob("*.json")):
+        for raw in json.loads(f.read_text()):
+            task = Task(**raw)
+            if category is None or task.category == category:
+                tasks.append(task)
+    return tasks

--- a/gitd/benchmarks/ghost_bench/__init__.py
+++ b/gitd/benchmarks/ghost_bench/__init__.py
@@ -1,0 +1,1 @@
+# Ghost Bench — lightweight built-in benchmark suite. No external deps.

--- a/gitd/benchmarks/ghost_bench/evaluators.py
+++ b/gitd/benchmarks/ghost_bench/evaluators.py
@@ -1,0 +1,57 @@
+"""Evaluators — run ADB commands to check if a task succeeded."""
+
+import subprocess
+
+from gitd.benchmarks.base import Task
+
+
+def _adb(serial: str, *args: str, timeout: int = 10) -> str:
+    cmd = ["adb", "-s", serial, "shell", *args]
+    r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    return r.stdout.strip()
+
+
+def initialize_task(task: Task, serial: str) -> str:
+    """Set up preconditions. Returns description of what was done."""
+    if not task.init or not task.init.get("cmd"):
+        return "no init needed"
+    _adb(serial, *task.init["cmd"].split())
+    return task.init.get("desc", task.init["cmd"])
+
+
+def evaluate_task(task: Task, serial: str) -> tuple[float, str]:
+    """Check if a task succeeded. Returns (score 0.0-1.0, reason)."""
+    ev = task.eval
+    if not ev or not ev.get("cmd"):
+        return 0.0, "no evaluator defined"
+
+    result = _adb(serial, *ev["cmd"].split())
+
+    if "expect" in ev:
+        expected = str(ev["expect"])
+        if result == expected:
+            return 1.0, f"got '{result}' (expected '{expected}')"
+        return 0.0, f"got '{result}' (expected '{expected}')"
+
+    if "expect_in" in ev:
+        if result in ev["expect_in"]:
+            return 1.0, f"got '{result}' (in {ev['expect_in']})"
+        return 0.0, f"got '{result}' (expected one of {ev['expect_in']})"
+
+    if "expect_contains" in ev:
+        needle = ev["expect_contains"]
+        if needle.lower() in result.lower():
+            return 1.0, f"found '{needle}' in output"
+        return 0.0, f"'{needle}' not found in output (got: {result[:200]})"
+
+    return 0.0, "unknown evaluator type"
+
+
+def teardown_task(task: Task, serial: str) -> None:
+    if task.teardown and task.teardown.get("cmd"):
+        _adb(serial, *task.teardown["cmd"].split())
+
+
+def reset_device(serial: str) -> None:
+    _adb(serial, "input", "keyevent", "KEYCODE_HOME")
+    _adb(serial, "input", "keyevent", "KEYCODE_HOME")

--- a/gitd/benchmarks/ghost_bench/task_data/navigation.json
+++ b/gitd/benchmarks/ghost_bench/task_data/navigation.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": "OpenAppSettings",
+    "goal": "Open the Settings app.",
+    "app": "com.android.settings",
+    "category": "navigation",
+    "complexity": 1,
+    "init": {"cmd": "input keyevent KEYCODE_HOME", "desc": "Go home"},
+    "eval": {"cmd": "dumpsys activity activities | grep mResumedActivity", "expect_contains": "com.android.settings"}
+  },
+  {
+    "id": "OpenAppContacts",
+    "goal": "Open the Contacts app.",
+    "app": "com.google.android.contacts",
+    "category": "navigation",
+    "complexity": 1,
+    "init": {"cmd": "input keyevent KEYCODE_HOME", "desc": "Go home"},
+    "eval": {"cmd": "dumpsys activity activities | grep mResumedActivity", "expect_contains": "contacts"}
+  },
+  {
+    "id": "OpenAppClock",
+    "goal": "Open the Clock app.",
+    "app": "com.google.android.deskclock",
+    "category": "navigation",
+    "complexity": 1,
+    "init": {"cmd": "input keyevent KEYCODE_HOME", "desc": "Go home"},
+    "eval": {"cmd": "dumpsys activity activities | grep mResumedActivity", "expect_contains": "deskclock"}
+  },
+  {
+    "id": "OpenAppCamera",
+    "goal": "Open the Camera app.",
+    "app": "com.android.camera2",
+    "category": "navigation",
+    "complexity": 1,
+    "init": {"cmd": "input keyevent KEYCODE_HOME", "desc": "Go home"},
+    "eval": {"cmd": "dumpsys activity activities | grep mResumedActivity", "expect_contains": "camera"}
+  },
+  {
+    "id": "OpenAppChrome",
+    "goal": "Open Chrome browser.",
+    "app": "com.android.chrome",
+    "category": "navigation",
+    "complexity": 1,
+    "init": {"cmd": "input keyevent KEYCODE_HOME", "desc": "Go home"},
+    "eval": {"cmd": "dumpsys activity activities | grep mResumedActivity", "expect_contains": "chrome"}
+  },
+  {
+    "id": "OpenAppCalculator",
+    "goal": "Open the Calculator app.",
+    "app": "com.google.android.calculator",
+    "category": "navigation",
+    "complexity": 1,
+    "init": {"cmd": "input keyevent KEYCODE_HOME", "desc": "Go home"},
+    "eval": {"cmd": "dumpsys activity activities | grep mResumedActivity", "expect_contains": "calculator"}
+  }
+]

--- a/gitd/benchmarks/ghost_bench/task_data/settings.json
+++ b/gitd/benchmarks/ghost_bench/task_data/settings.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "SystemWifiTurnOn",
+    "goal": "Turn wifi on.",
+    "app": "com.android.settings",
+    "category": "settings",
+    "complexity": 1,
+    "init": {"cmd": "svc wifi disable", "desc": "Disable WiFi"},
+    "eval": {"cmd": "settings get global wifi_on", "expect_in": ["1", "2"]}
+  },
+  {
+    "id": "SystemWifiTurnOff",
+    "goal": "Turn wifi off.",
+    "app": "com.android.settings",
+    "category": "settings",
+    "complexity": 1,
+    "init": {"cmd": "svc wifi enable", "desc": "Enable WiFi"},
+    "eval": {"cmd": "settings get global wifi_on", "expect": "0"}
+  },
+  {
+    "id": "SystemBluetoothTurnOn",
+    "goal": "Turn bluetooth on.",
+    "app": "com.android.settings",
+    "category": "settings",
+    "complexity": 1,
+    "init": {"cmd": "svc bluetooth disable", "desc": "Disable Bluetooth"},
+    "eval": {"cmd": "settings get global bluetooth_on", "expect": "1"}
+  },
+  {
+    "id": "SystemBluetoothTurnOff",
+    "goal": "Turn bluetooth off.",
+    "app": "com.android.settings",
+    "category": "settings",
+    "complexity": 1,
+    "init": {"cmd": "svc bluetooth enable", "desc": "Enable Bluetooth"},
+    "eval": {"cmd": "settings get global bluetooth_on", "expect": "0"}
+  },
+  {
+    "id": "SystemBrightnessMax",
+    "goal": "Set screen brightness to maximum.",
+    "app": "com.android.settings",
+    "category": "settings",
+    "complexity": 1,
+    "init": {"cmd": "settings put system screen_brightness 1", "desc": "Set brightness to min"},
+    "eval": {"cmd": "settings get system screen_brightness", "expect": "255"}
+  },
+  {
+    "id": "SystemBrightnessMin",
+    "goal": "Set screen brightness to minimum.",
+    "app": "com.android.settings",
+    "category": "settings",
+    "complexity": 1,
+    "init": {"cmd": "settings put system screen_brightness 255", "desc": "Set brightness to max"},
+    "eval": {"cmd": "settings get system screen_brightness", "expect": "1"}
+  },
+  {
+    "id": "SystemAirplaneModeOn",
+    "goal": "Turn on airplane mode.",
+    "app": "com.android.settings",
+    "category": "settings",
+    "complexity": 1.5,
+    "init": {"cmd": "settings put global airplane_mode_on 0", "desc": "Disable airplane mode"},
+    "eval": {"cmd": "settings get global airplane_mode_on", "expect": "1"}
+  },
+  {
+    "id": "SystemAirplaneModeOff",
+    "goal": "Turn off airplane mode.",
+    "app": "com.android.settings",
+    "category": "settings",
+    "complexity": 1.5,
+    "init": {"cmd": "settings put global airplane_mode_on 1", "desc": "Enable airplane mode"},
+    "eval": {"cmd": "settings get global airplane_mode_on", "expect": "0"}
+  }
+]

--- a/gitd/benchmarks/ghost_bench/tasks.py
+++ b/gitd/benchmarks/ghost_bench/tasks.py
@@ -1,0 +1,23 @@
+"""Ghost Bench task loading — reads task definitions from task_data/*.json."""
+
+from pathlib import Path
+
+from gitd.benchmarks.base import Task, load_tasks_from_dir
+
+TASK_DATA_DIR = Path(__file__).parent / "task_data"
+SUITE_NAME = "ghost_bench"
+
+
+def load_tasks(category: str | None = None) -> list[Task]:
+    return load_tasks_from_dir(TASK_DATA_DIR, category)
+
+
+def get_task(task_id: str) -> Task | None:
+    for task in load_tasks():
+        if task.id == task_id:
+            return task
+    return None
+
+
+def list_task_ids() -> list[str]:
+    return [t.id for t in load_tasks()]

--- a/gitd/benchmarks/results/.gitignore
+++ b/gitd/benchmarks/results/.gitignore
@@ -1,0 +1,2 @@
+*.json
+!.gitignore

--- a/gitd/benchmarks/runner.py
+++ b/gitd/benchmarks/runner.py
@@ -1,0 +1,251 @@
+"""Benchmark runner — orchestrates tasks through an agent and evaluates results."""
+
+import json
+import logging
+import queue
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+import requests
+
+from gitd.benchmarks.base import Task, TaskResult
+
+log = logging.getLogger(__name__)
+
+RESULTS_DIR = Path(__file__).parent / "results"
+RESULTS_DIR.mkdir(exist_ok=True)
+
+# ── Event pub/sub for live SSE streaming ─────────────────────────────────
+
+_event_queues: dict[str, list[queue.Queue]] = {}
+
+
+def subscribe(run_id: str) -> queue.Queue:
+    q: queue.Queue = queue.Queue(maxsize=500)
+    _event_queues.setdefault(run_id, []).append(q)
+    return q
+
+
+def unsubscribe(run_id: str, q: queue.Queue) -> None:
+    if run_id in _event_queues:
+        _event_queues[run_id] = [x for x in _event_queues[run_id] if x is not q]
+
+
+def _emit(run_id: str, event: dict) -> None:
+    for q in _event_queues.get(run_id, []):
+        try:
+            q.put_nowait(event)
+        except queue.Full:
+            pass
+
+
+# ── Run data structures ──────────────────────────────────────────────────
+
+
+@dataclass
+class BenchmarkRun:
+    id: str
+    suite: str
+    model: str
+    provider: str
+    device: str
+    status: str = "running"
+    results: list[TaskResult] = field(default_factory=list)
+    started_at: float = 0.0
+    finished_at: float = 0.0
+    current_task: str = ""
+
+    @property
+    def success_rate(self) -> float:
+        if not self.results:
+            return 0.0
+        return sum(r.score for r in self.results) / len(self.results)
+
+    @property
+    def total_time(self) -> float:
+        return sum(r.time_s for r in self.results)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "suite": self.suite,
+            "model": self.model,
+            "provider": self.provider,
+            "device": self.device,
+            "status": self.status,
+            "success_rate": round(self.success_rate, 3),
+            "total_tasks": len(self.results),
+            "passed": sum(1 for r in self.results if r.score > 0),
+            "total_time_s": round(self.total_time, 1),
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "current_task": self.current_task,
+            "results": [asdict(r) for r in self.results],
+        }
+
+    def save(self) -> None:
+        path = RESULTS_DIR / f"{self.id}.json"
+        path.write_text(json.dumps(self.to_dict(), indent=2))
+
+
+# ── Active runs registry ─────────────────────────────────────────────────
+
+_active_runs: dict[str, BenchmarkRun] = {}
+
+
+def list_runs() -> list[dict]:
+    seen = set()
+    runs = []
+    for run in _active_runs.values():
+        runs.append(run.to_dict())
+        seen.add(run.id)
+    for f in sorted(RESULTS_DIR.glob("*.json"), reverse=True):
+        try:
+            data = json.loads(f.read_text())
+            if data["id"] not in seen:
+                runs.append(data)
+        except Exception:
+            pass
+    return runs
+
+
+def get_run(run_id: str) -> dict | None:
+    if run_id in _active_runs:
+        return _active_runs[run_id].to_dict()
+    path = RESULTS_DIR / f"{run_id}.json"
+    if path.exists():
+        return json.loads(path.read_text())
+    return None
+
+
+def stop_run(run_id: str) -> bool:
+    if run_id in _active_runs:
+        _active_runs[run_id].status = "stopped"
+        return True
+    return False
+
+
+# ── Main runner ──────────────────────────────────────────────────────────
+
+
+def run_benchmark(
+    tasks: list[Task],
+    model: str,
+    device: str,
+    provider: str = "ollama",
+    suite: str = "ghost_bench",
+    api_base: str = "http://localhost:5055",
+    run_id: str = "",
+) -> BenchmarkRun:
+    """Run benchmark tasks sequentially. Blocking — run in a thread."""
+    from gitd.benchmarks.ghost_bench.evaluators import (
+        evaluate_task,
+        initialize_task,
+        reset_device,
+        teardown_task,
+    )
+
+    if not run_id:
+        run_id = str(uuid.uuid4())[:8]
+
+    run = BenchmarkRun(
+        id=run_id,
+        suite=suite,
+        model=model,
+        provider=provider,
+        device=device,
+        started_at=time.time(),
+    )
+    _active_runs[run_id] = run
+    _event_queues.setdefault(run_id, [])
+
+    for task in tasks:
+        if run.status == "stopped":
+            break
+
+        run.current_task = task.id
+        t0 = time.time()
+        _emit(run_id, {"type": "task_start", "task_id": task.id, "goal": task.goal})
+
+        try:
+            reset_device(device)
+            time.sleep(1)
+
+            init_desc = initialize_task(task, device)
+            _emit(run_id, {"type": "init", "task_id": task.id, "desc": init_desc})
+            time.sleep(1)
+
+            agent_log = _run_agent(task, model, device, provider, api_base, run_id)
+
+            time.sleep(1)
+            score, reason = evaluate_task(task, device)
+            _emit(run_id, {"type": "task_result", "task_id": task.id, "score": score, "reason": reason})
+
+            elapsed = time.time() - t0
+            result = TaskResult(
+                task_id=task.id,
+                goal=task.goal,
+                model=model,
+                device=device,
+                score=score,
+                reason=reason,
+                steps=len([e for e in agent_log if e.get("type") == "tool_call"]),
+                time_s=round(elapsed, 1),
+                agent_log=agent_log,
+            )
+            teardown_task(task, device)
+
+        except Exception as e:
+            elapsed = time.time() - t0
+            result = TaskResult(
+                task_id=task.id,
+                goal=task.goal,
+                model=model,
+                device=device,
+                reason=f"error: {e}",
+                time_s=round(elapsed, 1),
+                error=str(e),
+            )
+            log.exception("Benchmark task %s failed", task.id)
+
+        run.results.append(result)
+        run.save()
+
+    run.status = "completed" if run.status != "stopped" else "stopped"
+    run.finished_at = time.time()
+    run.current_task = ""
+    run.save()
+    _emit(run_id, {"type": "run_done", "status": run.status, "success_rate": run.success_rate})
+    _active_runs.pop(run_id, None)
+    _event_queues.pop(run_id, None)
+    return run
+
+
+def _run_agent(
+    task: Task, model: str, device: str, provider: str, api_base: str, run_id: str
+) -> list[dict]:
+    """Send task goal to agent chat endpoint and collect SSE events."""
+    events: list[dict] = []
+    try:
+        resp = requests.post(
+            f"{api_base}/api/agent-chat/message",
+            json={"content": task.goal, "device": device, "provider": provider, "model": model},
+            timeout=300,
+            stream=True,
+        )
+        for line in resp.iter_lines():
+            if not line:
+                continue
+            text = line.decode()
+            if text.startswith("data: "):
+                try:
+                    ev = json.loads(text[6:])
+                    events.append(ev)
+                    _emit(run_id, {"type": "agent", "task_id": task.id, **ev})
+                except json.JSONDecodeError:
+                    pass
+    except Exception as e:
+        events.append({"type": "error", "content": str(e)})
+    return events

--- a/gitd/config.py
+++ b/gitd/config.py
@@ -26,6 +26,9 @@ class Settings(BaseSettings):
     anthropic_api_key: str = ""
     openrouter_api_key: str = ""
 
+    # ── Ollama ──────────────────────────────────────────────────────────────
+    ollama_base_url: str = "http://localhost:11434"
+
     model_config = {
         "env_file": ".env",
         "env_file_encoding": "utf-8",

--- a/gitd/config.py
+++ b/gitd/config.py
@@ -34,9 +34,9 @@ class Settings(BaseSettings):
     # ── Ollama ──────────────────────────────────────────────────────────────
     ollama_base_url: str = "http://localhost:11434"
 
-    # ── vLLM (jsl-gpu, OpenAI-compatible) ────────────────────────────────────
+    # ── vLLM (OpenAI-compatible, remote GPU) ────────────────────────────────────
     # Default assumes a chained tunnel:
-    #   phone:8000 → adb reverse → mac:8000 → ssh -L 8000:localhost:8000 jsl-gpu
+    #   phone:8000 → adb reverse → mac:8000 → ssh -L 8000:localhost:8000 <your-gpu-host>
     # On the Mac dev backend, the same URL works directly because the ssh
     # tunnel is already on `localhost`. Override via env GITD_VLLM_BASE_URL.
     vllm_base_url: str = "http://127.0.0.1:8000/v1"

--- a/gitd/config.py
+++ b/gitd/config.py
@@ -1,10 +1,15 @@
 """
 Pydantic-settings configuration — reads from .env / environment variables.
+Compatible with both pydantic v1 and v2.
 """
 
 from pathlib import Path
 
-from pydantic_settings import BaseSettings
+try:
+    from pydantic_settings import BaseSettings
+except ImportError:
+    # pydantic v1 fallback — BaseSettings was in pydantic directly
+    from pydantic import BaseSettings
 
 
 class Settings(BaseSettings):
@@ -29,11 +34,10 @@ class Settings(BaseSettings):
     # ── Ollama ──────────────────────────────────────────────────────────────
     ollama_base_url: str = "http://localhost:11434"
 
-    model_config = {
-        "env_file": ".env",
-        "env_file_encoding": "utf-8",
-        "extra": "ignore",
-    }
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+        extra = "ignore"
 
 
 settings = Settings()

--- a/gitd/config.py
+++ b/gitd/config.py
@@ -34,6 +34,14 @@ class Settings(BaseSettings):
     # ── Ollama ──────────────────────────────────────────────────────────────
     ollama_base_url: str = "http://localhost:11434"
 
+    # ── vLLM (jsl-gpu, OpenAI-compatible) ────────────────────────────────────
+    # Default assumes a chained tunnel:
+    #   phone:8000 → adb reverse → mac:8000 → ssh -L 8000:localhost:8000 jsl-gpu
+    # On the Mac dev backend, the same URL works directly because the ssh
+    # tunnel is already on `localhost`. Override via env GITD_VLLM_BASE_URL.
+    vllm_base_url: str = "http://127.0.0.1:8000/v1"
+    vllm_api_key: str = "EMPTY"  # vLLM doesn't enforce auth; placeholder for OpenAI client
+
     class Config:
         env_file = ".env"
         env_file_encoding = "utf-8"

--- a/gitd/mcp_server.py
+++ b/gitd/mcp_server.py
@@ -552,5 +552,9 @@ def create_skill(name: str, app_package: str, steps: str) -> str:
     return f"Skill '{name}' created at skills/{name}/ with {len(parsed_steps)} steps"
 
 
-if __name__ == "__main__":
+def main():
     mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/gitd/mcp_server.py
+++ b/gitd/mcp_server.py
@@ -193,10 +193,24 @@ def press_key(device: str, key: str) -> str:
 
 
 @mcp.tool()
-def launch_app(device: str, package: str) -> str:
-    """Launch an Android app by package name. Use search_apps() to find the package name."""
-    Device(device).adb("shell", "monkey", "-p", package, "-c", "android.intent.category.LAUNCHER", "1")
-    return f"Launched {package}"
+def launch_app(device: str, package: str, fresh: bool = False) -> str:
+    """Launch an Android app by package name. Use search_apps() to find the package name.
+
+    Args:
+        device: ADB serial.
+        package: App package name, e.g. "com.android.chrome".
+        fresh: If True, force-stop the app first (cold start, clears in-memory
+            state — back stack, unsaved drafts, login flow position, etc.).
+            If False (default), reuses any existing background instance (warm
+            start — resumes wherever the user left off).
+            Use fresh=True for benchmarks, fresh start of a flow, or when the
+            current app state would interfere with the task.
+    """
+    dev = Device(device)
+    if fresh:
+        dev.adb("shell", "am", "force-stop", package)
+    dev.adb("shell", "monkey", "-p", package, "-c", "android.intent.category.LAUNCHER", "1")
+    return f"Launched {package}" + (" (fresh)" if fresh else "")
 
 
 @mcp.tool()
@@ -337,6 +351,25 @@ def open_notifications(device: str) -> str:
     """Pull down the notification shade."""
     from gitd.services.device_context import open_notifications as _open
     return "Notification shade opened" if _open(device) else "Failed"
+
+
+@mcp.tool()
+def web_search(device: str, query: str, engine: str = "google") -> str:
+    """Open a web search in whatever browser is on the device.
+
+    Faster than: launch Chrome → tap address bar → type → submit. Useful when
+    the user asks "search for X" or you need to look up info that's not on the
+    current screen. Picks the first installed browser from a fallback chain
+    (Chrome → Firefox → Samsung Internet → Edge → Brave → Opera → Vivaldi →
+    DuckDuckGo Browser → system default), so it works even if Chrome is missing.
+
+    Args:
+        device: ADB serial.
+        query: Free-text search terms (don't pre-escape — handled here).
+        engine: "google" (default), "ddg" / "duckduckgo", "bing", or "brave".
+    """
+    from gitd.services.web_search import open_search
+    return open_search(device, query, engine=engine)
 
 
 @mcp.tool()

--- a/gitd/mcp_server.py
+++ b/gitd/mcp_server.py
@@ -206,11 +206,8 @@ def launch_app(device: str, package: str, fresh: bool = False) -> str:
             Use fresh=True for benchmarks, fresh start of a flow, or when the
             current app state would interfere with the task.
     """
-    dev = Device(device)
-    if fresh:
-        dev.adb("shell", "am", "force-stop", package)
-    dev.adb("shell", "monkey", "-p", package, "-c", "android.intent.category.LAUNCHER", "1")
-    return f"Launched {package}" + (" (fresh)" if fresh else "")
+    from gitd.services.agent_tools import execute_tool
+    return execute_tool("launch_app", {"device": device, "package": package, "fresh": fresh})
 
 
 @mcp.tool()

--- a/gitd/models/__init__.py
+++ b/gitd/models/__init__.py
@@ -10,6 +10,7 @@ from .chat import ChatConversation, ChatMessageRow
 from .phone import Phone, TikTokAccount
 from .schedule import JobQueue, JobRun, ScheduledJob
 from .skill_compat import SkillCompat, SkillRun
+from .trace import Trace, TraceSpan
 
 __all__ = [
     # Base
@@ -30,6 +31,9 @@ __all__ = [
     # Chat
     "ChatConversation",
     "ChatMessageRow",
+    # Tracing
+    "Trace",
+    "TraceSpan",
     # Skill compat
     "SkillRun",
     "SkillCompat",

--- a/gitd/models/trace.py
+++ b/gitd/models/trace.py
@@ -1,0 +1,66 @@
+"""Local tracing — Trace and TraceSpan models.
+
+Mirrors Langfuse's data shape so the same write helpers can fan out to both:
+- Always: local SQLite (this module)
+- Optionally: Langfuse remote, when LANGFUSE_PUBLIC_KEY is set
+
+A *trace* is one user-message → final-answer round-trip ("turn"). A *span* is
+one tool call or LLM generation inside that trace.
+"""
+
+from typing import Optional
+
+from sqlalchemy import Float, ForeignKey, Index, Integer, Text, text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import Base
+
+
+class Trace(Base):
+    __tablename__ = "traces"
+
+    id: Mapped[str] = mapped_column(Text, primary_key=True)  # uuid4 hex (32-char)
+    # Soft reference (no FK): the trace is opened before the conversation row
+    # exists in chat_conversations (save_session_to_db runs in the SSE finally
+    # block, after the trace closes). Cascading deletes are handled in
+    # delete_conversation_endpoint.
+    conversation_id: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    provider: Mapped[str] = mapped_column(Text, nullable=False)        # claude-code, on-device, ollama, anthropic
+    model: Mapped[str] = mapped_column(Text, server_default=text("''"))
+    device: Mapped[str] = mapped_column(Text, server_default=text("''"))
+    source: Mapped[str] = mapped_column(Text, server_default=text("'mac'"))  # mac, android
+    user_input: Mapped[str] = mapped_column(Text, server_default=text("''"))
+    final_output: Mapped[str] = mapped_column(Text, server_default=text("''"))
+    status: Mapped[str] = mapped_column(Text, server_default=text("'running'"))  # running, success, error, stopped
+    error_text: Mapped[Optional[str]] = mapped_column(Text, server_default=text("''"))
+    input_tokens: Mapped[int] = mapped_column(Integer, server_default=text("0"))
+    output_tokens: Mapped[int] = mapped_column(Integer, server_default=text("0"))
+    cost_usd: Mapped[float] = mapped_column(Float, server_default=text("0"))
+    duration_ms: Mapped[int] = mapped_column(Integer, server_default=text("0"))
+    started_at: Mapped[str] = mapped_column(Text, nullable=False)  # ISO-8601 UTC
+    ended_at: Mapped[Optional[str]] = mapped_column(Text, server_default=text("''"))
+
+
+# Index for "list traces newest-first" — the dominant query.
+Index("ix_traces_started_at", Trace.started_at.desc())
+Index("ix_traces_conversation", Trace.conversation_id)
+
+
+class TraceSpan(Base):
+    __tablename__ = "trace_spans"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    trace_id: Mapped[str] = mapped_column(
+        Text, ForeignKey("traces.id", ondelete="CASCADE"), nullable=False
+    )
+    kind: Mapped[str] = mapped_column(Text, nullable=False)  # tool, generation, event
+    name: Mapped[str] = mapped_column(Text, nullable=False)  # e.g. "tool:web_search", "llm-call"
+    input_json: Mapped[Optional[str]] = mapped_column(Text, server_default=text("''"))
+    output_json: Mapped[Optional[str]] = mapped_column(Text, server_default=text("''"))
+    level: Mapped[str] = mapped_column(Text, server_default=text("'DEFAULT'"))  # DEFAULT, ERROR
+    started_at: Mapped[str] = mapped_column(Text, nullable=False)
+    ended_at: Mapped[Optional[str]] = mapped_column(Text, server_default=text("''"))
+    duration_ms: Mapped[int] = mapped_column(Integer, server_default=text("0"))
+
+
+Index("ix_trace_spans_trace_id", TraceSpan.trace_id)

--- a/gitd/routers/agent_chat.py
+++ b/gitd/routers/agent_chat.py
@@ -1,12 +1,29 @@
 """Agent Chat routes — interactive natural language phone control."""
 
 import json
+import logging
+import threading
 from typing import Optional
 
+import requests
 from fastapi import APIRouter, Body, HTTPException, Query
+from pydantic import BaseModel
 from starlette.responses import StreamingResponse
 
+from gitd.config import settings
+
+log = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/api/agent-chat", tags=["agent-chat"])
+
+OLLAMA_URL = settings.ollama_base_url
+
+
+# ── Request models ──────────────────────────────────────────────────────────
+
+
+class OllamaModelRequest(BaseModel):
+    model: str
 
 
 @router.post("/session", summary="Create Agent Chat Session")
@@ -184,3 +201,121 @@ def delete_conversation_endpoint(cid: str):
 
     delete_conversation(cid)
     return {"ok": True}
+
+
+@router.get("/providers", summary="List Chat Providers")
+def list_providers():
+    """Return available providers with models. Ollama models are discovered live."""
+    from gitd.services.agent_chat import get_providers
+
+    return get_providers()
+
+
+# ── Ollama model management ──────────────────────────────────────────────
+
+# Track background pull operations
+_pull_status: dict[str, dict] = {}  # model -> {"status": "pulling"|"done"|"error", "error": "..."}
+
+
+def _ollama_request(method: str, path: str, **kwargs) -> requests.Response:
+    """Make a request to the Ollama API. Raises on connection failure."""
+    url = f"{OLLAMA_URL}{path}"
+    try:
+        return requests.request(method, url, **kwargs)
+    except requests.ConnectionError:
+        raise HTTPException(status_code=503, detail="Ollama not reachable. Start it: ollama serve")
+
+
+@router.get("/ollama/status", summary="Ollama Model Status")
+def ollama_status():
+    """Return all installed Ollama models with loaded/unloaded status and VRAM usage."""
+    try:
+        tags = _ollama_request("GET", "/api/tags", timeout=3).json()
+        ps = _ollama_request("GET", "/api/ps", timeout=3).json()
+    except HTTPException:
+        return {"ok": False, "error": "Ollama not running", "models": []}
+
+    loaded = {m["name"]: m for m in ps.get("models", [])}
+    models = []
+    for m in tags.get("models", []):
+        name = m["name"]
+        lm = loaded.get(name)
+        models.append(
+            {
+                "name": name,
+                "size_gb": round(m.get("size", 0) / 1e9, 1),
+                "parameter_size": m.get("details", {}).get("parameter_size", ""),
+                "family": m.get("details", {}).get("family", ""),
+                "quantization": m.get("details", {}).get("quantization_level", ""),
+                "status": "loaded" if lm else "unloaded",
+                "vram_gb": round(lm["size_vram"] / 1e9, 1) if lm else 0,
+                "expires_at": lm.get("expires_at", "") if lm else "",
+            }
+        )
+    return {"ok": True, "models": models}
+
+
+@router.post("/ollama/load", summary="Load Ollama Model")
+def ollama_load(req: OllamaModelRequest):
+    """Load a model into VRAM. Sends an empty generate to warm up."""
+    r = _ollama_request(
+        "POST",
+        "/api/generate",
+        json={"model": req.model, "prompt": "", "keep_alive": "10m"},
+        timeout=120,
+    )
+    if r.status_code != 200:
+        error = r.json().get("error", r.text[:200])
+        if "not found" in error.lower():
+            return {"ok": False, "error": f"Model not found. Run: ollama pull {req.model}"}
+        return {"ok": False, "error": error}
+    return {"ok": True, "model": req.model, "status": "loaded"}
+
+
+@router.post("/ollama/pull", summary="Pull Ollama Model")
+def ollama_pull(req: OllamaModelRequest):
+    """Pull (download) a model from the Ollama registry. Non-blocking — runs in background."""
+    if req.model in _pull_status and _pull_status[req.model].get("status") == "pulling":
+        return {"ok": True, "model": req.model, "status": "already_pulling"}
+
+    _pull_status[req.model] = {"status": "pulling"}
+
+    def _do_pull():
+        try:
+            r = requests.post(
+                f"{OLLAMA_URL}/api/pull",
+                json={"name": req.model, "stream": False},
+                timeout=1800,
+            )
+            if r.status_code == 200:
+                _pull_status[req.model] = {"status": "done"}
+                log.info("Pulled Ollama model: %s", req.model)
+            else:
+                _pull_status[req.model] = {"status": "error", "error": r.json().get("error", "unknown")}
+        except Exception as e:
+            _pull_status[req.model] = {"status": "error", "error": str(e)}
+
+    threading.Thread(target=_do_pull, daemon=True).start()
+    return {"ok": True, "model": req.model, "status": "pulling"}
+
+
+@router.get("/ollama/pull/{model:path}", summary="Check Pull Status")
+def ollama_pull_status(model: str):
+    """Check the status of a background model pull."""
+    status = _pull_status.get(model, {"status": "unknown"})
+    return {"model": model, **status}
+
+
+@router.post("/ollama/unload", summary="Unload Ollama Model")
+def ollama_unload(req: OllamaModelRequest):
+    """Unload a model from VRAM (keep_alive=0)."""
+    try:
+        _ollama_request(
+            "POST",
+            "/api/generate",
+            json={"model": req.model, "keep_alive": 0},
+            timeout=10,
+        )
+    except HTTPException:
+        return {"ok": False, "error": "Ollama not running"}
+    return {"ok": True, "model": req.model, "status": "unloaded"}

--- a/gitd/routers/agent_chat.py
+++ b/gitd/routers/agent_chat.py
@@ -211,6 +211,57 @@ def list_providers():
     return get_providers()
 
 
+@router.post("/warmup", summary="Pre-fill on-device KV cache")
+def warmup_on_device(data: dict = Body({})):
+    """
+    Pre-bake the system + tool list prefix into the on-device LLM's KV cache
+    so the user's first chat turn lands as a "turn 2" with full prefix
+    reuse. Saves ~120 s of cold prefill on Snapdragon-class CPUs with the
+    default 1.3K-token system prompt.
+
+    The Android app should POST this once at launch (idempotent; subsequent
+    calls are near-free if the prefix is already cached). No-op for
+    non-llama.cpp runtimes.
+
+    Body: {"device": "<adb_serial>", "model": "gemma-4-e2b-gguf"}
+    """
+    from gitd.services.agent_chat import DEFAULT_SYSTEM
+    from gitd.services.agent_chat_ondevice import _kotlin_llm
+    from gitd.services.agent_tools import TOOLS
+
+    device = (data.get("device") or "").strip()
+    model_id = (data.get("model") or "").strip()
+    if not model_id:
+        raise HTTPException(status_code=400, detail="model required")
+
+    llm = _kotlin_llm()
+    if llm is None:
+        return {"ok": False, "warmed": 0, "reason": "Chaquopy bridge missing"}
+
+    try:
+        if not bool(llm.ensureLoaded(model_id)):
+            return {"ok": False, "warmed": 0, "reason": f"model {model_id} not loaded"}
+    except Exception as e:
+        return {"ok": False, "warmed": 0, "reason": f"ensureLoaded failed: {e}"}
+
+    # Build the same stable prefix _chat_ondevice uses (system + tools +
+    # [USER]\nDevice: ...). Keep this in sync with agent_chat_ondevice.py
+    # so the cached prefix actually matches the chat prompt.
+    tool_list = "\n".join(
+        f"- {t['name']}: {t['description']}  params: {list(t.get('input_schema', {}).get('properties', {}).keys())}"
+        for t in TOOLS
+    )
+    system = DEFAULT_SYSTEM.replace("{tool_list}", tool_list)
+    stable_prefix = f"[SYSTEM]\n{system}\n\n[USER]\nDevice: {device}\n\n"
+
+    try:
+        warmed = int(llm.warmup(model_id, stable_prefix))
+    except Exception as e:
+        return {"ok": False, "warmed": 0, "reason": f"warmup failed: {e}"}
+
+    return {"ok": True, "warmed": warmed, "model": model_id}
+
+
 # ── Ollama model management ──────────────────────────────────────────────
 
 # Track background pull operations

--- a/gitd/routers/agent_chat.py
+++ b/gitd/routers/agent_chat.py
@@ -244,15 +244,16 @@ def warmup_on_device(data: dict = Body({})):
     except Exception as e:
         return {"ok": False, "warmed": 0, "reason": f"ensureLoaded failed: {e}"}
 
-    # Build the same stable prefix _chat_ondevice uses (system + tools +
-    # [USER]\nDevice: ...). Keep this in sync with agent_chat_ondevice.py
-    # so the cached prefix actually matches the chat prompt.
+    # Build the same stable prefix _chat_ondevice uses. ondevice_stable_prefix
+    # is the single source of truth — keeping it shared ensures the warmup
+    # KV cache key matches the prefix the chat path actually decodes.
+    from gitd.services.agent_chat_ondevice import ondevice_stable_prefix
     tool_list = "\n".join(
         f"- {t['name']}: {t['description']}  params: {list(t.get('input_schema', {}).get('properties', {}).keys())}"
         for t in TOOLS
     )
     system = DEFAULT_SYSTEM.replace("{tool_list}", tool_list)
-    stable_prefix = f"[SYSTEM]\n{system}\n\n[USER]\nDevice: {device}\n\n"
+    stable_prefix = ondevice_stable_prefix(system, device)
 
     # Disk-persistence: hash the prefix to a deterministic filename. If a
     # previously-saved KV state with the same hash exists, restore it

--- a/gitd/routers/agent_chat.py
+++ b/gitd/routers/agent_chat.py
@@ -244,38 +244,26 @@ def warmup_on_device(data: dict = Body({})):
     except Exception as e:
         return {"ok": False, "warmed": 0, "reason": f"ensureLoaded failed: {e}"}
 
-    # Build the same stable prefix _chat_ondevice uses. ondevice_stable_prefix
-    # is the single source of truth — keeping it shared ensures the warmup
-    # KV cache key matches the prefix the chat path actually decodes.
-    from gitd.services.agent_chat_ondevice import ondevice_stable_prefix
+    # Stable prefix + disk cache path are computed in agent_chat_ondevice so
+    # chat and warmup share the same key. Without this, the chat path's
+    # generateStart sees an empty KV and pays a full cold prefill (~4 min on
+    # Q5_K_M / Q6_K) every time even though the prefix is already on disk.
+    from gitd.services.agent_chat_ondevice import (
+        _ensure_kv_warmed,
+        _kv_cache_path,
+        ondevice_stable_prefix,
+    )
     tool_list = "\n".join(
         f"- {t['name']}: {t['description']}  params: {list(t.get('input_schema', {}).get('properties', {}).keys())}"
         for t in TOOLS
     )
     system = DEFAULT_SYSTEM.replace("{tool_list}", tool_list)
     stable_prefix = ondevice_stable_prefix(system, device)
-
-    # Disk-persistence: hash the prefix to a deterministic filename. If a
-    # previously-saved KV state with the same hash exists, restore it
-    # (~hundred ms) instead of re-prefilling (~2 minutes). The hash covers
-    # both the system prompt and the device id, so a model swap or system
-    # prompt edit invalidates the cache automatically.
-    import hashlib
-    import os
-    cache_dir = "/data/data/com.ghostinthedroid.app/files/ondevice/kv-cache"
-    os.makedirs(cache_dir, exist_ok=True)
-    h = hashlib.sha256()
-    h.update(model_id.encode())
-    h.update(b"\n")
-    h.update(stable_prefix.encode())
-    cache_path = os.path.join(cache_dir, f"warmup-{h.hexdigest()[:16]}.bin")
+    cache_path = _kv_cache_path(model_id, stable_prefix)
 
     # Try restore first.
-    try:
-        loaded = int(getattr(llm, "loadState")(model_id, cache_path))
-    except Exception:
-        loaded = -1
-    if loaded > 0:
+    from_cache, loaded = _ensure_kv_warmed(llm, model_id, stable_prefix)
+    if from_cache:
         return {"ok": True, "warmed": loaded, "model": model_id, "from_cache": True}
 
     # Cold path: do the full prefill.

--- a/gitd/routers/agent_chat.py
+++ b/gitd/routers/agent_chat.py
@@ -254,12 +254,42 @@ def warmup_on_device(data: dict = Body({})):
     system = DEFAULT_SYSTEM.replace("{tool_list}", tool_list)
     stable_prefix = f"[SYSTEM]\n{system}\n\n[USER]\nDevice: {device}\n\n"
 
+    # Disk-persistence: hash the prefix to a deterministic filename. If a
+    # previously-saved KV state with the same hash exists, restore it
+    # (~hundred ms) instead of re-prefilling (~2 minutes). The hash covers
+    # both the system prompt and the device id, so a model swap or system
+    # prompt edit invalidates the cache automatically.
+    import hashlib
+    import os
+    cache_dir = "/data/data/com.ghostinthedroid.app/files/ondevice/kv-cache"
+    os.makedirs(cache_dir, exist_ok=True)
+    h = hashlib.sha256()
+    h.update(model_id.encode())
+    h.update(b"\n")
+    h.update(stable_prefix.encode())
+    cache_path = os.path.join(cache_dir, f"warmup-{h.hexdigest()[:16]}.bin")
+
+    # Try restore first.
+    try:
+        loaded = int(getattr(llm, "loadState")(model_id, cache_path))
+    except Exception:
+        loaded = -1
+    if loaded > 0:
+        return {"ok": True, "warmed": loaded, "model": model_id, "from_cache": True}
+
+    # Cold path: do the full prefill.
     try:
         warmed = int(llm.warmup(model_id, stable_prefix))
     except Exception as e:
         return {"ok": False, "warmed": 0, "reason": f"warmup failed: {e}"}
 
-    return {"ok": True, "warmed": warmed, "model": model_id}
+    # Save for next launch (best-effort; failure doesn't break the warmup).
+    try:
+        getattr(llm, "saveState")(model_id, cache_path)
+    except Exception:
+        pass
+
+    return {"ok": True, "warmed": warmed, "model": model_id, "from_cache": False}
 
 
 # ── Ollama model management ──────────────────────────────────────────────

--- a/gitd/routers/agent_chat.py
+++ b/gitd/routers/agent_chat.py
@@ -223,7 +223,7 @@ def warmup_on_device(data: dict = Body({})):
     calls are near-free if the prefix is already cached). No-op for
     non-llama.cpp runtimes.
 
-    Body: {"device": "<adb_serial>", "model": "gemma-4-e2b-gguf"}
+    Body: {"device": "<adb_serial>", "model": "gemma-4-e2b-q4km-gguf"}
     """
     from gitd.services.agent_chat import DEFAULT_SYSTEM
     from gitd.services.agent_chat_ondevice import _kotlin_llm

--- a/gitd/routers/benchmarks.py
+++ b/gitd/routers/benchmarks.py
@@ -1,0 +1,163 @@
+"""Benchmark API — run task suites through the agent, track results."""
+
+import json
+import logging
+import threading
+import uuid
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from starlette.responses import StreamingResponse
+
+from gitd.benchmarks.runner import get_run, list_runs, run_benchmark, stop_run, subscribe, unsubscribe
+
+log = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/benchmarks", tags=["benchmarks"])
+
+
+# ── Request/Response models ──────────────────────────────────────────────
+
+
+class RunRequest(BaseModel):
+    suite: str = "ghost_bench"
+    tasks: Optional[list[str]] = None  # None = all tasks in the suite
+    provider: str = "ollama"
+    model: str = "gemma3:4b"
+    device: str = "emulator-5554"
+
+
+class RunResponse(BaseModel):
+    ok: bool
+    run_id: str
+    message: str
+
+
+# ── Suites ───────────────────────────────────────────────────────────────
+
+
+SUITES = {
+    "ghost_bench": {
+        "name": "Ghost Bench",
+        "description": "Built-in lightweight benchmark — settings toggles, app navigation",
+        "module": "gitd.benchmarks.ghost_bench.tasks",
+    },
+}
+
+
+@router.get("/suites", summary="List Benchmark Suites")
+def api_list_suites():
+    return [{"id": k, "name": v["name"], "description": v["description"]} for k, v in SUITES.items()]
+
+
+# ── Tasks ────────────────────────────────────────────────────────────────
+
+
+def _get_suite_tasks(suite: str):
+    """Import and return tasks for a suite."""
+    if suite not in SUITES:
+        raise HTTPException(status_code=404, detail=f"Unknown suite: {suite}")
+    import importlib
+
+    mod = importlib.import_module(SUITES[suite]["module"])
+    return mod.load_tasks, mod.get_task, mod.list_task_ids
+
+
+@router.get("/tasks", summary="List Tasks in a Suite")
+def api_list_tasks(suite: str = "ghost_bench", category: Optional[str] = None):
+    load_tasks, _, _ = _get_suite_tasks(suite)
+    tasks = load_tasks(category)
+    return [
+        {
+            "id": t.id,
+            "goal": t.goal,
+            "app": t.app,
+            "category": t.category,
+            "complexity": t.complexity,
+            "max_steps": t.max_steps,
+        }
+        for t in tasks
+    ]
+
+
+# ── Runs ─────────────────────────────────────────────────────────────────
+
+
+@router.post("/runs", summary="Start Benchmark Run", response_model=RunResponse)
+def api_start_run(req: RunRequest):
+    load_tasks, get_task, list_task_ids = _get_suite_tasks(req.suite)
+
+    if req.tasks:
+        tasks = [get_task(tid) for tid in req.tasks]
+        tasks = [t for t in tasks if t is not None]
+        if not tasks:
+            raise HTTPException(status_code=400, detail="No valid task IDs provided")
+    else:
+        tasks = load_tasks()
+
+    run_id = str(uuid.uuid4())[:8]
+
+    def _run():
+        run_benchmark(
+            tasks,
+            req.model,
+            req.device,
+            provider=req.provider,
+            suite=req.suite,
+            run_id=run_id,
+        )
+
+    threading.Thread(target=_run, daemon=True).start()
+    log.info("Started benchmark %s: %d tasks, %s/%s on %s", run_id, len(tasks), req.provider, req.model, req.device)
+
+    return RunResponse(
+        ok=True,
+        run_id=run_id,
+        message=f"Started {len(tasks)} tasks with {req.provider}/{req.model}",
+    )
+
+
+@router.get("/runs", summary="List Benchmark Runs")
+def api_list_runs():
+    return list_runs()
+
+
+@router.get("/runs/{run_id}", summary="Get Run Details")
+def api_get_run(run_id: str):
+    run = get_run(run_id)
+    if not run:
+        raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
+    return run
+
+
+@router.post("/runs/{run_id}/stop", summary="Stop Running Benchmark")
+def api_stop_run(run_id: str):
+    ok = stop_run(run_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Run not found or already completed")
+    return {"ok": True}
+
+
+@router.get("/runs/{run_id}/events", summary="Stream Live Events (SSE)")
+def api_stream_events(run_id: str):
+    """Server-Sent Events stream of live benchmark progress."""
+    q = subscribe(run_id)
+
+    def event_generator():
+        try:
+            while True:
+                try:
+                    event = q.get(timeout=30)
+                    yield f"data: {json.dumps(event)}\n\n"
+                    if event.get("type") == "run_done":
+                        break
+                except Exception:
+                    yield ": keepalive\n\n"
+        finally:
+            unsubscribe(run_id, q)
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )

--- a/gitd/routers/emulators.py
+++ b/gitd/routers/emulators.py
@@ -1,11 +1,14 @@
 """
-Emulator management API — Flask Blueprint.
+Emulator management API — FastAPI Router.
 
 All emulator lifecycle operations: list, create, delete, start, stop,
 setup, install APK, snapshots, system images, pool management.
 """
 
-from flask import Blueprint, jsonify, request
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
 
 from gitd.services.emulator_service import (
     EmulatorConfig,
@@ -13,246 +16,265 @@ from gitd.services.emulator_service import (
     get_pool,
 )
 
-bp = Blueprint("emulators", __name__, url_prefix="/api/emulators")
-pool_bp = Blueprint("emulator_pool", __name__, url_prefix="/api/emulator-pool")
+router = APIRouter(prefix="/api/emulators", tags=["emulators"])
+pool_router = APIRouter(prefix="/api/emulator-pool", tags=["emulators"])
 
 
-# ── Prerequisites ────────────────────────────────────────────────────────────
+# ── Request models ──────────────────────────────────────────────────────────
 
 
-@bp.route("/prerequisites", methods=["GET"])
+class CreateAVDRequest(BaseModel):
+    name: str
+    api_level: int = 35
+    target: str = "google_apis_playstore"
+    arch: str = ""
+    device_profile: str = "medium_phone"
+    ram_mb: int = 2048
+    disk_mb: int = 6144
+    resolution: str = "1080x2400"
+    dpi: int = 420
+    gpu: str = "auto"
+    cores: int = 2
+    headless: bool = False
+    snapshot: bool = True
+
+
+class StartRequest(BaseModel):
+    headless: bool = False
+    gpu: str = "auto"
+    cold_boot: bool = False
+    extra_args: Optional[list[str]] = None
+
+
+class StopBySerialRequest(BaseModel):
+    serial: str
+
+
+class ApkRequest(BaseModel):
+    apk_path: str
+
+
+class SnapshotRequest(BaseModel):
+    snapshot_name: str = "automation_ready"
+
+
+class ImageInstallRequest(BaseModel):
+    api_level: int
+    target: str = "google_apis_playstore"
+    arch: str = ""
+
+
+class PoolScaleUpRequest(BaseModel):
+    count: int = 1
+    config: Optional[dict] = None
+
+
+class PoolScaleDownRequest(BaseModel):
+    count: Optional[int] = None
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _find_running_serial(name: str) -> str:
+    """Find the serial for a running emulator by AVD name. Raises 404 if not running."""
+    mgr = get_manager()
+    for info in mgr.list_running():
+        if info["name"] == name:
+            return info["serial"]
+    raise HTTPException(status_code=404, detail=f'Emulator "{name}" is not running')
+
+
+# ── Prerequisites ───────────────────────────────────────────────────────────
+
+
+@router.get("/prerequisites", summary="Check SDK Prerequisites")
 def prerequisites():
-    """Check SDK tool availability."""
+    """Check SDK tool availability and hardware acceleration."""
     mgr = get_manager()
-    return jsonify(mgr.check_prerequisites())
+    return mgr.check_prerequisites()
 
 
-# ── AVD CRUD ─────────────────────────────────────────────────────────────────
+# ── AVD CRUD ────────────────────────────────────────────────────────────────
 
 
-@bp.route("", methods=["GET"])
+@router.get("", summary="List All AVDs")
 def list_avds():
-    """List all AVDs (created + running status)."""
+    """List all AVDs with running status annotation."""
     mgr = get_manager()
-    return jsonify(mgr.list_avds())
+    return mgr.list_avds()
 
 
-@bp.route("", methods=["POST"])
-def create_avd():
-    """Create a new AVD.
-    Body: {name, api_level?, target?, device_profile?, ram_mb?, disk_mb?,
-           resolution?, dpi?, gpu?, cores?, headless?, snapshot?}
-    """
-    data = request.json or {}
-    name = data.get("name")
-    if not name:
-        return jsonify({"ok": False, "error": "name is required"}), 400
-
+@router.post("", summary="Create AVD", status_code=201)
+def create_avd(req: CreateAVDRequest):
+    """Create a new Android Virtual Device."""
     config = EmulatorConfig(
-        name=name,
-        api_level=data.get("api_level", 35),
-        target=data.get("target", "google_apis_playstore"),
-        arch=data.get("arch", "x86_64"),
-        device_profile=data.get("device_profile", "medium_phone"),
-        ram_mb=data.get("ram_mb", 2048),
-        disk_mb=data.get("disk_mb", 6144),
-        resolution=data.get("resolution", "1080x2400"),
-        dpi=data.get("dpi", 420),
-        gpu=data.get("gpu", "auto"),
-        cores=data.get("cores", 2),
-        headless=data.get("headless", False),
-        snapshot=data.get("snapshot", True),
+        name=req.name,
+        api_level=req.api_level,
+        target=req.target,
+        arch=req.arch,
+        device_profile=req.device_profile,
+        ram_mb=req.ram_mb,
+        disk_mb=req.disk_mb,
+        resolution=req.resolution,
+        dpi=req.dpi,
+        gpu=req.gpu,
+        cores=req.cores,
+        headless=req.headless,
+        snapshot=req.snapshot,
     )
     mgr = get_manager()
     result = mgr.create(config)
-    status_code = 201 if result.get("ok") else 400
-    return jsonify(result), status_code
+    if not result.get("ok"):
+        raise HTTPException(status_code=400, detail=result.get("error", "Create failed"))
+    return result
 
 
-@bp.route("/<name>", methods=["DELETE"])
-def delete_avd(name):
-    """Delete an AVD."""
+@router.delete("/{name}", summary="Delete AVD")
+def delete_avd(name: str):
+    """Delete an AVD and all its data."""
     mgr = get_manager()
     result = mgr.delete(name)
-    status_code = 200 if result.get("ok") else 404
-    return jsonify(result), status_code
+    if not result.get("ok"):
+        raise HTTPException(status_code=404, detail=result.get("error", "Not found"))
+    return result
 
 
-# ── Lifecycle ────────────────────────────────────────────────────────────────
+# ── Lifecycle ───────────────────────────────────────────────────────────────
 
 
-@bp.route("/<name>/start", methods=["POST"])
-def start_emulator(name):
-    """Start an emulator.
-    Body: {headless?: bool, gpu?: str, cold_boot?: bool, extra_args?: list}
-    """
-    data = request.json or {}
+@router.post("/{name}/start", summary="Start Emulator")
+def start_emulator(name: str, req: StartRequest = StartRequest()):
+    """Boot an emulator by AVD name."""
     mgr = get_manager()
     result = mgr.start(
         name,
-        headless=data.get("headless", False),
-        gpu=data.get("gpu", "auto"),
-        cold_boot=data.get("cold_boot", False),
-        extra_args=data.get("extra_args"),
+        headless=req.headless,
+        gpu=req.gpu,
+        cold_boot=req.cold_boot,
+        extra_args=req.extra_args,
     )
-    status_code = 200 if result.get("ok") else 400
-    return jsonify(result), status_code
+    if not result.get("ok"):
+        raise HTTPException(status_code=400, detail=result.get("error", "Start failed"))
+    return result
 
 
-@bp.route("/<name>/stop", methods=["POST"])
-def stop_emulator(name):
-    """Stop an emulator by AVD name — finds its serial first."""
+@router.post("/{name}/stop", summary="Stop Emulator by Name")
+def stop_emulator(name: str):
+    """Stop a running emulator by AVD name."""
+    serial = _find_running_serial(name)
     mgr = get_manager()
-    for info in mgr.list_running():
-        if info["name"] == name:
-            result = mgr.stop(info["serial"])
-            return jsonify(result)
-    return jsonify({"ok": False, "error": f'Emulator "{name}" is not running'}), 404
+    return mgr.stop(serial)
 
 
-@bp.route("/stop-by-serial", methods=["POST"])
-def stop_by_serial():
-    """Stop an emulator by serial. Body: {serial}"""
-    data = request.json or {}
-    serial = data.get("serial")
-    if not serial:
-        return jsonify({"ok": False, "error": "serial is required"}), 400
+@router.post("/stop-by-serial", summary="Stop Emulator by Serial")
+def stop_by_serial(req: StopBySerialRequest):
+    """Stop a running emulator by ADB serial."""
     mgr = get_manager()
-    result = mgr.stop(serial)
-    return jsonify(result)
+    return mgr.stop(req.serial)
 
 
-@bp.route("/running", methods=["GET"])
+@router.get("/running", summary="List Running Emulators")
 def list_running():
     """List running emulators with serials and AVD names."""
     mgr = get_manager()
-    return jsonify(mgr.list_running())
+    return mgr.list_running()
 
 
-@bp.route("/<name>/boot-status", methods=["GET"])
-def boot_status(name):
-    """Check if an emulator has booted. Finds serial by name."""
+@router.get("/{name}/boot-status", summary="Check Boot Status")
+def boot_status(name: str):
+    """Check if a named emulator has finished booting."""
+    serial = _find_running_serial(name)
     mgr = get_manager()
-    for info in mgr.list_running():
-        if info["name"] == name:
-            return jsonify(mgr.get_boot_status(info["serial"]))
-    return jsonify({"booted": False, "error": f'Emulator "{name}" is not running'}), 404
+    return mgr.get_boot_status(serial)
 
 
-# ── Setup & Apps ─────────────────────────────────────────────────────────────
+# ── Setup & Apps ────────────────────────────────────────────────────────────
 
 
-@bp.route("/<name>/setup", methods=["POST"])
-def setup_emulator(name):
-    """Run automation setup (disable animations, max timeout, etc.)."""
+@router.post("/{name}/setup", summary="Setup for Automation")
+def setup_emulator(name: str):
+    """Disable animations, set max timeout, configure for automation."""
+    serial = _find_running_serial(name)
     mgr = get_manager()
-    for info in mgr.list_running():
-        if info["name"] == name:
-            result = mgr.setup_for_automation(info["serial"])
-            return jsonify(result)
-    return jsonify({"ok": False, "error": f'Emulator "{name}" is not running'}), 404
+    return mgr.setup_for_automation(serial)
 
 
-@bp.route("/<name>/install-apk", methods=["POST"])
-def install_apk(name):
-    """Install APK on emulator. Body: {apk_path}"""
-    data = request.json or {}
-    apk_path = data.get("apk_path")
-    if not apk_path:
-        return jsonify({"ok": False, "error": "apk_path is required"}), 400
+@router.post("/{name}/install-apk", summary="Install APK")
+def install_apk(name: str, req: ApkRequest):
+    """Install an APK file on a running emulator."""
+    serial = _find_running_serial(name)
     mgr = get_manager()
-    for info in mgr.list_running():
-        if info["name"] == name:
-            result = mgr.install_apk(info["serial"], apk_path)
-            return jsonify(result)
-    return jsonify({"ok": False, "error": f'Emulator "{name}" is not running'}), 404
+    return mgr.install_apk(serial, req.apk_path)
 
 
-# ── Snapshots ────────────────────────────────────────────────────────────────
+# ── Snapshots ───────────────────────────────────────────────────────────────
 
 
-@bp.route("/<name>/snapshot/save", methods=["POST"])
-def snapshot_save(name):
-    """Save emulator snapshot. Body: {snapshot_name?: str}"""
-    data = request.json or {}
-    snap_name = data.get("snapshot_name", "automation_ready")
+@router.post("/{name}/snapshot/save", summary="Save Snapshot")
+def snapshot_save(name: str, req: SnapshotRequest = SnapshotRequest()):
+    """Save emulator state to a named snapshot."""
+    serial = _find_running_serial(name)
     mgr = get_manager()
-    for info in mgr.list_running():
-        if info["name"] == name:
-            result = mgr.snapshot_save(info["serial"], snap_name)
-            return jsonify(result)
-    return jsonify({"ok": False, "error": f'Emulator "{name}" is not running'}), 404
+    return mgr.snapshot_save(serial, req.snapshot_name)
 
 
-@bp.route("/<name>/snapshot/load", methods=["POST"])
-def snapshot_load(name):
-    """Load emulator snapshot. Body: {snapshot_name?: str}"""
-    data = request.json or {}
-    snap_name = data.get("snapshot_name", "automation_ready")
+@router.post("/{name}/snapshot/load", summary="Load Snapshot")
+def snapshot_load(name: str, req: SnapshotRequest = SnapshotRequest()):
+    """Restore emulator state from a named snapshot."""
+    serial = _find_running_serial(name)
     mgr = get_manager()
-    for info in mgr.list_running():
-        if info["name"] == name:
-            result = mgr.snapshot_load(info["serial"], snap_name)
-            return jsonify(result)
-    return jsonify({"ok": False, "error": f'Emulator "{name}" is not running'}), 404
+    return mgr.snapshot_load(serial, req.snapshot_name)
 
 
-@bp.route("/<name>/snapshots", methods=["GET"])
-def list_snapshots(name):
-    """List snapshots for a running emulator."""
+@router.get("/{name}/snapshots", summary="List Snapshots")
+def list_snapshots(name: str):
+    """List available snapshots for a running emulator."""
+    serial = _find_running_serial(name)
     mgr = get_manager()
-    for info in mgr.list_running():
-        if info["name"] == name:
-            result = mgr.list_snapshots(info["serial"])
-            return jsonify(result)
-    return jsonify({"ok": False, "error": f'Emulator "{name}" is not running'}), 404
+    return mgr.list_snapshots(serial)
 
 
-# ── System Images ────────────────────────────────────────────────────────────
+# ── System Images ───────────────────────────────────────────────────────────
 
 
-@bp.route("/system-images", methods=["GET"])
+@router.get("/system-images", summary="List System Images")
 def list_system_images():
-    """List installed system images."""
+    """List installed Android system images."""
     mgr = get_manager()
-    return jsonify(mgr.list_system_images())
+    return mgr.list_system_images()
 
 
-@bp.route("/system-images/install", methods=["POST"])
-def install_system_image():
-    """Download a new system image. Body: {api_level, target?, arch?}"""
-    data = request.json or {}
-    api_level = data.get("api_level")
-    if not api_level:
-        return jsonify({"ok": False, "error": "api_level is required"}), 400
+@router.post("/system-images/install", summary="Install System Image")
+def install_system_image(req: ImageInstallRequest):
+    """Download and install a system image via sdkmanager."""
     mgr = get_manager()
     result = mgr.install_system_image(
-        api_level=int(api_level),
-        target=data.get("target", "google_apis_playstore"),
-        arch=data.get("arch", "x86_64"),
+        api_level=req.api_level,
+        target=req.target,
+        arch=req.arch or "",
     )
-    status_code = 200 if result.get("ok") else 400
-    return jsonify(result), status_code
+    if not result.get("ok"):
+        raise HTTPException(status_code=400, detail=result.get("error", "Install failed"))
+    return result
 
 
-# ── Emulator Pool ────────────────────────────────────────────────────────────
+# ── Emulator Pool ───────────────────────────────────────────────────────────
 
 
-@pool_bp.route("/status", methods=["GET"])
+@pool_router.get("/status", summary="Pool Status")
 def pool_status():
-    """Pool status (active, idle, busy counts + resources)."""
+    """Get pool status: active, idle, busy counts + resource usage."""
     pool = get_pool()
-    return jsonify(pool.status())
+    return pool.status()
 
 
-@pool_bp.route("/scale-up", methods=["POST"])
-def pool_scale_up():
-    """Start N emulators. Body: {count, config?: {api_level, ram_mb, ...}}"""
-    data = request.json or {}
-    count = data.get("count", 1)
-    cfg_data = data.get("config", {})
+@pool_router.post("/scale-up", summary="Scale Up Pool")
+def pool_scale_up(req: PoolScaleUpRequest):
+    """Start N emulators in the pool."""
+    cfg_data = req.config or {}
     config = EmulatorConfig(
-        name="_template",  # ignored — pool generates names
+        name="_template",
         api_level=cfg_data.get("api_level", 35),
         target=cfg_data.get("target", "google_apis_playstore"),
         ram_mb=cfg_data.get("ram_mb", 2048),
@@ -262,31 +284,28 @@ def pool_scale_up():
         headless=True,
     )
     pool = get_pool()
-    result = pool.scale_up(count, config)
-    status_code = 200 if result.get("ok") else 400
-    return jsonify(result), status_code
+    result = pool.scale_up(req.count, config)
+    if not result.get("ok"):
+        raise HTTPException(status_code=400, detail=result.get("error", "Scale up failed"))
+    return result
 
 
-@pool_bp.route("/scale-down", methods=["POST"])
-def pool_scale_down():
-    """Stop N idle emulators. Body: {count?: int} (null = all idle)"""
-    data = request.json or {}
-    count = data.get("count")
+@pool_router.post("/scale-down", summary="Scale Down Pool")
+def pool_scale_down(req: PoolScaleDownRequest = PoolScaleDownRequest()):
+    """Stop N idle emulators from the pool."""
     pool = get_pool()
-    result = pool.scale_down(count)
-    return jsonify(result)
+    return pool.scale_down(req.count)
 
 
-@pool_bp.route("/stop-all", methods=["POST"])
+@pool_router.post("/stop-all", summary="Stop All Pool Emulators")
 def pool_stop_all():
-    """Stop all pool emulators."""
+    """Stop every emulator managed by the pool."""
     pool = get_pool()
-    result = pool.stop_all()
-    return jsonify(result)
+    return pool.stop_all()
 
 
-@pool_bp.route("/resources", methods=["GET"])
+@pool_router.get("/resources", summary="System Resources")
 def pool_resources():
-    """System resource usage (CPU, RAM, disk)."""
+    """Get system resource usage (CPU, RAM, disk)."""
     pool = get_pool()
-    return jsonify(pool.resource_usage())
+    return pool.resource_usage()

--- a/gitd/routers/streaming.py
+++ b/gitd/routers/streaming.py
@@ -35,7 +35,7 @@ def _stable_ws_port(serial: str) -> int:
 
 
 @router.get("/api/phone/stream", summary="Stream Phone Screen MJPEG")
-def phone_stream(device: str = "", fps: int = 30, quality: int = 8, mode: str = "portal"):
+def phone_stream(device: str = "", fps: int = 30, quality: int = 8, mode: str = "screencap"):
     """Stream phone screen via MJPEG."""
     fps = max(1, min(fps, 60))
     quality = max(1, min(quality, 31))

--- a/gitd/routers/traces.py
+++ b/gitd/routers/traces.py
@@ -1,0 +1,200 @@
+"""Local trace inspector API.
+
+Powers the in-app Traces tab. Read-only endpoints over the `traces` and
+`trace_spans` tables that the observability layer writes to.
+
+Endpoint surface kept small and JSON-shaped for the Android adapter:
+    GET  /api/traces                        list (filterable, paginated)
+    GET  /api/traces/stats                  aggregate counters for the header bar
+    GET  /api/traces/{trace_id}             full detail with all spans
+    DELETE /api/traces                      truncate (debug — clears all)
+    DELETE /api/traces/{trace_id}           single trace
+"""
+
+import json
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Query
+from sqlalchemy import desc, func
+
+router = APIRouter(prefix="/api/traces", tags=["traces"])
+
+
+def _row_to_summary(t) -> dict:
+    """Serialize one trace row → list-view summary (small payload)."""
+    return {
+        "id": t.id,
+        "conversation_id": t.conversation_id or "",
+        "provider": t.provider or "",
+        "model": t.model or "",
+        "device": t.device or "",
+        "source": t.source or "",
+        "status": t.status or "",
+        "user_input": t.user_input or "",
+        "final_output_preview": (t.final_output or "")[:200],
+        "input_tokens": t.input_tokens or 0,
+        "output_tokens": t.output_tokens or 0,
+        "cost_usd": float(t.cost_usd or 0),
+        "duration_ms": t.duration_ms or 0,
+        "started_at": t.started_at,
+        "ended_at": t.ended_at or "",
+        "error_text": t.error_text or "",
+    }
+
+
+def _span_to_dict(s) -> dict:
+    return {
+        "id": s.id,
+        "kind": s.kind,
+        "name": s.name,
+        "level": s.level or "DEFAULT",
+        "input": _safe_json_load(s.input_json),
+        "output": _safe_json_load(s.output_json),
+        "started_at": s.started_at,
+        "ended_at": s.ended_at or "",
+        "duration_ms": s.duration_ms or 0,
+    }
+
+
+def _safe_json_load(s: Optional[str]):
+    if not s:
+        return None
+    try:
+        return json.loads(s)
+    except (json.JSONDecodeError, TypeError):
+        return s  # raw string fallback for truncated/garbled values
+
+
+@router.get("", summary="List Traces")
+def list_traces(
+    limit: int = Query(50, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    provider: Optional[str] = Query(None, description="Filter by provider (claude-code, on-device, ollama, anthropic)"),
+    source: Optional[str] = Query(None, description="Filter by source (mac, android)"),
+    status: Optional[str] = Query(None, description="Filter by status (success, error, running, stopped)"),
+    conversation_id: Optional[str] = Query(None, description="Filter to one conversation"),
+):
+    """Newest-first list. Each row carries enough for the list-view card."""
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import Trace
+
+    db = SessionLocal()
+    try:
+        q = db.query(Trace).order_by(desc(Trace.started_at))
+        if provider:        q = q.filter(Trace.provider == provider)
+        if source:          q = q.filter(Trace.source == source)
+        if status:          q = q.filter(Trace.status == status)
+        if conversation_id: q = q.filter(Trace.conversation_id == conversation_id)
+
+        total = q.count()
+        rows = q.limit(limit).offset(offset).all()
+        return {"total": total, "limit": limit, "offset": offset,
+                "data": [_row_to_summary(r) for r in rows]}
+    finally:
+        db.close()
+
+
+@router.get("/stats", summary="Trace Stats")
+def trace_stats(
+    since_hours: int = Query(24, ge=1, le=24 * 30),
+):
+    """Aggregate counters for the Traces tab header bar."""
+    from datetime import datetime, timedelta, timezone
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import Trace
+
+    cutoff = (datetime.now(timezone.utc) - timedelta(hours=since_hours)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    db = SessionLocal()
+    try:
+        base_q = db.query(Trace).filter(Trace.started_at >= cutoff)
+        total = base_q.count()
+        errors = base_q.filter(Trace.status == "error").count()
+        avg_duration = db.query(func.avg(Trace.duration_ms)).filter(
+            Trace.started_at >= cutoff, Trace.status == "success"
+        ).scalar() or 0
+        total_cost = db.query(func.sum(Trace.cost_usd)).filter(
+            Trace.started_at >= cutoff
+        ).scalar() or 0.0
+        total_in = db.query(func.sum(Trace.input_tokens)).filter(
+            Trace.started_at >= cutoff
+        ).scalar() or 0
+        total_out = db.query(func.sum(Trace.output_tokens)).filter(
+            Trace.started_at >= cutoff
+        ).scalar() or 0
+        # Per-provider breakdown
+        per_provider = (
+            base_q.with_entities(Trace.provider, func.count(Trace.id))
+            .group_by(Trace.provider).all()
+        )
+        return {
+            "since_hours": since_hours,
+            "total": total,
+            "errors": errors,
+            "success_rate": round((total - errors) / total, 3) if total else 1.0,
+            "avg_duration_ms": int(avg_duration),
+            "total_cost_usd": round(float(total_cost), 4),
+            "total_input_tokens": int(total_in),
+            "total_output_tokens": int(total_out),
+            "by_provider": [{"provider": p or "?", "count": int(c)} for p, c in per_provider],
+        }
+    finally:
+        db.close()
+
+
+@router.get("/{trace_id}", summary="Get Trace With Spans")
+def get_trace(trace_id: str):
+    """Full detail view: trace metadata + ordered span timeline."""
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import Trace, TraceSpan
+
+    db = SessionLocal()
+    try:
+        t = db.get(Trace, trace_id)
+        if not t:
+            raise HTTPException(status_code=404, detail="trace not found")
+        spans = (
+            db.query(TraceSpan).filter_by(trace_id=trace_id)
+            .order_by(TraceSpan.started_at, TraceSpan.id).all()
+        )
+        return {
+            "trace": {
+                **_row_to_summary(t),
+                "final_output": t.final_output or "",
+            },
+            "spans": [_span_to_dict(s) for s in spans],
+        }
+    finally:
+        db.close()
+
+
+@router.delete("/{trace_id}", summary="Delete Trace")
+def delete_trace(trace_id: str):
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import Trace
+
+    db = SessionLocal()
+    try:
+        t = db.get(Trace, trace_id)
+        if not t:
+            raise HTTPException(status_code=404, detail="trace not found")
+        db.delete(t)  # ON DELETE CASCADE cleans up spans
+        db.commit()
+        return {"ok": True, "deleted": trace_id}
+    finally:
+        db.close()
+
+
+@router.delete("", summary="Clear All Traces (Debug)")
+def clear_all_traces():
+    """Wipe everything — useful when iterating on observability code."""
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import Trace, TraceSpan
+
+    db = SessionLocal()
+    try:
+        n_spans = db.query(TraceSpan).delete()
+        n_traces = db.query(Trace).delete()
+        db.commit()
+        return {"ok": True, "deleted_traces": n_traces, "deleted_spans": n_spans}
+    finally:
+        db.close()

--- a/gitd/services/_emulator_helpers.py
+++ b/gitd/services/_emulator_helpers.py
@@ -6,6 +6,7 @@ EmulatorConfig dataclass, and discovery/query functions.
 import configparser
 import logging
 import os
+import platform
 import shutil
 import subprocess
 import threading
@@ -19,7 +20,29 @@ logger = logging.getLogger(__name__)
 
 # ── SDK paths ────────────────────────────────────────────────────────────────
 
-SDK_ROOT = Path(os.environ.get("ANDROID_SDK_ROOT", os.environ.get("ANDROID_HOME", Path.home() / "Android" / "Sdk")))
+
+def _detect_sdk_root() -> Path:
+    """Auto-detect Android SDK root across platforms."""
+    for var in ("ANDROID_SDK_ROOT", "ANDROID_HOME"):
+        val = os.environ.get(var)
+        if val and Path(val).exists():
+            return Path(val)
+    # macOS: Homebrew commandline-tools
+    brew = Path("/opt/homebrew/share/android-commandlinetools")
+    if brew.exists():
+        return brew
+    # macOS: Android Studio default
+    mac_studio = Path.home() / "Library" / "Android" / "sdk"
+    if mac_studio.exists():
+        return mac_studio
+    # Linux default
+    linux = Path.home() / "Android" / "Sdk"
+    if linux.exists():
+        return linux
+    return brew if platform.system() == "Darwin" else linux
+
+
+SDK_ROOT = _detect_sdk_root()
 
 EMULATOR_BIN = SDK_ROOT / "emulator" / "emulator"
 ADB_BIN = shutil.which("adb") or str(SDK_ROOT / "platform-tools" / "adb")
@@ -48,8 +71,30 @@ def _adb(serial: str, *args, timeout: int = 30) -> str:
     return r.stdout.strip()
 
 
+def _safe_int(val: str, default: int = 0) -> int:
+    """Parse int from string, stripping size suffixes like 'M', 'G', '2G'."""
+    val = val.strip()
+    if not val:
+        return default
+    for suffix in ("MB", "GB", "KB", "M", "G", "K"):
+        if val.upper().endswith(suffix):
+            val = val[: -len(suffix)]
+            break
+    try:
+        return int(val)
+    except ValueError:
+        return default
+
+
 def is_emulator(serial: str) -> bool:
     return serial.startswith("emulator-")
+
+
+def default_arch() -> str:
+    """Return the correct emulator arch for this platform."""
+    if platform.machine().lower() in ("arm64", "aarch64"):
+        return "arm64-v8a"
+    return "x86_64"
 
 
 # ── Config dataclass ─────────────────────────────────────────────────────────
@@ -60,7 +105,7 @@ class EmulatorConfig:
     name: str
     api_level: int = 35
     target: str = "google_apis_playstore"  # google_apis | google_apis_playstore | default
-    arch: str = "x86_64"
+    arch: str = ""  # auto-detected if empty
     device_profile: str = "medium_phone"  # hardware profile name
     ram_mb: int = 2048
     disk_mb: int = 6144
@@ -70,6 +115,10 @@ class EmulatorConfig:
     cores: int = 2
     headless: bool = False
     snapshot: bool = True
+
+    def __post_init__(self):
+        if not self.arch:
+            self.arch = default_arch()
 
     def system_image_pkg(self) -> str:
         api = f"android-{self.api_level}"
@@ -87,13 +136,18 @@ class EmulatorConfig:
 
 def check_prerequisites() -> dict:
     """Check what SDK tools are available."""
+    is_mac = platform.system() == "Darwin"
+    hw_accel = True if is_mac else Path("/dev/kvm").exists()
     return {
         "sdk_root": str(SDK_ROOT),
         "sdk_exists": SDK_ROOT.exists(),
         "emulator_binary": EMULATOR_BIN.exists(),
         "adb_binary": shutil.which("adb") is not None or (SDK_ROOT / "platform-tools" / "adb").exists(),
         "cmdline_tools": _has_cmdline_tools(),
-        "kvm": Path("/dev/kvm").exists(),
+        "hw_accel": hw_accel,
+        "hw_accel_type": "HVF" if is_mac else "KVM",
+        "platform": platform.system(),
+        "arch": default_arch(),
         "avd_home": str(AVD_HOME),
     }
 
@@ -127,8 +181,10 @@ def list_system_images() -> list[dict]:
     return images
 
 
-def install_system_image(api_level: int, target: str = "google_apis_playstore", arch: str = "x86_64") -> dict:
+def install_system_image(api_level: int, target: str = "google_apis_playstore", arch: str = "") -> dict:
     """Download a system image via sdkmanager. Requires cmdline-tools."""
+    if not arch:
+        arch = default_arch()
     if not _has_cmdline_tools():
         return {
             "ok": False,
@@ -157,7 +213,6 @@ def list_avds(running_list: list[dict]) -> list[dict]:
     for ini_file in sorted(AVD_HOME.glob("*.ini")):
         if ini_file.suffix != ".ini":
             continue
-        # skip .avd directories, only process top-level .ini
         name_from_file = ini_file.stem
 
         cfg = configparser.ConfigParser()
@@ -171,7 +226,6 @@ def list_avds(running_list: list[dict]) -> list[dict]:
             "target": cfg.get("root", "target", fallback=""),
         }
 
-        # Read detailed config from the .avd/config.ini
         config_ini = avd_path / "config.ini" if avd_path else None
         if config_ini and config_ini.exists():
             lines = config_ini.read_text().splitlines()
@@ -189,16 +243,15 @@ def list_avds(running_list: list[dict]) -> list[dict]:
                     "target_flavor": kv.get("tag.display", ""),
                     "abi": kv.get("abi.type", ""),
                     "resolution": f"{kv.get('hw.lcd.width', '?')}x{kv.get('hw.lcd.height', '?')}",
-                    "dpi": int(kv.get("hw.lcd.density", 0)),
-                    "ram_mb": int(kv.get("hw.ramSize", 0)),
+                    "dpi": _safe_int(kv.get("hw.lcd.density", "0")),
+                    "ram_mb": _safe_int(kv.get("hw.ramSize", "0")),
                     "disk": kv.get("disk.dataPartition.size", ""),
                     "gpu_mode": kv.get("hw.gpu.mode", ""),
-                    "cores": int(kv.get("hw.cpu.ncore", 0)),
+                    "cores": _safe_int(kv.get("hw.cpu.ncore", "0")),
                     "playstore": kv.get("PlayStore.enabled", "false").lower() == "true",
                 }
             )
 
-        # Running status
         run_info = running.get(name_from_file)
         if run_info:
             adb_state = run_info.get("adb_state", "device")
@@ -215,14 +268,7 @@ def list_avds(running_list: list[dict]) -> list[dict]:
 
 
 def list_running(procs: dict, lock: threading.Lock) -> list[dict]:
-    """List running emulators with serials and AVD names.
-
-    Picks up both 'device' (fully booted) and 'offline' (booting) emulators.
-
-    Args:
-        procs: the EmulatorManager._procs dict (serial -> Popen).
-        lock: the EmulatorManager._lock.
-    """
+    """List running emulators with serials and AVD names."""
     try:
         r = _run([ADB_BIN, "devices"], timeout=10, check=False)
     except (subprocess.SubprocessError, OSError):
@@ -232,13 +278,11 @@ def list_running(procs: dict, lock: threading.Lock) -> list[dict]:
         parts = line.split()
         if len(parts) >= 2 and parts[0].startswith("emulator-") and parts[1] in ("device", "offline"):
             serial = parts[0]
-            adb_state = parts[1]  # 'device' or 'offline'
-            # get AVD name (only works if device is online)
+            adb_state = parts[1]
             avd_name = "unknown"
             if adb_state == "device":
                 name_out = _adb(serial, "emu", "avd", "name", timeout=5)
                 avd_name = name_out.splitlines()[0].strip() if name_out else "unknown"
-            # get pid from tracked procs or from system
             pid = None
             with lock:
                 proc = procs.get(serial)

--- a/gitd/services/_emulator_helpers.py
+++ b/gitd/services/_emulator_helpers.py
@@ -14,7 +14,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
-import psutil
+try:
+    import psutil
+except ImportError:
+    psutil = None  # Not available on Android (C extension)
 
 logger = logging.getLogger(__name__)
 
@@ -303,6 +306,8 @@ def list_running(procs: dict, lock: threading.Lock) -> list[dict]:
 
 def find_emulator_pid(serial: str) -> Optional[int]:
     """Find PID of emulator process by matching port."""
+    if psutil is None:
+        return None
     port = serial.replace("emulator-", "")
     try:
         for proc in psutil.process_iter(["pid", "name", "cmdline"]):

--- a/gitd/services/_emulator_pool.py
+++ b/gitd/services/_emulator_pool.py
@@ -11,7 +11,10 @@ import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
-import psutil
+try:
+    import psutil
+except ImportError:
+    psutil = None
 
 from gitd.services._emulator_helpers import EmulatorConfig
 

--- a/gitd/services/agent_chat.py
+++ b/gitd/services/agent_chat.py
@@ -310,6 +310,25 @@ def delete_conversation(conversation_id: str):
     _sessions.pop(conversation_id, None)
 
 
+def get_providers() -> list[dict]:
+    """Return providers with models. Ollama models are discovered live from the local server."""
+    import requests
+
+    result = []
+    for pid, info in PROVIDERS.items():
+        models = list(info["models"])
+        if pid == "ollama":
+            try:
+                r = requests.get("http://localhost:11434/api/tags", timeout=3)
+                installed = [m["name"] for m in r.json().get("models", [])]
+                if installed:
+                    models = installed
+            except Exception:
+                pass  # Ollama not running — return defaults
+        result.append({"id": pid, "label": info["label"], "models": models})
+    return result
+
+
 def chat_turn(session: ChatSession, user_message: str):
     """Run one agent turn. Yields SSE event dicts."""
     provider = session.provider
@@ -726,11 +745,22 @@ def _chat_ollama(session: ChatSession, user_message: str):
                 },
                 timeout=120,
             )
-            reply = r.json().get("message", {}).get("content", "")
+            data = r.json()
+            if r.status_code != 200:
+                error = data.get("error", r.text[:200])
+                if "not found" in error.lower():
+                    yield {
+                        "type": "error",
+                        "content": f"Model '{model}' not found. Pull it first: ollama pull {model}",
+                    }
+                else:
+                    yield {"type": "error", "content": f"Ollama error: {error}"}
+                return
+            reply = data.get("message", {}).get("content", "")
         except requests.ConnectionError:
             yield {
                 "type": "error",
-                "content": "Ollama not reachable at localhost:11434. Install: https://ollama.com/download",
+                "content": "Ollama not reachable at localhost:11434. Start it: ollama serve",
             }
             return
         except Exception as e:

--- a/gitd/services/agent_chat.py
+++ b/gitd/services/agent_chat.py
@@ -60,7 +60,17 @@ PROVIDERS = {
     "claude-code": {"label": "Claude Code (free)", "models": ["sonnet", "opus", "haiku"]},
     "anthropic": {"label": "Claude API", "models": ["claude-sonnet-4-20250514", "claude-opus-4-20250514"]},
     "openrouter": {"label": "OpenRouter", "models": ["anthropic/claude-sonnet-4", "google/gemini-2.5-pro"]},
-    "ollama": {"label": "Ollama (local)", "models": []},
+    "ollama": {
+        "label": "Ollama (local)",
+        "models": [
+            "llama3.2:3b",
+            "llama3.2:1b",
+            "gemma3:4b",
+            "qwen3:4b",
+            "phi4-mini:3.8b",
+            "mistral:7b",
+        ],
+    },
 }
 
 
@@ -645,12 +655,43 @@ def _chat_openrouter(session: ChatSession, user_message: str):
 # ── Ollama ───────────────────────────────────────────────────────────────────
 
 
+def _parse_tool_calls(text: str) -> list[dict]:
+    """Extract tool calls from LLM output. Handles ```tool blocks and common LLM quirks."""
+    import re
+
+    calls = []
+    for match in re.finditer(r"```tool\s*\n?(.*?)\n?```", text, re.DOTALL):
+        raw = match.group(1).strip()
+        # Try parsing as-is first (valid JSON)
+        try:
+            call = json.loads(raw)
+            if isinstance(call, dict) and "tool" in call:
+                calls.append(call)
+                continue
+        except json.JSONDecodeError:
+            pass
+        # Fallback: some models wrap JSON in doubled braces {{ ... }}
+        fixed = raw
+        for _ in range(3):
+            fixed = re.sub(r"\{\{", "{", fixed)
+            fixed = re.sub(r"\}\}", "}", fixed)
+            try:
+                call = json.loads(fixed)
+                if isinstance(call, dict) and "tool" in call:
+                    calls.append(call)
+                    break
+            except json.JSONDecodeError:
+                continue
+    return calls
+
+
 def _chat_ollama(session: ChatSession, user_message: str):
-    """Use local Ollama model."""
+    """Use local Ollama model with multi-turn tool execution loop."""
     import requests
 
     session.messages.append(ChatMessage(role="user", content=user_message))
 
+    # Build screen context
     context = ""
     try:
         tree = get_screen_tree(session.device)
@@ -659,45 +700,77 @@ def _chat_ollama(session: ChatSession, user_message: str):
     except Exception:
         pass
 
-    tool_list = "\n".join(f"- {t['name']}: {t['description']}" for t in TOOLS)
+    # Build tool list with param names so the LLM knows what args to send
+    tool_list = "\n".join(
+        f"- {t['name']}: {t['description']}  params: {list(t.get('input_schema', {}).get('properties', {}).keys())}"
+        for t in TOOLS
+    )
     system = DEFAULT_SYSTEM.replace("{tool_list}", tool_list)
 
-    try:
-        r = requests.post(
-            "http://localhost:11434/api/chat",
-            json={
-                "model": session.model or "llama3",
-                "messages": [
-                    {"role": "system", "content": system},
-                    {"role": "user", "content": f"{context}Device: {session.device}\n\n{user_message}"},
-                ],
-                "stream": False,
-            },
-            timeout=120,
-        )
-        reply = r.json().get("message", {}).get("content", "")
+    messages = [
+        {"role": "system", "content": system},
+        {"role": "user", "content": f"{context}Device: {session.device}\n\n{user_message}"},
+    ]
 
-        if reply:
-            session.messages.append(ChatMessage(role="assistant", content=reply))
-            yield {"type": "text", "content": reply}
+    model = session.model or "llama3.2:3b"
 
-            # Parse tool calls from response (same format as claude-code)
-            import re
+    for turn in range(MAX_TURNS):
+        try:
+            r = requests.post(
+                "http://localhost:11434/api/chat",
+                json={
+                    "model": model,
+                    "messages": messages,
+                    "stream": False,
+                    "options": {"num_ctx": 4096},
+                },
+                timeout=120,
+            )
+            reply = r.json().get("message", {}).get("content", "")
+        except requests.ConnectionError:
+            yield {
+                "type": "error",
+                "content": "Ollama not reachable at localhost:11434. Install: https://ollama.com/download",
+            }
+            return
+        except Exception as e:
+            yield {"type": "error", "content": str(e)}
+            return
 
-            tool_pattern = re.compile(r"```tool\s*\n(.*?)\n```", re.DOTALL)
-            for match in tool_pattern.finditer(reply):
-                try:
-                    call = json.loads(match.group(1).strip())
-                    tool_name = call.get("tool", "")
-                    tool_args = call.get("args", {})
-                    tool_args.setdefault("device", session.device)
-                    result = execute_tool(tool_name, tool_args)
-                    yield {"type": "tool_call", "name": tool_name, "args": tool_args}
-                    yield {"type": "tool_result", "name": tool_name, "result": result[:500]}
-                except Exception:
-                    pass
-    except Exception as e:
-        yield {"type": "error", "content": str(e)}
+        if not reply:
+            break
+
+        session.messages.append(ChatMessage(role="assistant", content=reply))
+        yield {"type": "text", "content": reply}
+        messages.append({"role": "assistant", "content": reply})
+
+        # Parse and execute tool calls
+        tool_calls = _parse_tool_calls(reply)
+        if not tool_calls:
+            break  # No tools requested — done
+
+        tool_results = []
+        for call in tool_calls:
+            tool_name = call.get("tool", "")
+            tool_args = call.get("args", {})
+            tool_args.setdefault("device", session.device)
+
+            session.messages.append(ChatMessage(role="tool_call", tool_name=tool_name, tool_args=tool_args, content=""))
+            yield {"type": "tool_call", "name": tool_name, "args": tool_args}
+
+            try:
+                result = execute_tool(tool_name, tool_args)
+                session.messages.append(ChatMessage(role="tool_result", content=result[:500], tool_name=tool_name))
+                yield {"type": "tool_result", "name": tool_name, "result": result[:500]}
+                tool_results.append(f"[{tool_name}] {result[:800]}")
+            except Exception as e:
+                err = f"Tool error: {e}"
+                session.messages.append(ChatMessage(role="tool_result", content=err, tool_name=tool_name))
+                yield {"type": "tool_result", "name": tool_name, "result": err}
+                tool_results.append(f"[{tool_name}] ERROR: {err}")
+
+        # Feed tool results back for next turn
+        messages.append({"role": "user", "content": "Tool results:\n" + "\n".join(tool_results)})
 
     yield {"type": "done"}
 

--- a/gitd/services/agent_chat.py
+++ b/gitd/services/agent_chat.py
@@ -679,7 +679,7 @@ def _parse_tool_calls(text: str) -> list[dict]:
     import re
 
     calls = []
-    for match in re.finditer(r"```tool\s*\n?(.*?)\n?```", text, re.DOTALL):
+    for match in re.finditer(r"```(?:tool|json)\s*\n?(.*?)\n?```", text, re.DOTALL):
         raw = match.group(1).strip()
         # Try parsing as-is first (valid JSON)
         try:

--- a/gitd/services/agent_chat.py
+++ b/gitd/services/agent_chat.py
@@ -826,6 +826,24 @@ def _parse_tool_calls(text: str) -> list[dict]:
             continue
         _attempt_repairs(raw)
 
+    if calls:
+        return calls
+
+    # 3) Last-ditch fallback — Gemma at temp 0 routinely emits inline doubled
+    #    braces with a mismatched count of closing `}` (e.g. five `}` for two
+    #    `{{`). The step-2 regex above can't match a `{{` start because it
+    #    expects a non-brace character after the first `{`. Collapse doubled
+    #    braces over the whole text and try the same scan again.
+    if "{{" in text or "}}" in text:
+        flattened = text.replace("{{", "{").replace("}}", "}")
+        for match in re.finditer(r"\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}", flattened, re.DOTALL):
+            raw = match.group(0)
+            if '"tool"' not in raw and '"action_type"' not in raw:
+                continue
+            if _try_loads(raw):
+                continue
+            _attempt_repairs(raw)
+
     return calls
 
 

--- a/gitd/services/agent_chat.py
+++ b/gitd/services/agent_chat.py
@@ -78,6 +78,19 @@ PROVIDERS = {
         "label": "On-device (Gemma)",
         "models": ["gemma-3-1b-it", "gemma-2-2b-it", "gemma-4-e2b-q4km-gguf"],
     },
+    # vLLM-on-jsl-gpu — full-precision Gemma 4 served from the GPU box,
+    # routed via Mac SSH tunnel + adb reverse so the phone hits it as if it
+    # were on localhost. Same OpenAI-compatible shape as openrouter; we just
+    # point the client at config.vllm_base_url instead.
+    "vllm": {
+        "label": "vLLM (jsl-gpu)",
+        "models": [
+            "unsloth/gemma-4-E2B-it",
+            "unsloth/gemma-4-E2B-it-bnb-4bit",
+            "unsloth/gemma-4-E4B-it",
+            "unsloth/gemma-4-E4B-it-bnb-4bit",
+        ],
+    },
 }
 
 
@@ -373,6 +386,8 @@ def chat_turn(session: ChatSession, user_message: str):
         yield from chat_claude_code(session, user_message)
     elif provider == "openrouter":
         yield from _chat_openrouter(session, user_message)
+    elif provider == "vllm":
+        yield from _chat_vllm(session, user_message)
     elif provider == "ollama":
         yield from _chat_ollama(session, user_message)
     elif provider == "on-device":
@@ -704,6 +719,135 @@ def _chat_openrouter(session: ChatSession, user_message: str):
 
     except Exception as e:
         yield {"type": "error", "content": str(e)}
+
+    yield {"type": "done"}
+
+
+# ── vLLM (OpenAI-compatible, points at jsl-gpu) ──────────────────────────────
+
+
+def _chat_vllm(session: ChatSession, user_message: str):
+    """Use a vLLM server (default: jsl-gpu via SSH tunnel + adb reverse) with
+    OpenAI-compatible tool calling and multi-turn agent loop.
+
+    Same OpenAI surface as _chat_openrouter, but unlike that one we DO loop on
+    tool results — the whole point of routing to a real GPU is to put a smarter
+    model into the actual agent loop (open Settings → tap Wi-Fi → ...), not
+    just emit a single round of tool calls.
+    """
+    from openai import OpenAI
+
+    from gitd.config import settings
+
+    session.messages.append(ChatMessage(role="user", content=user_message))
+
+    client = OpenAI(
+        api_key=os.environ.get("GITD_VLLM_API_KEY", settings.vllm_api_key) or "EMPTY",
+        base_url=os.environ.get("GITD_VLLM_BASE_URL", settings.vllm_base_url),
+    )
+
+    oai_tools = [
+        {
+            "type": "function",
+            "function": {"name": t["name"], "description": t["description"], "parameters": t["input_schema"]},
+        }
+        for t in TOOLS
+    ]
+
+    # Initial screen context.
+    context = ""
+    try:
+        tree = get_screen_tree(session.device)
+        state = get_phone_state(session.device)
+        context = f"[Screen]\n{tree[:1500]}\n[App: {state.get('currentApp', '?')}]\n\n"
+    except Exception:
+        pass
+
+    messages: list[dict] = [
+        {"role": "system", "content": ANTHROPIC_SYSTEM},
+        {"role": "user", "content": f"{context}Device: {session.device}\n\n{user_message}"},
+    ]
+
+    model = session.model or "unsloth/gemma-4-E4B-it"
+
+    for turn in range(MAX_TURNS):
+        yield {"type": "activity", "content": f"🧠 Inferring (turn {turn + 1})..."}
+
+        try:
+            resp = client.chat.completions.create(
+                model=model,
+                messages=messages,
+                tools=oai_tools,
+                max_tokens=2048,
+            )
+        except Exception as e:
+            yield {
+                "type": "error",
+                "content": (
+                    f"vLLM unreachable at {client.base_url}. "
+                    f"Start the server on jsl-gpu and ensure the SSH tunnel + "
+                    f"`adb reverse tcp:8000 tcp:8000` are up. ({e})"
+                ),
+            }
+            yield {"type": "done"}
+            return
+
+        msg = resp.choices[0].message
+
+        if msg.content:
+            session.messages.append(ChatMessage(role="assistant", content=msg.content))
+            yield {"type": "text", "content": msg.content}
+
+        # OpenAI-shape tool_calls. If absent, the model is done.
+        tool_calls = getattr(msg, "tool_calls", None) or []
+        if not tool_calls:
+            break
+
+        # Append the assistant turn to the rolling conversation BEFORE running
+        # tools so the next request sees the assistant's tool_calls in
+        # context (OpenAI shape requires this).
+        messages.append({
+            "role": "assistant",
+            "content": msg.content or "",
+            "tool_calls": [
+                {
+                    "id": tc.id,
+                    "type": "function",
+                    "function": {"name": tc.function.name, "arguments": tc.function.arguments},
+                }
+                for tc in tool_calls
+            ],
+        })
+
+        for tc in tool_calls:
+            tool_name = tc.function.name
+            try:
+                tool_args = json.loads(tc.function.arguments) if tc.function.arguments else {}
+            except json.JSONDecodeError:
+                tool_args = {}
+            tool_args.setdefault("device", session.device)
+
+            session.messages.append(
+                ChatMessage(role="tool_call", tool_name=tool_name, tool_args=tool_args, content="")
+            )
+            yield {"type": "tool_call", "name": tool_name, "args": tool_args}
+
+            try:
+                result = execute_tool(tool_name, tool_args)
+            except Exception as e:
+                result = f"Tool error: {e}"
+            session.messages.append(
+                ChatMessage(role="tool_result", content=result[:500], tool_name=tool_name)
+            )
+            yield {"type": "tool_result", "name": tool_name, "result": result[:500]}
+
+            # Feed result back to the model for the next turn.
+            messages.append({
+                "role": "tool",
+                "tool_call_id": tc.id,
+                "name": tool_name,
+                "content": result[:1500],
+            })
 
     yield {"type": "done"}
 

--- a/gitd/services/agent_chat.py
+++ b/gitd/services/agent_chat.py
@@ -342,6 +342,10 @@ def chat_turn(session: ChatSession, user_message: str):
         yield from _chat_openrouter(session, user_message)
     elif provider == "ollama":
         yield from _chat_ollama(session, user_message)
+    elif provider == "on-device":
+        from gitd.services.agent_chat_ondevice import chat_ondevice
+
+        yield from chat_ondevice(session, user_message)
     else:
         yield {"type": "error", "content": f"Unknown provider: {provider}"}
 

--- a/gitd/services/agent_chat.py
+++ b/gitd/services/agent_chat.py
@@ -71,6 +71,13 @@ PROVIDERS = {
             "mistral:7b",
         ],
     },
+    # On-device — runs the model in-process via MediaPipe (.task) or
+    # llama.cpp JNI (.gguf). The Kotlin OnDeviceModelRegistry is the source of
+    # truth for ids; we ship a default subset here and overlay live ids below.
+    "on-device": {
+        "label": "On-device (Gemma)",
+        "models": ["gemma-3-1b-it", "gemma-2-2b-it", "gemma-4-e2b-gguf"],
+    },
 }
 
 
@@ -679,32 +686,146 @@ def _chat_openrouter(session: ChatSession, user_message: str):
 
 
 def _parse_tool_calls(text: str) -> list[dict]:
-    """Extract tool calls from LLM output. Handles ```tool blocks and common LLM quirks."""
+    """Extract tool calls from LLM output.
+
+    Handles a fair amount of slop because small models — especially raw Gemma 4 —
+    emit f-string-style doubled braces, half-quoted keys, trailing ``, " "``
+    junk, missing/extra closing braces, and similar near-misses.
+
+    Accepted shapes:
+      - {"tool": "X", "args": {...}}           (canonical)
+      - {"tool": "X", "kwarg1": ..., ...}      (flat — e.g. ghost-gemma trained)
+      - {"action_type": "X", ...}              (action-schema — translated to tool)
+    """
     import re
 
-    calls = []
-    for match in re.finditer(r"```(?:tool|json)\s*\n?(.*?)\n?```", text, re.DOTALL):
-        raw = match.group(1).strip()
-        # Try parsing as-is first (valid JSON)
+    if not text:
+        return []
+
+    calls: list[dict] = []
+
+    # Map from action-schema "action_type" → ("tool", arg-key-rewrites). For raw
+    # Gemma 4 emitting the action schema we trained on, this lets the dispatcher
+    # see canonical tool calls without retraining the parser side.
+    action_to_tool = {
+        "open_app":   ("launch_app",  {"app_name": "package"}),
+        "click":      ("tap",         {"x": "x", "y": "y"}),
+        "tap":        ("tap",         {}),
+        "long_press": ("long_press",  {}),
+        "type_text":  ("input_text",  {"text": "text"}),
+        "input_text": ("input_text",  {}),
+        "swipe":      ("swipe",       {}),
+        "key_event":  ("key_event",   {"key": "key"}),
+        "screenshot": ("screenshot",  {}),
+        "wait":       ("wait",        {"duration_ms": "ms"}),
+        "force_stop": ("force_stop",  {}),
+    }
+
+    def _coerce_action(d: dict) -> dict | None:
+        action = d.get("action_type")
+        if not isinstance(action, str):
+            return None
+        mapping = action_to_tool.get(action)
+        if not mapping:
+            return None
+        tool_name, key_map = mapping
+        args = {}
+        for k, v in d.items():
+            if k == "action_type":
+                continue
+            args[key_map.get(k, k)] = v
+        return {"tool": tool_name, "args": args}
+
+    def _try_dict(d: object) -> bool:
+        if not isinstance(d, dict):
+            return False
+        if "tool" in d:
+            calls.append(d)
+            return True
+        coerced = _coerce_action(d)
+        if coerced:
+            calls.append(coerced)
+            return True
+        return False
+
+    def _try_loads(raw: str) -> bool:
         try:
-            call = json.loads(raw)
-            if isinstance(call, dict) and "tool" in call:
-                calls.append(call)
-                continue
-        except json.JSONDecodeError:
-            pass
-        # Fallback: some models wrap JSON in doubled braces {{ ... }}
-        fixed = raw
-        for _ in range(3):
-            fixed = re.sub(r"\{\{", "{", fixed)
-            fixed = re.sub(r"\}\}", "}", fixed)
-            try:
-                call = json.loads(fixed)
-                if isinstance(call, dict) and "tool" in call:
-                    calls.append(call)
-                    break
-            except json.JSONDecodeError:
-                continue
+            return _try_dict(json.loads(raw))
+        except (ValueError, TypeError):
+            return False
+
+    def _attempt_repairs(raw: str) -> bool:
+        """Run a chain of cleanups, retrying json.loads at every checkpoint."""
+        candidate = raw
+
+        # Doubled braces (Gemma f-string artefact) → singles. Only run when at
+        # least one ``{{`` is present — otherwise we'd corrupt valid JSON like
+        # ``{"a":{"b":1}}`` which has trailing ``}}`` for nested closes.
+        # Do it ONCE only; iterating collapses legitimate triples like ``}}}``
+        # (which is ``}}`` + ``}`` in the doubled convention) past the right
+        # shape.
+        if "{{" in candidate:
+            new = candidate.replace("{{", "{").replace("}}", "}")
+            if new != candidate:
+                candidate = new
+                if _try_loads(candidate):
+                    return True
+
+        # Strip dangling-comma "junk pairs" like ``, " "`` or ``, ""`` that some
+        # models tack on before a closing brace.
+        cleaned = re.sub(r',\s*"[^"]*"\s*(?=[,}])', "", candidate)
+        if cleaned != candidate:
+            candidate = cleaned
+            if _try_loads(candidate):
+                return True
+
+        # Drop trailing ``,`` before ``}`` / ``]``.
+        cleaned = re.sub(r",\s*([}\]])", r"\1", candidate)
+        if cleaned != candidate:
+            candidate = cleaned
+            if _try_loads(candidate):
+                return True
+
+        # Truncate to the first balanced brace span — handles trailing prose
+        # or extra closing braces.
+        depth = 0
+        start = candidate.find("{")
+        if start >= 0:
+            for i in range(start, len(candidate)):
+                ch = candidate[i]
+                if ch == "{":
+                    depth += 1
+                elif ch == "}":
+                    depth -= 1
+                    if depth == 0:
+                        if _try_loads(candidate[start : i + 1]):
+                            return True
+                        break
+
+        return False
+
+    # 1) ```tool / ```json fenced blocks (prompt asks for these)
+    for match in re.finditer(r"```(?:tool|json)?\s*\n?(.*?)\n?```", text, re.DOTALL):
+        raw = match.group(1).strip()
+        if not raw:
+            continue
+        if _try_loads(raw):
+            continue
+        _attempt_repairs(raw)
+
+    if calls:
+        return calls
+
+    # 2) No fences — scan for inline JSON objects mentioning "tool" or
+    #    "action_type". Greedy: match every {...} and try each.
+    for match in re.finditer(r"\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}", text, re.DOTALL):
+        raw = match.group(0)
+        if '"tool"' not in raw and '"action_type"' not in raw:
+            continue
+        if _try_loads(raw):
+            continue
+        _attempt_repairs(raw)
+
     return calls
 
 
@@ -737,16 +858,25 @@ def _chat_ollama(session: ChatSession, user_message: str):
 
     model = session.model or "llama3.2:3b"
 
+    # Gemma 4 (and other reasoning models) emit chain-of-thought into a
+    # separate `thinking` field. The agent loop wants direct JSON tool calls,
+    # so disable thinking for the action loop. Surface any thinking that does
+    # arrive as a `thinking` event so the UI can show it.
+    is_thinking_model = any(t in model.lower() for t in ("gemma-4", "gemma4", "ghost-gemma", "qwen3", "deepseek-r1"))
+
     for turn in range(MAX_TURNS):
         try:
+            payload = {
+                "model": model,
+                "messages": messages,
+                "stream": False,
+                "options": {"num_ctx": 4096, "num_predict": 512},
+            }
+            if is_thinking_model:
+                payload["think"] = False
             r = requests.post(
                 "http://localhost:11434/api/chat",
-                json={
-                    "model": model,
-                    "messages": messages,
-                    "stream": False,
-                    "options": {"num_ctx": 4096},
-                },
+                json=payload,
                 timeout=120,
             )
             data = r.json()
@@ -760,7 +890,14 @@ def _chat_ollama(session: ChatSession, user_message: str):
                 else:
                     yield {"type": "error", "content": f"Ollama error: {error}"}
                 return
-            reply = data.get("message", {}).get("content", "")
+            msg = data.get("message", {}) or {}
+            reply = msg.get("content", "") or ""
+            thinking = msg.get("thinking", "") or ""
+            if thinking:
+                yield {"type": "thinking", "content": thinking}
+            # Fallback: if think:false was ignored and content is empty but thinking has the answer
+            if not reply and thinking:
+                reply = thinking
         except requests.ConnectionError:
             yield {
                 "type": "error",
@@ -786,7 +923,15 @@ def _chat_ollama(session: ChatSession, user_message: str):
         tool_results = []
         for call in tool_calls:
             tool_name = call.get("tool", "")
-            tool_args = call.get("args", {})
+            # Two shapes seen in the wild:
+            #   {"tool": "X", "args": {...}}            (gemma-4-e2b, llama)
+            #   {"tool": "X", "package": "...", ...}    (ghost-gemma, qwen)
+            # Accept both: prefer nested args, else take the rest of the dict as kwargs.
+            raw_args = call.get("args")
+            if isinstance(raw_args, dict):
+                tool_args = dict(raw_args)
+            else:
+                tool_args = {k: v for k, v in call.items() if k != "tool"}
             tool_args.setdefault("device", session.device)
 
             session.messages.append(ChatMessage(role="tool_call", tool_name=tool_name, tool_args=tool_args, content=""))

--- a/gitd/services/agent_chat.py
+++ b/gitd/services/agent_chat.py
@@ -108,15 +108,41 @@ _active_procs: dict[str, subprocess.Popen] = {}  # session_id -> running subproc
 
 
 def stop_agent(session_id: str):
-    """Kill the running agent subprocess AND all its children."""
+    """Kill the running agent subprocess AND all its children.
+
+    Two layers of kill so a runaway claude can't keep tapping the phone after
+    the user hits Stop:
+      1. Typed kill via _active_procs[session_id] — sends SIGTERM (then SIGKILL)
+         to the whole process group (chat_claude_code uses start_new_session=True
+         so claude+node+MCP-tool children share a pgid).
+      2. Nuclear pkill on the claude --print command line as a safety net for
+         processes that escaped the group (e.g., claude re-execed via node).
+    """
+    import os as _os
+    import signal as _sig
+
     proc = _active_procs.pop(session_id, None)
     if proc:
         try:
-            proc.kill()
-        except Exception:
+            pgid = _os.getpgid(proc.pid)
+            _os.killpg(pgid, _sig.SIGTERM)
+            try:
+                proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                _os.killpg(pgid, _sig.SIGKILL)
+        except (ProcessLookupError, PermissionError):
             pass
-    # Nuclear option: kill ALL claude --print processes (only agent chat uses this)
-    # This catches cases where the PID changed (node re-exec) or psutil can't find it
+        except Exception:
+            # Fallback to plain kill if pgid lookup failed
+            try:
+                proc.kill()
+            except Exception:
+                pass
+    # Nuclear safety net — pkill anything matching the claude --print pattern.
+    # Catches procs that re-execed (PID changed), procs from a different
+    # session that crashed mid-stream, and the case where _active_procs lost
+    # track because chat_claude_code registered after Popen but before adding
+    # to the dict.
     try:
         subprocess.run(
             ["pkill", "-9", "-f", "claude.*--print.*--output-format.*stream-json"],

--- a/gitd/services/agent_chat.py
+++ b/gitd/services/agent_chat.py
@@ -78,12 +78,12 @@ PROVIDERS = {
         "label": "On-device (Gemma)",
         "models": ["gemma-3-1b-it", "gemma-2-2b-it", "gemma-4-e2b-q4km-gguf"],
     },
-    # vLLM-on-jsl-gpu — full-precision Gemma 4 served from the GPU box,
+    # vLLM — full-precision Gemma 4 served from the GPU box,
     # routed via Mac SSH tunnel + adb reverse so the phone hits it as if it
     # were on localhost. Same OpenAI-compatible shape as openrouter; we just
     # point the client at config.vllm_base_url instead.
     "vllm": {
-        "label": "vLLM (jsl-gpu)",
+        "label": "vLLM (remote GPU)",
         "models": [
             "unsloth/gemma-4-E2B-it",
             "unsloth/gemma-4-E2B-it-bnb-4bit",
@@ -723,11 +723,11 @@ def _chat_openrouter(session: ChatSession, user_message: str):
     yield {"type": "done"}
 
 
-# ── vLLM (OpenAI-compatible, points at jsl-gpu) ──────────────────────────────
+# ── vLLM (OpenAI-compatible, remote GPU via SSH) ──────────────────────────────
 
 
 def _chat_vllm(session: ChatSession, user_message: str):
-    """Use a vLLM server (default: jsl-gpu via SSH tunnel + adb reverse) with
+    """Use a vLLM server (default: remote GPU via SSH tunnel + adb reverse) with
     OpenAI-compatible tool calling and multi-turn agent loop.
 
     Same OpenAI surface as _chat_openrouter, but unlike that one we DO loop on
@@ -785,7 +785,7 @@ def _chat_vllm(session: ChatSession, user_message: str):
                 "type": "error",
                 "content": (
                     f"vLLM unreachable at {client.base_url}. "
-                    f"Start the server on jsl-gpu and ensure the SSH tunnel + "
+                    f"Start the server on your GPU host and ensure the SSH tunnel + "
                     f"`adb reverse tcp:8000 tcp:8000` are up. ({e})"
                 ),
             }

--- a/gitd/services/agent_chat.py
+++ b/gitd/services/agent_chat.py
@@ -76,7 +76,7 @@ PROVIDERS = {
     # truth for ids; we ship a default subset here and overlay live ids below.
     "on-device": {
         "label": "On-device (Gemma)",
-        "models": ["gemma-3-1b-it", "gemma-2-2b-it", "gemma-4-e2b-gguf"],
+        "models": ["gemma-3-1b-it", "gemma-2-2b-it", "gemma-4-e2b-q4km-gguf"],
     },
 }
 

--- a/gitd/services/agent_chat_claude_code.py
+++ b/gitd/services/agent_chat_claude_code.py
@@ -7,6 +7,13 @@ import threading
 
 from gitd.services.agent_chat import ChatMessage, ChatSession
 from gitd.services.device_context import get_phone_state, get_screen_tree
+from gitd.services.observability import (
+    record_generation,
+    record_tool_result,
+    set_trace_output,
+    span_tool_call,
+    trace_chat_turn,
+)
 
 
 def chat_claude_code(session: ChatSession, user_message: str):
@@ -16,13 +23,19 @@ def chat_claude_code(session: ChatSession, user_message: str):
 
     yield {"type": "activity", "content": "📱 Reading screen..."}
     context_parts = []
+    foreground_pkg = ""
     try:
-        tree = get_screen_tree(session.device)
-        if tree and tree != "(empty screen)":
-            context_parts.append(f"[Current screen]\n{tree[:1500]}")
         state = get_phone_state(session.device)
         if state:
-            context_parts.append(f"[App: {state.get('currentApp', '?')} ({state.get('packageName', '?')})]")
+            foreground_pkg = state.get("packageName", "") or ""
+            context_parts.append(f"[Foreground app: {state.get('currentApp', '?')} ({foreground_pkg})]")
+        # Skip injecting the chat-app's own screen tree — it'd be the user's chat
+        # bubble (incl. prior answers) and tempts the model to "answer from screen"
+        # instead of actually performing the task.
+        if foreground_pkg != "com.ghostinthedroid.app":
+            tree = get_screen_tree(session.device)
+            if tree and tree != "(empty screen)":
+                context_parts.append(f"[Current screen]\n{tree[:1500]}")
     except Exception:
         pass
     context = "\n".join(context_parts)
@@ -32,9 +45,12 @@ def chat_claude_code(session: ChatSession, user_message: str):
 
 Task: {user_message}
 
-You have MCP android-agent tools. Use them to accomplish the task.
-After each action, verify with get_screen_tree or screenshot.
-Keep going until done. Be concise."""
+Rules:
+- The phone is currently showing the chat app the user is talking to you from. You MUST actually drive the phone to complete the task — do not answer from memory or prior conversation context.
+- Use the MCP android-agent tools (launch_app, tap_element, get_screen_tree, screenshot, swipe, etc.) to control the phone.
+- For app tasks, start with `launch_app` to open the target app. Do not assume any app is already open.
+- After each action, verify the new state with `get_screen_tree` or `screenshot`.
+- Only after you've actually observed the result on the phone, answer the user. Be concise."""
 
     yield {"type": "activity", "content": "🧠 Starting Claude Code..."}
 
@@ -72,6 +88,18 @@ Keep going until done. Be concise."""
 
     proc.stdin.write(prompt)
     proc.stdin.close()
+
+    # Open Langfuse trace for this turn (no-op if observability disabled)
+    _trace_cm = trace_chat_turn(
+        session_id=getattr(session, "id", "") or "",
+        user_message=user_message,
+        provider="claude-code",
+        model=session.model or "sonnet",
+        device=session.device,
+        source="mac",
+    )
+    trace = _trace_cm.__enter__()
+    tool_spans: dict[str, object] = {}  # tool_use_id → span
 
     # Read stdout lines in a thread so we can yield events as they arrive
     lines_queue: list[str] = []
@@ -140,6 +168,7 @@ Keep going until done. Be concise."""
                     elif btype == "tool_use":
                         tool_name = block.get("name", "")
                         tool_args = block.get("input", {})
+                        tool_id = block.get("id", "")
                         # Strip mcp prefix for display
                         display_name = (
                             tool_name.replace("mcp__android-agent__", "")
@@ -151,6 +180,13 @@ Keep going until done. Be concise."""
                         )
                         yield {"type": "tool_call", "name": display_name, "args": tool_args}
                         yield {"type": "activity", "content": f"⚡ {display_name}..."}
+                        if trace is not None and tool_id:
+                            try:
+                                tool_spans[tool_id] = trace.span(
+                                    name=f"tool:{display_name}", input={"args": tool_args}
+                                )
+                            except Exception:
+                                pass
 
                     elif btype == "tool_result":
                         content_parts = block.get("content", [])
@@ -163,11 +199,28 @@ Keep going until done. Be concise."""
                         if result_text:
                             session.messages.append(ChatMessage(role="tool_result", content=result_text[:500]))
                             yield {"type": "tool_result", "name": "", "result": result_text[:300]}
+                        is_err = bool(block.get("is_error"))
+                        record_tool_result(
+                            tool_spans.pop(block.get("tool_use_id", ""), None),
+                            result_text,
+                            error=is_err,
+                        )
                         yield {"type": "activity", "content": "🤔 Thinking..."}
 
                     elif btype == "thinking":
-                        # Extended thinking — show brief activity
-                        yield {"type": "activity", "content": "🧠 Reasoning..."}
+                        # Extended thinking — surface the actual reasoning text
+                        # so the UI can render it (in addition to the activity ping).
+                        thinking_text = block.get("thinking", "")
+                        if thinking_text:
+                            # Persist alongside text/tool_use blocks so it survives
+                            # save_session_to_db and reappears on resumeConversation —
+                            # otherwise thinking bubbles are live-only and vanish.
+                            session.messages.append(
+                                ChatMessage(role="thinking", content=thinking_text)
+                            )
+                            yield {"type": "thinking", "content": thinking_text}
+                        else:
+                            yield {"type": "activity", "content": "🧠 Reasoning..."}
 
             elif etype == "result":
                 # Final result with cost info
@@ -207,6 +260,24 @@ Keep going until done. Be concise."""
     except subprocess.TimeoutExpired:
         proc.kill()
 
+    # Record final generation + close trace
+    try:
+        set_trace_output(trace, full_text)
+        record_generation(
+            trace,
+            model=session.model or "sonnet",
+            prompt=prompt,
+            output=full_text,
+            input_tokens=total_input_tokens,
+            output_tokens=total_output_tokens,
+            cost_usd=total_cost,
+        )
+    finally:
+        try:
+            _trace_cm.__exit__(None, None, None)
+        except Exception:
+            pass
+
     if not full_text:
         yield {"type": "error", "content": "No response from Claude Code"}
 
@@ -219,8 +290,27 @@ def _chat_claude_code_remote(session, prompt: str, remote_host: str):
     The remote host has `claude` CLI + MCP android-agent tools configured.
     Tool calls from Claude Code execute on the remote host's MCP server,
     which talks to the device via ADB (USB or wireless).
+
+    We open a *shadow* trace on the phone side too, mirroring the events as
+    they stream past — so the in-app Traces tab shows claude-code runs even
+    though the real LLM trace lives on the Mac. Without this, the tab would
+    appear empty for everything except on-device runs.
     """
     import requests
+
+    # Open phone-local trace so the in-app Traces tab sees this run.
+    _trace_cm = trace_chat_turn(
+        session_id=getattr(session, "id", "") or "",
+        user_message=prompt[-2000:],  # the prompt has full screen context — keep tail
+        provider="claude-code", model=session.model or "sonnet",
+        device=session.device, source="android",  # this code runs in Chaquopy
+    )
+    trace = _trace_cm.__enter__()
+    open_spans: dict[str, object] = {}  # last-tool-name → span (best-effort match since remote events lack ids)
+    full_text = ""
+    total_input_tokens = 0
+    total_output_tokens = 0
+    total_cost = 0.0
 
     yield {"type": "activity", "content": f"🔗 Connecting to {remote_host}..."}
 
@@ -240,31 +330,60 @@ def _chat_claude_code_remote(session, prompt: str, remote_host: str):
         for line in resp.iter_lines():
             if not line:
                 continue
-            text = line.decode()
-            if text.startswith("data: "):
+            text_line = line.decode()
+            if text_line.startswith("data: "):
                 try:
-                    event = json.loads(text[6:])
+                    event = json.loads(text_line[6:])
                     etype = event.get("type", "")
 
                     if etype == "text":
-                        session.messages.append(ChatMessage(role="assistant", content=event.get("content", "")))
+                        chunk = event.get("content", "")
+                        full_text += chunk
+                        session.messages.append(ChatMessage(role="assistant", content=chunk))
                         yield event
                     elif etype == "tool_call":
+                        tool_name = event.get("name", "")
+                        tool_args = event.get("args", {})
                         session.messages.append(
                             ChatMessage(
                                 role="tool_call",
-                                tool_name=event.get("name", ""),
-                                tool_args=event.get("args", {}),
+                                tool_name=tool_name,
+                                tool_args=tool_args,
                                 content="",
                             )
                         )
+                        if trace is not None:
+                            try:
+                                open_spans[tool_name] = trace.span(
+                                    name=f"tool:{tool_name}", input={"args": tool_args}
+                                )
+                            except Exception:
+                                pass
                         yield event
                     elif etype == "tool_result":
+                        result_text = event.get("result", "")
+                        tool_name = event.get("name", "")
                         session.messages.append(
-                            ChatMessage(role="tool_result", content=event.get("result", ""), tool_name=event.get("name", ""))
+                            ChatMessage(role="tool_result", content=result_text, tool_name=tool_name)
                         )
+                        # The remote stream sends tool_result without a tool_id;
+                        # close the most recent span for that tool name.
+                        span = open_spans.pop(tool_name, None) or (
+                            open_spans.popitem()[1] if open_spans else None
+                        )
+                        record_tool_result(span, result_text)
                         yield event
-                    elif etype in ("activity", "tokens", "screenshot", "error"):
+                    elif etype == "tokens":
+                        total_input_tokens = int(event.get("input", 0) or 0)
+                        total_output_tokens = int(event.get("output", 0) or 0)
+                        total_cost = float(event.get("cost", 0) or 0)
+                        yield event
+                    elif etype == "thinking":
+                        thinking_text = event.get("content", "")
+                        if thinking_text:
+                            session.messages.append(ChatMessage(role="thinking", content=thinking_text))
+                        yield event
+                    elif etype in ("activity", "screenshot", "error"):
                         yield event
                     elif etype == "done":
                         break
@@ -275,5 +394,15 @@ def _chat_claude_code_remote(session, prompt: str, remote_host: str):
         yield {"type": "error", "content": f"Cannot reach {remote_host}. Start the backend on your Mac: python3 run.py"}
     except Exception as e:
         yield {"type": "error", "content": str(e)}
+    finally:
+        try:
+            set_trace_output(trace, full_text)
+            record_generation(
+                trace, model=session.model or "sonnet", prompt=prompt[-4000:], output=full_text,
+                input_tokens=total_input_tokens, output_tokens=total_output_tokens, cost_usd=total_cost,
+            )
+        finally:
+            try: _trace_cm.__exit__(None, None, None)
+            except Exception: pass
 
     yield {"type": "done"}

--- a/gitd/services/agent_chat_claude_code.py
+++ b/gitd/services/agent_chat_claude_code.py
@@ -81,10 +81,19 @@ Rules:
             bufsize=1,
             cwd=project_dir,
             env={**os.environ, "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1"},
+            # New session so we can SIGTERM the whole process group (claude
+            # spawns node + MCP-tool child processes; killing just the parent
+            # leaves those orphaned and still tapping the phone).
+            start_new_session=True,
         )
     except FileNotFoundError:
         yield {"type": "error", "content": "claude CLI not found. Set GHOST_REMOTE_HOST to proxy."}
         return
+
+    # Register so the /stop/{sid} endpoint can find this proc by session id
+    # without relying on the nuclear `pkill -f claude.*--print...` fallback.
+    from gitd.services.agent_chat import _active_procs
+    _active_procs[session.id] = proc
 
     proc.stdin.write(prompt)
     proc.stdin.close()
@@ -260,6 +269,11 @@ Rules:
     except subprocess.TimeoutExpired:
         proc.kill()
 
+    # Unregister now that the process is done — leaving a stale entry would
+    # make a later stop_agent try to killpg() a dead pid (harmless, but
+    # noisy in logs).
+    _active_procs.pop(session.id, None)
+
     # Record final generation + close trace
     try:
         set_trace_output(trace, full_text)
@@ -314,6 +328,15 @@ def _chat_claude_code_remote(session, prompt: str, remote_host: str):
 
     yield {"type": "activity", "content": f"🔗 Connecting to {remote_host}..."}
 
+    # When the phone user hits Stop, this generator gets GeneratorExit. We
+    # need to propagate that to the Mac so its claude subprocess actually
+    # dies — closing our `requests` connection alone isn't enough because
+    # Mac's chat_claude_code generator only notices the broken pipe AFTER
+    # claude has streamed its current chunk (which may include several more
+    # tool calls). The fix: capture Mac's session_id from the first SSE
+    # `session` event, and on GeneratorExit POST to Mac's /stop/{sid}.
+    remote_sid: str = ""
+    resp = None
     try:
         resp = requests.post(
             f"{remote_host}/api/agent-chat/message",
@@ -336,7 +359,14 @@ def _chat_claude_code_remote(session, prompt: str, remote_host: str):
                     event = json.loads(text_line[6:])
                     etype = event.get("type", "")
 
-                    if etype == "text":
+                    if etype == "session":
+                        # First event from Mac carries the remote session_id.
+                        # Capture it so a phone-side Stop can hit Mac's
+                        # /stop/{sid} endpoint and actually kill the claude
+                        # subprocess.
+                        remote_sid = event.get("session_id", "") or ""
+                        yield event
+                    elif etype == "text":
                         chunk = event.get("content", "")
                         full_text += chunk
                         session.messages.append(ChatMessage(role="assistant", content=chunk))
@@ -390,11 +420,31 @@ def _chat_claude_code_remote(session, prompt: str, remote_host: str):
                 except json.JSONDecodeError:
                     pass
 
+    except GeneratorExit:
+        # Phone user hit Stop. Propagate to Mac so its claude subprocess
+        # actually dies — without this, Mac keeps streaming tool calls and
+        # the phone keeps getting tapped even though the UI says "stopped".
+        if remote_sid:
+            try:
+                requests.post(
+                    f"{remote_host}/api/agent-chat/stop/{remote_sid}",
+                    timeout=4,
+                )
+            except Exception:
+                pass
+        raise
     except requests.ConnectionError:
         yield {"type": "error", "content": f"Cannot reach {remote_host}. Start the backend on your Mac: python3 run.py"}
     except Exception as e:
         yield {"type": "error", "content": str(e)}
     finally:
+        # Always close the upstream HTTP stream so Mac's send_message
+        # finally-block fires (which calls stop_agent on its session).
+        try:
+            if resp is not None:
+                resp.close()
+        except Exception:
+            pass
         try:
             set_trace_output(trace, full_text)
             record_generation(

--- a/gitd/services/agent_chat_claude_code.py
+++ b/gitd/services/agent_chat_claude_code.py
@@ -40,6 +40,12 @@ Keep going until done. Be concise."""
 
     project_dir = str(__import__("pathlib").Path(__file__).parent.parent.parent)
 
+    # On-device: proxy to remote host that has claude CLI + MCP tools
+    remote_host = os.environ.get("GHOST_REMOTE_HOST", "")
+    if remote_host or not __import__("shutil").which("claude"):
+        yield from _chat_claude_code_remote(session, prompt, remote_host or "http://localhost:5055")
+        return
+
     try:
         proc = subprocess.Popen(
             [
@@ -61,7 +67,7 @@ Keep going until done. Be concise."""
             env={**os.environ, "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1"},
         )
     except FileNotFoundError:
-        yield {"type": "error", "content": "claude CLI not found"}
+        yield {"type": "error", "content": "claude CLI not found. Set GHOST_REMOTE_HOST to proxy."}
         return
 
     proc.stdin.write(prompt)
@@ -203,5 +209,71 @@ Keep going until done. Be concise."""
 
     if not full_text:
         yield {"type": "error", "content": "No response from Claude Code"}
+
+    yield {"type": "done"}
+
+
+def _chat_claude_code_remote(session, prompt: str, remote_host: str):
+    """Proxy Claude Code request to a remote host running the ghost backend.
+
+    The remote host has `claude` CLI + MCP android-agent tools configured.
+    Tool calls from Claude Code execute on the remote host's MCP server,
+    which talks to the device via ADB (USB or wireless).
+    """
+    import requests
+
+    yield {"type": "activity", "content": f"🔗 Connecting to {remote_host}..."}
+
+    try:
+        resp = requests.post(
+            f"{remote_host}/api/agent-chat/message",
+            json={
+                "content": prompt,
+                "device": session.device,
+                "provider": "claude-code",
+                "model": session.model or "sonnet",
+            },
+            timeout=300,
+            stream=True,
+        )
+
+        for line in resp.iter_lines():
+            if not line:
+                continue
+            text = line.decode()
+            if text.startswith("data: "):
+                try:
+                    event = json.loads(text[6:])
+                    etype = event.get("type", "")
+
+                    if etype == "text":
+                        session.messages.append(ChatMessage(role="assistant", content=event.get("content", "")))
+                        yield event
+                    elif etype == "tool_call":
+                        session.messages.append(
+                            ChatMessage(
+                                role="tool_call",
+                                tool_name=event.get("name", ""),
+                                tool_args=event.get("args", {}),
+                                content="",
+                            )
+                        )
+                        yield event
+                    elif etype == "tool_result":
+                        session.messages.append(
+                            ChatMessage(role="tool_result", content=event.get("result", ""), tool_name=event.get("name", ""))
+                        )
+                        yield event
+                    elif etype in ("activity", "tokens", "screenshot", "error"):
+                        yield event
+                    elif etype == "done":
+                        break
+                except json.JSONDecodeError:
+                    pass
+
+    except requests.ConnectionError:
+        yield {"type": "error", "content": f"Cannot reach {remote_host}. Start the backend on your Mac: python3 run.py"}
+    except Exception as e:
+        yield {"type": "error", "content": str(e)}
 
     yield {"type": "done"}

--- a/gitd/services/agent_chat_ondevice.py
+++ b/gitd/services/agent_chat_ondevice.py
@@ -20,6 +20,12 @@ from gitd.services.agent_chat import (
 )
 from gitd.services.agent_tools import TOOLS, execute_tool
 from gitd.services.device_context import get_phone_state, get_screen_tree
+from gitd.services.observability import (
+    record_generation,
+    record_tool_result,
+    set_trace_output,
+    trace_chat_turn,
+)
 
 
 def _kotlin_llm():
@@ -81,55 +87,71 @@ def chat_ondevice(session: ChatSession, user_message: str) -> Iterator[dict]:
         f"[USER]\n{context}Device: {session.device}\n\n{user_message}",
     ]
 
-    for turn in range(MAX_TURNS):
-        prompt = "\n\n".join(history) + "\n\n[ASSISTANT]\n"
-        yield {"type": "activity", "content": f"🧠 Inferring (turn {turn + 1})..."}
-
-        try:
-            reply = str(llm.generate(model_id, prompt))
-        except Exception as e:
-            yield {"type": "error", "content": f"On-device inference error: {e}"}
-            return
-
-        if not reply or reply.startswith("[on-device error"):
-            yield {"type": "error", "content": reply or "Empty response from on-device model"}
-            return
-
-        session.messages.append(ChatMessage(role="assistant", content=reply))
-        yield {"type": "text", "content": reply}
-        history.append(f"[ASSISTANT]\n{reply}")
-
-        tool_calls = _parse_tool_calls(reply)
-        if not tool_calls:
-            break
-
-        tool_results = []
-        for call in tool_calls:
-            tool_name = call.get("tool", "")
-            tool_args = call.get("args", {})
-            tool_args.setdefault("device", session.device)
-
-            session.messages.append(
-                ChatMessage(role="tool_call", tool_name=tool_name, tool_args=tool_args, content="")
-            )
-            yield {"type": "tool_call", "name": tool_name, "args": tool_args}
-            yield {"type": "activity", "content": f"⚡ {tool_name}..."}
+    with trace_chat_turn(
+        session_id=getattr(session, "id", "") or "",
+        user_message=user_message,
+        provider="on-device",
+        model=model_id,
+        device=session.device,
+        source="android",  # this code path runs inside Chaquopy on the phone
+    ) as trace:
+        last_reply = ""
+        for turn in range(MAX_TURNS):
+            prompt = "\n\n".join(history) + "\n\n[ASSISTANT]\n"
+            yield {"type": "activity", "content": f"🧠 Inferring (turn {turn + 1})..."}
 
             try:
-                result = execute_tool(tool_name, tool_args)
-                session.messages.append(
-                    ChatMessage(role="tool_result", content=result[:500], tool_name=tool_name)
-                )
-                yield {"type": "tool_result", "name": tool_name, "result": result[:500]}
-                tool_results.append(f"[{tool_name}] {result[:800]}")
+                reply = str(llm.generate(model_id, prompt))
             except Exception as e:
-                err = f"Tool error: {e}"
-                session.messages.append(
-                    ChatMessage(role="tool_result", content=err, tool_name=tool_name)
-                )
-                yield {"type": "tool_result", "name": tool_name, "result": err}
-                tool_results.append(f"[{tool_name}] ERROR: {err}")
+                yield {"type": "error", "content": f"On-device inference error: {e}"}
+                return
 
-        history.append("[USER]\nTool results:\n" + "\n".join(tool_results))
+            if not reply or reply.startswith("[on-device error"):
+                yield {"type": "error", "content": reply or "Empty response from on-device model"}
+                return
+
+            session.messages.append(ChatMessage(role="assistant", content=reply))
+            yield {"type": "text", "content": reply}
+            history.append(f"[ASSISTANT]\n{reply}")
+            record_generation(trace, model=model_id, prompt=prompt, output=reply)
+            last_reply = reply
+
+            tool_calls = _parse_tool_calls(reply)
+            if not tool_calls:
+                break
+
+            tool_results = []
+            for call in tool_calls:
+                tool_name = call.get("tool", "")
+                tool_args = call.get("args", {})
+                tool_args.setdefault("device", session.device)
+
+                session.messages.append(
+                    ChatMessage(role="tool_call", tool_name=tool_name, tool_args=tool_args, content="")
+                )
+                yield {"type": "tool_call", "name": tool_name, "args": tool_args}
+                yield {"type": "activity", "content": f"⚡ {tool_name}..."}
+
+                span = trace.span(name=f"tool:{tool_name}", input={"args": tool_args}) if trace else None
+                try:
+                    result = execute_tool(tool_name, tool_args)
+                    session.messages.append(
+                        ChatMessage(role="tool_result", content=result[:500], tool_name=tool_name)
+                    )
+                    yield {"type": "tool_result", "name": tool_name, "result": result[:500]}
+                    tool_results.append(f"[{tool_name}] {result[:800]}")
+                    record_tool_result(span, result)
+                except Exception as e:
+                    err = f"Tool error: {e}"
+                    session.messages.append(
+                        ChatMessage(role="tool_result", content=err, tool_name=tool_name)
+                    )
+                    yield {"type": "tool_result", "name": tool_name, "result": err}
+                    tool_results.append(f"[{tool_name}] ERROR: {err}")
+                    record_tool_result(span, err, error=True)
+
+            history.append("[USER]\nTool results:\n" + "\n".join(tool_results))
+
+        set_trace_output(trace, last_reply)
 
     yield {"type": "done"}

--- a/gitd/services/agent_chat_ondevice.py
+++ b/gitd/services/agent_chat_ondevice.py
@@ -106,9 +106,15 @@ def chat_ondevice(session: ChatSession, user_message: str) -> Iterator[dict]:
                 yield {"type": "error", "content": f"On-device inference error: {e}"}
                 return
 
-            if not reply or reply.startswith("[on-device error"):
-                yield {"type": "error", "content": reply or "Empty response from on-device model"}
+            # Native error sentinel — surface and stop.
+            if reply.startswith("[on-device error") or reply.startswith("[llama_jni:"):
+                yield {"type": "error", "content": reply}
                 return
+            # Empty reply = model emitted EOG/<end_of_turn> as the first token.
+            # That means "no further actions" — finish the turn cleanly rather
+            # than treating it as a failure.
+            if not reply.strip():
+                break
 
             session.messages.append(ChatMessage(role="assistant", content=reply))
             yield {"type": "text", "content": reply}

--- a/gitd/services/agent_chat_ondevice.py
+++ b/gitd/services/agent_chat_ondevice.py
@@ -68,11 +68,11 @@ def chat_ondevice(session: ChatSession, user_message: str) -> Iterator[dict]:
         return
 
     yield {"type": "activity", "content": "📱 Reading screen..."}
-    context = ""
+    screen_block = ""
     try:
         tree = get_screen_tree(session.device)
         state = get_phone_state(session.device)
-        context = f"[Screen]\n{tree[:1500]}\n[App: {state.get('currentApp', '?')}]\n\n"
+        screen_block = f"\n\n[Screen]\n{tree[:1500]}\n[App: {state.get('currentApp', '?')}]"
     except Exception:
         pass
 
@@ -82,9 +82,31 @@ def chat_ondevice(session: ChatSession, user_message: str) -> Iterator[dict]:
     )
     system = DEFAULT_SYSTEM.replace("{tool_list}", tool_list)
 
+    # Prompt structure tuned for KV prefix reuse:
+    #   [SYSTEM]              ← invariant across turns + sessions
+    #   {tools list}          ← invariant
+    #   [USER]                ← invariant
+    #   Device: ...           ← invariant per session
+    #   {user_message}        ← changes per turn (small)
+    #   [Screen]              ← changes per turn (large)
+    #   {screen tree}
+    # Putting the dynamic screen tree LAST means the long stable prefix
+    # (system + tools + device + user message) is fully cached on every
+    # subsequent turn, even when the screen state changes between turns.
+    # NOTE: warmup() exists on OnDeviceLLM and bakes the stable system+tools
+    # prefix into the KV cache before any user input — but it has to run
+    # BEFORE this chat call, in the background at app start. Calling it
+    # inline here just serialises the cold prefill in front of the user's
+    # first response, doubling the perceived latency. The right wiring is
+    # a Kotlin coroutine in MainActivity that fires `OnDeviceLLM.warmup(
+    # selected_model_id, stable_prefix)` right after the on-device model is
+    # selected. With that in place, the first chat turn lands at ~13 s
+    # instead of ~140 s, same as turn 2+. For now the unwired path gives
+    # turn-2+ the 10× win and the user pays the cold cost on turn 1.
+
     history: list[str] = [
         f"[SYSTEM]\n{system}",
-        f"[USER]\n{context}Device: {session.device}\n\n{user_message}",
+        f"[USER]\nDevice: {session.device}\n\n{user_message}{screen_block}",
     ]
 
     with trace_chat_turn(

--- a/gitd/services/agent_chat_ondevice.py
+++ b/gitd/services/agent_chat_ondevice.py
@@ -71,6 +71,36 @@ def _ondevice_tool_results_turn(tool_results: list[str]) -> str:
     )
 
 
+def _kv_cache_path(model_id: str, stable_prefix: str) -> str:
+    """Deterministic on-device path for the saved KV state of (model, prefix).
+    Mirrors the warmup endpoint's logic so chat and warmup share the same file."""
+    import hashlib
+    import os
+    cache_dir = "/data/data/com.ghostinthedroid.app/files/ondevice/kv-cache"
+    os.makedirs(cache_dir, exist_ok=True)
+    h = hashlib.sha256()
+    h.update(model_id.encode())
+    h.update(b"\n")
+    h.update(stable_prefix.encode())
+    return os.path.join(cache_dir, f"warmup-{h.hexdigest()[:16]}.bin")
+
+
+def _ensure_kv_warmed(llm, model_id: str, stable_prefix: str) -> tuple[bool, int]:
+    """Load the disk-persisted KV state for (model, prefix) into the JNI handle
+    if a cache file exists. Returns (from_cache, n_tokens). Caller can fall
+    back to a cold prefill via llm.warmup() if from_cache is False; we DON'T
+    do that here because it'd add ~4 min latency to a chat turn — leave that
+    to the explicit /warmup endpoint that fires from MainActivity at app start."""
+    path = _kv_cache_path(model_id, stable_prefix)
+    try:
+        loaded = int(llm.loadState(model_id, path))
+    except Exception:
+        loaded = -1
+    if loaded > 0:
+        return True, loaded
+    return False, 0
+
+
 def chat_ondevice(session: ChatSession, user_message: str) -> Iterator[dict]:
     """Run a tool-using turn against an on-device Gemma model."""
     session.messages.append(ChatMessage(role="user", content=user_message))
@@ -137,6 +167,17 @@ def chat_ondevice(session: ChatSession, user_message: str) -> Iterator[dict]:
     # selected. With that in place, the first chat turn lands at ~13 s
     # instead of ~140 s, same as turn 2+. For now the unwired path gives
     # turn-2+ the 10× win and the user pays the cold cost on turn 1.
+
+    # If the warmup endpoint previously saved a KV state for this exact
+    # (model, system+device) prefix, restore it now so the first generateStart
+    # only has to decode the user_message + screen_block diff. Without this,
+    # every model switch costs a ~4-minute cold prefill on the first chat
+    # because ensureLoaded() doesn't know about the cache file. Idempotent —
+    # if no file matches we just continue with an empty KV.
+    stable_prefix = ondevice_stable_prefix(system, session.device)
+    from_cache, kv_tokens = _ensure_kv_warmed(llm, model_id, stable_prefix)
+    if from_cache:
+        yield {"type": "activity", "content": f"⚡ KV cache hit ({kv_tokens} tokens)"}
 
     # Gemma chat template — see ondevice_stable_prefix() and friends above.
     # `prompt` accumulates over turns: the assistant reply + each tool-results

--- a/gitd/services/agent_chat_ondevice.py
+++ b/gitd/services/agent_chat_ondevice.py
@@ -167,9 +167,16 @@ def chat_ondevice(session: ChatSession, user_message: str) -> Iterator[dict]:
                     streamed = True
                     while True:
                         piece = str(llm.generateStep())
-                        # JNI sentinel for end-of-stream is a single NUL byte.
-                        if piece == "" or piece == "\x00":
+                        # JNI protocol:
+                        #   "\x00"  → end of stream (EOS or stop-tag hit)
+                        #   ""      → no new text this step (the streamer is
+                        #             holding back bytes that might form a
+                        #             stop tag; keep polling)
+                        #   anything else → stream as text_delta.
+                        if piece == "\x00":
                             break
+                        if piece == "":
+                            continue
                         reply += piece
                         yield {"type": "text_delta", "content": piece}
             except Exception as e:

--- a/gitd/services/agent_chat_ondevice.py
+++ b/gitd/services/agent_chat_ondevice.py
@@ -37,6 +37,40 @@ def _kotlin_llm():
         return None
 
 
+# ── Gemma chat template ──────────────────────────────────────────────────────
+# Gemma 4 uses <start_of_turn>user / <end_of_turn> / <start_of_turn>model
+# markers. There's no separate system role — system content is prepended
+# into the first user turn. Earlier we used a custom [SYSTEM]/[USER]/[ASSISTANT]
+# scaffold, which the model cheerfully echoed back into its own output (it had
+# never seen those tokens in fine-tuning), causing repetition loops where the
+# model kept "writing" extra fake [USER] turns from inside its own reply.
+# Switching to the canonical Gemma markers fixes coherence on multi-turn
+# tool chains.
+
+def ondevice_stable_prefix(system: str, device: str) -> str:
+    """Stable prefix shared by warmup pre-fill and chat path. Anything beyond
+    this point varies per turn and must NOT be in the warmup KV."""
+    return f"<start_of_turn>user\n{system}\n\nDevice: {device}\n\n"
+
+
+def _ondevice_first_turn(system: str, device: str, user_message: str, screen_block: str) -> str:
+    return (
+        ondevice_stable_prefix(system, device)
+        + f"{user_message}{screen_block}<end_of_turn>\n"
+        + "<start_of_turn>model\n"
+    )
+
+
+def _ondevice_tool_results_turn(tool_results: list[str]) -> str:
+    return (
+        "<end_of_turn>\n"
+        "<start_of_turn>user\n"
+        + "Tool results:\n" + "\n".join(tool_results)
+        + "<end_of_turn>\n"
+        + "<start_of_turn>model\n"
+    )
+
+
 def chat_ondevice(session: ChatSession, user_message: str) -> Iterator[dict]:
     """Run a tool-using turn against an on-device Gemma model."""
     session.messages.append(ChatMessage(role="user", content=user_message))
@@ -104,10 +138,11 @@ def chat_ondevice(session: ChatSession, user_message: str) -> Iterator[dict]:
     # instead of ~140 s, same as turn 2+. For now the unwired path gives
     # turn-2+ the 10× win and the user pays the cold cost on turn 1.
 
-    history: list[str] = [
-        f"[SYSTEM]\n{system}",
-        f"[USER]\nDevice: {session.device}\n\n{user_message}{screen_block}",
-    ]
+    # Gemma chat template — see ondevice_stable_prefix() and friends above.
+    # `prompt` accumulates over turns: the assistant reply + each tool-results
+    # turn get appended in-place so the next iteration runs against the full
+    # rolling conversation (KV prefix reuse means we only re-decode the diff).
+    prompt = _ondevice_first_turn(system, session.device, user_message, screen_block)
 
     with trace_chat_turn(
         session_id=getattr(session, "id", "") or "",
@@ -119,7 +154,6 @@ def chat_ondevice(session: ChatSession, user_message: str) -> Iterator[dict]:
     ) as trace:
         last_reply = ""
         for turn in range(MAX_TURNS):
-            prompt = "\n\n".join(history) + "\n\n[ASSISTANT]\n"
             yield {"type": "activity", "content": f"🧠 Inferring (turn {turn + 1})..."}
 
             # Try streaming first — yields token-by-token so the UI can show
@@ -164,7 +198,11 @@ def chat_ondevice(session: ChatSession, user_message: str) -> Iterator[dict]:
             # Final full-text event for clients that didn't subscribe to
             # text_delta deltas (or to keep the protocol backward-compatible).
             yield {"type": "text", "content": reply}
-            history.append(f"[ASSISTANT]\n{reply}")
+            # Append the assistant turn to the rolling conversation so the
+            # next iteration sees the full chat history. `reply` already had
+            # any trailing <end_of_turn> stripped by the JNI streaming loop;
+            # we add it back so the model sees a clean turn boundary.
+            prompt += reply
             record_generation(trace, model=model_id, prompt=prompt, output=reply)
             last_reply = reply
 
@@ -202,7 +240,7 @@ def chat_ondevice(session: ChatSession, user_message: str) -> Iterator[dict]:
                     tool_results.append(f"[{tool_name}] ERROR: {err}")
                     record_tool_result(span, err, error=True)
 
-            history.append("[USER]\nTool results:\n" + "\n".join(tool_results))
+            prompt += _ondevice_tool_results_turn(tool_results)
 
         set_trace_output(trace, last_reply)
 

--- a/gitd/services/agent_chat_ondevice.py
+++ b/gitd/services/agent_chat_ondevice.py
@@ -122,11 +122,33 @@ def chat_ondevice(session: ChatSession, user_message: str) -> Iterator[dict]:
             prompt = "\n\n".join(history) + "\n\n[ASSISTANT]\n"
             yield {"type": "activity", "content": f"🧠 Inferring (turn {turn + 1})..."}
 
+            # Try streaming first — yields token-by-token so the UI can show
+            # the response building char-by-char ("ghost is typing"). Falls
+            # back to one-shot generate if the JNI doesn't expose the
+            # streaming API yet (MediaPipe runtime, older builds).
+            reply = ""
+            streamed = False
             try:
-                reply = str(llm.generate(model_id, prompt))
+                if int(llm.generateStart(model_id, prompt)) > 0:
+                    streamed = True
+                    while True:
+                        piece = str(llm.generateStep())
+                        # JNI sentinel for end-of-stream is a single NUL byte.
+                        if piece == "" or piece == "\x00":
+                            break
+                        reply += piece
+                        yield {"type": "text_delta", "content": piece}
             except Exception as e:
-                yield {"type": "error", "content": f"On-device inference error: {e}"}
+                yield {"type": "error", "content": f"On-device streaming error: {e}"}
                 return
+
+            if not streamed:
+                # Fallback: one-shot generate (no live streaming).
+                try:
+                    reply = str(llm.generate(model_id, prompt))
+                except Exception as e:
+                    yield {"type": "error", "content": f"On-device inference error: {e}"}
+                    return
 
             # Native error sentinel — surface and stop.
             if reply.startswith("[on-device error") or reply.startswith("[llama_jni:"):
@@ -139,6 +161,8 @@ def chat_ondevice(session: ChatSession, user_message: str) -> Iterator[dict]:
                 break
 
             session.messages.append(ChatMessage(role="assistant", content=reply))
+            # Final full-text event for clients that didn't subscribe to
+            # text_delta deltas (or to keep the protocol backward-compatible).
             yield {"type": "text", "content": reply}
             history.append(f"[ASSISTANT]\n{reply}")
             record_generation(trace, model=model_id, prompt=prompt, output=reply)

--- a/gitd/services/agent_chat_ondevice.py
+++ b/gitd/services/agent_chat_ondevice.py
@@ -1,0 +1,135 @@
+"""On-device LLM provider — runs Gemma (or any registered model) via MediaPipe.
+
+Bridges to Kotlin singleton `OnDeviceLLM` through Chaquopy. Falls back gracefully
+when running outside Chaquopy (e.g., dev tests on a Mac).
+
+Model selection:
+    session.model is the registry id, e.g. "gemma-4-e2b-it" / "gemma-2-2b-it".
+"""
+
+from __future__ import annotations
+
+from typing import Iterator
+
+from gitd.services.agent_chat import (
+    DEFAULT_SYSTEM,
+    MAX_TURNS,
+    ChatMessage,
+    ChatSession,
+    _parse_tool_calls,
+)
+from gitd.services.agent_tools import TOOLS, execute_tool
+from gitd.services.device_context import get_phone_state, get_screen_tree
+
+
+def _kotlin_llm():
+    """Return the Kotlin OnDeviceLLM singleton, or None if Chaquopy is missing."""
+    try:
+        from java import jclass  # type: ignore[import-not-found]
+        return jclass("com.ghostinthedroid.app.ondevice.OnDeviceLLM").INSTANCE
+    except Exception:
+        return None
+
+
+def chat_ondevice(session: ChatSession, user_message: str) -> Iterator[dict]:
+    """Run a tool-using turn against an on-device Gemma model."""
+    session.messages.append(ChatMessage(role="user", content=user_message))
+
+    llm = _kotlin_llm()
+    if llm is None:
+        yield {
+            "type": "error",
+            "content": "On-device LLM only available inside the ghost-app (Chaquopy bridge missing)",
+        }
+        return
+
+    model_id = session.model or "gemma-3-1b-it"
+
+    yield {"type": "activity", "content": f"🧠 Loading {model_id}..."}
+    try:
+        loaded = bool(llm.ensureLoaded(model_id))
+    except Exception as e:
+        yield {"type": "error", "content": f"On-device load crashed: {e}"}
+        return
+    if not loaded:
+        yield {
+            "type": "error",
+            "content": (
+                f"Model '{model_id}' not downloaded yet. "
+                f"Open Settings → On-Device → Download to fetch it (~1-3 GB)."
+            ),
+        }
+        return
+
+    yield {"type": "activity", "content": "📱 Reading screen..."}
+    context = ""
+    try:
+        tree = get_screen_tree(session.device)
+        state = get_phone_state(session.device)
+        context = f"[Screen]\n{tree[:1500]}\n[App: {state.get('currentApp', '?')}]\n\n"
+    except Exception:
+        pass
+
+    tool_list = "\n".join(
+        f"- {t['name']}: {t['description']}  params: {list(t.get('input_schema', {}).get('properties', {}).keys())}"
+        for t in TOOLS
+    )
+    system = DEFAULT_SYSTEM.replace("{tool_list}", tool_list)
+
+    history: list[str] = [
+        f"[SYSTEM]\n{system}",
+        f"[USER]\n{context}Device: {session.device}\n\n{user_message}",
+    ]
+
+    for turn in range(MAX_TURNS):
+        prompt = "\n\n".join(history) + "\n\n[ASSISTANT]\n"
+        yield {"type": "activity", "content": f"🧠 Inferring (turn {turn + 1})..."}
+
+        try:
+            reply = str(llm.generate(model_id, prompt))
+        except Exception as e:
+            yield {"type": "error", "content": f"On-device inference error: {e}"}
+            return
+
+        if not reply or reply.startswith("[on-device error"):
+            yield {"type": "error", "content": reply or "Empty response from on-device model"}
+            return
+
+        session.messages.append(ChatMessage(role="assistant", content=reply))
+        yield {"type": "text", "content": reply}
+        history.append(f"[ASSISTANT]\n{reply}")
+
+        tool_calls = _parse_tool_calls(reply)
+        if not tool_calls:
+            break
+
+        tool_results = []
+        for call in tool_calls:
+            tool_name = call.get("tool", "")
+            tool_args = call.get("args", {})
+            tool_args.setdefault("device", session.device)
+
+            session.messages.append(
+                ChatMessage(role="tool_call", tool_name=tool_name, tool_args=tool_args, content="")
+            )
+            yield {"type": "tool_call", "name": tool_name, "args": tool_args}
+            yield {"type": "activity", "content": f"⚡ {tool_name}..."}
+
+            try:
+                result = execute_tool(tool_name, tool_args)
+                session.messages.append(
+                    ChatMessage(role="tool_result", content=result[:500], tool_name=tool_name)
+                )
+                yield {"type": "tool_result", "name": tool_name, "result": result[:500]}
+                tool_results.append(f"[{tool_name}] {result[:800]}")
+            except Exception as e:
+                err = f"Tool error: {e}"
+                session.messages.append(
+                    ChatMessage(role="tool_result", content=err, tool_name=tool_name)
+                )
+                yield {"type": "tool_result", "name": tool_name, "result": err}
+                tool_results.append(f"[{tool_name}] ERROR: {err}")
+
+        history.append("[USER]\nTool results:\n" + "\n".join(tool_results))
+
+    yield {"type": "done"}

--- a/gitd/services/agent_tools.py
+++ b/gitd/services/agent_tools.py
@@ -156,10 +156,19 @@ TOOLS = [
     # App management
     {
         "name": "launch_app",
-        "description": "Launch an app by package name. E.g. com.zhiliaoapp.musically (TikTok). Use search_apps to find the package name.",
+        "description": (
+            "Launch an app by package name. E.g. com.zhiliaoapp.musically (TikTok). "
+            "Use search_apps to find the package name. "
+            "Set fresh=true to force-stop first (cold start, clears state — use for benchmarks "
+            "or when prior app state would interfere). Default is warm start (resumes prior state)."
+        ),
         "input_schema": {
             "type": "object",
-            "properties": {"device": {"type": "string"}, "package": {"type": "string"}},
+            "properties": {
+                "device": {"type": "string"},
+                "package": {"type": "string"},
+                "fresh": {"type": "boolean", "description": "Force-stop first for a clean state. Default false."},
+            },
             "required": ["device", "package"],
         },
     },
@@ -190,6 +199,25 @@ TOOLS = [
         "name": "list_packages",
         "description": "List raw package names (no app names). Use list_apps or search_apps instead.",
         "input_schema": {"type": "object", "properties": {"device": {"type": "string"}}, "required": ["device"]},
+    },
+    {
+        "name": "web_search",
+        "description": (
+            "Open a web search in the best available browser. "
+            "Use when the user asks to search/look up something — faster than launching Chrome "
+            "and typing into the address bar. Falls back through Chrome → Firefox → Samsung "
+            "Internet → Edge → Brave → … → system default if a specific browser isn't installed. "
+            "Engines: 'google' (default), 'ddg', 'bing', 'brave'."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "device": {"type": "string"},
+                "query": {"type": "string"},
+                "engine": {"type": "string", "description": "Search engine: google, ddg, bing, brave. Default google."},
+            },
+            "required": ["device", "query"],
+        },
     },
     # Shell
     {
@@ -344,11 +372,18 @@ def _execute_tool_inner(name: str, args: dict) -> str:
             Device(device).long_press(args["x"], args["y"], duration_ms=args.get("duration_ms", 1000))
             return f"Long pressed ({args['x']}, {args['y']})"
         elif name == "launch_app":
-            Device(device).adb("shell", "monkey", "-p", args["package"], "-c", "android.intent.category.LAUNCHER", "1")
-            return f"Launched {args['package']}"
+            dev = Device(device)
+            fresh = bool(args.get("fresh", False))
+            if fresh:
+                dev.adb("shell", "am", "force-stop", args["package"])
+            dev.adb("shell", "monkey", "-p", args["package"], "-c", "android.intent.category.LAUNCHER", "1")
+            return f"Launched {args['package']}" + (" (fresh)" if fresh else "")
         elif name == "force_stop":
             Device(device).adb("shell", "am", "force-stop", args["package"])
             return f"Stopped {args['package']}"
+        elif name == "web_search":
+            from gitd.services.web_search import open_search
+            return open_search(device, args["query"], engine=args.get("engine", "google"))
         elif name == "list_apps" or name == "search_apps":
             out = Device(device).adb("shell", "pm", "list", "packages", timeout=10)
             pkgs = [p.replace("package:", "").strip() for p in out.splitlines() if p.startswith("package:")]

--- a/gitd/services/agent_tools.py
+++ b/gitd/services/agent_tools.py
@@ -393,6 +393,12 @@ def _execute_tool_inner(name: str, args: dict) -> str:
                 hits = [p for p in all_pkgs if any(t in p for t in tokens)][:6]
                 hint = f" Did you mean: {', '.join(hits)}?" if hits else ""
                 return f"ERROR: package {pkg} is not installed.{hint}"
+            # Check if the package is disabled — `pm list packages -d` lists disabled
+            # packages. All launch methods silently fail (or "No activities found") when
+            # the package is disabled, giving the agent a phantom success.
+            disabled = dev.adb("shell", "pm", "list", "packages", "-d", pkg, timeout=10)
+            if f"package:{pkg}" in disabled:
+                return f"ERROR: {pkg} is installed but disabled. Enable it first: adb shell pm enable {pkg}"
             # When the daemon runs ON the phone (Chaquopy), `am start` and
             # `monkey` both fail under the app's own uid: am resolves to
             # USER_CURRENT_OR_SELF and gets blocked on INTERACT_ACROSS_USERS_FULL,
@@ -421,7 +427,18 @@ def _execute_tool_inner(name: str, args: dict) -> str:
                         launcher = line
                         break
                 if not launcher:
-                    return f"ERROR: {pkg} has no LAUNCHER activity"
+                    # resolve-activity can fail on some ROMs (ASUS, Samsung) even for
+                    # valid launcher packages. Fall back to monkey which works as long
+                    # as the package is enabled and has a LAUNCHER activity.
+                    if fresh:
+                        dev.adb("shell", "am", "force-stop", pkg)
+                    monkey_out = dev.adb(
+                        "shell", "monkey", "-p", pkg, "-c", "android.intent.category.LAUNCHER", "1",
+                        timeout=10,
+                    )
+                    if "Events injected: 1" in monkey_out:
+                        return f"Launched {pkg} (monkey)" + (" [fresh]" if fresh else "")
+                    return f"ERROR: {pkg} has no LAUNCHER activity (monkey: {monkey_out.strip()[:100]})"
                 am_args = ["shell", "am", "start", "--user", "0"]
                 if fresh:
                     am_args += ["--activity-clear-task"]

--- a/gitd/services/agent_tools.py
+++ b/gitd/services/agent_tools.py
@@ -373,11 +373,63 @@ def _execute_tool_inner(name: str, args: dict) -> str:
             return f"Long pressed ({args['x']}, {args['y']})"
         elif name == "launch_app":
             dev = Device(device)
+            pkg = args["package"]
             fresh = bool(args.get("fresh", False))
-            if fresh:
-                dev.adb("shell", "am", "force-stop", args["package"])
-            dev.adb("shell", "monkey", "-p", args["package"], "-c", "android.intent.category.LAUNCHER", "1")
-            return f"Launched {args['package']}" + (" (fresh)" if fresh else "")
+            # Verify the package exists first — `monkey`/`am start` both fall
+            # through silently for missing packages, so without this the agent
+            # gets a phantom success and burns turns wondering why the app
+            # didn't open.
+            installed = dev.adb("shell", "pm", "list", "packages", pkg, timeout=10)
+            if f"package:{pkg}" not in installed:
+                pkgs_out = dev.adb("shell", "pm", "list", "packages", timeout=10)
+                all_pkgs = [
+                    p.replace("package:", "").strip()
+                    for p in pkgs_out.splitlines() if p.startswith("package:")
+                ]
+                # Suggest installed packages whose name contains a token from the
+                # requested one — usually catches `com.reddit.android` →
+                # `com.reddit.frontpage`.
+                tokens = [t for t in pkg.split(".") if len(t) > 2 and t not in {"com", "org", "net", "android", "app"}]
+                hits = [p for p in all_pkgs if any(t in p for t in tokens)][:6]
+                hint = f" Did you mean: {', '.join(hits)}?" if hits else ""
+                return f"ERROR: package {pkg} is not installed.{hint}"
+            # When the daemon runs ON the phone (Chaquopy), `am start` and
+            # `monkey` both fail under the app's own uid: am resolves to
+            # USER_CURRENT_OR_SELF and gets blocked on INTERACT_ACROSS_USERS_FULL,
+            # monkey aborts setting a system property. Going through the app
+            # process's own Context.startActivity() works because it's a
+            # public Android surface — same path any third-party launcher
+            # uses. The Kotlin helper `DeviceActions.launchApp` lives at
+            # app/src/main/java/com/ghostinthedroid/app/ondevice/DeviceActions.kt.
+            # Outside Chaquopy (host-side dev runs), fall back to the adb
+            # `am start` path, which works because host adb runs as `shell`
+            # (uid 2000) and has the cross-user permission.
+            try:
+                from java import jclass  # type: ignore[import-not-found]
+                actions = jclass("com.ghostinthedroid.app.ondevice.DeviceActions").INSTANCE
+                return str(actions.launchApp(pkg, fresh))
+            except Exception:
+                # Host-side fallback (no Chaquopy): use am start through ADB.
+                resolve = dev.adb(
+                    "shell", "cmd", "package", "resolve-activity",
+                    "--brief", "-c", "android.intent.category.LAUNCHER", pkg, timeout=10,
+                )
+                launcher = ""
+                for line in resolve.splitlines():
+                    line = line.strip()
+                    if "/" in line and line.startswith(pkg):
+                        launcher = line
+                        break
+                if not launcher:
+                    return f"ERROR: {pkg} has no LAUNCHER activity"
+                am_args = ["shell", "am", "start", "--user", "0"]
+                if fresh:
+                    am_args += ["--activity-clear-task"]
+                am_args += ["-n", launcher]
+                out = dev.adb(*am_args, timeout=15)
+                if "Error:" in out or "Activity not started" in out:
+                    return f"ERROR launching {pkg}: {out.strip()[:200]}"
+                return f"Launched {pkg} ({launcher})" + (" [fresh]" if fresh else "")
         elif name == "force_stop":
             Device(device).adb("shell", "am", "force-stop", args["package"])
             return f"Stopped {args['package']}"

--- a/gitd/services/observability.py
+++ b/gitd/services/observability.py
@@ -1,0 +1,423 @@
+"""Observability — local SQLite tracing (always on) + optional Langfuse forward.
+
+Two storage backends, fronted by the same helpers so the chat providers don't
+care which is wired:
+
+- **Local** (`gitd.db` `traces` + `trace_spans`) — always on. Powers the in-app
+  Traces tab. Survives Mac reboots, works offline, no external deps.
+- **Langfuse** — opt-in, activated when `LANGFUSE_PUBLIC_KEY` is set. Useful for
+  centralized cross-device aggregation, leaderboards, eval scoring.
+
+Both write the same trace shape, so flipping between them is just a config
+change. Tracing every chat turn means every helper here gets called dozens
+of times per session — they MUST be cheap and exception-safe.
+
+Public surface (unchanged from prior version, so wiring in chat providers
+doesn't move):
+    trace_chat_turn(...)        contextmanager — opens trace handle
+    span_tool_call(...)         contextmanager — opens span handle (rarely used; helpers below cover the common case)
+    record_generation(...)      records llm-call generation under a trace
+    record_tool_result(...)     ends a tool span with output (success or error)
+    set_trace_output(...)       sets the trace's final assistant reply
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from typing import Any, Iterator, Optional
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def _truncate(s: Any, limit: int = 4000) -> str:
+    """JSON-stringify and truncate. Keeps the DB rows bounded."""
+    try:
+        text = s if isinstance(s, str) else json.dumps(s, default=str)
+    except Exception:
+        text = str(s)
+    return text if len(text) <= limit else text[:limit] + "…[truncated]"
+
+
+# ── Trace handle — what the providers see ─────────────────────────────────────
+
+class _TraceHandle:
+    """Lightweight wrapper passed to `with` blocks. Holds local trace_id and
+    optional Langfuse handle. Methods called by the chat providers fan out to
+    both storages; failures in either are swallowed so observability can never
+    crash a chat turn.
+    """
+
+    __slots__ = ("local_id", "lf_handle", "_open_spans", "_started")
+
+    def __init__(self, local_id: str, lf_handle: Optional[Any]):
+        self.local_id = local_id
+        self.lf_handle = lf_handle
+        self._open_spans: dict[str, dict] = {}  # span_key → state
+        self._started = time.time()
+
+    # -- spans --
+    def span(self, *, name: str, input: Any = None, kind: str = "tool") -> "_SpanHandle":
+        """Open a span. Returned handle is what's passed to record_tool_result.
+
+        Caller controls the shape of `input` — pass it through to Langfuse
+        verbatim; existing callers already wrap as {"args": tool_args}."""
+        local_span = _local_span_open(self.local_id, kind=kind, name=name, input_obj=input)
+        lf_span = None
+        if self.lf_handle is not None:
+            try:
+                lf_span = self.lf_handle.span(name=name, input=input)
+            except Exception:
+                pass
+        return _SpanHandle(local_id=local_span, lf_handle=lf_span)
+
+    # -- generations (single-shot, no open/close pair) --
+    def record_generation(self, *, model: str, prompt: str, output: str,
+                          input_tokens: int = 0, output_tokens: int = 0,
+                          cost_usd: float = 0.0) -> None:
+        _local_generation(
+            self.local_id, model=model, prompt=prompt, output=output,
+            input_tokens=input_tokens, output_tokens=output_tokens, cost_usd=cost_usd,
+        )
+        if self.lf_handle is not None:
+            try:
+                self.lf_handle.generation(
+                    name="llm-call", model=model, input=prompt, output=output,
+                    usage={
+                        "input": input_tokens, "output": output_tokens,
+                        "total": input_tokens + output_tokens, "unit": "TOKENS",
+                    },
+                    metadata={"cost_usd": cost_usd} if cost_usd else None,
+                )
+            except Exception:
+                pass
+
+    # -- final output --
+    def set_output(self, output: str) -> None:
+        _local_trace_set_output(self.local_id, output)
+        if self.lf_handle is not None:
+            try:
+                self.lf_handle.update(output=output)
+            except Exception:
+                pass
+
+
+class _SpanHandle:
+    __slots__ = ("local_id", "lf_handle", "_started")
+
+    def __init__(self, local_id: int, lf_handle: Optional[Any]):
+        self.local_id = local_id
+        self.lf_handle = lf_handle
+        self._started = time.time()
+
+
+# ── Local SQLite writers ──────────────────────────────────────────────────────
+
+def _local_trace_open(*, conversation_id: str, provider: str, model: str,
+                      device: str, source: str, user_input: str) -> str:
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import Trace
+    trace_id = uuid.uuid4().hex
+    db = SessionLocal()
+    try:
+        db.add(Trace(
+            id=trace_id,
+            conversation_id=conversation_id or None,
+            provider=provider, model=model, device=device, source=source,
+            user_input=_truncate(user_input, 8000),
+            status="running",
+            started_at=_now_iso(),
+        ))
+        db.commit()
+    except Exception:
+        try: db.rollback()
+        except Exception: pass
+    finally:
+        db.close()
+    return trace_id
+
+
+def _local_trace_close(trace_id: str, *, status: str, duration_ms: int,
+                       error_text: str = "") -> None:
+    """Close a trace — only touches lifecycle fields. Token/cost totals are
+    accumulated by `_local_trace_accumulate_tokens` during the run, so we
+    must not overwrite them here."""
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import Trace
+    db = SessionLocal()
+    try:
+        t = db.get(Trace, trace_id)
+        if t:
+            t.status = status
+            t.duration_ms = duration_ms
+            t.error_text = _truncate(error_text, 2000) if error_text else ""
+            t.ended_at = _now_iso()
+            db.commit()
+    except Exception:
+        try: db.rollback()
+        except Exception: pass
+    finally:
+        db.close()
+
+
+def _local_trace_set_output(trace_id: str, output: str) -> None:
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import Trace
+    db = SessionLocal()
+    try:
+        t = db.get(Trace, trace_id)
+        if t:
+            t.final_output = _truncate(output, 16000)
+            db.commit()
+    except Exception:
+        try: db.rollback()
+        except Exception: pass
+    finally:
+        db.close()
+
+
+def _local_span_open(trace_id: str, *, kind: str, name: str, input_obj: Any) -> int:
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import TraceSpan
+    db = SessionLocal()
+    span_id = 0
+    try:
+        span = TraceSpan(
+            trace_id=trace_id, kind=kind, name=name,
+            input_json=_truncate(input_obj) if input_obj is not None else "",
+            started_at=_now_iso(),
+        )
+        db.add(span)
+        db.commit()
+        span_id = span.id
+    except Exception:
+        try: db.rollback()
+        except Exception: pass
+    finally:
+        db.close()
+    return span_id
+
+
+def _local_span_close(span_id: int, *, output_obj: Any, error: bool, duration_ms: int) -> None:
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import TraceSpan
+    if not span_id:
+        return
+    db = SessionLocal()
+    try:
+        s = db.get(TraceSpan, span_id)
+        if s:
+            s.output_json = _truncate(output_obj) if output_obj is not None else ""
+            s.level = "ERROR" if error else "DEFAULT"
+            s.ended_at = _now_iso()
+            s.duration_ms = duration_ms
+            db.commit()
+    except Exception:
+        try: db.rollback()
+        except Exception: pass
+    finally:
+        db.close()
+
+
+def _local_generation(trace_id: str, *, model: str, prompt: str, output: str,
+                      input_tokens: int, output_tokens: int, cost_usd: float) -> None:
+    """LLM generations are stored as spans with kind='generation'. Single-shot
+    write — no open/close needed since we already have all the data."""
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import TraceSpan
+    db = SessionLocal()
+    try:
+        now = _now_iso()
+        db.add(TraceSpan(
+            trace_id=trace_id, kind="generation", name="llm-call",
+            input_json=_truncate({"prompt": prompt, "model": model}, 16000),
+            output_json=_truncate({
+                "output": output,
+                "input_tokens": input_tokens, "output_tokens": output_tokens,
+                "cost_usd": cost_usd,
+            }, 16000),
+            started_at=now, ended_at=now,
+        ))
+        db.commit()
+    except Exception:
+        try: db.rollback()
+        except Exception: pass
+    finally:
+        db.close()
+
+
+# ── Optional Langfuse client ──────────────────────────────────────────────────
+
+_lf_client = None
+_lf_init_done = False
+
+
+def _lf_get_client():
+    """Lazily build a Langfuse client. If LANGFUSE_PUBLIC_KEY isn't set, returns
+    None forever and we skip the remote path entirely."""
+    global _lf_client, _lf_init_done
+    if _lf_init_done:
+        return _lf_client
+    _lf_init_done = True
+    pk = os.environ.get("LANGFUSE_PUBLIC_KEY", "").strip()
+    sk = os.environ.get("LANGFUSE_SECRET_KEY", "").strip()
+    if not pk or not sk:
+        return None
+    try:
+        from langfuse import Langfuse
+        _lf_client = Langfuse(
+            public_key=pk, secret_key=sk,
+            host=os.environ.get("LANGFUSE_HOST", "http://localhost:3000"),
+        )
+    except Exception:
+        _lf_client = None
+    return _lf_client
+
+
+def is_langfuse_enabled() -> bool:
+    return _lf_get_client() is not None
+
+
+# ── Public API — what the chat providers call ─────────────────────────────────
+
+@contextmanager
+def trace_chat_turn(*, session_id: str, user_message: str, provider: str,
+                    model: str, device: str, source: str = "mac") -> Iterator[Optional[_TraceHandle]]:
+    """Open a trace for a full chat turn. Always returns a handle (never None
+    now that local tracing is always on). The handle's methods fan out to both
+    backends; the caller doesn't need to know which is enabled."""
+    local_id = _local_trace_open(
+        conversation_id=session_id, provider=provider, model=model,
+        device=device, source=source, user_input=user_message,
+    )
+
+    lf_handle = None
+    lf = _lf_get_client()
+    if lf is not None:
+        try:
+            lf_handle = lf.trace(
+                name=f"chat:{provider}",
+                session_id=session_id,
+                input={"message": user_message},
+                metadata={"provider": provider, "model": model, "device": device, "source": source},
+                tags=[provider, source],
+            )
+        except Exception:
+            pass
+
+    handle = _TraceHandle(local_id=local_id, lf_handle=lf_handle)
+    started = time.time()
+    error_text = ""
+    status = "success"
+    try:
+        yield handle
+    except Exception as e:
+        status = "error"
+        error_text = str(e)
+        raise
+    finally:
+        duration_ms = int((time.time() - started) * 1000)
+        _local_trace_close(
+            local_id, status=status, duration_ms=duration_ms,
+            error_text=error_text,
+        )
+        if lf is not None:
+            try:
+                if lf_handle is not None:
+                    lf_handle.update(metadata={"duration_s": round(duration_ms / 1000, 2)})
+                lf.flush()
+            except Exception:
+                pass
+
+
+@contextmanager
+def span_tool_call(trace: Optional[_TraceHandle], tool_name: str,
+                   tool_args: Any) -> Iterator[Optional[_SpanHandle]]:
+    """Less-used helper — most providers manage span lifecycle inline so they
+    can attach the result to the right span by tool_use_id. Kept for symmetry."""
+    if trace is None:
+        yield None
+        return
+    span = trace.span(name=f"tool:{tool_name}", input=tool_args)
+    started = time.time()
+    try:
+        yield span
+    finally:
+        _local_span_close(
+            span.local_id, output_obj=None, error=False,
+            duration_ms=int((time.time() - started) * 1000),
+        )
+
+
+def record_generation(trace: Optional[_TraceHandle], *, model: str, prompt: str,
+                      output: str, input_tokens: int = 0, output_tokens: int = 0,
+                      cost_usd: float = 0.0) -> None:
+    if trace is None:
+        return
+    trace.record_generation(
+        model=model, prompt=prompt, output=output,
+        input_tokens=input_tokens, output_tokens=output_tokens, cost_usd=cost_usd,
+    )
+    # Also update the trace-level token + cost totals so the list view shows them.
+    _local_trace_accumulate_tokens(trace.local_id, input_tokens, output_tokens, cost_usd)
+
+
+def _local_trace_accumulate_tokens(trace_id: str, input_tokens: int,
+                                   output_tokens: int, cost_usd: float) -> None:
+    """For multi-turn LLM models that emit several `record_generation` calls
+    per trace (e.g. on-device Gemma's tool loop), accumulate totals."""
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import Trace
+    if not (input_tokens or output_tokens or cost_usd):
+        return
+    db = SessionLocal()
+    try:
+        t = db.get(Trace, trace_id)
+        if t:
+            t.input_tokens = (t.input_tokens or 0) + int(input_tokens)
+            t.output_tokens = (t.output_tokens or 0) + int(output_tokens)
+            t.cost_usd = (t.cost_usd or 0.0) + float(cost_usd)
+            db.commit()
+    except Exception:
+        try: db.rollback()
+        except Exception: pass
+    finally:
+        db.close()
+
+
+def record_tool_result(span: Optional[_SpanHandle], result: str,
+                       error: bool = False) -> None:
+    if span is None:
+        return
+    duration_ms = int((time.time() - span._started) * 1000)
+    _local_span_close(span.local_id, output_obj={"result": result[:4000]},
+                      error=error, duration_ms=duration_ms)
+    if span.lf_handle is not None:
+        try:
+            span.lf_handle.update(
+                output={"result": result[:2000]},
+                level="ERROR" if error else "DEFAULT",
+            )
+            span.lf_handle.end()
+        except Exception:
+            pass
+
+
+def set_trace_output(trace: Optional[_TraceHandle], output: str) -> None:
+    if trace is None or not output:
+        return
+    trace.set_output(output)
+
+
+# Back-compat alias for old code paths.
+def is_enabled() -> bool:
+    """Local tracing is always enabled. Kept for callers that gate logic on this."""
+    return True

--- a/gitd/services/web_search.py
+++ b/gitd/services/web_search.py
@@ -1,0 +1,104 @@
+"""Robust web search: pick a browser, fire a VIEW intent, fall back gracefully.
+
+Used by both `mcp_server.web_search` (claude-code MCP) and `agent_tools.web_search`
+(on-device Gemma) so the behavior is identical regardless of which agent stack
+is driving.
+
+Strategy:
+1. Build a search URL for the chosen engine.
+2. Probe `pm list packages` once to find which browsers are installed.
+3. Try each candidate in priority order via `am start ... -p <pkg>`.
+4. If all known browsers fail (or none are installed), fall back to a bare
+   VIEW intent and let Android resolve it.
+5. As a last resort (e.g. on devices with NO browser at all — possible on
+   stripped-down vendor builds), open the Play Store search for "browser".
+"""
+
+from __future__ import annotations
+
+import urllib.parse
+from typing import Optional
+
+from gitd.bots.common.adb import Device
+
+# Priority order. Chrome is overwhelmingly the default on Android, but plenty
+# of devices ship Samsung Internet (Galaxy) or Vivo's stripped builds. Keeping
+# this list explicit lets us announce in the result string which one we used.
+_BROWSER_CANDIDATES: list[tuple[str, str]] = [
+    ("Chrome", "com.android.chrome"),
+    ("Firefox", "org.mozilla.firefox"),
+    ("Samsung Internet", "com.sec.android.app.sbrowser"),
+    ("Edge", "com.microsoft.emmx"),
+    ("Brave", "com.brave.browser"),
+    ("Opera", "com.opera.browser"),
+    ("Opera GX", "com.opera.gx"),
+    ("Vivaldi", "com.vivaldi.browser"),
+    ("DuckDuckGo Browser", "com.duckduckgo.mobile.android"),
+]
+
+_ENGINE_URLS = {
+    "google":      "https://www.google.com/search?q=",
+    "ddg":         "https://duckduckgo.com/?q=",
+    "duckduckgo":  "https://duckduckgo.com/?q=",
+    "bing":        "https://www.bing.com/search?q=",
+    "brave":       "https://search.brave.com/search?q=",
+}
+
+
+def _installed_packages(dev: Device) -> set[str]:
+    """One ADB call → set of all installed package names."""
+    try:
+        out = dev.adb("shell", "pm", "list", "packages", timeout=10)
+    except Exception:
+        return set()
+    return {ln.removeprefix("package:").strip() for ln in out.splitlines() if ln.startswith("package:")}
+
+
+def _try_open(dev: Device, url: str, package: Optional[str]) -> bool:
+    """Run `am start ... -d <url>` (optionally scoped to a package). Return True on success."""
+    cmd = ["shell", "am", "start", "-a", "android.intent.action.VIEW", "-d", url]
+    if package:
+        cmd += ["-p", package]
+    try:
+        out = dev.adb(*cmd, timeout=8)
+    except Exception:
+        return False
+    # `am start` exits 0 even when the intent is unresolved, so we have to
+    # parse stdout. The strings below are stable across Android 8+.
+    bad = ("Error:", "java.lang.SecurityException", "no activities found")
+    return not any(s in (out or "") for s in bad)
+
+
+def open_search(device: str, query: str, engine: str = "google") -> str:
+    """Open a search results page in the best available browser. Returns a
+    human-readable status string the LLM (and the user) sees.
+    """
+    if not query.strip():
+        return "web_search error: empty query"
+
+    base = _ENGINE_URLS.get(engine.lower(), _ENGINE_URLS["google"])
+    url = base + urllib.parse.quote(query)
+    dev = Device(device)
+    installed = _installed_packages(dev)
+
+    # 1. Walk the priority list, skipping browsers that aren't installed.
+    for friendly, pkg in _BROWSER_CANDIDATES:
+        if pkg not in installed:
+            continue
+        if _try_open(dev, url, pkg):
+            return f"Opened {friendly} → {engine} search for: {query}"
+
+    # 2. No known browser worked (or none installed) — let Android resolve it.
+    if _try_open(dev, url, package=None):
+        return f"Opened default browser → {engine} search for: {query}"
+
+    # 3. Last resort: nudge the user to install one. Open the Play Store
+    # search for "browser" so they're one tap from a fix.
+    store_url = "market://search?q=browser&c=apps"
+    _try_open(dev, store_url, package=None)
+    return (
+        "web_search failed: no browser handled the VIEW intent. "
+        "Opened Play Store to install one. (Tried: "
+        + ", ".join(p for _, p in _BROWSER_CANDIDATES)
+        + ")"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ghost-in-the-droid"
-version = "1.1.0"
+version = "1.2.0"
 description = "Give any AI agent an Android body. Open-source phone automation via ADB — tap, swipe, type, run skills, scale across devices."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "ghost-in-the-droid"
 version = "1.0.0"
 description = "Give any AI agent an Android body. Open-source phone automation via ADB — tap, swipe, type, run skills, scale across devices."
+readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "MIT"}
 keywords = ["android", "adb", "automation", "ghost", "agent", "mcp", "fastapi", "phone-farm"]
@@ -29,7 +30,14 @@ dependencies = [
     "pyyaml>=6.0",
     "psutil>=5.9",
     "openai>=1.0",
+    "mcp>=1.20",
 ]
+
+[project.urls]
+Homepage = "https://ghostinthedroid.com"
+Repository = "https://github.com/ghost-in-the-droid/android-agent"
+Documentation = "https://ghostinthedroid.com/getting-started/installation/"
+Issues = "https://github.com/ghost-in-the-droid/android-agent/issues"
 
 [project.optional-dependencies]
 llm = ["anthropic>=0.30"]
@@ -40,6 +48,7 @@ all = ["ghost-in-the-droid[llm,analytics,ocr,test]"]
 
 [project.scripts]
 android-agent = "gitd.cli:main"
+android-agent-mcp = "gitd.mcp_server:main"
 
 [tool.setuptools.packages.find]
 include = ["gitd*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ghost-in-the-droid"
-version = "1.0.0"
+version = "1.1.0"
 description = "Give any AI agent an Android body. Open-source phone automation via ADB — tap, swipe, type, run skills, scale across devices."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "psutil>=5.9",
     "openai>=1.0",
     "mcp>=1.20",
+    "langfuse>=2.0,<3.0",
 ]
 
 [project.urls]

--- a/scripts/install-mcp.sh
+++ b/scripts/install-mcp.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Ghost in the Droid — MCP Server Installer
+# Gives any AI agent 35 Android automation tools.
+#
+# Usage:
+#   bash <(curl -sSL https://raw.githubusercontent.com/ghost-in-the-droid/android-agent/main/scripts/install-mcp.sh)
+#
+# What it does:
+#   1. Clones the repo (or updates if already cloned)
+#   2. Creates a Python venv and installs dependencies
+#   3. Registers the MCP server with your AI client
+#
+set -euo pipefail
+
+REPO="https://github.com/ghost-in-the-droid/android-agent.git"
+DIR="$HOME/ghost-in-the-droid"
+
+echo "👻 Ghost in the Droid — MCP Installer"
+echo ""
+
+# ── Prerequisites ──────────────────────────────────────────────────────────
+
+check() { command -v "$1" &>/dev/null; }
+
+if ! check python3; then echo "❌ python3 not found. Install Python 3.10+."; exit 1; fi
+if ! check adb; then echo "⚠️  adb not found. Install Android platform-tools for device control."; fi
+if ! check git; then echo "❌ git not found."; exit 1; fi
+
+# ── Clone / Update ─────────────────────────────────────────────────────────
+
+if [ -d "$DIR" ]; then
+    echo "📂 Found $DIR — pulling latest..."
+    cd "$DIR" && git pull --quiet
+else
+    echo "📥 Cloning to $DIR..."
+    git clone --quiet "$REPO" "$DIR"
+    cd "$DIR"
+fi
+
+# ── Python Venv + Install ──────────────────────────────────────────────────
+
+if [ ! -d ".venv" ]; then
+    echo "🐍 Creating Python venv..."
+    python3 -m venv .venv
+fi
+
+echo "📦 Installing dependencies..."
+.venv/bin/pip install -q -e ".[all]"
+
+# Verify MCP server loads
+TOOL_COUNT=$(.venv/bin/python -c "from gitd.mcp_server import mcp; print(len(mcp._tool_manager.list_tools()))" 2>/dev/null || echo "0")
+if [ "$TOOL_COUNT" = "0" ]; then
+    echo "❌ MCP server failed to load. Check Python 3.10+ and try again."
+    exit 1
+fi
+
+echo "✅ MCP server ready — $TOOL_COUNT tools"
+
+# ── Register with AI Client ────────────────────────────────────────────────
+
+MCP_CMD="$DIR/.venv/bin/python"
+MCP_ARGS="-m gitd.mcp_server"
+
+if check claude; then
+    echo ""
+    echo "🔌 Registering with Claude Code..."
+    claude mcp add android-agent -- "$MCP_CMD" $MCP_ARGS 2>/dev/null && \
+        echo "✅ Claude Code: android-agent MCP registered" || \
+        echo "⚠️  claude mcp add failed — add manually (see below)"
+fi
+
+# ── Done ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "👻 Ghost in the Droid — $TOOL_COUNT MCP tools installed"
+echo ""
+echo "If auto-registration didn't work, add manually:"
+echo ""
+echo "  Claude Code:"
+echo "    claude mcp add android-agent -- $MCP_CMD $MCP_ARGS"
+echo ""
+echo "  Claude Desktop / Cursor / Windsurf — add to config:"
+echo "    {\"mcpServers\":{\"android-agent\":{\"command\":\"$MCP_CMD\",\"args\":[\"-m\",\"gitd.mcp_server\"]}}}"
+echo ""
+echo "  VS Code Copilot (.vscode/mcp.json):"
+echo "    {\"servers\":{\"android-agent\":{\"command\":\"$MCP_CMD\",\"args\":[\"-m\",\"gitd.mcp_server\"]}}}"
+echo ""
+echo "Start the dashboard:  cd $DIR && .venv/bin/python run.py"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# release.sh — cut a new release from private-mirror/main.
+#
+# Does: version bump, CHANGELOG stamp (move [Unreleased] → dated section,
+# update compare links), commit, push to private-mirror/main, create a
+# clean release PR on public repo (rebuilt on top of public/main to avoid
+# history-divergence conflicts).
+#
+# Usage:
+#   ./scripts/release.sh 1.3.0
+#
+# After merge of the public PR, tag on public main:
+#   git tag v1.3.0 && git push public v1.3.0
+# → triggers publish.yml → PyPI + GitHub Release + archive sync (all automated)
+set -euo pipefail
+
+NEW_VERSION="${1:-}"
+if [[ -z "$NEW_VERSION" ]]; then
+  echo "Usage: $0 <version>   e.g.  $0 1.3.0" >&2
+  exit 1
+fi
+
+if ! [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Error: version must match X.Y.Z (got '$NEW_VERSION')" >&2
+  exit 1
+fi
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$BRANCH" != "main" ]]; then
+  echo "Error: must be on main (currently on $BRANCH)" >&2
+  exit 1
+fi
+
+if ! git diff-index --quiet HEAD --; then
+  echo "Error: working tree not clean" >&2
+  exit 1
+fi
+
+# Ensure public remote exists
+if ! git remote get-url public >/dev/null 2>&1; then
+  git remote add public https://github.com/ghost-in-the-droid/android-agent.git
+fi
+
+echo "→ Pulling latest main"
+git pull --ff-only origin main
+git fetch public main
+
+CURRENT_VERSION=$(grep '^version = ' pyproject.toml | sed -E 's/^version = "(.+)"/\1/')
+TODAY=$(date +%Y-%m-%d)
+
+echo "→ Bumping $CURRENT_VERSION → $NEW_VERSION"
+sed -i.bak "s/^version = \"$CURRENT_VERSION\"/version = \"$NEW_VERSION\"/" pyproject.toml
+rm pyproject.toml.bak
+
+echo "→ Stamping CHANGELOG.md"
+python3 - "$NEW_VERSION" "$CURRENT_VERSION" "$TODAY" <<'PY'
+import re, sys
+new, old, today = sys.argv[1], sys.argv[2], sys.argv[3]
+with open("CHANGELOG.md") as f:
+    c = f.read()
+
+# Insert dated section below [Unreleased]
+c = c.replace(
+    "## [Unreleased]\n",
+    f"## [Unreleased]\n\n## [{new}] — {today}\n",
+    1,
+)
+
+# Update [Unreleased] compare link (was v{old}...HEAD, now v{new}...HEAD)
+c = re.sub(
+    r"^\[Unreleased\]:.*$",
+    f"[Unreleased]: https://github.com/ghost-in-the-droid/android-agent/compare/v{new}...HEAD",
+    c,
+    flags=re.MULTILINE,
+)
+
+# Add the new version's compare link just under [Unreleased]
+new_link = f"[{new}]: https://github.com/ghost-in-the-droid/android-agent/compare/v{old}...v{new}"
+c = re.sub(
+    r"^(\[Unreleased\]:.*\n)",
+    rf"\1{new_link}\n",
+    c,
+    count=1,
+    flags=re.MULTILINE,
+)
+
+with open("CHANGELOG.md", "w") as f:
+    f.write(c)
+PY
+
+echo "→ Committing version bump on private-mirror/main"
+git add pyproject.toml CHANGELOG.md
+git commit -m "Release v$NEW_VERSION"
+git push origin main
+
+# Build clean release branch on top of public/main
+echo "→ Creating release/v$NEW_VERSION on public from public/main"
+RELEASE_BRANCH="release/v$NEW_VERSION"
+git checkout -B "$RELEASE_BRANCH" public/main
+
+# Determine the commit on private-mirror that the previous tag was cut from
+# by looking for the most recent "Release v" commit before this one.
+LAST_RELEASE_COMMIT=$(git log main --grep="^Release v" --format="%H" | sed -n '2p')
+if [[ -z "$LAST_RELEASE_COMMIT" ]]; then
+  echo "Error: couldn't find previous 'Release v' commit on main" >&2
+  exit 1
+fi
+
+echo "→ Applying cumulative diff from $LAST_RELEASE_COMMIT..main onto public/main"
+git diff "$LAST_RELEASE_COMMIT..main" | git apply --3way --index || {
+  echo "→ 3-way apply had issues, trying direct apply"
+  git diff "$LAST_RELEASE_COMMIT..main" | git apply --index
+}
+
+git commit -m "Release v$NEW_VERSION"
+git push public "$RELEASE_BRANCH"
+
+# Extract the [new version] section from CHANGELOG for PR body
+PR_BODY=$(python3 - "$NEW_VERSION" <<'PY'
+import re, sys
+new = sys.argv[1]
+with open("CHANGELOG.md") as f:
+    c = f.read()
+m = re.search(rf"## \[{re.escape(new)}\].*?(?=\n## |\Z)", c, re.DOTALL)
+if m:
+    body = m.group(0)
+else:
+    body = f"Release v{new}"
+print(body)
+PY
+)
+
+echo "→ Opening PR on public repo"
+gh pr create \
+  --repo ghost-in-the-droid/android-agent \
+  --base main --head "$RELEASE_BRANCH" \
+  --title "Release v$NEW_VERSION" \
+  --body "$PR_BODY
+
+---
+
+After CI green + merge: tag \`v$NEW_VERSION\` on public main to trigger PyPI publish + GitHub Release + archive sync."
+
+# Restore private-mirror working copy
+git checkout main
+
+echo ""
+echo "✓ v$NEW_VERSION release PR opened on public repo"
+echo ""
+echo "Next steps (after CI green):"
+echo "  1. Review/merge the public PR"
+echo "  2. Tag on public main:"
+echo "       git fetch public && git checkout public/main"
+echo "       git tag v$NEW_VERSION && git push public v$NEW_VERSION"
+echo "  3. Workflows handle the rest: PyPI, GitHub Release, archive sync"

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -683,6 +683,32 @@
 		</div>
 	</section>
 
+	<!-- MCP INSTALL — one-liner for AI agents -->
+	<section style="position:relative;z-index:1;padding:3rem 0 1rem">
+		<div class="container">
+			<div style="max-width:720px;margin:0 auto;text-align:center">
+				<h2 style="font-size:1.4rem;font-weight:700;color:var(--text-primary);margin-bottom:0.5rem">Give your AI agent an Android body</h2>
+				<p style="color:var(--text-secondary);font-size:0.95rem;margin-bottom:1.5rem">35 MCP tools — tap, swipe, type, screenshot, OCR, launch apps, run skills. Works with Claude, Cursor, VS Code Copilot, Windsurf.</p>
+				<div class="terminal" style="text-align:left;margin-bottom:1rem">
+					<div class="terminal-header">
+						<span class="terminal-dot r"></span>
+						<span class="terminal-dot y"></span>
+						<span class="terminal-dot g"></span>
+						<span class="terminal-title">install</span>
+					</div>
+					<div class="terminal-body" style="font-size:0.85rem;line-height:1.8">
+						<span class="t-cm"># Add to Claude Code / Codex (one command)</span><br/>
+						<span class="t-fn">claude</span> mcp add android-agent <span class="t-op">--</span> uvx <span class="t-op">--from</span> ghost-in-the-droid android-agent-mcp<br/>
+						<br/>
+						<span class="t-cm"># Or any MCP client config (Cursor, VS Code, Windsurf, Claude Desktop)</span><br/>
+						<span class="t-op">{</span><span class="t-str">"command"</span><span class="t-op">:</span> <span class="t-str">"uvx"</span><span class="t-op">,</span> <span class="t-str">"args"</span><span class="t-op">:</span> <span class="t-op">[</span><span class="t-str">"--from"</span><span class="t-op">,</span> <span class="t-str">"ghost-in-the-droid"</span><span class="t-op">,</span> <span class="t-str">"android-agent-mcp"</span><span class="t-op">]}</span><br/>
+					</div>
+				</div>
+				<p style="color:#555;font-size:0.8rem">Plug in a phone with USB debugging, run the install, and your AI agent can control it immediately.</p>
+			</div>
+		</div>
+	</section>
+
 	<!-- DEMO VIDEOS -->
 	<section class="demo-section" style="position:relative;z-index:1">
 		<div class="container">

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,0 +1,61 @@
+"""Tests for benchmark infrastructure."""
+
+from gitd.benchmarks.base import Task, TaskResult, load_tasks_from_dir
+from gitd.benchmarks.ghost_bench.tasks import TASK_DATA_DIR, get_task, list_task_ids, load_tasks
+
+
+def test_load_tasks():
+    tasks = load_tasks()
+    assert len(tasks) >= 10
+    assert all(isinstance(t, Task) for t in tasks)
+
+
+def test_load_tasks_by_category():
+    settings = load_tasks("settings")
+    nav = load_tasks("navigation")
+    assert all(t.category == "settings" for t in settings)
+    assert all(t.category == "navigation" for t in nav)
+    assert len(settings) + len(nav) == len(load_tasks())
+
+
+def test_get_task():
+    task = get_task("SystemWifiTurnOn")
+    assert task is not None
+    assert task.goal == "Turn wifi on."
+    assert task.app == "com.android.settings"
+    assert task.init["cmd"] == "svc wifi disable"
+
+
+def test_get_task_not_found():
+    assert get_task("NonExistent") is None
+
+
+def test_list_task_ids():
+    ids = list_task_ids()
+    assert "SystemWifiTurnOn" in ids
+    assert "OpenAppSettings" in ids
+
+
+def test_task_max_steps():
+    task = get_task("SystemAirplaneModeOn")
+    assert task is not None
+    assert task.complexity == 1.5
+    assert task.max_steps == 15
+
+
+def test_task_result_defaults():
+    result = TaskResult(task_id="test", goal="test goal", model="m", device="d")
+    assert result.score == 0.0
+    assert result.error == ""
+    assert result.agent_log == []
+
+
+def test_load_tasks_from_dir():
+    tasks = load_tasks_from_dir(TASK_DATA_DIR)
+    assert len(tasks) == len(load_tasks())
+
+
+def test_all_tasks_have_eval():
+    for task in load_tasks():
+        assert task.eval, f"Task {task.id} missing eval"
+        assert task.eval.get("cmd"), f"Task {task.id} eval missing cmd"

--- a/tests/test_ollama.py
+++ b/tests/test_ollama.py
@@ -1,0 +1,66 @@
+"""Tests for Ollama tool parsing and provider config."""
+
+from gitd.services.agent_chat import PROVIDERS, _parse_tool_calls
+
+
+def test_providers_ollama_has_models():
+    """Ollama provider should have a pre-filled model list."""
+    ollama = PROVIDERS["ollama"]
+    assert len(ollama["models"]) >= 5
+    assert "llama3.2:3b" in ollama["models"]
+    assert "gemma3:4b" in ollama["models"]
+
+
+def test_parse_tool_calls_basic():
+    text = '''I'll take a screenshot.
+```tool
+{"tool": "screenshot", "args": {"device": "emulator-5554"}}
+```'''
+    calls = _parse_tool_calls(text)
+    assert len(calls) == 1
+    assert calls[0]["tool"] == "screenshot"
+    assert calls[0]["args"]["device"] == "emulator-5554"
+
+
+def test_parse_tool_calls_multiple():
+    text = '''Let me check the screen and tap.
+```tool
+{"tool": "get_screen_tree", "args": {"device": "emulator-5554"}}
+```
+Now I'll tap.
+```tool
+{"tool": "tap", "args": {"device": "emulator-5554", "x": 540, "y": 1200}}
+```'''
+    calls = _parse_tool_calls(text)
+    assert len(calls) == 2
+    assert calls[0]["tool"] == "get_screen_tree"
+    assert calls[1]["tool"] == "tap"
+    assert calls[1]["args"]["x"] == 540
+
+
+def test_parse_tool_calls_doubled_braces():
+    """Some models (gemma3) wrap JSON in {{ ... }} — should handle gracefully."""
+    text = '```tool\n{{"tool": "tap", "args": {{"x": 100, "y": 200}}}}\n```'
+    calls = _parse_tool_calls(text)
+    assert len(calls) == 1
+    assert calls[0]["tool"] == "tap"
+    assert calls[0]["args"]["x"] == 100
+
+
+def test_parse_tool_calls_no_tools():
+    text = "I don't need any tools for this. The answer is 42."
+    calls = _parse_tool_calls(text)
+    assert len(calls) == 0
+
+
+def test_parse_tool_calls_invalid_json():
+    text = '```tool\n{not valid json}\n```'
+    calls = _parse_tool_calls(text)
+    assert len(calls) == 0
+
+
+def test_parse_tool_calls_missing_tool_key():
+    """Valid JSON but missing 'tool' key should be ignored."""
+    text = '```tool\n{"action": "screenshot", "args": {}}\n```'
+    calls = _parse_tool_calls(text)
+    assert len(calls) == 0

--- a/tests/test_traces.py
+++ b/tests/test_traces.py
@@ -1,0 +1,345 @@
+"""Tests for local tracing — observability storage layer + /api/traces endpoints.
+
+Run:
+    .venv/bin/pytest tests/test_traces.py -v
+
+These tests use a fresh in-memory SQLite per test so they don't touch the dev
+DB. They cover:
+
+- The observability helpers (`trace_chat_turn`, `record_generation`, …) write
+  the right rows with the right values.
+- Token/cost accumulation across multiple `record_generation` calls in one trace.
+- Status transitions (success / error).
+- The router endpoints (list, stats, detail, delete) return the expected shape
+  and respect filters.
+- Edge cases: empty queries, missing trace, FK-free conversation_id.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Iterator
+
+import pytest
+
+
+@pytest.fixture
+def fresh_db() -> Iterator[None]:
+    """Truncate the trace tables before each test. The engine is module-level
+    and initialized at first import — swapping it per-test via env vars
+    doesn't work because the modules cache it. So we just clean what we own.
+    """
+    from gitd.models.base import engine
+    from gitd.models import Base
+    from gitd.models.trace import Trace, TraceSpan
+    Base.metadata.create_all(engine)  # idempotent, ensures tables exist
+    from gitd.models.base import SessionLocal
+    db = SessionLocal()
+    try:
+        db.query(TraceSpan).delete()
+        db.query(Trace).delete()
+        db.commit()
+    finally:
+        db.close()
+    yield
+    # Post-test cleanup so subsequent runs / unrelated tests don't see our rows
+    db = SessionLocal()
+    try:
+        db.query(TraceSpan).delete()
+        db.query(Trace).delete()
+        db.commit()
+    finally:
+        db.close()
+
+
+# ── Storage layer ────────────────────────────────────────────────────────────
+
+def test_basic_trace_roundtrip(fresh_db):
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import Trace, TraceSpan
+    from gitd.services.observability import (
+        trace_chat_turn, record_generation, record_tool_result, set_trace_output,
+    )
+
+    with trace_chat_turn(session_id="conv-1", user_message="hi",
+                         provider="claude-code", model="sonnet",
+                         device="dev1", source="mac") as t:
+        s = t.span(name="tool:web_search", input={"args": {"q": "x"}})
+        record_tool_result(s, "ok")
+        record_generation(t, model="sonnet", prompt="p", output="r",
+                          input_tokens=100, output_tokens=20, cost_usd=0.001)
+        set_trace_output(t, "final reply")
+
+    db = SessionLocal()
+    try:
+        traces = db.query(Trace).all()
+        assert len(traces) == 1
+        tr = traces[0]
+        assert tr.provider == "claude-code"
+        assert tr.model == "sonnet"
+        assert tr.source == "mac"
+        assert tr.status == "success"
+        assert tr.user_input == "hi"
+        assert tr.final_output == "final reply"
+        assert tr.input_tokens == 100
+        assert tr.output_tokens == 20
+        assert tr.cost_usd == pytest.approx(0.001)
+        assert tr.duration_ms >= 0
+
+        spans = db.query(TraceSpan).filter_by(trace_id=tr.id).all()
+        kinds = sorted([s.kind for s in spans])
+        assert kinds == ["generation", "tool"]
+        tool = next(s for s in spans if s.kind == "tool")
+        assert tool.name == "tool:web_search"
+        assert tool.level == "DEFAULT"
+    finally:
+        db.close()
+
+
+def test_token_accumulation_across_generations(fresh_db):
+    """on-device gemma calls record_generation per turn — totals should sum."""
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import Trace
+    from gitd.services.observability import trace_chat_turn, record_generation
+
+    with trace_chat_turn(session_id="c", user_message="hi", provider="on-device",
+                         model="g4-e4b", device="d", source="android") as t:
+        record_generation(t, model="g4-e4b", prompt="p1", output="r1",
+                          input_tokens=50, output_tokens=10, cost_usd=0.0)
+        record_generation(t, model="g4-e4b", prompt="p2", output="r2",
+                          input_tokens=70, output_tokens=15, cost_usd=0.0)
+        record_generation(t, model="g4-e4b", prompt="p3", output="r3",
+                          input_tokens=80, output_tokens=5, cost_usd=0.0)
+
+    db = SessionLocal()
+    try:
+        tr = db.query(Trace).first()
+        assert tr.input_tokens == 200
+        assert tr.output_tokens == 30
+    finally:
+        db.close()
+
+
+def test_error_status_on_exception(fresh_db):
+    """If the wrapped block raises, trace.status should flip to 'error'."""
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import Trace
+    from gitd.services.observability import trace_chat_turn
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with trace_chat_turn(session_id="c", user_message="hi", provider="x",
+                             model="m", device="d", source="mac"):
+            raise RuntimeError("boom")
+
+    db = SessionLocal()
+    try:
+        tr = db.query(Trace).first()
+        assert tr.status == "error"
+        assert "boom" in tr.error_text
+    finally:
+        db.close()
+
+
+def test_tool_error_marks_span_error(fresh_db):
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import TraceSpan
+    from gitd.services.observability import (
+        trace_chat_turn, record_tool_result,
+    )
+
+    with trace_chat_turn(session_id="c", user_message="x", provider="x",
+                         model="m", device="d", source="mac") as t:
+        s_ok = t.span(name="tool:a", input={})
+        record_tool_result(s_ok, "fine")
+        s_err = t.span(name="tool:b", input={})
+        record_tool_result(s_err, "boom", error=True)
+
+    db = SessionLocal()
+    try:
+        spans = {s.name: s for s in db.query(TraceSpan).all()}
+        assert spans["tool:a"].level == "DEFAULT"
+        assert spans["tool:b"].level == "ERROR"
+    finally:
+        db.close()
+
+
+def test_orphan_conversation_id_does_not_break(fresh_db):
+    """conversation_id is a soft reference, not a FK — non-existent IDs are fine."""
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import Trace
+    from gitd.services.observability import trace_chat_turn
+
+    with trace_chat_turn(session_id="never-existed", user_message="hi",
+                         provider="x", model="m", device="d", source="mac"):
+        pass
+
+    db = SessionLocal()
+    try:
+        assert db.query(Trace).count() == 1
+    finally:
+        db.close()
+
+
+def test_truncation_keeps_rows_bounded(fresh_db):
+    """Huge tool inputs/outputs shouldn't blow the row size."""
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import TraceSpan
+    from gitd.services.observability import (
+        trace_chat_turn, record_tool_result,
+    )
+
+    huge = "X" * 50_000
+    with trace_chat_turn(session_id="c", user_message="x", provider="x",
+                         model="m", device="d", source="mac") as t:
+        s = t.span(name="tool:big", input={"giant": huge})
+        record_tool_result(s, huge)
+
+    db = SessionLocal()
+    try:
+        sp = db.query(TraceSpan).filter_by(name="tool:big").first()
+        # Truncated to ~4000 chars + ellipsis marker
+        assert len(sp.input_json) < 5000
+        assert len(sp.output_json) < 5000
+        assert "[truncated]" in sp.input_json
+    finally:
+        db.close()
+
+
+# ── API endpoints ────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def client(fresh_db):
+    """FastAPI TestClient against the gitd app."""
+    from fastapi.testclient import TestClient
+    from gitd.app import create_app
+    app = create_app()
+    with TestClient(app) as c:
+        yield c
+
+
+def _seed(provider="claude-code", source="mac", status_set="success"):
+    """Helper — create one full trace in the DB and return its id."""
+    from gitd.services.observability import (
+        trace_chat_turn, record_tool_result, record_generation, set_trace_output,
+    )
+    if status_set == "error":
+        try:
+            with trace_chat_turn(session_id="c", user_message="bad",
+                                 provider=provider, model="m1",
+                                 device="d", source=source) as t:
+                s = t.span(name="tool:thing", input={})
+                record_tool_result(s, "err", error=True)
+                raise RuntimeError("simulated")
+        except RuntimeError:
+            pass
+        # Find the most recent and return its id
+        from gitd.models.base import SessionLocal
+        from gitd.models.trace import Trace
+        db = SessionLocal()
+        try:
+            return db.query(Trace).order_by(Trace.started_at.desc()).first().id
+        finally:
+            db.close()
+
+    with trace_chat_turn(session_id="c", user_message="hi",
+                         provider=provider, model="m1",
+                         device="d", source=source) as t:
+        s = t.span(name="tool:thing", input={"x": 1})
+        record_tool_result(s, "ok")
+        record_generation(t, model="m1", prompt="p", output="r",
+                          input_tokens=5, output_tokens=3, cost_usd=0.001)
+        set_trace_output(t, "out")
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import Trace
+    db = SessionLocal()
+    try:
+        return db.query(Trace).order_by(Trace.started_at.desc()).first().id
+    finally:
+        db.close()
+
+
+def test_list_endpoint_returns_paginated(client):
+    for _ in range(3):
+        _seed()
+    r = client.get("/api/traces?limit=2")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] == 3
+    assert len(body["data"]) == 2
+    assert all("provider" in t for t in body["data"])
+
+
+def test_list_endpoint_filters_by_provider(client):
+    _seed(provider="claude-code", source="mac")
+    _seed(provider="on-device", source="android")
+    _seed(provider="ollama", source="mac")
+
+    r = client.get("/api/traces?provider=on-device")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] == 1
+    assert body["data"][0]["provider"] == "on-device"
+
+
+def test_list_endpoint_filters_by_status_error(client):
+    _seed(status_set="success")
+    _seed(status_set="error")
+    r = client.get("/api/traces?status=error")
+    body = r.json()
+    assert body["total"] == 1
+    assert body["data"][0]["status"] == "error"
+
+
+def test_stats_endpoint(client):
+    _seed(provider="claude-code")
+    _seed(provider="claude-code")
+    _seed(provider="on-device", status_set="error")
+
+    r = client.get("/api/traces/stats")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] == 3
+    assert body["errors"] == 1
+    assert body["success_rate"] == pytest.approx(2 / 3, rel=1e-3)
+    providers = {p["provider"]: p["count"] for p in body["by_provider"]}
+    assert providers["claude-code"] == 2
+    assert providers["on-device"] == 1
+
+
+def test_detail_endpoint_includes_spans(client):
+    tid = _seed()
+    r = client.get(f"/api/traces/{tid}")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["trace"]["id"] == tid
+    assert body["trace"]["final_output"] == "out"
+    kinds = sorted(s["kind"] for s in body["spans"])
+    assert kinds == ["generation", "tool"]
+    tool = next(s for s in body["spans"] if s["kind"] == "tool")
+    assert tool["input"] == {"args": None} or "x" in (tool["input"] or {})
+
+
+def test_detail_endpoint_404_on_unknown(client):
+    r = client.get("/api/traces/does-not-exist")
+    assert r.status_code == 404
+
+
+def test_delete_single_trace(client):
+    tid = _seed()
+    r = client.delete(f"/api/traces/{tid}")
+    assert r.status_code == 200
+    assert r.json()["deleted"] == tid
+    r2 = client.get(f"/api/traces/{tid}")
+    assert r2.status_code == 404
+
+
+def test_clear_all_traces(client):
+    for _ in range(3):
+        _seed()
+    r = client.delete("/api/traces")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["deleted_traces"] == 3
+    list_r = client.get("/api/traces")
+    assert list_r.json()["total"] == 0


### PR DESCRIPTION
# On-device parser + Gemma chat template + stop-fix + WIP vLLM provider

Python-side companion to the app's `feature/llama-cpp-vulkan-adreno` PR.
Everything here is provider/agent-loop work: tool-call parsing, prompt
template, KV cache hashing, multi-turn coherence, and the stop button.

## Companion PR

- `ghost-app` → `feature/llama-cpp-vulkan-adreno` (the Kotlin / JNI / Gradle
  side; carries this submodule bump)

## Commits

| Commit | What |
|---|---|
| `fe17427` | Gemma chat template (`<start_of_turn>` markers) + DeviceActions Python wiring + n_ctx=4096 |
| `d869a6f` | Stream-side protocol: empty piece ≠ EOS (needed for JNI hold-back) |
| `c1823b7` | Chat path loads disk-persist KV cache before generateStart |
| `64769e9` | Rename `gemma-4-e2b-gguf` → `gemma-4-e2b-q4km-gguf` |
| `2096c08` | **Stop button actually stops claude** (orphan subproc fix) |
| `06fea2f` | WIP: vLLM provider for jsl-gpu via SSH tunnel + adb reverse |

## The big-deal fixes

### 1. Gemma chat template

Was using a custom `[SYSTEM]/[USER]/[ASSISTANT]` scaffold the model had
never seen in training. Gemma cheerfully echoed those markers back inside
its own replies, then started hallucinating fake follow-up turns. Result:
"`com.android.settings, com.android.settings, com.android.settings, ...`"
× hundreds, eventual context overflow on turn 7.

Switched to canonical `<start_of_turn>user / model / <end_of_turn>`.
Single source of truth via `ondevice_stable_prefix(system, device)` so
the warmup endpoint and the chat path can never drift apart. Multi-turn
coherence holds for 6+ turns now (verified live on Snapdragon 888).

### 2. Stop button propagates across the phone↔Mac boundary

Phone's `_chat_claude_code_remote` is a proxy: phone hits its own
`/api/agent-chat/message` → that hits Mac's same endpoint → Mac spawns
`claude` CLI. Two separate session ids. When the user hit Stop on the
phone, the phone-side stop fired against the phone's own session_id —
but the claude subprocess lives on the Mac under a different session.
Mac's `send_message` generator was blocked in `iter_lines()` waiting for
claude's next chunk, so it didn't notice the broken pipe until claude
had emitted 3-5 more tool calls. Multiple stops accumulated multiple
runaway claudes fighting each other for phone control.

Fix is layered:

- Phone-side proxy captures Mac's session_id from the first SSE `session`
  event and on `GeneratorExit` POSTs `/stop/{remote_sid}` to Mac before
  the connection dies.
- Mac-side `chat_claude_code` spawns claude with `start_new_session=True`
  so it has its own pgid, then registers the `Popen` in `_active_procs`.
- `stop_agent` does `killpg(SIGTERM)` → wait 2s → `killpg(SIGKILL)`,
  wiping claude + node + MCP-tool children together. Nuclear pkill kept
  as safety net.

Verified live: Stop now halts within ~1 s instead of letting claude run
wild for 30+ seconds.

### 3. Chat path loads disk-persist KV cache

Previously only the warmup endpoint loaded it. The chat path's
`generateStart` saw an empty KV and paid a full cold prefill (~4 min on
Q5_K_M) on every first chat call after a model switch. Now both callers
share `_ensure_kv_warmed()` so the cache file lands the same way.

### 4. Tool-call parser handles model slop

Three layers, applied in order:

1. `tool` / ` ```json ` fenced block parse
2. Inline `{...}` scan with `_attempt_repairs` (doubled-brace collapse,
   trailing-junk strip, balanced-brace truncation)
3. **NEW**: global `{{ ` → `{` flatten + re-scan if both prior passes
   missed (Gemma at temp 0 routinely emits inline doubled braces with
   mismatched closing counts that the step-2 regex couldn't match)

Plus action-schema (`{"action_type": "open_app", "app_name": "X"}`)
translation for ghost-gemma-style trained outputs.

### 5. launch_app: package verifier + Chaquopy bridge

Was failing two ways on-phone:

1. Model hallucinated package names (`com.reddit.android` when reality
   was `com.reddit.frontpage`). `monkey` returns 0 for missing packages,
   so the agent thought it succeeded.
2. `monkey` and `am force-stop` both require permissions uid 10030 doesn't
   have. Both fall back silently from host adb (uid 2000 shell) which
   masked the bug during dev.

Fix: verify the package exists first (returns "Did you mean: X?" hint),
then call into `DeviceActions.launchApp()` via the Chaquopy `jclass`
bridge — uses the app's own `Context.startActivity()` which doesn't
need cross-user permissions. Falls back to the `am start` path when
Chaquopy isn't available (host-side dev runs).

## Numbers

End-to-end first-turn UX, gemma-4-e2b-q4km-gguf on Snapdragon 888:

| Phase | Tokens | ms |
|---|---:|---:|
| App cold launch → daemon ready | — | ~15 000 |
| KV restore from disk (warmup-d5e... or warmup-c7b7...) | 1263 | 155 |
| Prefill turn 1 (KV cache hit + user msg diff) | ~50 new | 6 000 – 13 000 |
| Decode turn 1 | 30–90 | 7 000 – 22 000 |

## Untested / WIP

- **vLLM provider** (`06fea2f`): code-complete (full multi-turn loop,
  OpenAI conversation-history wiring, tool dispatch, helpful error
  messages) but never run against a live vLLM server. Doesn't affect
  any existing provider. Verification path documented in the commit
  message.

## How to verify

Without vLLM, on a real phone:

```bash
# Mac side
cd android-agent && source .venv/bin/activate
uvicorn gitd.app:app --port 15055 --host 127.0.0.1 &
adb reverse tcp:15055 tcp:15055
adb reverse tcp:3000 tcp:3000  # optional, for Langfuse tracing

# Phone side — the bundled gitd is on localhost:5055 inside the app's process
# Use the on-device picker → gemma-4-e2b-q4km-gguf
# Tap a suggestion chip (e.g. Wi-Fi toggle)

# Watch for:
adb logcat | grep -F -e BENCH -e DeviceActions -e nativeLoadState
```