### PR TITLE
docs(ios): public iOS documentation set — setup, remote fleet, troubleshooting, tools

### DIFF
--- a/site/src/content/docs/ios/remote-fleet/index.md
+++ b/site/src/content/docs/ios/remote-fleet/index.md
@@ -27,13 +27,16 @@ The iPhone-facing leg (RemoteXPC tunnel, code-signing, WDA lifecycle) stays **en
 
 ## Rollout status
 
+Remote fleet is rolling out in slices. **Local (on-Mac) iOS automation and streaming work today**; the Linux→Mac remote-drive path becomes real-device-ready once the security hardening lands — it is deliberately gated on that, not on features.
+
 | Piece | Status |
 |---|---|
-| `remotes:` config, `<name>@<host>` ref grammar, remote→iOS routing | ✅ Shipped (slice 1) |
-| Destructive-action confirmation gate | ✅ Shipped (slice 1) |
+| `remotes:` config, `<name>@<host>` ref grammar, remote→iOS routing | ✅ Built (slice 1) |
+| Destructive-action confirmation gate | ✅ Built (slice 1) |
 | `ghost-ios report --json` device discovery from the Mac | 🚧 In progress (slice 2) |
+| Security hardening pass (gates real-device remote use) | 🚧 In progress |
 | Remote H.264 streaming over the forwarded port | 🔜 Pending |
-| WireGuard underlay, SSH certificate CA (multi-site fleets) | 🔮 Planned (v2) |
+| WireGuard underlay, SSH certificate CA (multi-site fleets) | 🔮 Planned |
 
 ## Setup guides
 

--- a/site/src/content/docs/ios/remote-fleet/index.md
+++ b/site/src/content/docs/ios/remote-fleet/index.md
@@ -33,7 +33,8 @@ Remote fleet is an **advanced, experimental** feature rolling out in slices. **L
 |---|---|
 | Remotes config, `<name>@<host>` ref grammar, remote→iOS routing | ✅ Built (slice 1) |
 | Destructive-action confirmation gate (tool-level) | ✅ Built (slice 1) |
-| `ghost-ios report --json` device discovery from the Mac | 🚧 In progress (slice 2) |
+| Mac-side device inventory (`ghost-ios report`) | ✅ Ships with the toolkit (`scripts/ios/`) |
+| Ghost-side auto-discovery (`ghost probe` consuming the report) | 🚧 In progress (slice 2) |
 | Security hardening — gate coverage across composite tools, endpoint-based remote detection, supervised mode for UI-level actions, API auth. **Gates real-device remote use** | 🚧 In progress |
 | Remote H.264 streaming over the forwarded port | 🔜 Pending |
 | WireGuard underlay, SSH certificate CA (multi-site fleets) | 🔮 Planned |

--- a/site/src/content/docs/ios/remote-fleet/index.md
+++ b/site/src/content/docs/ios/remote-fleet/index.md
@@ -27,14 +27,14 @@ The iPhone-facing leg (RemoteXPC tunnel, code-signing, WDA lifecycle) stays **en
 
 ## Rollout status
 
-Remote fleet is rolling out in slices. **Local (on-Mac) iOS automation and streaming work today**; the Linux→Mac remote-drive path becomes real-device-ready once the security hardening lands — it is deliberately gated on that, not on features.
+Remote fleet is an **advanced, experimental** feature rolling out in slices. **Local (on-Mac) iOS automation and streaming work today.** The Linux→Mac remote-drive path becomes real-device-ready only once the security hardening lands — deliberately gated on security, not on features. Until then, point it at test devices, not a phone with real accounts.
 
 | Piece | Status |
 |---|---|
-| `remotes:` config, `<name>@<host>` ref grammar, remote→iOS routing | ✅ Built (slice 1) |
-| Destructive-action confirmation gate | ✅ Built (slice 1) |
+| Remotes config, `<name>@<host>` ref grammar, remote→iOS routing | ✅ Built (slice 1) |
+| Destructive-action confirmation gate (tool-level) | ✅ Built (slice 1) |
 | `ghost-ios report --json` device discovery from the Mac | 🚧 In progress (slice 2) |
-| Security hardening pass (gates real-device remote use) | 🚧 In progress |
+| Security hardening — gate coverage across composite tools, endpoint-based remote detection, supervised mode for UI-level actions, API auth. **Gates real-device remote use** | 🚧 In progress |
 | Remote H.264 streaming over the forwarded port | 🔜 Pending |
 | WireGuard underlay, SSH certificate CA (multi-site fleets) | 🔮 Planned |
 
@@ -43,5 +43,5 @@ Remote fleet is rolling out in slices. **Local (on-Mac) iOS automation and strea
 Set up the two ends in order:
 
 1. **[Mac Setup](/ios/remote-fleet/mac-setup/)** — auto-login session, restricted SSH key, keychain, installer
-2. **[Linux Setup](/ios/remote-fleet/linux-setup/)** — `remotes:` config, the tunnel, device refs, probing
+2. **[Linux Setup](/ios/remote-fleet/linux-setup/)** — remotes config, the tunnel, device refs, probing
 3. **[Security Model](/ios/remote-fleet/security/)** — threat model and why it's built this way

--- a/site/src/content/docs/ios/remote-fleet/index.md
+++ b/site/src/content/docs/ios/remote-fleet/index.md
@@ -1,0 +1,44 @@
+---
+title: "Remote Fleet: iPhones from Linux"
+description: Drive a USB iPhone attached to a Mac from a Linux Ghost host over one SSH tunnel — topology, principles, and rollout status.
+---
+
+Your Ghost host runs on Linux, but iPhones can only be driven from a Mac. The remote-fleet feature bridges that gap with one SSH tunnel:
+
+```
+Linux Ghost host ──SSH──> Mac (Appium + WDA) ──RemoteXPC tunnel──> USB iPhone
+```
+
+The iPhone-facing leg (RemoteXPC tunnel, code-signing, WDA lifecycle) stays **entirely Mac-local** — exactly as in a single-Mac setup. The only new leg is Ghost→Mac, and it follows one core principle:
+
+> **The Ghost host talks to Appium/WDA HTTP over an SSH port-forward; it never touches the device's IPv6 tunnel directly.**
+
+## Why a Mac is unavoidable
+
+`xcodebuild`/`codesign`, the CoreDevice/RemoteXPC tunnel, and the Simulator runtime are macOS-only with no Linux equivalent. Linux cannot talk to an iPhone. So "iOS in the fleet" means "the fleet contains at least one always-logged-in Mac node" — the Mac is a dumb worker, the Linux master stays the brain.
+
+## How it fits together
+
+- **One persistent, multiplexed SSH tunnel per Mac** (`ControlMaster` + `ControlPersist`, supervised with `autossh`), forwarding four ports: Appium `:4723` (control plane), WDA `:8100` (direct `/wda/*` calls Appium doesn't proxy), MJPEG `:9100`, H.264 WebSocket `:9200`. Not per-session forwards — one warm tunnel, sessions come and go.
+- **Latency is WDA-bound, not transport-bound.** Measured WDA-side: `status` ~5 ms, `screenshot` ~190 ms, `tap` ~730 ms. LAN SSH adds ~1–3 ms — HTTP-over-SSH is comfortably good enough for interactive control.
+- **An SSH drop does not kill your session.** The Appium/WDA session lives on the Mac and survives a transport blip until Appium's `newCommandTimeout` (default posture: 300 s). Ghost reconnects with backoff, revalidates the cached session, and reattaches — it re-initializes only if the session actually expired.
+- **Remote devices are named, not numbered.** A remote iPhone is `my-iphone-15-pro@my-mac` — the UDID stays out of the ref and is resolved on the Mac. Refs stay stable and human-readable; a phone that moves Macs just changes its `@host`.
+- **Destructive actions get a confirmation gate.** A remote phone is often a real, personal device. Destructive tool calls on a remote device return `CONFIRM_REQUIRED` unless explicitly confirmed. See [Security](/ios/remote-fleet/security/).
+
+## Rollout status
+
+| Piece | Status |
+|---|---|
+| `remotes:` config, `<name>@<host>` ref grammar, remote→iOS routing | ✅ Shipped (slice 1) |
+| Destructive-action confirmation gate | ✅ Shipped (slice 1) |
+| `ghost-ios report --json` device discovery from the Mac | 🚧 In progress (slice 2) |
+| Remote H.264 streaming over the forwarded port | 🔜 Pending |
+| WireGuard underlay, SSH certificate CA (multi-site fleets) | 🔮 Planned (v2) |
+
+## Setup guides
+
+Set up the two ends in order:
+
+1. **[Mac Setup](/ios/remote-fleet/mac-setup/)** — auto-login session, restricted SSH key, keychain, installer
+2. **[Linux Setup](/ios/remote-fleet/linux-setup/)** — `remotes:` config, the tunnel, device refs, probing
+3. **[Security Model](/ios/remote-fleet/security/)** — threat model and why it's built this way

--- a/site/src/content/docs/ios/remote-fleet/linux-setup.md
+++ b/site/src/content/docs/ios/remote-fleet/linux-setup.md
@@ -95,10 +95,10 @@ screenshot("my-iphone@my-mac")
 Rather than hand-typing device details, ask the Mac what's attached (requires the discovery command to be allowed by the [forced-command wrapper](/ios/remote-fleet/mac-setup/#2-enable-ssh-add-a-restricted-key) on the Mac's restricted key):
 
 ```bash
-ssh my-mac ghost-ios report --json
+ssh my-mac ghost-ios report
 ```
 
-> The `ghost-ios` toolkit is being packaged into the repository — see [Utility Scripts](/ios/util-scripts/) for its status and full command reference.
+> The `ghost-ios` toolkit ships in the repo at `scripts/ios/` — see [Utility Scripts](/ios/util-scripts/) for install and the full command reference.
 
 The JSON inventory (schema in [Mac Setup](/ios/remote-fleet/mac-setup/#5-health-surface)) gives you each phone's `ref_slug`, iOS version, and per-leg health: `tunnel_up`, `appium_up`, `wda_up`. Remember `wda_up: false` on an idle phone is normal — readiness is `tunnel_up && appium_up`.
 

--- a/site/src/content/docs/ios/remote-fleet/linux-setup.md
+++ b/site/src/content/docs/ios/remote-fleet/linux-setup.md
@@ -1,0 +1,107 @@
+---
+title: "Remote Fleet: Linux Setup"
+description: Point a Linux Ghost host at a remote Mac — remotes config, the supervised SSH tunnel, device refs, and probing.
+---
+
+With the [Mac side](/ios/remote-fleet/mac-setup/) prepared, the Linux Ghost host needs three things: a `remotes:` entry describing the Mac, a persistent SSH tunnel forwarding four ports, and a device ref that names the phone.
+
+## 1. Configure the remote
+
+A remote Mac is one JSON entry. Ghost reads it from `GITD_REMOTES_JSON` (a JSON blob), `GITD_REMOTES_FILE` (a path), or a `remotes` key inside your existing `IOS_DEVICES_JSON` / `IOS_CONFIG_FILE` — one config file can describe the whole fleet.
+
+```bash
+export GITD_REMOTES_JSON='{
+  "my-mac": {
+    "ssh": "automation@my-mac.local",
+    "appium_port": 4723,
+    "wda_port": 8100,
+    "mjpeg_port": 9100,
+    "h264_port": 9200
+  }
+}'
+```
+
+The ports are **local, Linux-side forwarded ports** — where the tunnel delivers each Mac service. With one Mac the defaults are fine; with several Macs give each its own port range so they never collide:
+
+```json
+{
+  "my-mac":     { "ssh": "automation@my-mac.local" },
+  "studio-mac": { "ssh": "automation@studio-mac.local",
+                  "appium_port": 14723, "wda_port": 18100,
+                  "mjpeg_port": 19100, "h264_port": 19200 }
+}
+```
+
+Host keys are simple identifiers (they appear after the `@` in device refs, so they can't contain `@`). Malformed entries are skipped rather than crashing device listing — check your JSON if a remote silently doesn't appear.
+
+## 2. Open the tunnel
+
+One persistent, multiplexed tunnel per Mac, forwarding the four service ports to the local ports you configured. In `~/.ssh/config` on the Ghost host:
+
+```text
+Host my-mac
+  HostName my-mac.local
+  User automation
+  IdentityFile ~/.ssh/ghost_fleet_ed25519
+  ControlMaster auto
+  ControlPath ~/.ssh/cm-%r@%h:%p
+  ControlPersist yes
+  ServerAliveInterval 15
+  ExitOnForwardFailure yes
+  LocalForward 4723 127.0.0.1:4723
+  LocalForward 8100 127.0.0.1:8100
+  LocalForward 9100 127.0.0.1:9100
+  LocalForward 9200 127.0.0.1:9200
+```
+
+Supervise it so it survives blips — `autossh` is the simplest option:
+
+```bash
+autossh -M 0 -N my-mac
+```
+
+(or an equivalent systemd unit / restart loop). Key properties of this design:
+
+- **One warm tunnel, not per-session forwards** — no setup/teardown churn, simpler reconnection.
+- **A dropped tunnel does not kill your automation session.** The Appium/WDA session lives on the Mac and survives until `newCommandTimeout`. Ghost reconnects, revalidates its cached session ID, and reattaches; it re-creates the session only if it truly expired. For links that blip longer, raise `newCommandTimeout` (e.g. 600 s) or keep a periodic `GET /status` keepalive so a 30–60 s reconnect never races the timeout.
+- **Two failure domains, fixed from two places.** Ghost→Mac SSH is supervised on the Linux side (this page). Mac→iPhone RemoteXPC is supervised on the Mac and is *not* something a Linux reconnect should touch — if the device leg died, the Mac's health surface reports it.
+
+## 3. Address the phone
+
+A remote iPhone is `<name>@<host>` — no `ios:` prefix, no UDID:
+
+```text
+my-iphone@my-mac
+```
+
+- `<host>` must match a configured `remotes:` key; an `@` ref whose host is unknown is *not* treated as remote (so it can never mis-route), and Android serials never contain `@`, so the grammar is unambiguous.
+- `<name>` is the phone's `ref_slug` from `ghost-ios report` — derived from the device's user-assigned name. The UDID is resolved on the Mac; **never hand-maintain UDID lists** (they rot). A phone that moves to another Mac keeps its name and just changes its `@host`.
+
+Remote refs route to the iOS backend automatically and use the standard `IOS_WDA_URL`-style plumbing pointed at your forwarded ports.
+
+Use it anywhere a device ref is accepted:
+
+```text
+launch_app("my-iphone@my-mac", "com.google.chrome.ios")
+screenshot("my-iphone@my-mac")
+```
+
+## 4. Discover devices from the Mac
+
+Rather than hand-typing device details, ask the Mac what's attached (requires the discovery command to be allowed by the forced-command wrapper on the Mac's restricted key):
+
+```bash
+ssh my-mac ghost-ios report --json
+```
+
+The JSON inventory (schema in [Mac Setup](/ios/remote-fleet/mac-setup/#5-health-surface)) gives you each phone's `ref_slug`, iOS version, and per-leg health: `tunnel_up`, `appium_up`, `wda_up`. Remember `wda_up: false` on an idle phone is normal — readiness is `tunnel_up && appium_up`.
+
+> `ghost probe <host>` — a one-command wrapper that runs the report and auto-populates device entries — is landing as part of discovery (slice 2). Until then, the SSH one-liner above is the way.
+
+## 5. Confirmation gate for destructive actions
+
+On a remote device, destructive tool calls (shell-level ops, app force-stop, code-executing skill tools, …) return `CONFIRM_REQUIRED` instead of executing, unless the call carries `confirm: true`. Local Android/USB devices are unaffected. This is deliberate: remote phones are often real, personal devices. Details, scope, and the kill-switch are in [Security](/ios/remote-fleet/security/).
+
+## Design record
+
+The full design discussion behind these choices (latency budgets, failure-model analysis, transport trade-offs) lives in the repo: `docs/ios/remote-fleet/` — the Mac-side and Ghost-side design docs pair up and cross-reference this guide.

--- a/site/src/content/docs/ios/remote-fleet/linux-setup.md
+++ b/site/src/content/docs/ios/remote-fleet/linux-setup.md
@@ -3,7 +3,11 @@ title: "Remote Fleet: Linux Setup"
 description: Point a Linux Ghost host at a remote Mac — remotes config, the supervised SSH tunnel, device refs, and probing.
 ---
 
-With the [Mac side](/ios/remote-fleet/mac-setup/) prepared, the Linux Ghost host needs three things: a `remotes:` entry describing the Mac, a persistent SSH tunnel forwarding four ports, and a device ref that names the phone.
+:::caution[Experimental — not yet for real personal devices]
+Remote drive is an advanced feature rolling out in slices. The configuration below is built, but the Linux→Mac path becomes **real-device-ready only once the security hardening lands** (see the [rollout status](/ios/remote-fleet/#rollout-status)). Until then, use it with test devices only — not a phone with real accounts. Local on-Mac iOS automation is unaffected and works today.
+:::
+
+With the [Mac side](/ios/remote-fleet/mac-setup/) prepared, the Linux Ghost host needs three things: a remotes-config entry describing the Mac, a persistent SSH tunnel forwarding four ports, and a device ref that names the phone.
 
 ## 1. Configure the remote
 
@@ -32,7 +36,7 @@ The ports are **local, Linux-side forwarded ports** — where the tunnel deliver
 }
 ```
 
-Host keys are simple identifiers (they appear after the `@` in device refs, so they can't contain `@`). Malformed entries are skipped rather than crashing device listing — check your JSON if a remote silently doesn't appear.
+Remote names — the keys of the remotes map, `my-mac` above — are simple identifiers (they appear after the `@` in device refs, so they can't contain `@`). Malformed entries are skipped rather than crashing device listing — check your JSON if a remote silently doesn't appear.
 
 ## 2. Open the tunnel
 
@@ -74,7 +78,7 @@ A remote iPhone is `<name>@<host>` — no `ios:` prefix, no UDID:
 my-iphone@my-mac
 ```
 
-- `<host>` must match a configured `remotes:` key; an `@` ref whose host is unknown is *not* treated as remote (so it can never mis-route), and Android serials never contain `@`, so the grammar is unambiguous.
+- `<host>` must match a remote name from your remotes config; an `@` ref whose host is unknown is *not* treated as remote (so it can never mis-route), and Android serials never contain `@`, so the grammar is unambiguous.
 - `<name>` is the phone's `ref_slug` from `ghost-ios report` — derived from the device's user-assigned name. The UDID is resolved on the Mac; **never hand-maintain UDID lists** (they rot). A phone that moves to another Mac keeps its name and just changes its `@host`.
 
 Remote refs route to the iOS backend automatically and use the standard `IOS_WDA_URL`-style plumbing pointed at your forwarded ports.
@@ -88,11 +92,13 @@ screenshot("my-iphone@my-mac")
 
 ## 4. Discover devices from the Mac
 
-Rather than hand-typing device details, ask the Mac what's attached (requires the discovery command to be allowed by the forced-command wrapper on the Mac's restricted key):
+Rather than hand-typing device details, ask the Mac what's attached (requires the discovery command to be allowed by the [forced-command wrapper](/ios/remote-fleet/mac-setup/#2-enable-ssh-add-a-restricted-key) on the Mac's restricted key):
 
 ```bash
 ssh my-mac ghost-ios report --json
 ```
+
+> The `ghost-ios` toolkit is being packaged into the repository — see [Utility Scripts](/ios/util-scripts/) for its status and full command reference.
 
 The JSON inventory (schema in [Mac Setup](/ios/remote-fleet/mac-setup/#5-health-surface)) gives you each phone's `ref_slug`, iOS version, and per-leg health: `tunnel_up`, `appium_up`, `wda_up`. Remember `wda_up: false` on an idle phone is normal — readiness is `tunnel_up && appium_up`.
 

--- a/site/src/content/docs/ios/remote-fleet/mac-setup.md
+++ b/site/src/content/docs/ios/remote-fleet/mac-setup.md
@@ -55,6 +55,8 @@ export IOS_USE_PREINSTALLED_WDA="true"
 
 The Mac owns WDA end-to-end. The remote Ghost host never builds, signs, or spawns WDA — it just drives sessions through the forwarded ports.
 
+Day-to-day the node runs under the `ghost-ios` toolkit: `ghost-ios keychain` once (grants CLI codesign access), then `ghost-ios up` starts the backend, Appium, and a self-healing RemoteXPC tunnel supervisor. Full command reference: [Utility Scripts](/ios/util-scripts/).
+
 ## 4. Keep everything loopback-only
 
 Appium, WDA, MJPEG, and the H.264 stream must stay bound to `127.0.0.1` on the Mac — the defaults. **Never bind them to `0.0.0.0`.** Exposure happens exclusively through the SSH forward, so access requires possession of the restricted key. This is the primary security control; see [Security](/ios/remote-fleet/security/).
@@ -70,7 +72,7 @@ Appium, WDA, MJPEG, and the H.264 stream must stay bound to `127.0.0.1` on the M
   "generated_at": "2026-07-11T21:33Z",
   "devices": [
     {
-      "udid": "00008110-0012345678901234",
+      "udid": "00008XXX-XXXXXXXXXXXXXXXX",
       "name": "my iPhone",
       "ref_slug": "my-iphone",
       "ios_version": "26.4",

--- a/site/src/content/docs/ios/remote-fleet/mac-setup.md
+++ b/site/src/content/docs/ios/remote-fleet/mac-setup.md
@@ -31,7 +31,7 @@ What this buys you:
 
 - `restrict` — no PTY, no agent forwarding, no X11: the key can't get a shell.
 - `permitopen` ×4 — the key can forward **only** the four automation ports (Appium, WDA, MJPEG, H.264), all on loopback.
-- `command="/usr/bin/false"` — any exec attempt dies immediately. If you also want the Ghost host to run `ghost-ios report --json` over SSH (device discovery), replace `/usr/bin/false` with a forced-command wrapper that allows exactly that command.
+- `command="/usr/bin/false"` — any exec attempt dies immediately. If you also want the Ghost host to run `ghost-ios report` over SSH (device discovery), replace `/usr/bin/false` with a forced-command wrapper that allows exactly that command.
 
 Never forward your SSH agent from the Ghost host to the Mac.
 
@@ -55,7 +55,7 @@ export IOS_USE_PREINSTALLED_WDA="true"
 
 The Mac owns WDA end-to-end. The remote Ghost host never builds, signs, or spawns WDA — it just drives sessions through the forwarded ports.
 
-Day-to-day the node runs under the `ghost-ios` toolkit: `ghost-ios keychain` once (grants CLI codesign access), then `ghost-ios up` starts the backend, Appium, and a self-healing RemoteXPC tunnel supervisor. Note the toolkit is still being packaged into the repository — see [Utility Scripts](/ios/util-scripts/) for its status and full command reference.
+Day-to-day the node runs under the `ghost-ios` toolkit, which ships in the repo at `scripts/ios/`: `ghost-ios keychain` once (grants CLI codesign access), `ghost-ios doctor` to preflight, then `ghost-ios up` starts the backend, Appium, and a self-healing RemoteXPC tunnel supervisor. Zero-config with one attached iPhone and one signing identity; see [Utility Scripts](/ios/util-scripts/) for the full command reference.
 
 ## 4. Keep everything loopback-only
 
@@ -63,19 +63,19 @@ Appium, WDA, MJPEG, and the H.264 stream must stay bound to `127.0.0.1` on the M
 
 ## 5. Health surface
 
-`ghost-ios status` enumerates attached devices plus tunnel/WDA health on the node, and `ghost-ios report --json` emits a machine-readable inventory the Linux side uses for discovery:
+`ghost-ios status` enumerates attached devices plus tunnel/WDA health on the node, and `ghost-ios report` emits a machine-readable inventory the Linux side uses for discovery:
 
 ```json
 {
   "schema": 1,
-  "host": "my-mac",
-  "generated_at": "2026-07-11T21:33Z",
+  "host": "mac1",
+  "generated_at": "2026-01-01T00:00Z",
   "devices": [
     {
       "udid": "00008XXX-XXXXXXXXXXXXXXXX",
-      "name": "my iPhone",
-      "ref_slug": "my-iphone",
-      "ios_version": "26.4",
+      "name": "Demo iPhone",
+      "ref_slug": "demo-iphone",
+      "ios_version": "26.4.2",
       "wda_up": false,
       "appium_up": true,
       "tunnel_up": true

--- a/site/src/content/docs/ios/remote-fleet/mac-setup.md
+++ b/site/src/content/docs/ios/remote-fleet/mac-setup.md
@@ -55,7 +55,7 @@ export IOS_USE_PREINSTALLED_WDA="true"
 
 The Mac owns WDA end-to-end. The remote Ghost host never builds, signs, or spawns WDA — it just drives sessions through the forwarded ports.
 
-Day-to-day the node runs under the `ghost-ios` toolkit: `ghost-ios keychain` once (grants CLI codesign access), then `ghost-ios up` starts the backend, Appium, and a self-healing RemoteXPC tunnel supervisor. Full command reference: [Utility Scripts](/ios/util-scripts/).
+Day-to-day the node runs under the `ghost-ios` toolkit: `ghost-ios keychain` once (grants CLI codesign access), then `ghost-ios up` starts the backend, Appium, and a self-healing RemoteXPC tunnel supervisor. Note the toolkit is still being packaged into the repository — see [Utility Scripts](/ios/util-scripts/) for its status and full command reference.
 
 ## 4. Keep everything loopback-only
 

--- a/site/src/content/docs/ios/remote-fleet/mac-setup.md
+++ b/site/src/content/docs/ios/remote-fleet/mac-setup.md
@@ -1,0 +1,95 @@
+---
+title: "Remote Fleet: Mac Setup"
+description: Prepare a Mac as an iOS fleet node — auto-login GUI session, restricted SSH key, keychain auto-unlock, and the ghost-ios tooling.
+---
+
+The Mac in a remote fleet is a worker node: it owns the WebDriverAgent lifecycle, the RemoteXPC device tunnel, and code-signing. The Linux Ghost host only ever reaches it through an SSH port-forward. This page turns a stock Mac into that node.
+
+## 1. The GUI-session requirement (read this first)
+
+WDA code-signing fails with `errSecInternalComponent` from a headless context. A fleet Mac **must auto-login to a desktop (Aqua) session and stay unlocked**:
+
+- **Auto-login:** System Settings → Users & Groups → Automatically log in as the automation user. (FileVault must be off for true unattended reboot-to-desktop.)
+- **Never sleep:** System Settings → Lock Screen → never require password after screensaver; Energy → prevent sleeping. Belt-and-suspenders: run `caffeinate -dis` as a login item or LaunchAgent.
+- **Keychain stays unlocked:** the login keychain unlocks with auto-login, but disable auto-lock so long-running signing works:
+
+  ```bash
+  security set-keychain-settings login.keychain   # no -l/-u/-t flags = never auto-lock
+  ```
+
+A headless CI Mac won't work unless it auto-logs into a GUI session. This bounds what an iOS fleet node can be: an always-logged-in Mac, physical or hosted-with-auto-login.
+
+## 2. Enable SSH, add a restricted key
+
+Enable Remote Login (System Settings → General → Sharing → Remote Login), then authorize the Ghost host's key — **restricted**, not a plain key line. Generate a dedicated `ed25519` keypair per Ghost host, and in `~/.ssh/authorized_keys` on the Mac:
+
+```text
+restrict,permitopen="127.0.0.1:4723",permitopen="127.0.0.1:8100",permitopen="127.0.0.1:9100",permitopen="127.0.0.1:9200",command="/usr/bin/false" ssh-ed25519 AAAA...ghost-host-key
+```
+
+What this buys you:
+
+- `restrict` — no PTY, no agent forwarding, no X11: the key can't get a shell.
+- `permitopen` ×4 — the key can forward **only** the four automation ports (Appium, WDA, MJPEG, H.264), all on loopback.
+- `command="/usr/bin/false"` — any exec attempt dies immediately. If you also want the Ghost host to run `ghost-ios report --json` over SSH (device discovery), replace `/usr/bin/false` with a forced-command wrapper that allows exactly that command.
+
+Never forward your SSH agent from the Ghost host to the Mac.
+
+## 3. Install the Ghost iOS tooling
+
+On the Mac, install Ghost plus the iOS host tools:
+
+```bash
+git clone https://github.com/ghost-in-the-droid/android-agent.git
+cd android-agent
+pip install -e .
+npm install -g appium && appium driver install xcuitest
+```
+
+Then follow the standard [WebDriverAgent setup](/ios/setup/wda/) once at the Mac's console (the signing step needs the GUI). Set the node up for warm sessions:
+
+```bash
+export IOS_USE_PREBUILT_WDA="true"
+export IOS_USE_PREINSTALLED_WDA="true"
+```
+
+The Mac owns WDA end-to-end. The remote Ghost host never builds, signs, or spawns WDA — it just drives sessions through the forwarded ports.
+
+## 4. Keep everything loopback-only
+
+Appium, WDA, MJPEG, and the H.264 stream must stay bound to `127.0.0.1` on the Mac — the defaults. **Never bind them to `0.0.0.0`.** Exposure happens exclusively through the SSH forward, so access requires possession of the restricted key. This is the primary security control; see [Security](/ios/remote-fleet/security/).
+
+## 5. Health surface
+
+`ghost-ios status` enumerates attached devices plus tunnel/WDA health on the node, and `ghost-ios report --json` emits a machine-readable inventory the Linux side uses for discovery:
+
+```json
+{
+  "schema": 1,
+  "host": "my-mac",
+  "generated_at": "2026-07-11T21:33Z",
+  "devices": [
+    {
+      "udid": "00008110-0012345678901234",
+      "name": "my iPhone",
+      "ref_slug": "my-iphone",
+      "ios_version": "26.4",
+      "wda_up": false,
+      "appium_up": true,
+      "tunnel_up": true
+    }
+  ]
+}
+```
+
+Notes on reading it honestly:
+
+- `ref_slug` derives from the phone's user-assigned device name — that's what you use in `<name>@<host>` refs. Two phones of the same model stay distinct.
+- `wda_up` means "a WDA session is live *right now*". Idle devices report `false`; that is normal. Readiness for a new session is `tunnel_up && appium_up`.
+- Identity comes from `xctrace list devices` and is cached — a slow Xcode toolchain still yields a full record.
+
+See [Utility Scripts](/ios/util-scripts/) for the full `ghost-ios` command reference.
+
+## Recovery expectations
+
+The Mac node self-heals the device leg: the RemoteXPC tunnel supervisor auto-reconnects, and stale WDA sessions are reset by the health/fix surface. If the device tunnel dies, the **Mac's** supervisor reports and repairs it — a reconnecting Linux client should never try to fix the device tunnel from afar (it can't; those tunnel IPv6 addresses aren't routable off the Mac).

--- a/site/src/content/docs/ios/remote-fleet/security.md
+++ b/site/src/content/docs/ios/remote-fleet/security.md
@@ -38,7 +38,7 @@ Use a dedicated `ed25519` keypair per Ghost host, and never forward your SSH age
 
 On a **remote** device, a destructive tool call is intercepted *before dispatch* and returns `CONFIRM_REQUIRED` unless the call carries `confirm: true`:
 
-- **Gated tools:** inherently irreversible / high-impact / code-executing ones — `shell`, `launch_intent`, `run_skill` / `run_action` / `run_workflow`, `create_skill`, `force_stop`, `clear_notifications`. Extend the set with `GITD_DESTRUCTIVE_TOOLS_EXTRA="tool_a,tool_b"`.
+- **Gated tools:** inherently irreversible / high-impact / code-executing ones — `shell`, `launch_intent`, `run_skill` / `run_action` / `run_workflow`, `create_skill`, `force_stop`, `clear_notifications`. Extend the set with `GITD_DESTRUCTIVE_TOOLS_EXTRA="tool_a,tool_b"`. (On a remote *iPhone* specifically, `shell` and `launch_intent` don't exist at all — they're Android-only — so the gate's practical iOS coverage is the skill-executing and app-level tools.)
 - **Fail-closed for unknown tools:** a tool name the gate doesn't recognize, targeting a remote device, is treated as destructive if its name reads destructive (`delete`, `uninstall`, `purchase`, `wipe`, `reset`, `transfer`, …). A tool added later is never silently un-gated.
 - **Local devices unaffected:** USB Android/iOS behave exactly as before.
 - **Kill-switch:** `REMOTE_CONFIRM_REQUIRED=false` disables the gate. Default is on; think twice before turning it off for a phone you care about.

--- a/site/src/content/docs/ios/remote-fleet/security.md
+++ b/site/src/content/docs/ios/remote-fleet/security.md
@@ -45,7 +45,7 @@ On a **remote** device, a destructive tool call is intercepted *before dispatch*
 
 ### Honest scope note (v1)
 
-The gate is **tool-name-based**. It catches semantic destructive tools and the control plane, but on iOS many destructive actions are performed through *generic* `tap`/`type` calls — tapping a "Delete", "Buy", or "Send" button has no destructive tool name to match. That is a conscious v1 limitation, not an oversight: the mitigations there are agent judgment and a human watching remote sessions. A perception-based "confirm irreversible UI sequences" check is planned research, not a shipped control. Size your trust accordingly: the gate meaningfully raises the bar; it is not a sandbox.
+The gate is **tool-name-based**. It catches semantic destructive tools and the control plane, but on iOS many destructive actions are performed through *generic* `tap`/`type` calls — tapping a "Delete", "Buy", or "Send" button has no destructive tool name to match. That is a conscious v1 limitation, not an oversight: the mitigations there are agent judgment and a human watching remote sessions. A session-level supervised mode for UI-level actions is planned (part of the security hardening the remote path is gated on), not a shipped control. Size your trust accordingly: the gate meaningfully raises the bar; it is not a sandbox.
 
 ## Why not just put a token on WDA?
 

--- a/site/src/content/docs/ios/remote-fleet/security.md
+++ b/site/src/content/docs/ios/remote-fleet/security.md
@@ -1,0 +1,66 @@
+---
+title: "Remote Fleet: Security Model"
+description: The threat model behind remote iOS — why localhost-only + SSH-forward, the restricted key, and the destructive-action confirmation gate.
+---
+
+Remote-driving a phone is a security-sensitive feature: the phone at the end of the tunnel is often someone's **real, personal device** — live Apple ID, messengers, banking apps, photos. This page explains what the design protects against and why, so you can judge whether the defaults fit your deployment.
+
+## The surfaces involved
+
+On the Mac, four services participate: Appium (`:4723`), WDA (`:8100`), MJPEG (`:9100`), and the H.264 stream (`:9200`). All four are **unauthenticated by design** — their only protection is *who can reach them*. That is fine while they are loopback-only on the Mac; it becomes the whole ballgame the moment you add remote access. Hence the two load-bearing rules:
+
+1. **Never bind any of them to `0.0.0.0`.** They stay on `127.0.0.1`.
+2. **The only remote path is an SSH port-forward.** Access is equivalent to possession of the SSH key.
+
+## Threat model
+
+In priority order:
+
+| # | Threat | Mitigation |
+|---|---|---|
+| 1 | **Compromised or confused Ghost host** — the Linux machine holding the key is tricked (prompt injection, malicious skill) or breached, and now "legitimately" drives the phone | **Ghost-side destructive-action confirmation gate** (below). Note a WDA-side auth token does *not* help here — the attacker proxies through the legitimate tunnel |
+| 2 | **LAN attacker** reaching the Mac's automation ports | Loopback-only bind + SSH-only exposure; nothing listens on the network |
+| 3 | **Lateral movement on the Mac** — a process already on the Mac's loopback, without the SSH key | Restricted key limits what the *key* can do; an optional WDA shared-secret header raises this bar further (modest value, defense-in-depth) |
+
+The ranking matters: the realistic risk is #1, and it's the one most "add a token" proposals don't address. The gate does.
+
+## The restricted SSH key
+
+The key authorized on the Mac can forward exactly four loopback ports and nothing else — no shell, no PTY, no agent or X11 forwarding, every exec attempt fails:
+
+```text
+restrict,permitopen="127.0.0.1:4723",permitopen="127.0.0.1:8100",permitopen="127.0.0.1:9100",permitopen="127.0.0.1:9200",command="/usr/bin/false" ssh-ed25519 AAAA...
+```
+
+Use a dedicated `ed25519` keypair per Ghost host, and never forward your SSH agent onto the Mac. If discovery (`ghost-ios report --json`) should run over the same key, swap `/usr/bin/false` for a forced-command wrapper that permits exactly that command.
+
+## The destructive-action confirmation gate
+
+On a **remote** device, a destructive tool call is intercepted *before dispatch* and returns `CONFIRM_REQUIRED` unless the call carries `confirm: true`:
+
+- **Gated tools:** inherently irreversible / high-impact / code-executing ones — `shell`, `launch_intent`, `run_skill` / `run_action` / `run_workflow`, `create_skill`, `force_stop`, `clear_notifications`. Extend the set with `GITD_DESTRUCTIVE_TOOLS_EXTRA="tool_a,tool_b"`.
+- **Fail-closed for unknown tools:** a tool name the gate doesn't recognize, targeting a remote device, is treated as destructive if its name reads destructive (`delete`, `uninstall`, `purchase`, `wipe`, `reset`, `transfer`, …). A tool added later is never silently un-gated.
+- **Local devices unaffected:** USB Android/iOS behave exactly as before.
+- **Kill-switch:** `REMOTE_CONFIRM_REQUIRED=false` disables the gate. Default is on; think twice before turning it off for a phone you care about.
+
+### Honest scope note (v1)
+
+The gate is **tool-name-based**. It catches semantic destructive tools and the control plane, but on iOS many destructive actions are performed through *generic* `tap`/`type` calls — tapping a "Delete", "Buy", or "Send" button has no destructive tool name to match. That is a conscious v1 limitation, not an oversight: the mitigations there are agent judgment and a human watching remote sessions. A perception-based "confirm irreversible UI sequences" check is planned research, not a shipped control. Size your trust accordingly: the gate meaningfully raises the bar; it is not a sandbox.
+
+## Why not just put a token on WDA?
+
+Because of threat #1. A shared-secret header on WDA (or Appium) authenticates *the tunnel*, and the compromised Ghost host *owns* the tunnel. A token only helps against threat #3 (loopback neighbors on the Mac), which is why it's an optional hardening layer, not the primary control. The primary controls are the restricted key (who can reach the ports) and the Ghost-side gate (what a reached port will do).
+
+## Hardening for larger fleets (planned)
+
+- **SSH certificate CA** — short-lived certs signed by a fleet CA instead of `authorized_keys` on every Mac; expiry and revocation for free. Worth it at N Macs, overkill at one.
+- **WireGuard underlay** — mutual auth and encryption at the network layer, and (as a bonus) fixes the TCP-over-TCP head-of-line blocking that makes the H.264 stream degrade on lossy WAN links. LAN deployments don't need it.
+- **Optional WDA header token** — cheap defense-in-depth against loopback neighbors.
+
+## Operator checklist
+
+- [ ] Appium/WDA/MJPEG/H.264 bound to `127.0.0.1` on the Mac (default — verify nothing re-bound them)
+- [ ] Dedicated restricted key per Ghost host; `permitopen` matches exactly the four ports
+- [ ] No SSH agent forwarding to the Mac
+- [ ] Confirmation gate on (`REMOTE_CONFIRM_REQUIRED` unset or `true`)
+- [ ] Humans review what remote agents do on personal devices, especially UI-level actions the gate can't classify

--- a/site/src/content/docs/ios/remote-fleet/security.md
+++ b/site/src/content/docs/ios/remote-fleet/security.md
@@ -32,7 +32,7 @@ The key authorized on the Mac can forward exactly four loopback ports and nothin
 restrict,permitopen="127.0.0.1:4723",permitopen="127.0.0.1:8100",permitopen="127.0.0.1:9100",permitopen="127.0.0.1:9200",command="/usr/bin/false" ssh-ed25519 AAAA...
 ```
 
-Use a dedicated `ed25519` keypair per Ghost host, and never forward your SSH agent onto the Mac. If discovery (`ghost-ios report --json`) should run over the same key, swap `/usr/bin/false` for a forced-command wrapper that permits exactly that command.
+Use a dedicated `ed25519` keypair per Ghost host, and never forward your SSH agent onto the Mac. If discovery (`ghost-ios report`) should run over the same key, swap `/usr/bin/false` for a forced-command wrapper that permits exactly that command.
 
 ## The destructive-action confirmation gate
 

--- a/site/src/content/docs/ios/setup/configuration.md
+++ b/site/src/content/docs/ios/setup/configuration.md
@@ -6,7 +6,7 @@ description: Every IOS_* environment variable, multi-device JSON config, and how
 Ghost's iOS backend is configured entirely through environment variables (or their JSON-config equivalents). The minimal setup is two lines:
 
 ```bash
-export IOS_DEVICE_UDID="00008110-0012345678901234"
+export IOS_DEVICE_UDID="00008XXX-XXXXXXXXXXXXXXXX"
 export IOS_APPIUM_URL="http://127.0.0.1:4723"
 ```
 
@@ -55,14 +55,22 @@ export IOS_SHOW_XCODE_LOG="false"
 
 See [WebDriverAgent Setup](/ios/setup/wda/) for what these mean and when to use them.
 
+## Interaction timing
+
+Ghost disables WDA's post-interaction quiescence waits (`animationCoolOffTimeout`, `waitForIdleTimeout`) by default — that's the difference between ~2.7 s and ~0.7 s per tap. If a flaky flow needs the conservative behavior back:
+
+```bash
+export IOS_WAIT_FOR_QUIESCENCE="1"   # restore WDA's animation/idle waits (slower, more patient)
+```
+
 ## Multiple iPhones
 
 For more than one device, list the UDIDs and give each its own config block — each device gets its own Appium URL and MJPEG port so they never collide:
 
 ```bash
-export IOS_DEVICE_UDIDS="00008110-0012345678901234,00008101-0098765432109876"
+export IOS_DEVICE_UDIDS="00008XXX-XXXXXXXXXXXXXXXX,00008YYY-YYYYYYYYYYYYYYYY"
 export IOS_DEVICES_JSON='{
-  "00008110-0012345678901234": {
+  "00008XXX-XXXXXXXXXXXXXXXX": {
     "appium_url": "http://127.0.0.1:4723",
     "bundle_id": "com.google.chrome.ios",
     "known_apps": [
@@ -76,7 +84,7 @@ export IOS_DEVICES_JSON='{
     "screenshot_quality": 2,
     "wda_launch_timeout": 180000
   },
-  "00008101-0098765432109876": {
+  "00008YYY-YYYYYYYYYYYYYYYY": {
     "appium_url": "http://127.0.0.1:4725",
     "bundle_id": "com.apple.mobilesafari",
     "mjpeg_server_port": 9101

--- a/site/src/content/docs/ios/setup/configuration.md
+++ b/site/src/content/docs/ios/setup/configuration.md
@@ -1,0 +1,107 @@
+---
+title: "iOS Configuration"
+description: Every IOS_* environment variable, multi-device JSON config, and how app discovery works on iOS.
+---
+
+Ghost's iOS backend is configured entirely through environment variables (or their JSON-config equivalents). The minimal setup is two lines:
+
+```bash
+export IOS_DEVICE_UDID="00008110-0012345678901234"
+export IOS_APPIUM_URL="http://127.0.0.1:4723"
+```
+
+## Core variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `IOS_DEVICE_UDID` | — | UDID of the device to drive |
+| `IOS_APPIUM_URL` | `http://127.0.0.1:4723` | Appium server (may be remote) |
+| `IOS_APPIUM_COMMAND` | `appium` | Command Ghost uses to launch Appium / the tunnel (`npx appium`, absolute path, …) |
+| `IOS_DEVICE_NAME` | — | Human label, e.g. `my-iphone-15-pro` |
+| `IOS_PLATFORM_VERSION` | — | iOS version hint, e.g. `18.5` |
+| `IOS_BUNDLE_ID` | `com.google.chrome.ios` | Default target app for browser workflows |
+| `IOS_WDA_URL` | — | Attach to an already-running WebDriverAgent |
+| `IOS_KNOWN_APPS_JSON` | — | Extra name→bundle-ID entries for app discovery |
+
+If `IOS_BUNDLE_ID` is omitted, Ghost targets Chrome because the first release-quality iOS workflow is browser/news automation. Set it to `com.apple.mobilesafari` or any installed browser when needed.
+
+## Streaming and screenshots
+
+WDA serves an MJPEG stream that Ghost uses for live view and recordings. Tune it for your link — the defaults below are chosen for a tunnel-friendly balance:
+
+```bash
+export IOS_MJPEG_SERVER_PORT="9100"
+export IOS_MJPEG_SERVER_FRAMERATE="12"
+export IOS_MJPEG_SCALING_FACTOR="60"            # percent; 50 ≈ 4× less data than full-res
+export IOS_MJPEG_SERVER_SCREENSHOT_QUALITY="45"
+export IOS_MJPEG_FIX_ORIENTATION="false"
+export IOS_SCREENSHOT_QUALITY="2"
+export IOS_MJPEG_SCREENSHOT_URL=""              # only when the stream is behind a custom tunnel/proxy
+```
+
+By default Ghost builds the MJPEG URL from the `IOS_APPIUM_URL` host plus `IOS_MJPEG_SERVER_PORT`. `/api/phone/health/<device>`, `/api/phone/stream-info`, and the stream headers all expose the effective settings, so you can verify what actually applied.
+
+## WDA lifecycle
+
+```bash
+export IOS_USE_PREBUILT_WDA="true"        # skip xcodebuild
+export IOS_USE_PREINSTALLED_WDA="true"    # skip install; just launch the WDA already on the phone
+export IOS_WDA_LAUNCH_TIMEOUT="180000"    # ms
+export IOS_XCODE_ORG_ID="EXAMPLE123"
+export IOS_XCODE_SIGNING_ID="Apple Development"
+export IOS_UPDATED_WDA_BUNDLE_ID="com.example.WebDriverAgentRunner"
+export IOS_SHOW_XCODE_LOG="false"
+```
+
+See [WebDriverAgent Setup](/ios/setup/wda/) for what these mean and when to use them.
+
+## Multiple iPhones
+
+For more than one device, list the UDIDs and give each its own config block — each device gets its own Appium URL and MJPEG port so they never collide:
+
+```bash
+export IOS_DEVICE_UDIDS="00008110-0012345678901234,00008101-0098765432109876"
+export IOS_DEVICES_JSON='{
+  "00008110-0012345678901234": {
+    "appium_url": "http://127.0.0.1:4723",
+    "bundle_id": "com.google.chrome.ios",
+    "known_apps": [
+      {"name": "Chrome", "bundle_id": "com.google.chrome.ios"},
+      {"name": "NPR", "bundle_id": "org.npr.NPR"}
+    ],
+    "mjpeg_server_port": 9100,
+    "mjpeg_server_framerate": 12,
+    "mjpeg_scaling_factor": 60,
+    "mjpeg_server_screenshot_quality": 45,
+    "screenshot_quality": 2,
+    "wda_launch_timeout": 180000
+  },
+  "00008101-0098765432109876": {
+    "appium_url": "http://127.0.0.1:4725",
+    "bundle_id": "com.apple.mobilesafari",
+    "mjpeg_server_port": 9101
+  }
+}'
+```
+
+Or keep it in a file:
+
+```bash
+export IOS_CONFIG_FILE="$PWD/config/ios-devices.json"
+```
+
+The same file can also hold a `remotes` key for [remote Mac hosts](/ios/remote-fleet/linux-setup/), so one config describes your whole fleet.
+
+## App discovery on iOS
+
+iOS does not expose Android-style full package enumeration. Ghost combines three sources, then verifies through Appium when WDA is available:
+
+1. Bundle IDs you configure (`IOS_KNOWN_APPS_JSON`, per-device `known_apps`)
+2. A built-in list of common bundle IDs
+3. Appium verification of what is actually installed
+
+```bash
+export IOS_KNOWN_APPS_JSON='{"Chrome":"com.google.chrome.ios","TikTok":"com.zhiliaoapp.musically"}'
+```
+
+On macOS hosts with Xcode tools, Ghost also discovers connected iPhones and booted simulators from `xcrun xctrace list devices` — discovery supplies device refs and labels, while explicit config remains the place for URLs, ports, and signing capabilities.

--- a/site/src/content/docs/ios/setup/requirements.md
+++ b/site/src/content/docs/ios/setup/requirements.md
@@ -1,0 +1,73 @@
+---
+title: "iOS Requirements"
+description: What you need before Ghost in the Droid can drive an iPhone — macOS, Xcode, Appium 2, and a trusted device.
+---
+
+Ghost in the Droid drives iOS devices through [Appium](https://appium.io/) XCUITest and WebDriverAgent (WDA). Android devices keep using ADB — nothing about your Android setup changes.
+
+Everything that touches an iPhone is macOS-only: `xcodebuild` and `codesign` (to build and sign WebDriverAgent), the CoreDevice/RemoteXPC tunnel to a physical device, and the Simulator runtime. **Linux cannot talk to an iPhone directly.** If your Ghost host is a Linux machine, you drive the iPhone through a Mac — see [Remote Fleet](/ios/remote-fleet/) for that topology. This page covers the Mac itself.
+
+## Checklist
+
+| Requirement | Why |
+|---|---|
+| macOS with Xcode installed | Builds and signs WebDriverAgent; provides the device tunnel |
+| Node.js + Appium 2 with the XCUITest driver | The automation control plane Ghost talks to |
+| A physical iPhone or a booted iOS Simulator | The device under automation |
+| An Apple developer team (free tier works) | Signs WebDriverAgent for a real device |
+| `ffmpeg` (optional) | iOS screen recordings from the WDA MJPEG stream |
+
+## Real-device prerequisites
+
+A physical iPhone needs a one-time trust dance:
+
+1. **Trust the Mac** — connect via USB and accept the "Trust This Computer?" prompt on the phone.
+2. **Enable Developer Mode** — Settings → Privacy & Security → Developer Mode (iOS 16+). The phone reboots.
+3. **Enable UI Automation** if prompted — Settings → Developer → UI Automation.
+4. **Sign WebDriverAgent** with your Apple developer team — see [WebDriverAgent Setup](/ios/setup/wda/).
+5. **Keep the phone unlocked** during sessions. A locked device is the single most common cause of session hangs.
+
+## Install Appium
+
+```bash
+npm install -g appium
+appium driver install xcuitest
+appium --base-path /
+```
+
+Run Appium in its own terminal (or as a service). The default URL Ghost expects is `http://127.0.0.1:4723`.
+
+If `appium` is not directly on your `PATH`, tell Ghost how to launch it:
+
+```bash
+export IOS_APPIUM_COMMAND="npx appium"   # or "/opt/homebrew/bin/appium"
+```
+
+Ghost uses the same command when it starts the XCUITest RemoteXPC tunnel for you.
+
+## Simulator shortcut
+
+Simulators are useful for development and CI — no signing, no trust prompts. Boot one with Xcode or `simctl`, then point Ghost at its UDID:
+
+```bash
+xcrun simctl list devices booted
+export IOS_DEVICE_UDID="<simulator-udid>"
+```
+
+The same Appium/WDA route works for simulators and real iPhones, so anything you build against a simulator carries over.
+
+## Device addressing
+
+iOS devices are addressed with an `ios:` prefix wherever Ghost takes a device ref:
+
+```text
+ios:00008110-0012345678901234
+```
+
+Android serials stay as-is. Remote iPhones attached to another Mac use `<name>@<host>` refs instead — see [Remote Fleet](/ios/remote-fleet/).
+
+## Next steps
+
+- [WebDriverAgent Setup](/ios/setup/wda/) — signing, provisioning, prebuilt/preinstalled WDA
+- [Configuration](/ios/setup/configuration/) — every `IOS_*` variable, multi-device JSON
+- [Verify the Connection](/ios/setup/verify/) — smoke tests and health probes

--- a/site/src/content/docs/ios/setup/requirements.md
+++ b/site/src/content/docs/ios/setup/requirements.md
@@ -14,7 +14,7 @@ Everything that touches an iPhone is macOS-only: `xcodebuild` and `codesign` (to
 | macOS with Xcode installed | Builds and signs WebDriverAgent; provides the device tunnel |
 | Node.js + Appium 2 with the XCUITest driver | The automation control plane Ghost talks to |
 | A physical iPhone or a booted iOS Simulator | The device under automation |
-| An Apple developer team (free tier works) | Signs WebDriverAgent for a real device |
+| An Apple developer team (free tier works, but its certificates expire every 7 days — WDA needs weekly re-signing; a paid team avoids that, which matters for always-on setups) | Signs WebDriverAgent for a real device |
 | `ffmpeg` (optional) | iOS screen recordings from the WDA MJPEG stream |
 
 ## Real-device prerequisites

--- a/site/src/content/docs/ios/setup/requirements.md
+++ b/site/src/content/docs/ios/setup/requirements.md
@@ -61,7 +61,7 @@ The same Appium/WDA route works for simulators and real iPhones, so anything you
 iOS devices are addressed with an `ios:` prefix wherever Ghost takes a device ref:
 
 ```text
-ios:00008110-0012345678901234
+ios:00008XXX-XXXXXXXXXXXXXXXX
 ```
 
 Android serials stay as-is. Remote iPhones attached to another Mac use `<name>@<host>` refs instead — see [Remote Fleet](/ios/remote-fleet/).

--- a/site/src/content/docs/ios/setup/verify.md
+++ b/site/src/content/docs/ios/setup/verify.md
@@ -1,0 +1,100 @@
+---
+title: "Verify the Connection"
+description: Prove the whole iOS stack works — dry-run device resolution, health probes, smoke scripts, and MCP checks.
+---
+
+Verify in layers, cheapest first. Each step isolates a different failure point, so when something breaks you know *which* leg is broken instead of staring at a generic session error.
+
+## 1. Dry-run: what does Ghost think is connected?
+
+Before touching Appium/WDA, inspect the resolved device/config plan:
+
+```bash
+uv run python scripts/ios_chrome_news_smoke.py --list-devices
+
+IOS_DEVICE_UDID="<udid>" IOS_BUNDLE_ID="com.google.chrome.ios" \
+uv run python scripts/ios_chrome_news_smoke.py --dry-run --no-simulators
+```
+
+`--list-devices` and `--dry-run` print configured plus host-discovered iPhones and booted simulators, the selected `ios:<udid>` ref, Appium URL, bundle defaults, WDA URL, and MJPEG settings — **without creating a session**. Use `--no-simulators` when the run must target real hardware only.
+
+## 2. Health probe
+
+```bash
+curl "http://localhost:5055/api/phone/devices?probe=deep" | python3 -m json.tool
+curl "http://localhost:5055/api/phone/health/ios:<udid>" | python3 -m json.tool
+```
+
+The normal device list uses a lightweight Appium status probe; `probe=deep` additionally checks WDA session, screenshot, and source readiness. Health responses include `connection.status`, a `recommended_fix`, and a `recovery.steps` list — when Ghost can't fix something automatically, iOS RemoteXPC failures include copyable `recovery.commands`.
+
+Apply an automatic fix:
+
+```bash
+curl -X POST "http://localhost:5055/api/phone/health/ios:<udid>/fix" \
+  -H 'Content-Type: application/json' -d '{"issue":"reset_session"}'
+```
+
+The Phone Admin dashboard reads the same payload: Appium/WDA health dots, recovery steps, and a one-click fix button whenever the recovery is `auto_fixable` (`reset_session`, `appium_session`, `wda_session`, `start_appium`, `restart_remote_xpc_tunnel`).
+
+## 3. Smoke test: a real browser workflow
+
+The smoke script drives the same `read_news` service used by REST, MCP, and agent tools — it is a product-path test, not a synthetic ping.
+
+```bash
+IOS_DEVICE_UDID="<udid>" IOS_BUNDLE_ID="com.google.chrome.ios" \
+uv run python scripts/ios_chrome_news_smoke.py \
+  --url https://text.npr.org/ \
+  --max-headlines 5 \
+  --max-articles 3 \
+  --fix-health \
+  --out-dir data/ios_chrome_news_smoke
+```
+
+The script runs an Appium/WDA health preflight first and saves `health.json` plus `result.json` in the output directory. With `--fix-health` it applies the `recommended_fix` once, saves `health_fix.json`, and re-runs the preflight before opening the browser. If WDA is locked, unsigned, or unreachable, `result.json` contains the health recovery payload instead of a confusing failure deep in the workflow.
+
+After a live run, check `result.json.extraction` to see which source produced the article text (WebView, native tree, or OCR fallback) and whether readiness waits hit their targets.
+
+A single-screenshot variant, browser-configurable:
+
+```bash
+IOS_DEVICE_UDID="<udid>" IOS_BUNDLE_ID="com.apple.mobilesafari" \
+uv run python scripts/ios_safari_smoke.py \
+  --url https://ghostinthedroid.com \
+  --screenshot-out data/ios_browser_smoke.png
+```
+
+## 4. From MCP
+
+If you drive Ghost from an LLM agent, the same checks are tools:
+
+```text
+list_devices()
+device_health("ios:<udid>")
+fix_device_health("ios:<udid>", "reset_session")
+launch_app("ios:<udid>", "com.google.chrome.ios")
+open_url("ios:<udid>", "https://text.npr.org/", "com.google.chrome.ios")
+get_screen_tree("ios:<udid>")
+```
+
+## 5. Live pytest (optional)
+
+To run the Chrome/news acceptance path through pytest on a real device:
+
+```bash
+IOS_LIVE_NEWS_TEST=1 IOS_DEVICE_UDID="<udid>" IOS_APPIUM_URL="http://127.0.0.1:4723" \
+IOS_BUNDLE_ID="com.google.chrome.ios" \
+uv run --extra test python -m pytest tests/test_browser_news.py::test_live_ios_chrome_news_workflow
+```
+
+CI runs the non-live iOS parity suite on every PR (Appium/WDA mocked); live-device checks only run when these environment variables are set.
+
+## What "healthy" actually means
+
+Two independent legs must both be up, and they fail independently:
+
+- **Appium reachable** (`appium_up`) — the control plane is listening.
+- **RemoteXPC tunnel up** (`tunnel_up`) — the Mac can reach the physical device (iOS 17+).
+
+`wda_up` means *a WDA session is live right now* — Appium launches WDA per-session, so an idle device correctly reports `wda_up: false`. The readiness signal for "can I start a session" is `tunnel_up && appium_up`, not `wda_up`.
+
+If a step here fails, jump to [Troubleshooting](/ios/troubleshooting/) — it is organized by the same layers.

--- a/site/src/content/docs/ios/setup/wda.md
+++ b/site/src/content/docs/ios/setup/wda.md
@@ -1,0 +1,77 @@
+---
+title: "WebDriverAgent Setup"
+description: Sign, provision, and manage WebDriverAgent — including prebuilt and preinstalled WDA for fast, reliable sessions.
+---
+
+WebDriverAgent (WDA) is the on-device automation server that XCUITest drives. On a simulator it just works. On a **real iPhone** it must be code-signed for your device — this page is mostly about making that painless and then never thinking about it again.
+
+## First-time signing (real device)
+
+If session creation fails with signing, provisioning, or `xcodebuild` errors:
+
+1. Open the XCUITest driver's WebDriverAgent project in Xcode:
+
+   ```bash
+   appium driver run xcuitest open-wda
+   ```
+
+2. Select the **WebDriverAgentRunner** target → Signing & Capabilities → set your development **Team**.
+3. If the default bundle ID collides (common with free developer accounts), change it to something unique, e.g. `com.example.WebDriverAgentRunner`, and tell Ghost:
+
+   ```bash
+   export IOS_UPDATED_WDA_BUNDLE_ID="com.example.WebDriverAgentRunner"
+   ```
+
+4. Run the WebDriverAgentRunner test target once against your phone (⌘U with the device selected). Accept the "Untrusted Developer" prompt on the phone: Settings → General → VPN & Device Management → trust your certificate.
+
+Or skip Xcode's UI and let Appium sign via config:
+
+```bash
+export IOS_XCODE_ORG_ID="EXAMPLE123"        # your Apple Team ID
+export IOS_XCODE_SIGNING_ID="Apple Development"
+export IOS_SHOW_XCODE_LOG="true"            # verbose xcodebuild output while debugging
+```
+
+## Signing needs a GUI login session
+
+`codesign` fails with `errSecInternalComponent` when run from a headless context (plain SSH, CI runner without a desktop). The Mac that builds/signs WDA **must have an active Aqua (GUI) login session** and an unlocked keychain. For an interactive workstation this is automatic; for an always-on automation Mac, set up auto-login — see [Remote Fleet: Mac Setup](/ios/remote-fleet/mac-setup/).
+
+## Prebuilt and preinstalled WDA
+
+By default Appium builds, installs, and launches WDA on every fresh session — slow (up to minutes) and dependent on signing working right then. Two flags make sessions fast and predictable:
+
+```bash
+export IOS_USE_PREBUILT_WDA="true"        # appium:usePrebuiltWDA — don't rebuild, reuse the built .app
+export IOS_USE_PREINSTALLED_WDA="true"    # appium:usePreinstalledWDA — WDA is already on the phone; just launch it
+```
+
+- **Prebuilt** skips the `xcodebuild` step: Appium installs the WDA it already built. Build once (per Xcode/iOS update), reuse forever.
+- **Preinstalled** skips install too: WDA is already on the device and Appium only launches it. This is the recommended posture for always-on setups and **required thinking for remote fleets** — the Mac owns the WDA lifecycle, and a remote Ghost host never builds, signs, or spawns WDA. Combined with a warm prebuilt WDA, session start drops from minutes to seconds.
+
+Session creation can still be slow the very first time (device symbols, tunnel warmup). Give it room:
+
+```bash
+export IOS_WDA_LAUNCH_TIMEOUT="180000"    # ms, appium:wdaLaunchTimeout
+```
+
+## Attaching to a running WDA
+
+If WDA is already up (started by a previous session, another tool, or a remote tunnel), point Ghost straight at it:
+
+```bash
+export IOS_WDA_URL="http://127.0.0.1:8100"
+```
+
+`IOS_WDA_URL` is wired into both the Appium session capabilities (`appium:webDriverAgentUrl`) and Ghost's direct WDA calls, so the WDA client is URL-agnostic: local port, forwarded SSH port — same code path.
+
+## Common signing blockers
+
+| Symptom | Fix |
+|---|---|
+| `xcodebuild failed` / `wda_signing_failed` | Set the team on WebDriverAgentRunner in Xcode; check `IOS_XCODE_ORG_ID` / `IOS_XCODE_SIGNING_ID` / `IOS_UPDATED_WDA_BUNDLE_ID`; run with `IOS_SHOW_XCODE_LOG=true` |
+| `errSecInternalComponent` | You're headless — sign from a GUI login session with the keychain unlocked |
+| "Untrusted Developer" on launch | Trust the certificate on the phone under VPN & Device Management |
+| Session hangs, then times out | Phone is locked, or Developer Mode is off |
+| Works, then breaks after an iOS/Xcode update | Rebuild WDA once (drop `IOS_USE_PREBUILT_WDA` for one session), re-trust if needed |
+
+More in [Troubleshooting](/ios/troubleshooting/).

--- a/site/src/content/docs/ios/setup/wda.md
+++ b/site/src/content/docs/ios/setup/wda.md
@@ -34,7 +34,7 @@ export IOS_SHOW_XCODE_LOG="true"            # verbose xcodebuild output while de
 
 ## Signing needs a GUI login session
 
-`codesign` fails with `errSecInternalComponent` when run from a headless context (plain SSH, CI runner without a desktop). The Mac that builds/signs WDA **must have an active Aqua (GUI) login session** and an unlocked keychain. For an interactive workstation this is automatic; for an always-on automation Mac, set up auto-login — see [Remote Fleet: Mac Setup](/ios/remote-fleet/mac-setup/).
+`codesign` fails with `errSecInternalComponent` when run from a headless context (plain SSH, CI runner without a desktop) — and no, unlocking the keychain over SSH or `security set-key-partition-list` does **not** fix it; only a real interactive login session does. The Mac that builds/signs WDA **must have an active Aqua (GUI) login session** and an unlocked keychain. For an interactive workstation this is automatic; for an always-on automation Mac, set up auto-login — see [Remote Fleet: Mac Setup](/ios/remote-fleet/mac-setup/).
 
 ## Prebuilt and preinstalled WDA
 

--- a/site/src/content/docs/ios/tool-support.mdx
+++ b/site/src/content/docs/ios/tool-support.mdx
@@ -1,0 +1,122 @@
+---
+title: "Tool Support on iOS"
+description: Per-tool iOS support status and behavior notes — what works, what differs from Android, and what's coming.
+---
+
+import PlatformBadges from '../../../components/PlatformBadges.astro';
+
+{/* DRAFT NOTE (remove before merge):
+    - The support matrix below will be GENERATED from gitd/services/tool_platforms.py
+      (core-dev's markdown emitter) so it never drifts from code. Prose sections are
+      hand-written and stay.
+    - Badges for chain / a11y_diff / screenshot_sequence / sub_agent: cross-platform by
+      design per core-dev; flip 🔜→✅ per tool once ios-tester confirms on live hardware. */}
+
+Every Ghost tool states its platform support up front. This page covers the agent-facing tools on iOS: what each one does differently than on Android, and a working iOS example. For the setup that makes these work, start at [Requirements](/ios/setup/requirements/).
+
+**How iOS control differs from Android, in one paragraph:** Android tools talk to ADB (fast, no session); iOS tools drive WebDriverAgent through Appium (session-based, slower per action, but with a richer native accessibility tree). Expect actions to be correct but not instant — measured on real hardware: `status` ~5 ms, `screenshot` ~190 ms, `tap` ~730 ms. Design flows around *fewer, more certain* actions rather than rapid-fire tapping.
+
+## screenshot
+
+<PlatformBadges android="yes" ios="yes" />
+
+Base64 PNG of the current screen, captured through WDA.
+
+```text
+screenshot("ios:00008110-0012345678901234")
+```
+
+iOS notes: ~190 ms per capture; quality/size tunable via `IOS_SCREENSHOT_QUALITY`. `screenshot_annotated` and `screenshot_cropped` work on iOS too. Coordinates in the PNG are screenshot pixels — Ghost converts to WDA points for you on input gestures (see `tap`).
+
+## tap / swipe / long_press
+
+<PlatformBadges android="yes" ios="yes" />
+
+```text
+tap("ios:00008110-0012345678901234", 200, 640)
+swipe("ios:00008110-0012345678901234", 200, 900, 200, 300)
+```
+
+iOS notes: WDA gestures wait for UI quiescence, so a tap during an animation *blocks until the animation settles* — that's the dominant part of the ~730 ms tap latency, and it's why taps are reliable during transitions rather than fast. Ghost scales screenshot-pixel coordinates to WDA points and back automatically; if taps land wrong, compare screenshot dimensions with the WDA window rect in `get_phone_state` (see [Troubleshooting](/ios/troubleshooting/#sessions)). `tap_element` (by index from `get_elements`) is the more robust choice when the tree is available.
+
+## type_text
+
+<PlatformBadges android="yes" ios="yes" />
+
+```text
+type_text("ios:00008110-0012345678901234", "hello from ghost")
+```
+
+iOS notes: text goes to the focused element via WDA — tap the field first. `press_key` supports `HOME`, `ENTER`, and best-effort `BACK` (iOS has no system back button; Ghost falls back to navigation-bar/edge heuristics). Clipboard round-trips work: `clipboard_set` + `paste_text` is the fast path for long strings.
+
+## launch_app
+
+<PlatformBadges android="yes" ios="yes" />
+
+```text
+launch_app("ios:00008110-0012345678901234", "com.google.chrome.ios")
+```
+
+iOS notes: takes a bundle ID, not an Android package name. iOS can't enumerate all installed apps the way Android can — `list_apps`/`search_apps` cover configured (`IOS_KNOWN_APPS_JSON`) plus common bundle IDs, verified through Appium. See [Configuration](/ios/setup/configuration/#app-discovery-on-ios).
+
+## ocr_screen
+
+<PlatformBadges android="yes" ios="yes" />
+
+```text
+ocr_screen("ios:00008110-0012345678901234")
+```
+
+iOS notes: OCR runs host-side on the WDA screenshot (RapidOCR must be installed), so behavior matches Android — same engine, different capture path. On iOS prefer the native tree (`get_screen_tree`, `get_elements`) when the app exposes one; OCR is the fallback for WebViews, games, and stubborn custom UI.
+
+## speak_text
+
+<PlatformBadges android="yes" ios="yes" />
+
+```text
+speak_text("ios:00008110-0012345678901234", "task complete")
+```
+
+iOS notes: served by a dedicated `/wda/speak` endpoint on Ghost's WDA build — one of the direct WDA calls that bypasses Appium (in a remote fleet this is why the WDA port is forwarded alongside Appium's). Returns an `audio` diagnostics block so a silent phone is debuggable, not a mystery. Android's equivalent uses the Portal TTS path.
+
+## run_flow
+
+<PlatformBadges android="yes" ios="yes" />
+
+```text
+run_flow("ios:00008110-0012345678901234", "open_ghost_site")
+```
+
+iOS notes: recorded skills/flows carry `platforms: ["ios"]`, an `ios_bundle_id`, and iOS element locators (`elements_ios.yaml`) — a flow recorded on Android needs its iOS variant recorded once before it runs here. The Skill Creator targets `ios:` devices natively.
+
+## chain
+
+<PlatformBadges android="yes" ios="soon" />
+
+Batched sub-actions with settle-detection between steps. Cross-platform by design — lands for iOS with v1.3.x.
+
+## screenshot_sequence
+
+<PlatformBadges android="yes" ios="soon" />
+
+Timed screenshot bursts for capturing transitions. Cross-platform screenshot path; iOS support lands with v1.3.x.
+
+## sub_agent
+
+<PlatformBadges android="yes" ios="soon" />
+
+Delegate a sub-task to a scoped agent. Device-neutral by design; iOS support lands with v1.3.x.
+
+## a11y_diff
+
+<PlatformBadges android="yes" ios="soon" />
+
+Before/after UI-tree diffing to verify an action did what you think. Cross-platform by design; iOS's native accessibility tree makes this a strong fit. Lands with v1.3.x.
+
+---
+
+## Beyond the agent tools
+
+The full surface — browser primitives (`open_url`, `extract_articles`, …), notifications, clipboard, streaming, recording — with per-tool platform status lives in the generated support matrix below.
+
+{/* GENERATED MATRIX PLACEHOLDER — emitted from gitd/services/tool_platforms.py */}

--- a/site/src/content/docs/ios/tool-support.mdx
+++ b/site/src/content/docs/ios/tool-support.mdx
@@ -131,8 +131,7 @@ The full surface — browser primitives (`open_url`, `web_search`, `extract_arti
     reconciliation lands — e.g. speak_text flips to cross-platform (native iOS TTS),
     and chain/screenshot_sequence/sub_agent auto-appear once merged. */}
 
-{/* GENERATED from gitd/services/tool_platforms.py — do not edit by hand.
-     Regenerate: python -m gitd.services.tool_platforms */}
+{/* GENERATED from gitd/services/tool_platforms.py — do not edit by hand. Regenerate: python -m gitd.services.tool_platforms --mdx */}
 
 Legend: ✅ supported · 🔜 iOS planned · ⚠️ n/a (platform can't support it).
 Classification only — overlay a 'hardware-confirmed on iOS' badge separately;
@@ -216,4 +215,3 @@ several cross-platform tools fall back to OCR on iOS (weaker a11y tree).
 | `shell` | ✅ | ⚠️ n/a | ADB shell has no iOS equivalent. |
 | `speak_text` | ✅ | ⚠️ n/a | Uses the Android Portal app TTS path. |
 | `toggle_overlay` | ✅ | ⚠️ n/a | Portal overlay is Android-only. |
-

--- a/site/src/content/docs/ios/tool-support.mdx
+++ b/site/src/content/docs/ios/tool-support.mdx
@@ -1,29 +1,32 @@
 ---
 title: "Tool Support on iOS"
-description: Per-tool iOS support status and behavior notes — what works, what differs from Android, and what's coming.
+description: Per-tool iOS support status and behavior notes — what works, what's hardware-confirmed, what differs from Android, and what's coming.
 ---
 
 import PlatformBadges from '../../../components/PlatformBadges.astro';
 
 {/* DRAFT NOTE (remove before merge):
-    - The support matrix below will be GENERATED from gitd/services/tool_platforms.py
-      (core-dev's markdown emitter) so it never drifts from code. Prose sections are
-      hand-written and stay.
-    - Badges for chain / a11y_diff / screenshot_sequence / sub_agent: cross-platform by
-      design per core-dev; flip 🔜→✅ per tool once ios-tester confirms on live hardware. */}
+    - The full support matrix will be GENERATED from gitd/services/tool_platforms.py
+      (core-dev's markdown emitter) so it never drifts from code. Prose stays hand-written.
+    - Hardware-confirmed markers come from ios-tester's confirmed list; update as
+      post-reconciliation runtime confirmation lands. */}
 
 Every Ghost tool states its platform support up front. This page covers the agent-facing tools on iOS: what each one does differently than on Android, and a working iOS example. For the setup that makes these work, start at [Requirements](/ios/setup/requirements/).
 
-**How iOS control differs from Android, in one paragraph:** Android tools talk to ADB (fast, no session); iOS tools drive WebDriverAgent through Appium (session-based, slower per action, but with a richer native accessibility tree). Expect actions to be correct but not instant — measured on real hardware: `status` ~5 ms, `screenshot` ~190 ms, `tap` ~730 ms. Design flows around *fewer, more certain* actions rather than rapid-fire tapping.
+**How iOS control differs from Android, in one paragraph:** Android tools talk to ADB (fast, no session, system-level reach); iOS tools drive WebDriverAgent through Appium — session-based, UI-automation only, no system shell. Expect actions to be correct but not instant: measured on real hardware, `status` ~5 ms, `screenshot` ~190 ms, `tap` ~730 ms. iOS also exposes a weaker accessibility tree than Android's uiautomator, so several tools transparently fall back to OCR on iOS. Design flows around *fewer, more certain* actions rather than rapid-fire tapping.
+
+**How to read the badges.** iOS ✅ means the tool is classified iOS-supported in `tool_platforms.py` — the authoritative, machine-readable source. Tools additionally marked **hardware-confirmed** have been individually exercised on a real iPhone (iOS 26.x); the rest of the ✅ set shares the same code paths but hasn't been individually run on hardware. iOS 🔜 means expected to work cross-platform by design, but not yet available or runtime-confirmed on iOS.
+
+Three Android tools fundamentally cannot exist on iOS — `shell`, `launch_intent`, and `toggle_overlay` — because iOS offers no system shell, intents, or overlay injection to automation. Two tools are iOS-first: `get_current_url` and `read_news`.
 
 ## screenshot
 
 <PlatformBadges android="yes" ios="yes" />
 
-Base64 PNG of the current screen, captured through WDA.
+**Hardware-confirmed.** Base64 PNG of the current screen, captured through WDA.
 
 ```text
-screenshot("ios:00008110-0012345678901234")
+screenshot("ios:00008XXX-XXXXXXXXXXXXXXXX")
 ```
 
 iOS notes: ~190 ms per capture; quality/size tunable via `IOS_SCREENSHOT_QUALITY`. `screenshot_annotated` and `screenshot_cropped` work on iOS too. Coordinates in the PNG are screenshot pixels — Ghost converts to WDA points for you on input gestures (see `tap`).
@@ -32,19 +35,23 @@ iOS notes: ~190 ms per capture; quality/size tunable via `IOS_SCREENSHOT_QUALITY
 
 <PlatformBadges android="yes" ios="yes" />
 
+**Hardware-confirmed** (`tap`, `tap_element`).
+
 ```text
-tap("ios:00008110-0012345678901234", 200, 640)
-swipe("ios:00008110-0012345678901234", 200, 900, 200, 300)
+tap("ios:00008XXX-XXXXXXXXXXXXXXXX", 200, 640)
+swipe("ios:00008XXX-XXXXXXXXXXXXXXXX", 200, 900, 200, 300)
 ```
 
-iOS notes: WDA gestures wait for UI quiescence, so a tap during an animation *blocks until the animation settles* — that's the dominant part of the ~730 ms tap latency, and it's why taps are reliable during transitions rather than fast. Ghost scales screenshot-pixel coordinates to WDA points and back automatically; if taps land wrong, compare screenshot dimensions with the WDA window rect in `get_phone_state` (see [Troubleshooting](/ios/troubleshooting/#sessions)). `tap_element` (by index from `get_elements`) is the more robust choice when the tree is available.
+iOS notes: out of the box, WDA waits for animations and app idleness after every interaction, which pushed taps to ~2.7 s. Ghost zeroes those waits (`animationCoolOffTimeout`, `waitForIdleTimeout` — WDA *settings*, applied per session) for ~730 ms taps. If a flaky flow needs the conservative behavior back, set `IOS_WAIT_FOR_QUIESCENCE=1` and Ghost restores the quiescence waits for that device. Ghost scales screenshot-pixel coordinates to WDA points and back automatically; if taps land wrong, compare screenshot dimensions with the WDA window rect in `get_phone_state` (see [Troubleshooting](/ios/troubleshooting/#sessions)). `tap_element` (by index from `get_elements`) is the more robust choice when the tree is available.
 
 ## type_text
 
 <PlatformBadges android="yes" ios="yes" />
 
+**Hardware-confirmed.**
+
 ```text
-type_text("ios:00008110-0012345678901234", "hello from ghost")
+type_text("ios:00008XXX-XXXXXXXXXXXXXXXX", "hello from ghost")
 ```
 
 iOS notes: text goes to the focused element via WDA — tap the field first. `press_key` supports `HOME`, `ENTER`, and best-effort `BACK` (iOS has no system back button; Ghost falls back to navigation-bar/edge heuristics). Clipboard round-trips work: `clipboard_set` + `paste_text` is the fast path for long strings.
@@ -54,69 +61,69 @@ iOS notes: text goes to the focused element via WDA — tap the field first. `pr
 <PlatformBadges android="yes" ios="yes" />
 
 ```text
-launch_app("ios:00008110-0012345678901234", "com.google.chrome.ios")
+launch_app("ios:00008XXX-XXXXXXXXXXXXXXXX", "com.google.chrome.ios")
 ```
 
-iOS notes: takes a bundle ID, not an Android package name. iOS can't enumerate all installed apps the way Android can — `list_apps`/`search_apps` cover configured (`IOS_KNOWN_APPS_JSON`) plus common bundle IDs, verified through Appium. See [Configuration](/ios/setup/configuration/#app-discovery-on-ios).
+iOS notes: takes a bundle ID, not an Android package name. iOS can't enumerate all installed apps the way Android can — `list_apps`/`search_apps` cover configured (`IOS_KNOWN_APPS_JSON`) plus common bundle IDs, verified through Appium. See [Configuration](/ios/setup/configuration/#app-discovery-on-ios). `force_stop` and `app_state` work on iOS too.
 
 ## ocr_screen
 
 <PlatformBadges android="yes" ios="yes" />
 
+**Hardware-confirmed** (as the extraction fallback in live browser workflows).
+
 ```text
-ocr_screen("ios:00008110-0012345678901234")
+ocr_screen("ios:00008XXX-XXXXXXXXXXXXXXXX")
 ```
 
-iOS notes: OCR runs host-side on the WDA screenshot (RapidOCR must be installed), so behavior matches Android — same engine, different capture path. On iOS prefer the native tree (`get_screen_tree`, `get_elements`) when the app exposes one; OCR is the fallback for WebViews, games, and stubborn custom UI.
+iOS notes: OCR runs host-side on the WDA screenshot (RapidOCR must be installed), so behavior matches Android — same engine, different capture path. `ocr_region` works the same way. OCR matters *more* on iOS: the accessibility tree is weaker than Android's, so tools that read the screen fall back to OCR more often — prefer the native tree (`get_screen_tree`, `get_elements`) when the app exposes one, and expect OCR to carry WebViews, games, and stubborn custom UI.
 
 ## speak_text
 
 <PlatformBadges android="yes" ios="yes" />
 
+**Hardware-confirmed — audibly, on a real iPhone.**
+
 ```text
-speak_text("ios:00008110-0012345678901234", "task complete")
+speak_text("ios:00008XXX-XXXXXXXXXXXXXXXX", "task complete")
 ```
 
-iOS notes: served by a dedicated `/wda/speak` endpoint on Ghost's WDA build — one of the direct WDA calls that bypasses Appium (in a remote fleet this is why the WDA port is forwarded alongside Appium's). Returns an `audio` diagnostics block so a silent phone is debuggable, not a mystery. Android's equivalent uses the Portal TTS path.
+iOS notes: native on-device TTS (`AVSpeechSynthesizer`) served by a dedicated `/wda/speak` endpoint on Ghost's WDA build — one of the direct WDA calls that bypasses Appium (in a remote fleet this is why the WDA port is forwarded alongside Appium's). Returns an `audio` diagnostics block so a silent phone is debuggable, not a mystery. Android's equivalent uses the Portal TTS path.
 
 ## run_flow
 
-<PlatformBadges android="yes" ios="yes" />
+<PlatformBadges android="yes" ios="soon" />
 
-```text
-run_flow("ios:00008110-0012345678901234", "open_ghost_site")
-```
-
-iOS notes: recorded skills/flows carry `platforms: ["ios"]`, an `ios_bundle_id`, and iOS element locators (`elements_ios.yaml`) — a flow recorded on Android needs its iOS variant recorded once before it runs here. The Skill Creator targets `ios:` devices natively.
+Expected cross-platform by design; iOS runtime unconfirmed until it lands alongside the current iOS branch work. What works on iOS **today** is the skill path underneath it: `create_skill` and `run_skill` are iOS-supported — recorded skills carry `platforms: ["ios"]`, an `ios_bundle_id`, and iOS element locators (`elements_ios.yaml`), and the Skill Creator targets `ios:` devices natively. A flow recorded on Android needs its iOS variant recorded once before it runs on an iPhone.
 
 ## chain
 
 <PlatformBadges android="yes" ios="soon" />
 
-Batched sub-actions with settle-detection between steps. Cross-platform by design — lands for iOS with v1.3.x.
+Batched sub-actions with settle-detection between steps. Expected cross-platform by design; iOS runtime unconfirmed until the iOS branch and this feature converge.
 
 ## screenshot_sequence
 
 <PlatformBadges android="yes" ios="soon" />
 
-Timed screenshot bursts for capturing transitions. Cross-platform screenshot path; iOS support lands with v1.3.x.
+Timed screenshot bursts for capturing transitions. Cross-platform screenshot path by design; iOS runtime unconfirmed yet.
 
 ## sub_agent
 
 <PlatformBadges android="yes" ios="soon" />
 
-Delegate a sub-task to a scoped agent. Device-neutral by design; iOS support lands with v1.3.x.
+Delegate a sub-task to a scoped agent. Device-neutral by design; iOS runtime unconfirmed yet.
 
 ## a11y_diff
 
 <PlatformBadges android="yes" ios="soon" />
 
-Before/after UI-tree diffing to verify an action did what you think. Cross-platform by design; iOS's native accessibility tree makes this a strong fit. Lands with v1.3.x.
+Before/after UI-tree diffing to verify an action did what you think. Expected cross-platform by design — with the caveat that iOS's accessibility tree is sparser than Android's, so expect coarser diffs where apps expose little. iOS runtime unconfirmed yet.
 
 ---
 
 ## Beyond the agent tools
 
-The full surface — browser primitives (`open_url`, `extract_articles`, …), notifications, clipboard, streaming, recording — with per-tool platform status lives in the generated support matrix below.
+The full surface — browser primitives (`open_url`, `web_search`, `extract_articles`, `wait_for_text`, …), notifications, clipboard, screen recording, streaming, health — with per-tool platform status lives in the generated support matrix below. Hardware-confirmed on a real iPhone so far: `read_news`, `screenshot`, `tap`/`tap_element`, `type_text`, `get_screen_tree`/`get_elements`, `press_home`, `open_url`, `extract_visible_text`/`extract_articles`, the OCR fallback, `speak_text`, and MJPEG + H.264 streaming with tap control.
 
 {/* GENERATED MATRIX PLACEHOLDER — emitted from gitd/services/tool_platforms.py */}

--- a/site/src/content/docs/ios/tool-support.mdx
+++ b/site/src/content/docs/ios/tool-support.mdx
@@ -17,7 +17,7 @@ Every Ghost tool states its platform support up front. This page covers the agen
 
 **How to read the badges.** iOS ✅ means the tool is classified iOS-supported in `tool_platforms.py` — the authoritative, machine-readable source. Tools additionally marked **hardware-confirmed** have been individually exercised on a real iPhone (iOS 26.x); the rest of the ✅ set shares the same code paths but hasn't been individually run on hardware. iOS 🔜 means expected to work cross-platform by design, but not yet available or runtime-confirmed on iOS.
 
-Three Android tools fundamentally cannot exist on iOS — `shell`, `launch_intent`, and `toggle_overlay` — because iOS offers no system shell, intents, or overlay injection to automation. Two tools are iOS-first: `get_current_url` and `read_news`.
+Three Android tools fundamentally cannot exist on iOS — `shell`, `launch_intent`, and `toggle_overlay` — because iOS offers no system shell, intents, or overlay injection to automation. Two more (`get_crash`, `list_crashes`) are Android-only today because they read the logcat crash buffer; an iOS equivalent needs syslog/CrashReporter support. Two tools are iOS-first: `get_current_url` and `read_news`.
 
 ## screenshot
 
@@ -126,4 +126,94 @@ Before/after UI-tree diffing to verify an action did what you think. Expected cr
 
 The full surface — browser primitives (`open_url`, `web_search`, `extract_articles`, `wait_for_text`, …), notifications, clipboard, screen recording, streaming, health — with per-tool platform status lives in the generated support matrix below. Hardware-confirmed on a real iPhone so far: `read_news`, `screenshot`, `tap`/`tap_element`, `type_text`, `get_screen_tree`/`get_elements`, `press_home`, `open_url`, `extract_visible_text`/`extract_articles`, the OCR fallback, `speak_text`, and MJPEG + H.264 streaming with tap control.
 
-{/* GENERATED MATRIX PLACEHOLDER — emitted from gitd/services/tool_platforms.py */}
+{/* DRAFT NOTE (remove before merge): matrix below generated from mirror
+    feat/platform-matrix-emitter (PR #43). MUST be regenerated after the iOS-branch
+    reconciliation lands — e.g. speak_text flips to cross-platform (native iOS TTS),
+    and chain/screenshot_sequence/sub_agent auto-appear once merged. */}
+
+{/* GENERATED from gitd/services/tool_platforms.py — do not edit by hand.
+     Regenerate: python -m gitd.services.tool_platforms */}
+
+Legend: ✅ supported · 🔜 iOS planned · ⚠️ n/a (platform can't support it).
+Classification only — overlay a 'hardware-confirmed on iOS' badge separately;
+several cross-platform tools fall back to OCR on iOS (weaker a11y tree).
+
+### Cross-platform (Android + iOS) (56)
+
+| Tool | Android | iOS | Notes |
+| --- | :---: | :---: | --- |
+| `app_state` | ✅ | ✅ | Checks installed/running/foreground state for Android packages or iOS bundle ids. |
+| `browser_back` | ✅ | ✅ | Android back or iOS browser/WDA back fallback. |
+| `classify_screen` | ✅ | ✅ | Runs against normalized state/tree data. |
+| `clear_notifications` | ✅ | ✅ | Android notification service clear or best-effort iOS Clear control tap. |
+| `clipboard_get` | ✅ | ✅ | Uses Android clipboard helpers or Appium clipboard extensions on iOS. |
+| `clipboard_set` | ✅ | ✅ | Uses Android clipboard helpers or Appium clipboard extensions on iOS. |
+| `create_skill` | ✅ | ✅ | Creates recorded skills with Android package or iOS bundle metadata and per-platform element files. |
+| `crm_list_unread_messages` | ✅ | ✅ | Device-neutral local CRM unread-message listing. |
+| `crm_lookup_contact` | ✅ | ✅ | Device-neutral local CRM contact lookup. |
+| `device_health` | ✅ | ✅ | Checks Android Portal/device subsystems or iOS Appium/WDA health with actionable recovery steps. |
+| `explore_app` | ✅ | ✅ | BFS explorer over Android uiautomator XML or normalized iOS WDA XML with iOS tree/screenshot state identity. |
+| `extract_articles` | ✅ | ✅ | Best-effort article/headline extraction on either platform, with OCR fallback on iOS. |
+| `extract_visible_text` | ✅ | ✅ | Android normalized text extraction or iOS WebView/native/OCR text extraction. |
+| `find_on_screen` | ✅ | ✅ | Searches normalized XML with OCR fallback. |
+| `fix_device_health` | ✅ | ✅ | Applies Android Portal/screen fixes or iOS Appium/WDA recovery actions returned by device_health. |
+| `force_stop` | ✅ | ✅ | Force-stops Android packages or terminates iOS bundle ids. |
+| `get_elements` | ✅ | ✅ | Uses normalized Android/iOS element shape. |
+| `get_notifications` | ✅ | ✅ | Android dumpsys notifications or iOS Notification Center text extraction through WDA. |
+| `get_phone_state` | ✅ | ✅ | Uses Android state probes or iOS activeAppInfo/window state. |
+| `get_screen_tree` | ✅ | ✅ | Uses normalized Android/iOS XML. |
+| `get_screen_xml` | ✅ | ✅ | Returns Android uiautomator XML or normalized iOS WDA XML. |
+| `get_stream_info` | ✅ | ✅ | Returns effective Android Portal/H264/screencap or iOS WDA MJPEG stream metadata. |
+| `launch_app` | ✅ | ✅ | Launches Android packages or iOS bundle ids. |
+| `list_apps` | ✅ | ✅ | Android package manager or iOS configured/common bundle inventory with Appium verification. |
+| `list_devices` | ✅ | ✅ | Lists Android ADB devices and configured iOS Appium devices. |
+| `list_packages` | ✅ | ✅ | Android package manager or iOS configured/common bundle inventory with Appium verification. |
+| `list_skills` | ✅ | ✅ | Lists skills with platform metadata. |
+| `long_press` | ✅ | ✅ | Routes to ADB/Portal or WDA pointer actions. |
+| `ocr_region` | ✅ | ✅ | Runs OCR on cropped screenshot bytes. |
+| `ocr_screen` | ✅ | ✅ | Runs OCR on platform screenshot bytes. |
+| `open_camera` | ✅ | ✅ | Android camera launcher or best-effort iOS Camera app launch/mode selection. |
+| `open_notifications` | ✅ | ✅ | Android statusbar expansion or iOS Notification Center swipe gesture. |
+| `open_url` | ✅ | ✅ | Android VIEW intent or iOS Appium browser navigation. |
+| `paste_text` | ✅ | ✅ | Android clipboard paste keyevent or iOS clipboard plus WDA text insertion into the focused field. |
+| `press_back` | ✅ | ✅ | Best-effort back action on each platform. |
+| `press_home` | ✅ | ✅ | Uses Android HOME keyevent or iOS mobile: pressButton. |
+| `press_key` | ✅ | ✅ | Shared key facade with per-platform key support. |
+| `run_action` | ✅ | ✅ | Runs platform-aware skill actions when supported. |
+| `run_flow` | ✅ | ✅ | Batched execution of allow-listed tools; each step routes per-platform. |
+| `run_skill` | ✅ | ✅ | Runs platform-aware skills when the skill supports the target platform. |
+| `run_workflow` | ✅ | ✅ | Runs platform-aware skills when the skill supports the target platform. |
+| `screen_recording_status` | ✅ | ✅ | Reports active cross-platform phone screen recording status. |
+| `screenshot` | ✅ | ✅ | Uses Android screencap or Appium screenshot. |
+| `screenshot_annotated` | ✅ | ✅ | Draws labels from the normalized platform UI tree. |
+| `screenshot_cropped` | ✅ | ✅ | Crops screenshots from either backend. |
+| `search_apps` | ✅ | ✅ | Android package manager or iOS configured/common bundle inventory with Appium verification. |
+| `start_screen_recording` | ✅ | ✅ | Android adb screenrecord or iOS WDA MJPEG captured through ffmpeg. |
+| `stop_screen_recording` | ✅ | ✅ | Stops Android adb screenrecord or iOS WDA MJPEG/ffmpeg recording. |
+| `swipe` | ✅ | ✅ | Routes to ADB input swipe or WDA pointer actions. |
+| `tap` | ✅ | ✅ | Routes to ADB input tap or WDA pointer actions. |
+| `tap_element` | ✅ | ✅ | Taps normalized element centers. |
+| `type_text` | ✅ | ✅ | Routes to ADB input text or WDA keys/value. |
+| `type_unicode` | ✅ | ✅ | Routes to Android unicode input or iOS WDA text entry. |
+| `wait` | ✅ | ✅ | Device-neutral delay. |
+| `wait_for_text` | ✅ | ✅ | Android screen search or iOS visible text wait. |
+| `web_search` | ✅ | ✅ | Android VIEW intent or iOS Appium browser navigation. |
+
+### iOS-first (2)
+
+| Tool | Android | iOS | Notes |
+| --- | :---: | :---: | --- |
+| `get_current_url` | ⚠️ n/a | ✅ | Currently implemented through iOS WebDriver/WebView state; Android current URL support is not exposed yet. |
+| `read_news` | ⚠️ n/a | ✅ | iOS Chrome/WebDriver news-reading workflow that opens headlines and extracts article snippets. |
+
+### Android-only (6)
+
+| Tool | Android | iOS | Notes |
+| --- | :---: | :---: | --- |
+| `get_crash` | ✅ | ⚠️ n/a | Reads the Android logcat crash buffer; iOS needs syslog/CrashReporter support. |
+| `launch_intent` | ✅ | ⚠️ n/a | Android intents have no iOS equivalent. |
+| `list_crashes` | ✅ | ⚠️ n/a | Reads the Android logcat crash buffer; iOS needs syslog/CrashReporter support. |
+| `shell` | ✅ | ⚠️ n/a | ADB shell has no iOS equivalent. |
+| `speak_text` | ✅ | ⚠️ n/a | Uses the Android Portal app TTS path. |
+| `toggle_overlay` | ✅ | ⚠️ n/a | Portal overlay is Android-only. |
+

--- a/site/src/content/docs/ios/tool-support.mdx
+++ b/site/src/content/docs/ios/tool-support.mdx
@@ -126,10 +126,17 @@ Before/after UI-tree diffing to verify an action did what you think. Expected cr
 
 The full surface — browser primitives (`open_url`, `web_search`, `extract_articles`, `wait_for_text`, …), notifications, clipboard, screen recording, streaming, health — with per-tool platform status lives in the generated support matrix below. Hardware-confirmed on a real iPhone so far: `read_news`, `screenshot`, `tap`/`tap_element`, `type_text`, `get_screen_tree`/`get_elements`, `press_home`, `open_url`, `extract_visible_text`/`extract_articles`, the OCR fallback, `speak_text`, and MJPEG + H.264 streaming with tap control.
 
+**Population note:** the matrix lists Ghost's *full* tool surface — a superset of the tools exposed over MCP (`run_skill` and `shell` are in the matrix but aren't MCP-registered). If you cross-reference a page that counts MCP tools, expect its totals to be smaller by exactly those entries; both counts are correct for their population.
+
 {/* DRAFT NOTE (remove before merge): matrix below generated from mirror
     feat/platform-matrix-emitter (PR #43). MUST be regenerated after the iOS-branch
-    reconciliation lands — e.g. speak_text flips to cross-platform (native iOS TTS),
-    and chain/screenshot_sequence/sub_agent auto-appear once merged. */}
+    reconciliation lands. KNOWN on-page contradiction until then (flagged by
+    neutral-review): the matrix row classifies speak_text iOS-n/a (mirror/main truth —
+    the /wda/speak TTS route isn't merged there) while the prose section above is
+    iOS-✅ hardware-confirmed (feat/ios-support truth). The reconciliation flips
+    tool_platforms.py (feat/ios-support already reclassifies it) and the regen resolves
+    this; chain/screenshot_sequence/sub_agent also auto-appear once merged. Post-regen
+    expected split: 57 cross-platform / 2 iOS-first / 5 Android-only. */}
 
 {/* GENERATED from gitd/services/tool_platforms.py — do not edit by hand. Regenerate: python -m gitd.services.tool_platforms --mdx */}
 

--- a/site/src/content/docs/ios/troubleshooting.md
+++ b/site/src/content/docs/ios/troubleshooting.md
@@ -68,7 +68,7 @@ The health fix endpoint can attempt this (`{"issue":"restart_remote_xpc_tunnel"}
 
 ```bash
 xcrun xctrace list devices        # Mac-local
-ghost-ios report --json           # fleet node inventory
+ghost-ios report                  # fleet node inventory
 ```
 
 Prefer name-based refs (`my-iphone@my-mac`) and let the Mac resolve name→UDID. If a configured UDID stops matching (phone restored, replaced, or re-provisioned), re-run discovery rather than editing by hand.
@@ -93,4 +93,4 @@ Prefer name-based refs (`my-iphone@my-mac`) and let the Mac resolve name→UDID.
 
 ## Still stuck?
 
-Grab the health payload, the resolved dry-run plan, and (for remote setups) `ghost-ios report --json` from the Mac, and open an issue — those three artifacts answer the first ten questions we'd ask.
+Grab the health payload, the resolved dry-run plan, and (for remote setups) `ghost-ios report` from the Mac, and open an issue — those three artifacts answer the first ten questions we'd ask.

--- a/site/src/content/docs/ios/troubleshooting.md
+++ b/site/src/content/docs/ios/troubleshooting.md
@@ -1,0 +1,94 @@
+---
+title: "iOS Troubleshooting"
+description: Diagnose iOS automation failures layer by layer — Appium, WDA, RemoteXPC tunnel, sessions, streaming, and remote fleets.
+---
+
+Work from the health payload, not from guesses: `GET /api/phone/health/ios:<udid>` returns `connection.status`, a `recommended_fix`, `recovery.steps`, and — when Ghost can't fix it automatically — copyable `recovery.commands`. `recovery.auto_fixable=true` means one call (or the dashboard button) applies the fix:
+
+```bash
+curl -X POST "http://localhost:5055/api/phone/health/ios:<udid>/fix" \
+  -H 'Content-Type: application/json' -d '{"issue":"reset_session"}'
+```
+
+The sections below follow the stack bottom-up: control plane → device tunnel → WDA → session → streaming → remote.
+
+## Appium (control plane)
+
+**`Could not create Appium iOS session`** — confirm Appium is running and `IOS_APPIUM_URL` is right.
+
+**`appium_down`** — `fix_device_health("ios:<udid>", "start_appium")` or the dashboard button starts a *local* Appium (`http://127.0.0.1:...` URLs only). Remote or HTTPS Appium URLs get manual steps instead — start it yourself on that host. If `appium` isn't on `PATH`, set `IOS_APPIUM_COMMAND` (e.g. `npx appium`).
+
+**`configured_unreachable`** — some part of the config points nowhere. Re-check `ios:<udid>`, `IOS_DEVICE_UDID`, `IOS_DEVICES_JSON`, the Appium URL, WDA URL, and ports. A dry run prints the fully-resolved plan without touching the device:
+
+```bash
+uv run python scripts/ios_chrome_news_smoke.py --dry-run
+```
+
+## RemoteXPC tunnel (Mac ↔ iPhone, iOS 17+)
+
+**`remote_xpc_tunnel_unavailable`** — the CoreDevice tunnel to the phone is down or stale:
+
+```bash
+sudo appium driver run xcuitest tunnel-creation --udid <udid>
+```
+
+Then verify the registry entry at `http://127.0.0.1:42314/remotexpc/tunnels/<udid>` points at the same tunnel address reported by `xcrun devicectl device info details --device <udid>`. Non-default registry ports: set `IOS_REMOTE_XPC_REGISTRY_PORT` / `IOS_REMOTE_XPC_REGISTRY_PORTS`.
+
+The health fix endpoint can attempt this (`{"issue":"restart_remote_xpc_tunnel"}`) when the stale tunnel process belongs to your user; root-owned tunnels still need sudo by hand. `IOS_REMOTE_XPC_TUNNEL_START_TIMEOUT` controls how long the automatic fix waits before falling back to manual steps.
+
+**Tunnel IPv6 quirk:** the tunnel gives the phone an `fdxx::` IPv6 address that is **only routable on the Mac itself**. Anything that discovers device URLs through the tunnel registry (e.g. stream candidates) only works Mac-locally — a remote client must use forwarded localhost ports instead. If a URL with an `fdxx::` host leaks into a remote config, that's the bug.
+
+**Wedged CoreDevice connection** — when the tunnel won't come back at all, reset `usbmuxd` (unplug/replug USB helps too).
+
+## WebDriverAgent
+
+**Signing failures** (`xcodebuild failed`, `wda_signing_failed`, `errSecInternalComponent`) — see [WebDriverAgent Setup](/ios/setup/wda/); the short version: set a team in Xcode, trust the cert on the phone, and make sure signing runs in a GUI login session, never headless.
+
+**WDA crashes or dies mid-session** — Appium relaunches WDA on the next session; with `IOS_USE_PREBUILT_WDA`/`IOS_USE_PREINSTALLED_WDA` that's seconds. Crash loops usually mean an iOS/Xcode version mismatch: rebuild WDA once against the current Xcode, re-trust, re-enable the prebuilt flags.
+
+**`wda_up: false` on a healthy idle phone is not a fault.** Appium launches WDA per-session; `:8100` is only up while a session is live. Readiness for a new session is `tunnel_up && appium_up`.
+
+**Single WDA owner per device.** One iPhone supports one WDA session at a time. If a local process and a remote Ghost host both drive the same phone — or two Ghost instances share it — they contend and sessions die confusingly. Route everything through the one Appium on the owning Mac so access serializes. Symptoms of a second owner: sessions that vanish immediately after creation, or `Could not create Appium iOS session` while another session is visibly running.
+
+## Sessions
+
+**Session hangs on a real device / `locked`** — unlock the iPhone; accept any trust/automation prompts. A locked phone is the most common hang.
+
+**Stale session** — `{"issue":"reset_session"}` on the fix endpoint, restart Appium, or run the smoke script with `--close`.
+
+**Session expired while you weren't looking** — Appium kills idle sessions after `newCommandTimeout` (default posture 300 s). Ghost caches session IDs and revalidates before reuse, so normally you just get a fresh session. If your workflow legitimately idles for minutes (or rides a flaky link), raise `newCommandTimeout` or send a periodic no-op `GET /status` keepalive.
+
+**Taps land in the wrong place** — compare screenshot dimensions with the WDA window rect in `get_phone_state`. Ghost scales WDA points to screenshot pixels and back for gestures; a mismatch there (orientation change mid-session, unusual display zoom) is the culprit. Reset the session after rotating.
+
+## UDIDs and device identity
+
+**Don't hand-maintain UDID lists — they rot.** UDIDs are 40-char opaque strings; typos and stale entries produce phantom devices that exist nowhere and mislead every later debugging step. Discover instead:
+
+```bash
+xcrun xctrace list devices        # Mac-local
+ghost-ios report --json           # fleet node inventory
+```
+
+Prefer name-based refs (`my-iphone@my-mac`) and let the Mac resolve name→UDID. If a configured UDID stops matching (phone restored, replaced, or re-provisioned), re-run discovery rather than editing by hand.
+
+**`xcrun devicectl device info details` hangs** — known flake; it can hang indefinitely where `xctrace list devices` answers reliably. Ghost's tooling uses `xctrace` for identity for exactly this reason. If your own scripts wrap `devicectl`, add a timeout.
+
+## Streaming
+
+**Stream shows a frozen frame but health is green** — MJPEG can stall silently (no error event, connection stays open). Ghost's viewer runs a stall-watchdog that force-reconnects after ~7.5 s of frozen frames; if you consume the stream yourself, watch frame arrival, not endpoint reachability.
+
+**Stream URL unreachable from another machine** — the MJPEG/H.264 ports are loopback-only by design. Use the documented proxy (`/api/phone/stream?device=ios:<udid>`) or, in a remote fleet, the forwarded localhost port — never try to reach the Mac's `:9100`/`:9200` directly across the network.
+
+## Remote fleet
+
+**Remote ref not recognized (`my-iphone@my-mac` treated as unknown device)** — the host after `@` must exactly match a `remotes:` key, and malformed JSON makes the whole remotes map empty (by design, malformed entries are skipped silently). Validate: `echo "$GITD_REMOTES_JSON" | python3 -m json.tool`.
+
+**Everything times out after a network blip** — the SSH tunnel died and isn't supervised. Run it under `autossh` (or systemd with restart). Remember the session itself survives on the Mac until `newCommandTimeout` — a supervised tunnel usually reattaches without losing the session.
+
+**Destructive call returns `CONFIRM_REQUIRED`** — not an error: the [confirmation gate](/ios/remote-fleet/security/#the-destructive-action-confirmation-gate) is doing its job on a remote device. Re-issue with `confirm: true` if intended.
+
+**Reconnected, but the phone leg is dead** — two failure domains: Linux→Mac SSH (yours to supervise) and Mac→iPhone RemoteXPC (the Mac's). A Linux-side reconnect must not try to repair the device tunnel; check `ghost-ios status` on the Mac.
+
+## Still stuck?
+
+Grab the health payload, the resolved dry-run plan, and (for remote setups) `ghost-ios report --json` from the Mac, and open an issue — those three artifacts answer the first ten questions we'd ask.

--- a/site/src/content/docs/ios/troubleshooting.md
+++ b/site/src/content/docs/ios/troubleshooting.md
@@ -60,6 +60,8 @@ The health fix endpoint can attempt this (`{"issue":"restart_remote_xpc_tunnel"}
 
 **Taps land in the wrong place** — compare screenshot dimensions with the WDA window rect in `get_phone_state`. Ghost scales WDA points to screenshot pixels and back for gestures; a mismatch there (orientation change mid-session, unusual display zoom) is the culprit. Reset the session after rotating.
 
+**Every tap takes ~3 seconds** — WDA's animation/idle quiescence waits are on. Ghost disables them by default (~0.7 s taps); if you set `IOS_WAIT_FOR_QUIESCENCE=1` (or another client re-enabled the WDA settings), that's the cost. Conversely, if a *flaky* flow mis-taps during animations, turning quiescence back on is the fix, not shorter waits.
+
 ## UDIDs and device identity
 
 **Don't hand-maintain UDID lists — they rot.** UDIDs are 40-char opaque strings; typos and stale entries produce phantom devices that exist nowhere and mislead every later debugging step. Discover instead:

--- a/site/src/content/docs/ios/troubleshooting.md
+++ b/site/src/content/docs/ios/troubleshooting.md
@@ -83,7 +83,7 @@ Prefer name-based refs (`my-iphone@my-mac`) and let the Mac resolve name→UDID.
 
 ## Remote fleet
 
-**Remote ref not recognized (`my-iphone@my-mac` treated as unknown device)** — the host after `@` must exactly match a `remotes:` key, and malformed JSON makes the whole remotes map empty (by design, malformed entries are skipped silently). Validate: `echo "$GITD_REMOTES_JSON" | python3 -m json.tool`.
+**Remote ref not recognized (`my-iphone@my-mac` treated as unknown device)** — the host after `@` must exactly match a remote name in the remotes map, and malformed JSON makes the whole map empty (by design, malformed entries are skipped silently). Validate: `echo "$GITD_REMOTES_JSON" | python3 -m json.tool`.
 
 **Everything times out after a network blip** — the SSH tunnel died and isn't supervised. Run it under `autossh` (or systemd with restart). Remember the session itself survives on the Mac until `newCommandTimeout` — a supervised tunnel usually reattaches without losing the session.
 

--- a/site/src/content/docs/ios/util-scripts.md
+++ b/site/src/content/docs/ios/util-scripts.md
@@ -1,0 +1,89 @@
+---
+title: "iOS Utility Scripts"
+description: The ghost-ios host toolkit — status, JSON reports, doctor preflight, and WDA signing repair on the Mac node.
+---
+
+<!-- DRAFT NOTE (remove before merge): sections marked [PENDING ios-tester] await the
+     util-script inventory interview — exact install path, args, and sample outputs. -->
+
+`ghost-ios` is the Mac-side host toolkit: everything about the Mac↔iPhone leg (tunnel, WDA, Appium health) in one command, designed so both humans and the Linux Ghost host can query the node the same way.
+
+## Install
+
+<!-- [PENDING ios-tester]: confirm packaging/install path for the toolkit. -->
+
+The toolkit ships with the repo and installs on the Mac node alongside Ghost:
+
+```bash
+git clone https://github.com/ghost-in-the-droid/android-agent.git
+cd android-agent
+pip install -e .
+```
+
+## `ghost-ios status`
+
+Human-readable node overview: attached devices plus tunnel/WDA/Appium health per phone. Your first stop when anything on the Mac leg misbehaves.
+
+```bash
+ghost-ios status
+```
+
+## `ghost-ios report --json`
+
+The machine-readable version — the discovery source the Linux side consumes (directly or via `ssh <mac> ghost-ios report --json`). Runs in about 1.6 s; device identity comes from `xctrace list devices` (chosen over `devicectl`, which can hang indefinitely) and is cached, so a slow Xcode toolchain still yields a full record.
+
+```json
+{
+  "schema": 1,
+  "host": "my-mac",
+  "generated_at": "2026-07-11T21:33Z",
+  "devices": [
+    {
+      "udid": "00008110-0012345678901234",
+      "name": "my iPhone",
+      "ref_slug": "my-iphone",
+      "ios_version": "26.4",
+      "wda_up": false,
+      "appium_up": true,
+      "tunnel_up": true
+    }
+  ]
+}
+```
+
+Field notes:
+
+| Field | Meaning |
+|---|---|
+| `schema` | Envelope version (currently `1`) — the envelope is extensible on purpose |
+| `host` | The Mac self-identifies; useful when aggregating several nodes |
+| `ref_slug` | Slug of the phone's *user-assigned* device name — this is the `<name>` in `<name>@<host>` refs. Two phones of the same model stay distinct |
+| `wda_up` | A WDA session is live *right now*. Idle ⇒ `false` (normal — Appium launches WDA per-session) |
+| `appium_up` / `tunnel_up` | The two legs that must both be up to start a session: readiness = `tunnel_up && appium_up` |
+
+## `ghost-ios doctor`
+
+Preflight that walks every known failure point of the Mac leg — tunnel registry, Appium, WDA signing state, device trust — before you burn time on a session that was never going to start.
+
+```bash
+ghost-ios doctor
+```
+
+<!-- [PENDING ios-tester]: doctor's exact check list + sample output. -->
+
+## WDA build/signing helpers
+
+`ios-fix-wda-signing.sh` repairs the WDA signing/install state (the fix for `wda_signing_failed` loops) — see [WebDriverAgent Setup](/ios/setup/wda/) for when signing breaks and why it needs a GUI session.
+
+<!-- [PENDING ios-tester]: helper script inventory — exact names/paths/args for the WDA
+     build helpers, and any additional utilities to document here. -->
+
+## Using the toolkit from Linux
+
+In a [remote fleet](/ios/remote-fleet/), the Linux host runs these over the restricted SSH key (the forced-command wrapper must allow the report command):
+
+```bash
+ssh my-mac ghost-ios report --json
+```
+
+That one line is device discovery: no hand-typed UDIDs, no stale device lists.

--- a/site/src/content/docs/ios/util-scripts.md
+++ b/site/src/content/docs/ios/util-scripts.md
@@ -3,47 +3,57 @@ title: "iOS Utility Scripts"
 description: The ghost-ios host toolkit — one command to start, check, repair, and report on the Mac↔iPhone leg.
 ---
 
-<!-- DRAFT NOTE (remove before merge): ghost-ios currently lives as an operational helper
-     outside the repo tree; packaging into the repo is pending. Install section below is
-     provisional until packaging lands — flagged with core-dev/ios-tester. -->
-
-`ghost-ios` is the Mac-side host toolkit: everything about the Mac↔iPhone leg (RemoteXPC tunnel, WDA, Appium, backend) in one command, designed so both humans and a remote Linux Ghost host can operate the node the same way.
+`ghost-ios` is the Mac-side host toolkit, vendored in the repo at `scripts/ios/`: the whole iOS device stack — RemoteXPC tunnel, Appium, backend, web dashboard, and a self-healing supervisor — in a single terminal window, plus preflight, a JSON device inventory, and WDA build/sign helpers. It carries no baked-in identifiers; everything is auto-detected or comes from env/config. Both humans and a remote Linux Ghost host operate the node the same way. (Full reference also ships in-repo: `scripts/ios/README.md`.)
 
 Two ground rules, both consequences of how Apple's tooling works:
 
-- **Run it from a GUI Terminal session** — WDA code-signing needs the login keychain of an interactive desktop session and fails headless (see [Mac Setup](/ios/remote-fleet/mac-setup/)).
+- **Run it from a GUI Terminal session** — WDA code-signing needs an interactive desktop session and fails over SSH/headless (`errSecInternalComponent`); see [Mac Setup](/ios/remote-fleet/mac-setup/).
 - **It prompts for sudo once** — the iOS 17+ RemoteXPC tunnel is privileged.
 
 ## Install
 
+There is no install step — run the scripts in place from a repo checkout. Optionally put the launcher on your `PATH`:
+
 ```bash
-git clone https://github.com/ghost-in-the-droid/android-agent.git
-cd android-agent
-pip install -e .
+ln -s "$PWD/scripts/ios/ghost-ios" /usr/local/bin/ghost-ios   # optional
 ```
 
-<!-- [PENDING packaging]: exact ghost-ios install path once it ships in the repo tree. -->
+**Zero-config** works when exactly one iPhone is attached and one "Apple Development" identity is in your keychain — UDID, team, signing identity, Appium, and repo location are auto-detected. Otherwise copy the template and set the few values it can't detect:
+
+```bash
+cp scripts/ios/ghost-ios.env.example scripts/ios/ghost-ios.env
+$EDITOR scripts/ios/ghost-ios.env       # e.g. IOS_DEVICE_UDID, IOS_XCODE_ORG_ID
+```
+
+`ghost-ios.env` is gitignored, so your identifiers never end up in a commit. `ghost-ios config` shows what resolved and from where.
 
 ## Subcommands
 
 | Command | What it does |
 |---|---|
 | `ghost-ios up` | Start the whole stack — backend, Appium, and a **self-healing RemoteXPC tunnel supervisor** that auto-reconnects until you Ctrl-C |
-| `ghost-ios doctor` | Preflight every known failure point (tunnel registry, Appium, WDA signing, device trust) and apply fixes where it can |
-| `ghost-ios status` | Human-readable health lines per attached device |
-| `ghost-ios report --json` | Machine-readable device inventory — the remote-fleet discovery source |
-| `ghost-ios dashboard` | Launch the web dashboard (Vite) |
-| `ghost-ios smoke` | Run the Chrome→news end-to-end smoke workflow |
-| `ghost-ios speak` | Test native TTS through the `/wda/speak` endpoint |
-| `ghost-ios keychain` | One-time grant of CLI codesign access to the login keychain |
-| `ghost-ios rebuild-wda` (alias `wda`) | Rebuild and re-sign WebDriverAgent (see below) |
+| `ghost-ios doctor` | Preflight every known failure point (tunnel registry, Appium, WDA signing, device trust) with the fix for each |
+| `ghost-ios status` | Tunnel / Appium / backend / dashboard health lines |
+| `ghost-ios report` | Machine-readable JSON device inventory — the remote-fleet discovery source |
+| `ghost-ios dashboard` | Start the web dashboard (Vite) and open it |
+| `ghost-ios smoke` | Run the sample Chrome→news end-to-end smoke workflow |
+| `ghost-ios speak TEXT` | Speak `TEXT` aloud on the phone (native WDA TTS) |
+| `ghost-ios keychain` | One-time: grant CLI codesign access to your signing key (prevents mid-build keychain re-locks) |
+| `ghost-ios rebuild-wda` | (Re)build, sign, and install the patched WebDriverAgent onto the phone |
+| `ghost-ios config` | Show resolved configuration and where each value came from |
 | `ghost-ios down` | Stop tunnel, Appium, and backend |
 
-Day-one sequence on a fresh node: `keychain` (once) → `up` → `status`.
+Typical first run on a fresh node:
 
-## `ghost-ios report --json`
+```bash
+ghost-ios keychain      # once
+ghost-ios doctor        # verify every prerequisite is green
+ghost-ios up            # start everything; Ctrl-C tears it down
+```
 
-The discovery source the Linux side consumes (directly or via `ssh my-mac ghost-ios report --json`). Runs in about 1.6 s; device identity comes from `xctrace list devices` — chosen over `devicectl`, which can hang indefinitely — and is cached, so a slow Xcode toolchain still yields a full record.
+## `ghost-ios report`
+
+The discovery source the Linux side consumes (directly or via `ssh my-mac ghost-ios report`). Runs in about 1.6 s; device identity comes from `xctrace list devices` — chosen over `devicectl`, which can hang indefinitely — and is cached, so a slow Xcode toolchain still yields a full record.
 
 ```json
 {
@@ -74,16 +84,24 @@ Field notes:
 | `wda_up` | A WDA session is live *right now*. Idle ⇒ `false` (normal — Appium launches WDA per-session) |
 | `appium_up` / `tunnel_up` | The two legs that must both be up to start a session: readiness = `tunnel_up && appium_up` |
 
-## WDA build/signing repair
+## The files in `scripts/ios/`
 
-`ios-fix-wda-signing.sh` (companion script, also reachable as `ghost-ios rebuild-wda`) builds and signs a known-good prebuilt WebDriverAgent — including Ghost's `/wda/speak` TTS patch — into a fixed DerivedData path, so Appium reuses it on every session with **no per-launch codesign**. This is the fix for `wda_signing_failed` loops and the setup step behind `IOS_USE_PREBUILT_WDA`; background in [WebDriverAgent Setup](/ios/setup/wda/).
+| File | What |
+|---|---|
+| `ghost-ios` | The launcher / supervisor + all subcommands |
+| `doctor.sh` | Preflight checks (invoked by `ghost-ios doctor`) |
+| `fix-wda-signing.sh` | Clean WDA build + sign + install — the fix for keychain-lock codesign failures and `wda_signing_failed` loops (also reachable as `ghost-ios rebuild-wda`) |
+| `lib.sh` | Shared config resolution + auto-detection (sourced by the others) |
+| `ghost-ios.env.example` | Config template — copy to `ghost-ios.env` (gitignored) |
+
+The rebuilt WDA includes Ghost's `/wda/speak` TTS patch and lands in a fixed DerivedData path so Appium reuses it on every session with no per-launch codesign — the setup step behind `IOS_USE_PREBUILT_WDA`; background in [WebDriverAgent Setup](/ios/setup/wda/).
 
 ## Using the toolkit from Linux
 
 In a [remote fleet](/ios/remote-fleet/), the Linux host runs the report over the restricted SSH key (the forced-command wrapper must allow exactly this command):
 
 ```bash
-ssh my-mac ghost-ios report --json
+ssh my-mac ghost-ios report
 ```
 
 That one line is device discovery: no hand-typed UDIDs, no stale device lists.

--- a/site/src/content/docs/ios/util-scripts.md
+++ b/site/src/content/docs/ios/util-scripts.md
@@ -1,18 +1,20 @@
 ---
 title: "iOS Utility Scripts"
-description: The ghost-ios host toolkit — status, JSON reports, doctor preflight, and WDA signing repair on the Mac node.
+description: The ghost-ios host toolkit — one command to start, check, repair, and report on the Mac↔iPhone leg.
 ---
 
-<!-- DRAFT NOTE (remove before merge): sections marked [PENDING ios-tester] await the
-     util-script inventory interview — exact install path, args, and sample outputs. -->
+<!-- DRAFT NOTE (remove before merge): ghost-ios currently lives as an operational helper
+     outside the repo tree; packaging into the repo is pending. Install section below is
+     provisional until packaging lands — flagged with core-dev/ios-tester. -->
 
-`ghost-ios` is the Mac-side host toolkit: everything about the Mac↔iPhone leg (tunnel, WDA, Appium health) in one command, designed so both humans and the Linux Ghost host can query the node the same way.
+`ghost-ios` is the Mac-side host toolkit: everything about the Mac↔iPhone leg (RemoteXPC tunnel, WDA, Appium, backend) in one command, designed so both humans and a remote Linux Ghost host can operate the node the same way.
+
+Two ground rules, both consequences of how Apple's tooling works:
+
+- **Run it from a GUI Terminal session** — WDA code-signing needs the login keychain of an interactive desktop session and fails headless (see [Mac Setup](/ios/remote-fleet/mac-setup/)).
+- **It prompts for sudo once** — the iOS 17+ RemoteXPC tunnel is privileged.
 
 ## Install
-
-<!-- [PENDING ios-tester]: confirm packaging/install path for the toolkit. -->
-
-The toolkit ships with the repo and installs on the Mac node alongside Ghost:
 
 ```bash
 git clone https://github.com/ghost-in-the-droid/android-agent.git
@@ -20,29 +22,40 @@ cd android-agent
 pip install -e .
 ```
 
-## `ghost-ios status`
+<!-- [PENDING packaging]: exact ghost-ios install path once it ships in the repo tree. -->
 
-Human-readable node overview: attached devices plus tunnel/WDA/Appium health per phone. Your first stop when anything on the Mac leg misbehaves.
+## Subcommands
 
-```bash
-ghost-ios status
-```
+| Command | What it does |
+|---|---|
+| `ghost-ios up` | Start the whole stack — backend, Appium, and a **self-healing RemoteXPC tunnel supervisor** that auto-reconnects until you Ctrl-C |
+| `ghost-ios doctor` | Preflight every known failure point (tunnel registry, Appium, WDA signing, device trust) and apply fixes where it can |
+| `ghost-ios status` | Human-readable health lines per attached device |
+| `ghost-ios report --json` | Machine-readable device inventory — the remote-fleet discovery source |
+| `ghost-ios dashboard` | Launch the web dashboard (Vite) |
+| `ghost-ios smoke` | Run the Chrome→news end-to-end smoke workflow |
+| `ghost-ios speak` | Test native TTS through the `/wda/speak` endpoint |
+| `ghost-ios keychain` | One-time grant of CLI codesign access to the login keychain |
+| `ghost-ios rebuild-wda` (alias `wda`) | Rebuild and re-sign WebDriverAgent (see below) |
+| `ghost-ios down` | Stop tunnel, Appium, and backend |
+
+Day-one sequence on a fresh node: `keychain` (once) → `up` → `status`.
 
 ## `ghost-ios report --json`
 
-The machine-readable version — the discovery source the Linux side consumes (directly or via `ssh <mac> ghost-ios report --json`). Runs in about 1.6 s; device identity comes from `xctrace list devices` (chosen over `devicectl`, which can hang indefinitely) and is cached, so a slow Xcode toolchain still yields a full record.
+The discovery source the Linux side consumes (directly or via `ssh my-mac ghost-ios report --json`). Runs in about 1.6 s; device identity comes from `xctrace list devices` — chosen over `devicectl`, which can hang indefinitely — and is cached, so a slow Xcode toolchain still yields a full record.
 
 ```json
 {
   "schema": 1,
-  "host": "my-mac",
-  "generated_at": "2026-07-11T21:33Z",
+  "host": "mac1",
+  "generated_at": "2026-01-01T00:00Z",
   "devices": [
     {
-      "udid": "00008110-0012345678901234",
-      "name": "my iPhone",
-      "ref_slug": "my-iphone",
-      "ios_version": "26.4",
+      "udid": "00008XXX-XXXXXXXXXXXXXXXX",
+      "name": "Demo iPhone",
+      "ref_slug": "demo-iphone",
+      "ios_version": "26.4.2",
       "wda_up": false,
       "appium_up": true,
       "tunnel_up": true
@@ -61,26 +74,13 @@ Field notes:
 | `wda_up` | A WDA session is live *right now*. Idle ⇒ `false` (normal — Appium launches WDA per-session) |
 | `appium_up` / `tunnel_up` | The two legs that must both be up to start a session: readiness = `tunnel_up && appium_up` |
 
-## `ghost-ios doctor`
+## WDA build/signing repair
 
-Preflight that walks every known failure point of the Mac leg — tunnel registry, Appium, WDA signing state, device trust — before you burn time on a session that was never going to start.
-
-```bash
-ghost-ios doctor
-```
-
-<!-- [PENDING ios-tester]: doctor's exact check list + sample output. -->
-
-## WDA build/signing helpers
-
-`ios-fix-wda-signing.sh` repairs the WDA signing/install state (the fix for `wda_signing_failed` loops) — see [WebDriverAgent Setup](/ios/setup/wda/) for when signing breaks and why it needs a GUI session.
-
-<!-- [PENDING ios-tester]: helper script inventory — exact names/paths/args for the WDA
-     build helpers, and any additional utilities to document here. -->
+`ios-fix-wda-signing.sh` (companion script, also reachable as `ghost-ios rebuild-wda`) builds and signs a known-good prebuilt WebDriverAgent — including Ghost's `/wda/speak` TTS patch — into a fixed DerivedData path, so Appium reuses it on every session with **no per-launch codesign**. This is the fix for `wda_signing_failed` loops and the setup step behind `IOS_USE_PREBUILT_WDA`; background in [WebDriverAgent Setup](/ios/setup/wda/).
 
 ## Using the toolkit from Linux
 
-In a [remote fleet](/ios/remote-fleet/), the Linux host runs these over the restricted SSH key (the forced-command wrapper must allow the report command):
+In a [remote fleet](/ios/remote-fleet/), the Linux host runs the report over the restricted SSH key (the forced-command wrapper must allow exactly this command):
 
 ```bash
 ssh my-mac ghost-ios report --json


### PR DESCRIPTION
## What

The public iOS documentation set for the docs site (`site/src/content/docs/ios/`), covering iOS support end to end:

- **setup/** — requirements, WebDriverAgent (signing, prebuilt/preinstalled, GUI-session constraint), full `IOS_*` configuration, layered verification
- **remote-fleet/** — Linux→SSH→Mac→USB-iPhone topology: Mac node setup (auto-login Aqua, restricted `permitopen` key, keychain), Linux setup (`remotes:` config, supervised tunnel, `<name>@<host>` refs), and the security model (threat model, destructive-action confirmation gate incl. its honest v1 scope limits)
- **troubleshooting** — layered bottom-up: Appium → RemoteXPC tunnel (incl. the `fdxx::` IPv6 quirk, `devicectl` hang) → WDA (single-owner rule) → sessions → streaming → remote fleet
- **tool-support.mdx** — per-tool badges distinguishing *classified cross-platform* from *hardware-confirmed on a real iPhone*; iOS behavior notes (tap quiescence/latency, coordinate scaling, OCR fallback, bundle-ID discovery)
- **util-scripts** — the `ghost-ios` host toolkit (up/doctor/status/report/dashboard/smoke/speak/keychain/rebuild-wda/down) with the redacted `report --json` schema

## Honesty rules applied

- No version pins: remote-drive path phrased as "real-device-ready once the security hardening lands"
- `wda_up` documented as "session live now"; readiness = `tunnel_up && appium_up`
- v1 gate limitation (UI-sequence destructive actions) documented as a conscious decision
- All UDIDs/hostnames/device names are fake placeholders (`00008XXX-…`, `my-mac`, `demo-iphone`); grep-sweep gate run before every commit

## Depends on (do not merge before)

1. ghost-public-web branch `chore/platform-badges-component` (PlatformBadges.astro) + '🍎 iOS' sidebar group + `ios/index` (their `getting-started/ios.md` moves in as the section index). `tool-support.mdx` imports the component.
2. iOS-branch reconciliation + matrix REGEN (`python -m gitd.services.tool_platforms --mdx`). DECIDED (core-dev): `speak_text` stays android_only on mirror/main until reconciliation — feat/ios-support already reclassifies it cross-platform, so the flip is carried automatically when it lands. Until the regen, tool-support.mdx knowingly self-contradicts on speak_text (named in its draft note). Expected post-regen split: 57 cross-platform / 2 iOS-first / 5 Android-only; chain/screenshot_sequence/sub_agent auto-appear once merged.
3. ~~Packaging decision for `ghost-ios`~~ RESOLVED: toolkit vendored at `scripts/ios/` on feat/ios-support (9b1b995, PII-swept). util-scripts.md is finalized against it — its draft note is gone. Like the rest of the iOS surface, `scripts/ios/` reaches public at reconciliation, so this folds into dependency 2.

Site builds clean (58 pages) with the component present.

## Review plan

- [ ] ghost-core-dev: technical pass
- [ ] ghost-neutral-review: never-seen-iOS-docs reader pass
- [x] ghost-neutral-review: fresh-reader pass — round 1 complete, 7 content pages green (@aea8fb8)
- [ ] Pre-merge housekeeping: remove the 2 remaining DRAFT NOTE comments (both `{/* */}` in tool-support.mdx — MDX-stripped, invisible; the risky .md one is already gone) and regenerate the tool matrix post-reconciliation
- [ ] CKL green light (hard gate — this PR does not merge without it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)