### PR TITLE
chore(site): wire Vercel Analytics into landing + Skill Hub pages

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -605,6 +605,8 @@
 			.hero h1 { letter-spacing: -1.5px; }
 		}
 	</style>
+	<!-- Vercel Web Analytics (Starlight head-injection doesn't reach this standalone page) -->
+	<script defer src="/_vercel/insights/script.js"></script>
 </head>
 <body>
 	<!-- NAV -->

--- a/site/src/pages/skills/[slug].astro
+++ b/site/src/pages/skills/[slug].astro
@@ -99,6 +99,8 @@ const { skill } = Astro.props
 			.nav-links a:not(.nav-cta) { display: none; }
 		}
 	</style>
+	<!-- Vercel Web Analytics (Starlight head-injection doesn't reach this standalone page) -->
+	<script defer src="/_vercel/insights/script.js"></script>
 </head>
 <body>
 	<nav>

--- a/site/src/pages/skills/index.astro
+++ b/site/src/pages/skills/index.astro
@@ -141,6 +141,8 @@ const totalElements = skills.reduce((s, k) => s + k.elements, 0)
 			.nav-links a:not(.nav-cta) { display: none; }
 		}
 	</style>
+	<!-- Vercel Web Analytics (Starlight head-injection doesn't reach this standalone page) -->
+	<script defer src="/_vercel/insights/script.js"></script>
 </head>
 <body>
 	<nav>


### PR DESCRIPTION
## What

Adds Vercel Web Analytics tracking script to the 3 standalone Astro pages that don't go through Starlight:

- `site/src/pages/index.astro` — landing page
- `site/src/pages/skills/index.astro` — Skill Hub
- `site/src/pages/skills/[slug].astro` — per-skill detail pages

## Why

Starlight docs already emit the analytics tag via the `head` config in `astro.config.mjs`, so `/getting-started/*`, `/features/*`, `/guides/*`, `/api/*` are covered. The 3 custom pages above weren't — so landing traffic (including recent viral spikes) went uncounted.

After merge:

| Page type | Tracked? |
|---|---|
| Docs (Starlight) | ✅ already |
| Landing `/` | ✅ this PR |
| Skill Hub `/skills` | ✅ this PR |
| Per-skill `/skills/<name>` | ✅ this PR |

## Verification

`astro build` clean — 46/47 built pages now emit the script (only `bg-test` dev page excluded intentionally).

## Deploy

`cd site && npx vercel --prod` after merge.

## Scope

Site-only. No Python, no gitd changes. +6 lines total, all in 3 site pages.