### PR TITLE
chore(site): SEO frontmatter + OG tag polish

### DIFF
--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: "👻 Ghost in the Droid Documentation"
 description: Open-source framework for automating Android devices using real phones.
 ---
 
-Ghost in the Droid is an open-source agent harness for Android — give any AI agent full control of a real Android phone via ADB, with 41 MCP tools, a skill system, and on-device Gemma inference.
+Ghost in the Droid is an open-source agent harness for Android — give any AI agent full control of a real Android phone via ADB, with 35 MCP tools and a reusable skill system.
 
 Welcome to the documentation. Use the sidebar to navigate.
 

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -3,7 +3,9 @@ title: "👻 Ghost in the Droid Documentation"
 description: Open-source framework for automating Android devices using real phones.
 ---
 
-Welcome to the Ghost in the Droid documentation. Use the sidebar to navigate.
+Ghost in the Droid is an open-source agent harness for Android — give any AI agent full control of a real Android phone via ADB, with 41 MCP tools, a skill system, and on-device Gemma inference.
+
+Welcome to the documentation. Use the sidebar to navigate.
 
 ## Quick Links
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -11,11 +11,12 @@
 	<meta name="description" content="Summon a ghost into your Android. Open-source framework for controlling real phones via ADB. No root required. No cloud dependency. Pure automation." />
 	<meta property="og:title" content="Ghost in the Droid — Android Body for AI Agents" />
 	<meta property="og:description" content="Open-source Python framework for automating Android devices. Build skills, manage phone farms, zero cloud dependency." />
-	<meta property="og:image" content="/mascot/40-lineup-banner.png" />
+	<meta property="og:image" content="https://ghostinthedroid.com/mascot/40-lineup-banner.png" />
+	<meta property="og:url" content="https://ghostinthedroid.com/" />
 	<meta property="og:type" content="website" />
 	<meta name="twitter:card" content="summary_large_image" />
 	<meta name="twitter:title" content="Ghost in the Droid" />
-	<meta name="twitter:image" content="/mascot/40-lineup-banner.png" />
+	<meta name="twitter:image" content="https://ghostinthedroid.com/mascot/40-lineup-banner.png" />
 	<link rel="preconnect" href="https://fonts.googleapis.com" />
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 	<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />

--- a/site/src/pages/skills/index.astro
+++ b/site/src/pages/skills/index.astro
@@ -41,6 +41,13 @@ const totalElements = skills.reduce((s, k) => s + k.elements, 0)
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<title>Skill Hub — Ghost in the Droid</title>
 	<meta name="description" content="Browse, install, and share automation skills for any Android app." />
+	<meta property="og:title" content="Skill Hub — Ghost in the Droid" />
+	<meta property="og:description" content="Browse, install, and share automation skills for any Android app. TikTok, Instagram, Gmail and more." />
+	<meta property="og:image" content="/mascot/40-lineup-banner.png" />
+	<meta property="og:type" content="website" />
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:title" content="Skill Hub — Ghost in the Droid" />
+	<meta name="twitter:image" content="/mascot/40-lineup-banner.png" />
 	<link rel="preconnect" href="https://fonts.googleapis.com" />
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 	<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />

--- a/site/src/pages/skills/index.astro
+++ b/site/src/pages/skills/index.astro
@@ -43,11 +43,11 @@ const totalElements = skills.reduce((s, k) => s + k.elements, 0)
 	<meta name="description" content="Browse, install, and share automation skills for any Android app." />
 	<meta property="og:title" content="Skill Hub — Ghost in the Droid" />
 	<meta property="og:description" content="Browse, install, and share automation skills for any Android app. TikTok, Instagram, Gmail and more." />
-	<meta property="og:image" content="/mascot/40-lineup-banner.png" />
+	<meta property="og:image" content="https://ghostinthedroid.com/mascot/40-lineup-banner.png" />
 	<meta property="og:type" content="website" />
 	<meta name="twitter:card" content="summary_large_image" />
 	<meta name="twitter:title" content="Skill Hub — Ghost in the Droid" />
-	<meta name="twitter:image" content="/mascot/40-lineup-banner.png" />
+	<meta name="twitter:image" content="https://ghostinthedroid.com/mascot/40-lineup-banner.png" />
 	<link rel="preconnect" href="https://fonts.googleapis.com" />
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 	<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />

--- a/site/src/pages/skills/index.astro
+++ b/site/src/pages/skills/index.astro
@@ -45,6 +45,7 @@ const totalElements = skills.reduce((s, k) => s + k.elements, 0)
 	<meta property="og:description" content="Browse, install, and share automation skills for any Android app. TikTok, Instagram, Gmail and more." />
 	<meta property="og:image" content="https://ghostinthedroid.com/mascot/40-lineup-banner.png" />
 	<meta property="og:type" content="website" />
+	<meta property="og:url" content="https://ghostinthedroid.com/skills/" />
 	<meta name="twitter:card" content="summary_large_image" />
 	<meta name="twitter:title" content="Skill Hub — Ghost in the Droid" />
 	<meta name="twitter:image" content="https://ghostinthedroid.com/mascot/40-lineup-banner.png" />


### PR DESCRIPTION
## Summary

- **skills/index.astro**: add Open Graph + Twitter Card meta tags so the Skill Hub page shows rich previews when shared on social/Slack/Discord
- **index.mdx**: replace thin "Welcome to the docs" opener with a descriptive one-liner so GSC/crawlers index the page for the right keywords

## Files changed

| File | Change |
|---|---|
| `site/src/pages/skills/index.astro` | +7 OG/Twitter meta tags |
| `site/src/content/docs/index.mdx` | +1 descriptive first sentence, -1 bare welcome line |

## Test plan

- [ ] Build site locally (`npm run build` in `site/`) — no build errors
- [ ] View `/` and `/skills/` in browser, check `<head>` in devtools for OG tags
- [ ] Paste skill hub URL into [opengraph.xyz](https://www.opengraph.xyz) or Twitter card validator to confirm preview renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)