### PR TITLE
feat: v1.3.0 — iOS support, on-device inference, LangChain/LlamaIndex, ghost CLI, run_flow, 62 MCP tools

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,5 +30,11 @@
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "sharp"
+    ]
   }
 }

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -8,6 +8,7 @@ import SkillHubView from '@/views/SkillHubView.vue'
 import SkillCreatorView from '@/views/SkillCreatorView.vue'
 import ExplorerView from '@/views/ExplorerView.vue'
 import ToolsHubView from '@/views/ToolsHubView.vue'
+import DeviceHealthView from '@/views/DeviceHealthView.vue'
 import EmulatorTab from '@/components/emulator/EmulatorTab.vue'
 import BenchmarkTab from '@/components/benchmark/BenchmarkTab.vue'
 
@@ -20,6 +21,7 @@ const coreTabs = [
   { id: 'tools', label: '🔧 Tools' },
   { id: 'bot', label: '▶️ Manual Run' },
   { id: 'tests', label: '🧪 Tests' },
+  { id: 'health', label: '🩺 Device Health' },
   { id: 'emulators', label: '🖥️ Emulators' },
   { id: 'benchmarks', label: '📊 Benchmarks' },
 ]
@@ -58,7 +60,10 @@ async function pollGhostState() {
     ghostState.value = 'idle'
   } catch { ghostState.value = 'disconnected' }
 }
+const publicView = new URLSearchParams(window.location.search).has('public')
+
 async function fetchFeatures() {
+  if (publicView) return
   try {
     const resp = await fetch('/api/features')
     if (resp.ok) {
@@ -139,6 +144,7 @@ async function restartServer() {
       <ToolsHubView v-else-if="activeTab === 'tools'" />
       <BotView v-else-if="activeTab === 'bot'" />
       <TestsView v-else-if="activeTab === 'tests'" />
+      <DeviceHealthView v-else-if="activeTab === 'health'" />
       <EmulatorTab v-else-if="activeTab === 'emulators'" />
       <BenchmarkTab v-else-if="activeTab === 'benchmarks'" />
       <!-- Premium tabs: rendered as iframes from premium frontend server -->

--- a/frontend/src/components/PhoneStreamWidget.vue
+++ b/frontend/src/components/PhoneStreamWidget.vue
@@ -9,6 +9,7 @@
  *   showKeys    — show hardware key buttons (default: true)
  *   showVolume  — show vol+/vol- buttons (default: false)
  *   showOverlay — show overlay toggle button (default: false)
+ *   showRecording — show screen recording controls (default: true)
  *   compact     — smaller padding/fonts (default: false)
  *   autoStream  — start streaming on mount (default: false)
  *   fps         — screenshot poll interval in ms (default: 300)
@@ -16,7 +17,7 @@
  * Emits:
  *   tap(x, y, streamW, streamH)  — user clicked/tapped on the stream
  */
-import { ref, onMounted, onUnmounted, watch } from 'vue'
+import { computed, ref, onMounted, onUnmounted, watch } from 'vue'
 import { api } from '@/composables/useApi'
 
 const props = withDefaults(defineProps<{
@@ -26,6 +27,7 @@ const props = withDefaults(defineProps<{
   showKeys?: boolean
   showVolume?: boolean
   showOverlay?: boolean
+  showRecording?: boolean
   compact?: boolean
   autoStream?: boolean
   fps?: number
@@ -35,6 +37,7 @@ const props = withDefaults(defineProps<{
   showKeys: true,
   showVolume: false,
   showOverlay: false,
+  showRecording: true,
   compact: false,
   autoStream: false,
   fps: 300,
@@ -48,13 +51,95 @@ const streaming = ref(false)
 const streamImg = ref('')
 const mjpegUrl = ref('')
 const overlayOn = ref(false)
+const recording = ref(false)
+const recordingBusy = ref(false)
+const recordingStatusText = ref('')
+const recordingFilename = ref('')
+const recordingUrl = ref('')
+const streamInfoStatus = ref('')
 let timer: number | null = null
 
-function startStream() {
+type RecordingResponse = {
+  ok?: boolean
+  running?: boolean
+  filename?: string
+  mode?: string
+  url?: string
+  error?: string
+}
+
+type StreamInfo = {
+  ok?: boolean
+  stream_url?: string
+  effective_mode?: string
+  fallback_mode?: string
+  unsupported_actions?: string[]
+}
+
+const isIos = computed(() => props.serial?.startsWith('ios:') || false)
+const platformLabel = computed(() => isIos.value ? 'iOS' : 'Android')
+const streamMode = computed(() => isIos.value ? 'mjpeg' : props.mode)
+const streamModeLabel = computed(() => {
+  if (isIos.value && streamMode.value === 'mjpeg') return 'WDA MJPEG'
+  return streamMode.value === 'mjpeg' ? 'MJPEG' : 'Screenshot'
+})
+const recordingButtonLabel = computed(() => {
+  if (recordingBusy.value) return '...'
+  return recording.value ? 'Stop Rec' : 'Record'
+})
+const recordingButtonTitle = computed(() => {
+  if (recording.value) return 'Stop screen recording and save MP4'
+  return isIos.value
+    ? 'Record WDA MJPEG stream to MP4'
+    : 'Record Android screen to MP4'
+})
+const keyButtons = computed(() => {
+  if (isIos.value) {
+    return [
+      { label: 'Back', value: 'BACK', title: 'Back' },
+      { label: 'Home', value: 'HOME', title: 'Home' },
+      { label: 'Enter', value: 'ENTER', title: 'Enter' },
+    ]
+  }
+  const keys: { label: string; value: number; title: string }[] = [
+    { label: '\u25C0', value: 4, title: 'Back' },
+    { label: '\u2302', value: 3, title: 'Home' },
+    { label: '\u25A6', value: 187, title: 'Recents' },
+    { label: '\u23FB', value: 26, title: 'Power' },
+  ]
+  if (props.showVolume) {
+    keys.push({ label: 'Vol+', value: 24, title: 'Volume up' })
+    keys.push({ label: 'Vol-', value: 25, title: 'Volume down' })
+  }
+  return keys
+})
+
+function defaultMjpegUrl(): string {
+  const modeParam = isIos.value ? '&mode=wda-mjpeg' : ''
+  return `/api/phone/stream?device=${encodeURIComponent(props.serial)}&fps=5${modeParam}`
+}
+
+async function resolveMjpegUrl(): Promise<string> {
+  const fallback = defaultMjpegUrl()
+  try {
+    const mode = isIos.value ? 'mjpeg' : 'screencap'
+    const info = await api<StreamInfo>(
+      `/api/phone/stream-info?device=${encodeURIComponent(props.serial)}&fps=5&mode=${encodeURIComponent(mode)}`
+    )
+    streamInfoStatus.value = ''
+    return info.stream_url || fallback
+  } catch (error) {
+    streamInfoStatus.value = error instanceof Error ? error.message.replace(/^API \d+:\s*/, '') : 'Stream metadata unavailable'
+    return fallback
+  }
+}
+
+async function startStream() {
   if (streaming.value) return
   streaming.value = true
-  if (props.mode === 'mjpeg') {
-    mjpegUrl.value = `/api/phone/stream?device=${encodeURIComponent(props.serial)}&fps=5`
+  if (streamMode.value === 'mjpeg') {
+    mjpegUrl.value = defaultMjpegUrl()
+    mjpegUrl.value = await resolveMjpegUrl()
   } else {
     pollFrame()
     timer = window.setInterval(pollFrame, props.fps)
@@ -66,6 +151,7 @@ function stopStream() {
   if (timer) { clearInterval(timer); timer = null }
   streamImg.value = ''
   mjpegUrl.value = ''
+  streamInfoStatus.value = ''
 }
 
 function toggleStream() {
@@ -81,8 +167,15 @@ async function pollFrame() {
   } catch {}
 }
 
-function sendKey(key: number) {
+function sendKey(key: number | string) {
   if (!props.serial) return
+  if (typeof key === 'string') {
+    api('/api/phone/key', {
+      method: 'POST',
+      body: JSON.stringify({ device: props.serial, key })
+    })
+    return
+  }
   api('/api/phone/input', {
     method: 'POST',
     body: JSON.stringify({ device: props.serial, action: 'keyevent', keycode: key })
@@ -90,6 +183,7 @@ function sendKey(key: number) {
 }
 
 async function toggleOverlayFn() {
+  if (isIos.value) return
   overlayOn.value = !overlayOn.value
   await api(`/api/phone/overlay/${props.serial}`, {
     method: 'POST', body: JSON.stringify({ visible: overlayOn.value })
@@ -99,21 +193,85 @@ async function toggleOverlayFn() {
 function handleClick(e: MouseEvent) {
   const el = e.target as HTMLImageElement
   const rect = el.getBoundingClientRect()
-  // Scale from display coords to device coords (assume 1080x2400 or use naturalWidth)
+  // Screenshot polling is half-res; iOS WDA MJPEG already reports its own frame size.
   const sw = el.naturalWidth || 540
   const sh = el.naturalHeight || 1170
-  const x = Math.round((e.clientX - rect.left) / rect.width * sw * 2)
-  const y = Math.round((e.clientY - rect.top) / rect.height * sh * 2)
-  emit('tap', x, y, sw * 2, sh * 2)
-  // Also send tap directly
+  const scale = isIos.value && streamMode.value === 'mjpeg' ? 1 : 2
+  const streamW = sw * scale
+  const streamH = sh * scale
+  const x = Math.round((e.clientX - rect.left) / rect.width * streamW)
+  const y = Math.round((e.clientY - rect.top) / rect.height * streamH)
+  emit('tap', x, y, streamW, streamH)
   api('/api/phone/tap', {
     method: 'POST',
-    body: JSON.stringify({ device: props.serial, x, y, stream_w: sw * 2, stream_h: sh * 2 })
+    body: JSON.stringify({ device: props.serial, x, y, stream_w: streamW, stream_h: streamH })
   })
 }
 
+function resetRecordingState() {
+  recording.value = false
+  recordingBusy.value = false
+  recordingStatusText.value = ''
+  recordingFilename.value = ''
+  recordingUrl.value = ''
+}
+
+function applyRecordingStatus(result: RecordingResponse) {
+  recording.value = !!result.running
+  recordingFilename.value = result.filename || recordingFilename.value
+  if (result.url) recordingUrl.value = result.url
+  if (result.error) {
+    recordingStatusText.value = result.error
+  } else if (result.running) {
+    recordingStatusText.value = result.mode ? `Recording: ${result.mode}` : 'Recording'
+  } else if (result.url) {
+    recordingStatusText.value = 'Saved recording'
+  } else {
+    recordingStatusText.value = ''
+  }
+}
+
+function recordingErrorText(error: unknown) {
+  if (error instanceof Error) return error.message.replace(/^API \d+:\s*/, '')
+  return 'Recording request failed'
+}
+
+async function refreshRecordingStatus() {
+  if (!props.serial) {
+    resetRecordingState()
+    return
+  }
+  try {
+    const result = await api<RecordingResponse>(`/api/phone/recording/status/${encodeURIComponent(props.serial)}`)
+    applyRecordingStatus(result)
+  } catch (error) {
+    recordingStatusText.value = recordingErrorText(error)
+  }
+}
+
+async function toggleRecording() {
+  if (!props.serial || recordingBusy.value) return
+  recordingBusy.value = true
+  recordingStatusText.value = ''
+  try {
+    const endpoint = recording.value ? '/api/phone/recording/stop' : '/api/phone/recording/start'
+    const result = await api<RecordingResponse>(endpoint, {
+      method: 'POST',
+      body: JSON.stringify({ device: props.serial })
+    })
+    applyRecordingStatus(result)
+  } catch (error) {
+    recordingStatusText.value = recordingErrorText(error)
+  } finally {
+    recordingBusy.value = false
+  }
+}
+
 // Auto-stream on mount if requested
-onMounted(() => { if (props.autoStream && props.serial) startStream() })
+onMounted(() => {
+  if (props.autoStream && props.serial) startStream()
+  void refreshRecordingStatus()
+})
 onUnmounted(() => stopStream())
 
 // Restart stream if serial changes
@@ -122,9 +280,10 @@ watch(() => props.serial, (newVal, oldVal) => {
     stopStream()
     if (newVal) startStream()
   }
+  if (newVal !== oldVal) void refreshRecordingStatus()
 })
 
-defineExpose({ startStream, stopStream, streaming })
+defineExpose({ startStream, stopStream, streaming, refreshRecordingStatus, toggleRecording })
 </script>
 
 <template>
@@ -133,17 +292,25 @@ defineExpose({ startStream, stopStream, streaming })
     <div class="psw-header">
       <span class="psw-status-dot" :style="{ background: streaming ? '#22c55e' : '#475569' }" :title="streaming ? 'Streaming' : 'Idle'"></span>
       <span class="psw-label">{{ label || serial?.slice(0, 10) || 'No device' }}</span>
+      <span class="psw-platform">{{ platformLabel }}</span>
+      <span class="psw-stream-mode">{{ streamModeLabel }}</span>
+      <span v-if="recording" class="psw-recording-dot" title="Screen recording active"></span>
       <div class="psw-keys" v-if="showKeys">
-        <button class="psw-key" @click="sendKey(4)" title="Back">&#x25C0;</button>
-        <button class="psw-key" @click="sendKey(3)" title="Home">&#x2302;</button>
-        <button class="psw-key" @click="sendKey(187)" title="Recents">&#x25A6;</button>
-        <button class="psw-key" @click="sendKey(26)" title="Power">&#x23FB;</button>
-        <button v-if="showVolume" class="psw-key" @click="sendKey(24)" title="Vol+">&#x1F50A;</button>
-        <button v-if="showVolume" class="psw-key" @click="sendKey(25)" title="Vol-">&#x1F509;</button>
-        <button v-if="showOverlay" class="psw-key"
+        <button v-for="key in keyButtons" :key="String(key.value)" class="psw-key"
+          @click="sendKey(key.value)" :title="key.title">{{ key.label }}</button>
+        <button v-if="showOverlay && !isIos" class="psw-key"
           :style="{ background: overlayOn ? '#fbbf24' : '', color: overlayOn ? '#000' : '#fbbf24' }"
           @click="toggleOverlayFn" title="Toggle Overlay">&#x1F522;</button>
       </div>
+      <button v-if="showRecording" class="psw-record-btn"
+        :class="{ 'psw-record-btn--active': recording }"
+        :disabled="!serial || recordingBusy"
+        @click="toggleRecording"
+        :title="recordingButtonTitle">
+        {{ recordingButtonLabel }}
+      </button>
+      <a v-if="recordingUrl" class="psw-record-link" :href="recordingUrl" target="_blank" rel="noopener"
+        :title="recordingFilename || 'Open recording'">MP4</a>
       <button class="psw-stream-btn" @click="toggleStream"
         :style="{ background: streaming ? '#ef444433' : '#22c55e33', color: streaming ? '#f87171' : '#4ade80' }">
         {{ streaming ? 'Stop' : 'Stream' }}
@@ -151,13 +318,19 @@ defineExpose({ startStream, stopStream, streaming })
     </div>
     <!-- Stream area -->
     <div class="psw-stream">
-      <img v-if="streaming && mode === 'screenshot' && streamImg" :src="streamImg" class="psw-img"
+      <img v-if="streaming && streamMode === 'screenshot' && streamImg" :src="streamImg" class="psw-img"
         @click="handleClick" />
-      <img v-else-if="streaming && mode === 'mjpeg' && mjpegUrl" :src="mjpegUrl" class="psw-img"
+      <img v-else-if="streaming && streamMode === 'mjpeg' && mjpegUrl" :src="mjpegUrl" class="psw-img"
         draggable="false" @click="handleClick" @dragstart.prevent />
       <div v-else class="psw-placeholder">
-        <slot name="placeholder">Click Stream to watch</slot>
+        <slot name="placeholder">{{ streamInfoStatus || recordingStatusText || (isIos ? 'Start WDA stream' : 'Click Stream to watch') }}</slot>
       </div>
+    </div>
+    <div v-if="streamInfoStatus && streaming" class="psw-record-status" :title="streamInfoStatus">
+      {{ streamInfoStatus }}
+    </div>
+    <div v-if="recordingStatusText && streaming" class="psw-record-status" :title="recordingStatusText">
+      {{ recordingStatusText }}
     </div>
     <!-- Optional slot for extra content below stream (progress, logs, etc.) -->
     <slot name="footer"></slot>
@@ -194,9 +367,28 @@ defineExpose({ startStream, stopStream, streaming })
   font-weight: 600;
   color: var(--text-3, #94a3b8);
 }
+.psw-platform {
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0;
+  padding: 1px 5px;
+  border-radius: 4px;
+  background: #1f2937;
+  color: #cbd5e1;
+}
+.psw-stream-mode {
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0;
+  padding: 1px 5px;
+  border-radius: 4px;
+  background: #0f172a;
+  color: #38bdf8;
+}
 .psw-keys {
   display: flex;
   gap: 2px;
+  flex-wrap: wrap;
 }
 .psw-key {
   padding: 2px 5px;
@@ -210,6 +402,47 @@ defineExpose({ startStream, stopStream, streaming })
 }
 .psw-key:hover { background: #252b3d; color: #e2e8f0; }
 .psw-key:active { background: #6366f133; }
+.psw-recording-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #ef4444;
+  box-shadow: 0 0 0 2px #7f1d1d55;
+  flex-shrink: 0;
+}
+.psw-record-btn {
+  padding: 2px 7px;
+  background: #1a1f2e;
+  border: 1px solid #3f1d26;
+  border-radius: 4px;
+  color: #fca5a5;
+  font-size: 9px;
+  font-weight: 700;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.psw-record-btn:hover:not(:disabled) {
+  background: #3f1d26;
+  color: #fecaca;
+}
+.psw-record-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+.psw-record-btn--active {
+  background: #ef444433;
+  border-color: #ef444466;
+  color: #fecaca;
+}
+.psw-record-link {
+  padding: 2px 5px;
+  border-radius: 4px;
+  border: 1px solid #164e63;
+  color: #67e8f9;
+  font-size: 8px;
+  font-weight: 700;
+  text-decoration: none;
+}
 .psw-stream-btn {
   margin-left: auto;
   padding: 2px 8px;
@@ -240,9 +473,22 @@ defineExpose({ startStream, stopStream, streaming })
   text-align: center;
   padding: 20px;
 }
+.psw-record-status {
+  padding: 4px 8px;
+  border-top: 1px solid #1e293b;
+  color: #94a3b8;
+  font-size: 9px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 /* Compact mode */
 .psw--compact .psw-header { padding: 4px 8px; }
 .psw--compact .psw-label { font-size: 9px; }
+.psw--compact .psw-platform { font-size: 8px; padding: 1px 4px; }
+.psw--compact .psw-stream-mode { font-size: 8px; padding: 1px 4px; }
 .psw--compact .psw-key { padding: 1px 4px; font-size: 9px; }
+.psw--compact .psw-record-btn { font-size: 8px; padding: 1px 5px; }
+.psw--compact .psw-record-link { font-size: 8px; padding: 1px 4px; }
 .psw--compact .psw-stream-btn { font-size: 8px; padding: 1px 6px; }
 </style>

--- a/frontend/src/components/benchmark/BenchmarkTab.vue
+++ b/frontend/src/components/benchmark/BenchmarkTab.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref, computed } from 'vue'
+import { onMounted, onUnmounted, ref, computed, watch } from 'vue'
 import { useBenchmarkStore } from '@/stores/benchmarks'
 
 const store = useBenchmarkStore()
@@ -17,18 +17,57 @@ const runModel = ref('gemma3:4b')
 const runDevice = ref('emulator-5554')
 const selectAll = ref(false)
 
-const PROVIDERS = [
+type Provider = {
+  id: string
+  label: string
+  models: string[]
+}
+
+const PROVIDERS: Provider[] = [
   { id: 'claude-code', label: 'Claude Code', models: ['sonnet', 'opus', 'haiku'] },
   { id: 'anthropic', label: 'Claude API', models: ['claude-sonnet-4-20250514', 'claude-opus-4-20250514'] },
   { id: 'openrouter', label: 'OpenRouter', models: ['anthropic/claude-sonnet-4', 'google/gemini-2.5-pro'] },
   { id: 'ollama', label: 'Ollama (local)', models: ['llama3.2:3b', 'gemma3:4b', 'qwen3:4b', 'phi4-mini:3.8b', 'mistral:7b'] },
 ]
 
-const currentModels = computed(() => PROVIDERS.find(p => p.id === runProvider.value)?.models || [])
+const currentModels = computed<string[]>(() => PROVIDERS.find(p => p.id === runProvider.value)?.models || [])
+const runPlatform = computed<'android' | 'ios'>(() => runDevice.value.trim().startsWith('ios:') ? 'ios' : 'android')
+const selectedTaskIds = computed(() => [...selectedTasks.value])
+const tasksForRun = computed(() => {
+  if (!selectedTasks.value.size) return store.tasks
+  const selected = selectedTasks.value
+  return store.tasks.filter(t => selected.has(t.id))
+})
+const unsupportedTasksForRun = computed(() => tasksForRun.value.filter(t => !taskSupportsPlatform(t, runPlatform.value)))
+const canStartRun = computed(() => store.tasks.length > 0 && unsupportedTasksForRun.value.length === 0)
+const runButtonTitle = computed(() => {
+  if (!store.tasks.length) return 'No benchmark tasks loaded'
+  if (!unsupportedTasksForRun.value.length) return ''
+  const sample = unsupportedTasksForRun.value.slice(0, 3).map(t => t.id).join(', ')
+  const suffix = unsupportedTasksForRun.value.length > 3 ? ` and ${unsupportedTasksForRun.value.length - 3} more` : ''
+  return `${sample}${suffix} ${unsupportedTasksForRun.value.length === 1 ? 'does' : 'do'} not support ${runPlatform.value}`
+})
+
+function taskPlatforms(task: any): string[] {
+  const platforms = Array.isArray(task.platforms) && task.platforms.length ? task.platforms : ['android']
+  return platforms.map((p: string) => String(p).toLowerCase())
+}
+
+function taskSupportsPlatform(task: any, platform: 'android' | 'ios') {
+  const platforms = taskPlatforms(task)
+  return platforms.includes('all') || platforms.includes(platform)
+}
+
+function taskPlatformLabel(task: any) {
+  const platforms = taskPlatforms(task)
+  if (platforms.includes('all')) return 'All'
+  return platforms.map((p: string) => p === 'ios' ? 'iOS' : 'Android').join(', ')
+}
 
 function onProviderChange() {
   const p = PROVIDERS.find(p => p.id === runProvider.value)
-  if (p?.models.length) runModel.value = p.models[0]
+  const firstModel = p?.models[0]
+  if (firstModel) runModel.value = firstModel
 }
 
 // Also try to fetch live Ollama models
@@ -40,7 +79,8 @@ async function fetchOllamaModels() {
       const ollama = providers.find((p: any) => p.id === 'ollama')
       if (ollama?.models?.length) {
         const idx = PROVIDERS.findIndex(p => p.id === 'ollama')
-        if (idx >= 0) PROVIDERS[idx].models = ollama.models
+        const provider = idx >= 0 ? PROVIDERS[idx] : null
+        if (provider) provider.models = ollama.models
       }
     }
   } catch {}
@@ -58,16 +98,37 @@ function showToast(msg: string, type: 'ok' | 'err' = 'ok') {
 }
 
 function toggleSelectAll() {
-  if (selectAll.value) store.tasks.forEach(t => selectedTasks.value.add(t.id))
-  else selectedTasks.value.clear()
+  if (selectAll.value) {
+    const compatible = store.tasks.filter(t => taskSupportsPlatform(t, runPlatform.value))
+    selectedTasks.value = new Set(compatible.map(t => t.id))
+    if (!compatible.length) {
+      selectAll.value = false
+      showToast(`No ${runPlatform.value} benchmark tasks are available`, 'err')
+    }
+  } else {
+    selectedTasks.value = new Set()
+  }
 }
 
 function toggleTask(id: string) {
-  if (selectedTasks.value.has(id)) selectedTasks.value.delete(id)
-  else selectedTasks.value.add(id)
+  const task = store.tasks.find(t => t.id === id)
+  if (task && !taskSupportsPlatform(task, runPlatform.value)) {
+    showToast(`${id} does not support ${runPlatform.value}`, 'err')
+    return
+  }
+  const next = new Set(selectedTasks.value)
+  if (next.has(id)) next.delete(id)
+  else next.add(id)
+  selectedTasks.value = next
+  const compatibleCount = store.tasks.filter(t => taskSupportsPlatform(t, runPlatform.value)).length
+  selectAll.value = compatibleCount > 0 && next.size === compatibleCount
 }
 
 async function startRun() {
+  if (!canStartRun.value) {
+    showToast(runButtonTitle.value || `No compatible ${runPlatform.value} benchmark tasks selected`, 'err')
+    return
+  }
   const ids = selectedTasks.value.size > 0 ? [...selectedTasks.value] : null
   try {
     const result = await store.startRun(runSuite.value, ids, runModel.value, runDevice.value, runProvider.value)
@@ -109,6 +170,12 @@ async function handleStop(id: string) {
 }
 
 const activeRun = computed(() => store.runs.find(r => r.status === 'running'))
+
+watch(runPlatform, () => {
+  const allowed = new Set(store.tasks.filter(t => taskSupportsPlatform(t, runPlatform.value)).map(t => t.id))
+  selectedTasks.value = new Set(selectedTaskIds.value.filter(id => allowed.has(id)))
+  selectAll.value = selectedTasks.value.size > 0 && selectedTasks.value.size === allowed.size
+})
 
 onMounted(async () => {
   await Promise.all([store.fetchSuites(), store.fetchTasks(), store.fetchRuns()])
@@ -159,15 +226,23 @@ onUnmounted(() => {
               <option v-for="m in currentModels" :key="m" :value="m">{{ m }}</option>
             </select>
             <input v-model="runDevice" class="text-xs px-2 py-1 rounded" style="background: var(--bg-deep); border: 1px solid var(--border); color: var(--text-2); width: 140px" placeholder="device serial" />
-            <button @click="startRun" class="ml-auto px-4 py-1.5 text-sm font-semibold rounded-lg" style="background: #059669; color: white">
+            <span class="text-xs px-2 py-1 rounded font-semibold" style="background: var(--bg-deep); color: var(--text-3); border: 1px solid var(--border)">
+              {{ runPlatform === 'ios' ? 'iOS' : 'Android' }}
+            </span>
+            <button @click="startRun" :disabled="!canStartRun" :title="runButtonTitle"
+              class="ml-auto px-4 py-1.5 text-sm font-semibold rounded-lg disabled:cursor-not-allowed disabled:opacity-50"
+              style="background: #059669; color: white">
               Run {{ selectedTasks.size || 'All' }} Tasks
             </button>
+          </div>
+          <div v-if="unsupportedTasksForRun.length" class="card px-4 py-2 text-xs" style="border-color: #f59e0b55; color: #fbbf24; background: #f59e0b0d">
+            {{ unsupportedTasksForRun.length }} {{ selectedTasks.size ? 'selected' : 'available' }} benchmark task{{ unsupportedTasksForRun.length === 1 ? '' : 's' }} cannot run on {{ runPlatform }}.
           </div>
 
           <div class="card" style="min-height: 200px">
             <div class="flex items-center justify-between mb-3">
               <h2 class="text-base font-semibold" style="color: var(--text-1)">Ghost Bench</h2>
-              <span class="text-xs" style="color: var(--text-4)">{{ store.tasks.length }} tasks</span>
+              <span class="text-xs" style="color: var(--text-4)">{{ store.tasks.length }} tasks · {{ runPlatform }}</span>
             </div>
             <div class="overflow-x-auto">
               <table class="w-full text-sm">
@@ -177,16 +252,23 @@ onUnmounted(() => {
                     <th class="pb-2 pr-2">Task</th>
                     <th class="pb-2 pr-2">Goal</th>
                     <th class="pb-2 pr-2">Category</th>
+                    <th class="pb-2 pr-2">Platform</th>
                     <th class="pb-2 pr-2">Steps</th>
                   </tr>
                 </thead>
                 <tbody>
                   <tr v-for="task in store.tasks" :key="task.id" class="border-t" style="border-color: var(--border)"
-                    :class="{ 'bg-indigo-500/5': selectedTasks.has(task.id) }">
-                    <td class="py-2 pr-2"><input type="checkbox" :checked="selectedTasks.has(task.id)" @change="toggleTask(task.id)" /></td>
+                    :class="{ 'bg-indigo-500/5': selectedTasks.has(task.id), 'opacity-50': !taskSupportsPlatform(task, runPlatform) }">
+                    <td class="py-2 pr-2"><input type="checkbox" :checked="selectedTasks.has(task.id)" :disabled="!taskSupportsPlatform(task, runPlatform)" @change="toggleTask(task.id)" /></td>
                     <td class="py-2 pr-2 font-mono text-xs" style="color: var(--text-2)">{{ task.id }}</td>
                     <td class="py-2 pr-2 truncate" style="color: var(--text-1); max-width: 280px" :title="task.goal">{{ task.goal }}</td>
                     <td class="py-2 pr-2 text-xs" style="color: var(--text-3)">{{ task.category }}</td>
+                    <td class="py-2 pr-2 text-xs">
+                      <span class="px-2 py-0.5 rounded-full font-semibold"
+                        :style="{ background: taskSupportsPlatform(task, runPlatform) ? '#05966922' : '#64748b22', color: taskSupportsPlatform(task, runPlatform) ? '#34d399' : 'var(--text-4)' }">
+                        {{ taskPlatformLabel(task) }}
+                      </span>
+                    </td>
                     <td class="py-2 pr-2 text-xs" style="color: var(--text-3)">{{ task.max_steps }}</td>
                   </tr>
                 </tbody>

--- a/frontend/src/components/emulator/EmulatorList.vue
+++ b/frontend/src/components/emulator/EmulatorList.vue
@@ -20,7 +20,10 @@ const busy = ref<Set<string>>(new Set())
 async function act(name: string, event: 'start' | 'stop' | 'delete' | 'setup') {
   busy.value.add(name)
   try {
-    emit(event, name)
+    if (event === 'start') emit('start', name)
+    else if (event === 'stop') emit('stop', name)
+    else if (event === 'delete') emit('delete', name)
+    else emit('setup', name)
   } finally {
     // Clear after a short delay so the poll can update status first
     setTimeout(() => busy.value.delete(name), 3000)

--- a/frontend/src/composables/useH264Stream.ts
+++ b/frontend/src/composables/useH264Stream.ts
@@ -1,0 +1,155 @@
+/**
+ * GhostAgent H.264 stream client — decodes the WebSocket Annex-B H.264 stream
+ * (proxied by the Ghost backend at /api/phone/h264/<device>) with WebCodecs and
+ * renders to a <canvas>. Robust by design: auto-reconnects, surfaces detailed
+ * metrics, waits for a keyframe, and BOUNDS LATENCY by dropping the backlog when
+ * decode/draw can't keep up (so it stays live instead of drifting seconds behind).
+ *
+ * Metrics (the important part for diagnosing "lag"):
+ *   recvFps    — H.264 access units arriving per second (network throughput)
+ *   renderFps  — frames actually painted per second
+ *   queue      — decoder backlog; if this grows, latency is accumulating
+ *   latencyMs  — decode→paint latency of the most recent frame
+ *   kbps       — bandwidth
+ *   dropped    — frames skipped to stay live
+ */
+import { ref, type Ref } from 'vue'
+
+export function h264Supported(): boolean {
+  return typeof window !== 'undefined' && 'VideoDecoder' in window
+}
+
+function nalType(byte: number): number { return byte & 0x1f }
+function isKeyframe(buf: Uint8Array): boolean {
+  for (let i = 0; i + 4 < buf.length; i++) {
+    if (buf[i] === 0 && buf[i + 1] === 0 && (buf[i + 2] === 1 || (buf[i + 2] === 0 && buf[i + 3] === 1))) {
+      const s = buf[i + 2] === 1 ? i + 3 : i + 4
+      const t = nalType(buf[s] ?? 0)
+      if (t === 5 || t === 7) return true
+      if (t === 1) return false
+    }
+  }
+  return false
+}
+
+export interface H264Metrics {
+  status: Ref<string>
+  recvFps: Ref<number>
+  renderFps: Ref<number>
+  queue: Ref<number>
+  latencyMs: Ref<number>
+  kbps: Ref<number>
+  dropped: Ref<number>
+  stop: () => void
+}
+
+// If the decoder falls this far behind, drop everything until the next keyframe
+// so latency can't run away. Keyframes arrive ~every 2s, so this bounds lag.
+const MAX_QUEUE = 4
+
+export function startH264Stream(wsUrl: string, canvas: HTMLCanvasElement): H264Metrics {
+  const status = ref('connecting')
+  const recvFps = ref(0)
+  const renderFps = ref(0)
+  const queue = ref(0)
+  const latencyMs = ref(0)
+  const kbps = ref(0)
+  const dropped = ref(0)
+
+  const ctx = canvas.getContext('2d')
+  let decoder: VideoDecoder | null = null
+  let ws: WebSocket | null = null
+  let stopped = false
+  let haveKeyframe = false
+  let reconnectTimer: number | null = null
+  let backoff = 500
+
+  // rolling-window counters (reset each second by the metrics timer)
+  let recvWin = 0, renderWin = 0, byteWin = 0
+  let lastDecodeAt = 0
+
+  const metricsTimer = window.setInterval(() => {
+    recvFps.value = recvWin; renderFps.value = renderWin
+    kbps.value = Math.round(byteWin * 8 / 1000)
+    queue.value = decoder ? decoder.decodeQueueSize : 0
+    recvWin = 0; renderWin = 0; byteWin = 0
+  }, 1000)
+
+  function setupDecoder() {
+    try {
+      decoder = new VideoDecoder({
+        output: (frame: VideoFrame) => {
+          try {
+            if (ctx) {
+              if (canvas.width !== frame.displayWidth) canvas.width = frame.displayWidth
+              if (canvas.height !== frame.displayHeight) canvas.height = frame.displayHeight
+              ctx.drawImage(frame, 0, 0)
+            }
+            renderWin++
+            if (lastDecodeAt) latencyMs.value = Math.round(performance.now() - lastDecodeAt)
+          } finally { frame.close() }
+        },
+        error: () => { status.value = 'decoder error — reconnecting'; scheduleReconnect() },
+      })
+      decoder.configure({ codec: 'avc1.42E01E', optimizeForLatency: true } as VideoDecoderConfig)
+    } catch { status.value = 'WebCodecs unavailable'; decoder = null }
+  }
+
+  function onBinary(data: ArrayBuffer) {
+    if (!decoder || decoder.state !== 'configured') return
+    const buf = new Uint8Array(data)
+    recvWin++; byteWin += buf.length
+    const key = isKeyframe(buf)
+
+    // Latency bound: if we're behind, drop until the next keyframe.
+    if (decoder.decodeQueueSize > MAX_QUEUE && !key) { dropped.value++; return }
+    if (!haveKeyframe) { if (!key) return; haveKeyframe = true; status.value = 'streaming' }
+
+    try {
+      lastDecodeAt = performance.now()
+      decoder.decode(new EncodedVideoChunk({ type: key ? 'key' : 'delta', timestamp: lastDecodeAt * 1000, data: buf }))
+    } catch { haveKeyframe = false }
+  }
+
+  function connect() {
+    if (stopped) return
+    haveKeyframe = false
+    setupDecoder()
+    try { ws = new WebSocket(wsUrl); ws.binaryType = 'arraybuffer' } catch { scheduleReconnect(); return }
+    ws.onopen = () => { status.value = 'connected'; backoff = 500 }
+    ws.onmessage = (ev: MessageEvent) => {
+      if (typeof ev.data === 'string') {
+        try { const j = JSON.parse(ev.data); if (j.status) status.value = j.status } catch {}
+        return
+      }
+      onBinary(ev.data as ArrayBuffer)
+    }
+    ws.onclose = () => { if (!stopped) scheduleReconnect() }
+    ws.onerror = () => { try { ws?.close() } catch {} }
+  }
+
+  function scheduleReconnect() {
+    if (stopped || reconnectTimer != null) return
+    status.value = 'reconnecting'
+    cleanupConnection()
+    reconnectTimer = window.setTimeout(() => { reconnectTimer = null; backoff = Math.min(5000, backoff * 2); connect() }, backoff)
+  }
+
+  function cleanupConnection() {
+    try { ws?.close() } catch {}
+    ws = null
+    try { if (decoder && decoder.state !== 'closed') decoder.close() } catch {}
+    decoder = null
+  }
+
+  function stop() {
+    stopped = true
+    clearInterval(metricsTimer)
+    if (reconnectTimer != null) { clearTimeout(reconnectTimer); reconnectTimer = null }
+    cleanupConnection()
+    status.value = 'stopped'
+  }
+
+  connect()
+  return { status, recvFps, renderFps, queue, latencyMs, kbps, dropped, stop }
+}

--- a/frontend/src/stores/benchmarks.ts
+++ b/frontend/src/stores/benchmarks.ts
@@ -9,6 +9,9 @@ export interface BenchmarkTask {
   category: string
   complexity: number
   max_steps: number
+  platforms?: string[]
+  supports_android?: boolean
+  supports_ios?: boolean
 }
 
 export interface BenchmarkSuite {

--- a/frontend/src/views/BotView.vue
+++ b/frontend/src/views/BotView.vue
@@ -4,7 +4,7 @@ import { api } from '@/composables/useApi'
 
 /* ── State ── */
 const activity = ref('post')
-const devices = ref<{serial: string; nickname?: string; model?: string; label?: string}[]>([])
+const devices = ref<{serial: string; nickname?: string; model?: string; label?: string; platform?: string}[]>([])
 const selectedDevice = ref('')
 const accounts = ref<{handle: string; is_default?: number}[]>([])
 const selectedAccount = ref('')
@@ -40,11 +40,24 @@ const history = ref<any[]>([])
 
 /* ── Computed ── */
 const startButtonLabel = computed(() => {
+  if (!selectedActivitySupported.value) return 'Not Available on iOS'
   const labels: Record<string, string> = {
     post: '📹 Start Upload',
     publish_draft: '📤 Publish Draft',
   }
   return labels[activity.value] || '▶ Start'
+})
+const selectedDeviceRow = computed(() => devices.value.find(d => d.serial === selectedDevice.value))
+const selectedDevicePlatform = computed<'android' | 'ios'>(() => {
+  const platform = String(selectedDeviceRow.value?.platform || '').toLowerCase()
+  if (platform === 'ios') return 'ios'
+  return selectedDevice.value.startsWith('ios:') ? 'ios' : 'android'
+})
+const selectedActivitySupported = computed(() => selectedDevicePlatform.value !== 'ios')
+const selectedActivitySupportMessage = computed(() => {
+  if (selectedActivitySupported.value) return ''
+  const label = activity.value === 'publish_draft' ? 'Publish draft' : 'Post'
+  return `${label} jobs are Android-only until the iOS TikTok workflow is ported.`
 })
 
 /* ── Data loading ── */
@@ -52,7 +65,8 @@ async function loadDevices() {
   try {
     const resp = await api('/api/phone/devices')
     devices.value = resp.devices || resp || []
-    if (devices.value.length && !selectedDevice.value) selectedDevice.value = devices.value[0].serial
+    const firstDevice = devices.value[0]
+    if (firstDevice && !selectedDevice.value) selectedDevice.value = firstDevice.serial
   } catch { /* ignore */ }
 }
 
@@ -186,6 +200,10 @@ function pbVideoClear() {
   postVideoLabel.value = ''
 }
 
+function hidePostVideoDropdownSoon() {
+  window.setTimeout(() => { postVideoDropdownVisible.value = false }, 150)
+}
+
 /* ── Hashtag pill helpers ── */
 function addHashtag(e?: KeyboardEvent) {
   const raw = postHashtagInput.value.trim().replace(/^#/, '')
@@ -204,6 +222,10 @@ function removeHashtag(tag: string) {
 
 /* ── Actions ── */
 async function botStart() {
+  if (!selectedActivitySupported.value) {
+    alert(selectedActivitySupportMessage.value)
+    return
+  }
   const device = selectedDevice.value
   const account = selectedAccount.value.replace(/^@/, '') || undefined
   const payload: any = { job_type: activity.value, device, account }
@@ -228,7 +250,7 @@ async function botStart() {
       pollStart()
       loadHistory()
     } else {
-      alert((r && r.error) || 'Failed to add job')
+      alert((r && (r.message || r.error)) || 'Failed to add job')
     }
   } catch (e: any) {
     alert('Failed: ' + e.message)
@@ -268,6 +290,14 @@ function phoneName(serial: string): string {
   const ph = devices.value.find(p => p.serial === serial)
   if (ph) return ph.nickname || ph.model || ph.label || serial.slice(0, 5)
   return serial.slice(0, 5)
+}
+
+function deviceLabel(d: {serial: string; nickname?: string; model?: string; label?: string; platform?: string}): string {
+  const name = d.nickname || d.model || d.label || d.serial
+  const platform = (d.platform || (d.serial.startsWith('ios:') ? 'ios' : 'android')).toLowerCase() === 'ios'
+    ? 'iOS'
+    : 'Android'
+  return `${name} (${platform}, ${d.serial.slice(0, 4)}…)`
 }
 
 function historyName(r: any): string {
@@ -362,7 +392,7 @@ onUnmounted(() => { pollStop() })
                 autocomplete="off" class="bot-input" style="width: 100%; box-sizing: border-box; max-width: none"
                 @input="pbVideoFilter(postVideoSearch)"
                 @focus="postVideoDropdownVisible = true"
-                @blur="setTimeout(() => postVideoDropdownVisible = false, 150)" />
+                @blur="hidePostVideoDropdownSoon" />
               <div v-if="postVideoDropdownVisible && postVideoResults.length"
                 style="position: absolute; top: 100%; left: 0; right: 0; z-index: 200;
                   background: #0f172a; border: 1px solid #1e293b; border-radius: 6px;
@@ -444,7 +474,16 @@ onUnmounted(() => { pollStop() })
 
         <!-- Start / Stop -->
         <div style="display: flex; flex-direction: column; gap: 8px">
-          <button v-if="!botRunning" class="btn btn-primary" style="width: 100%; justify-content: center; display: flex; align-items: center; gap: 6px" @click="botStart">
+          <div v-if="selectedActivitySupportMessage"
+            style="font-size: 11px; line-height: 1.4; color: #fbbf24; background: #f59e0b0d; border: 1px solid #f59e0b33; border-radius: 6px; padding: 7px 9px">
+            {{ selectedActivitySupportMessage }}
+          </div>
+          <button v-if="!botRunning" class="btn btn-primary"
+            :disabled="!selectedActivitySupported"
+            :title="selectedActivitySupportMessage"
+            style="width: 100%; justify-content: center; display: flex; align-items: center; gap: 6px"
+            :style="{ opacity: selectedActivitySupported ? 1 : 0.5, cursor: selectedActivitySupported ? 'pointer' : 'not-allowed' }"
+            @click="botStart">
             {{ startButtonLabel }}
           </button>
           <button v-else style="width: 100%; justify-content: center; display: flex; align-items: center; gap: 6px;
@@ -460,7 +499,7 @@ onUnmounted(() => { pollStop() })
         <div class="bot-row">
           <label class="bot-label">Device</label>
           <select v-model="selectedDevice" class="bot-select" style="flex: 1">
-            <option v-for="d in devices" :key="d.serial" :value="d.serial">{{ (d.nickname || d.model || d.label || d.serial) + ' (' + d.serial.slice(0, 4) + '\u2026)' }}</option>
+            <option v-for="d in devices" :key="d.serial" :value="d.serial">{{ deviceLabel(d) }}</option>
           </select>
         </div>
 

--- a/frontend/src/views/DeviceHealthView.vue
+++ b/frontend/src/views/DeviceHealthView.vue
@@ -1,0 +1,230 @@
+<script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue'
+import { api } from '@/composables/useApi'
+
+interface TestFile { file: string; tests: string[] }
+
+const testCatalog = ref<TestFile[]>([])
+const devices = ref<any[]>([])
+const selectedTest = ref('')
+const phoneStates = ref<Record<string, any>>({})
+const phoneLogs = ref<Record<string, string[]>>({})
+const phoneLogSeq = ref<Record<string, number>>({})
+const phoneAutoScroll = ref<Record<string, boolean>>({})
+const loading = ref(false)
+let pollTimer: number | null = null
+
+/* Curate the catalog down to health/smoke-relevant tests. */
+const HEALTH_RE = /health|smoke|news/i
+const healthTests = computed(() =>
+  testCatalog.value.filter(f => HEALTH_RE.test(f.file))
+)
+
+function healthColor(status: string): string {
+  const s = (status || '').toLowerCase()
+  if (['available', 'ready', 'connected', 'online'].includes(s)) return '#22c55e'
+  if (!s) return '#6b7280'
+  return '#f87171'
+}
+function healthLabel(status: string): string {
+  const s = (status || '').toLowerCase()
+  if (['available', 'ready', 'connected', 'online'].includes(s)) return 'HEALTHY'
+  if (!s) return 'UNKNOWN'
+  return 'DEGRADED'
+}
+function checks(d: any): { label: string; ok: boolean; detail: string }[] {
+  const c = d?.details?.checks || {}
+  const out: { label: string; ok: boolean; detail: string }[] = []
+  if ('appium_status_code' in c)
+    out.push({ label: 'Appium', ok: c.appium_status_code === 200, detail: String(c.appium_status_code ?? '') })
+  if (c.remote_xpc_tunnel)
+    out.push({ label: 'Tunnel', ok: !!c.remote_xpc_tunnel.ok, detail: c.remote_xpc_tunnel.state || '' })
+  if (c.host_device)
+    out.push({ label: 'USB', ok: (c.host_device.state || '') === 'connected', detail: c.host_device.state || '' })
+  return out
+}
+function phoneName(d: any): string {
+  return d.nickname || d.model || d.device_name || d.label || d.serial
+}
+
+async function load() {
+  loading.value = true
+  try {
+    const [t, d] = await Promise.all([
+      api('/api/tests').catch(() => []),
+      api('/api/phone/devices').catch(() => ({ devices: [] })),
+    ])
+    testCatalog.value = Array.isArray(t) ? t : t.tests || []
+    devices.value = d.devices || d || []
+    if (!selectedTest.value) {
+      const smoke = healthTests.value.find(f => /chrome_news_smoke_device/.test(f.file))
+      if (smoke) {
+        const t2 = smoke.tests.find(x => /on_device/.test(x)) || ''
+        selectedTest.value = smoke.file + '|' + t2
+      } else if (healthTests.value[0]) {
+        selectedTest.value = healthTests.value[0].file + '|'
+      }
+    }
+  } finally {
+    loading.value = false
+  }
+}
+
+async function runCheck(serial: string) {
+  if (!selectedTest.value) { alert('Select a health check first'); return }
+  const [file, test] = selectedTest.value.split('|')
+  phoneStates.value[serial] = { running: true, returncode: null }
+  phoneLogs.value[serial] = []
+  phoneLogSeq.value[serial] = 0
+  phoneAutoScroll.value[serial] = true
+  await api('/api/test-runner/start', {
+    method: 'POST',
+    body: JSON.stringify({ file, test: test || '', device: serial, retry: false }),
+  })
+  if (!pollTimer) pollTimer = window.setInterval(pollStatus, 1500)
+}
+
+async function stopCheck(serial: string) {
+  await api('/api/test-runner/stop', { method: 'POST', body: JSON.stringify({ device: serial }) })
+}
+
+async function pollStatus() {
+  try {
+    const s = await api('/api/test-runner/status')
+    phoneStates.value = s.devices || s || {}
+    for (const serial of Object.keys(phoneStates.value)) await pollDeviceLogs(serial)
+    const anyRunning = Object.values(phoneStates.value).some((d: any) => d.running)
+    if (!anyRunning && pollTimer) { clearInterval(pollTimer); pollTimer = null; await load() }
+  } catch {}
+}
+
+async function pollDeviceLogs(serial: string) {
+  try {
+    const since = phoneLogSeq.value[serial] || 0
+    const resp = await api(`/api/test-runner/logs?device=${serial}&since=${since}`)
+    if (resp.lines?.length) {
+      if (!phoneLogs.value[serial]) phoneLogs.value[serial] = []
+      phoneLogs.value[serial].push(...resp.lines)
+      phoneLogSeq.value[serial] = resp.total
+      if (phoneLogs.value[serial].length > 400) phoneLogs.value[serial] = phoneLogs.value[serial].slice(-250)
+      await nextTick()
+      if (phoneAutoScroll.value[serial]) {
+        const el = document.getElementById(`hlog-${serial}`)
+        if (el) el.scrollTop = el.scrollHeight
+      }
+    }
+  } catch {}
+}
+
+onMounted(load)
+onUnmounted(() => { if (pollTimer) clearInterval(pollTimer) })
+</script>
+
+<template>
+  <div>
+    <!-- Intro -->
+    <div class="card p-4 mb-4">
+      <div class="flex items-center justify-between">
+        <div>
+          <div class="text-sm font-semibold" style="color: var(--text-1)">🩺 Device Health</div>
+          <div class="text-xs mt-1" style="color: var(--text-4)">
+            Live device status + on-demand health/smoke checks. Runs real end-to-end tests through the device backend.
+          </div>
+        </div>
+        <button class="text-xs" style="color: var(--text-5); cursor: pointer" @click="load">
+          {{ loading ? '…' : 'Refresh' }}
+        </button>
+      </div>
+    </div>
+
+    <!-- Health check selector -->
+    <div class="card p-4 mb-4">
+      <div class="text-xs font-semibold uppercase tracking-widest mb-3" style="color: var(--text-3)">Health check</div>
+      <select v-model="selectedTest"
+        style="width: 100%; padding: 7px 10px; font-size: 13px; background: var(--bg-deep); border: 1px solid var(--border); border-radius: 8px; color: var(--text-1)">
+        <optgroup v-for="f in healthTests" :key="f.file" :label="f.file.replace(/\.py$/, '')">
+          <option :value="f.file + '|'">&mdash; all in {{ f.file.replace(/\.py$/, '') }} &mdash;</option>
+          <option v-for="t in f.tests" :key="t" :value="f.file + '|' + t">{{ t }}</option>
+        </optgroup>
+      </select>
+      <div v-if="!healthTests.length" class="text-xs mt-2" style="color: var(--text-5)">
+        No health/smoke tests found. (Looking for files matching health / smoke / news.)
+      </div>
+    </div>
+
+    <!-- Device cards -->
+    <div class="grid grid-cols-1 gap-4">
+      <div v-for="d in devices" :key="d.serial" class="card p-4 flex flex-col gap-3">
+        <!-- status header -->
+        <div class="flex items-center gap-3">
+          <div :style="{ width: '10px', height: '10px', borderRadius: '50%', flexShrink: 0, background: healthColor(d.status), boxShadow: `0 0 8px ${healthColor(d.status)}` }" />
+          <div class="flex-1" style="min-width: 0">
+            <div class="text-sm font-semibold" style="color: var(--text-1)">
+              {{ phoneName(d) }}
+              <span style="color: var(--text-5); font-weight: 400">· {{ (d.platform || '').toUpperCase() }} {{ d.platform_version || '' }}</span>
+            </div>
+            <div class="text-xs" style="color: var(--text-5)">{{ d.serial }}</div>
+          </div>
+          <span :style="{ padding: '2px 8px', borderRadius: '10px', fontSize: '10px', fontWeight: 700, background: healthColor(d.status) + '22', color: healthColor(d.status) }">
+            {{ healthLabel(d.status) }}
+          </span>
+        </div>
+
+        <!-- status message -->
+        <div v-if="d.status_message && healthLabel(d.status) !== 'HEALTHY'"
+          class="text-xs" style="color: #fbbf24; background: #2a220a; border-radius: 6px; padding: 6px 9px">
+          {{ d.status_message }}
+        </div>
+
+        <!-- sub-checks -->
+        <div v-if="checks(d).length" class="flex flex-wrap gap-2">
+          <span v-for="c in checks(d)" :key="c.label"
+            :style="{ fontSize: '11px', padding: '2px 8px', borderRadius: '6px', background: 'var(--bg-deep)', border: '1px solid var(--border)', color: c.ok ? '#4ade80' : '#f87171' }">
+            {{ c.ok ? '✓' : '✕' }} {{ c.label }}<span v-if="c.detail" style="opacity:0.6"> · {{ c.detail }}</span>
+          </span>
+        </div>
+
+        <!-- run controls -->
+        <div class="flex gap-2 items-center">
+          <button class="btn btn-primary" style="justify-content: center; display: flex; align-items: center; gap: 5px; font-size: 12px; padding: 5px 14px"
+            @click="runCheck(d.serial)" :disabled="phoneStates[d.serial]?.running">
+            &#9654; Run health check
+          </button>
+          <button v-show="phoneStates[d.serial]?.running" class="btn"
+            style="font-size: 12px; padding: 5px 14px; background: #7f1d1d; color: #fca5a5; border: none"
+            @click="stopCheck(d.serial)">&#9632; Stop</button>
+          <span v-if="phoneStates[d.serial]?.returncode === 0"
+            style="padding: 2px 8px; border-radius: 10px; font-size: 10px; font-weight: 700; background: #14532d; color: #4ade80">PASSED</span>
+          <span v-else-if="phoneStates[d.serial]?.returncode != null"
+            style="padding: 2px 8px; border-radius: 10px; font-size: 10px; font-weight: 700; background: #450a0a; color: #f87171">FAILED</span>
+        </div>
+
+        <!-- live logs -->
+        <div v-if="phoneLogs[d.serial]?.length || phoneStates[d.serial]?.running">
+          <div class="flex items-center justify-between mb-1">
+            <span class="text-xs font-semibold" style="color: var(--text-4)">Live logs</span>
+            <label class="flex items-center gap-1 text-xs cursor-pointer" style="color: var(--text-4)">
+              <input type="checkbox" :checked="phoneAutoScroll[d.serial] !== false"
+                @change="phoneAutoScroll[d.serial] = ($event.target as HTMLInputElement).checked"
+                style="width: 10px; height: 10px; accent-color: var(--accent)" /> auto-scroll
+            </label>
+          </div>
+          <div :id="`hlog-${d.serial}`"
+            style="height: 200px; overflow-y: auto; background: var(--bg-deep); border: 1px solid var(--border); border-radius: 8px; padding: 8px 10px; font-family: 'SF Mono','Fira Code',monospace; font-size: 11px; line-height: 1.55; white-space: pre-wrap; word-break: break-all">
+            <div v-for="(line, i) in (phoneLogs[d.serial] || []).slice(-200)" :key="i"
+              :style="{ color: line.includes('PASSED') ? '#4ade80' : (line.includes('FAILED') || line.includes('ERROR')) ? '#f87171' : line.includes('SKIP') ? '#94a3b8' : 'var(--text-3)' }">{{ line }}</div>
+            <div v-if="phoneStates[d.serial]?.running && !(phoneLogs[d.serial] || []).length" style="color: var(--text-4)">Waiting for output…</div>
+          </div>
+        </div>
+      </div>
+
+      <div v-if="!devices.length" class="card p-4 text-sm" style="color: var(--text-5)">
+        No devices connected. Start the stack with <code>ghost-ios up</code>.
+      </div>
+    </div>
+
+    <div class="text-xs mt-4" style="color: var(--text-5)">
+      Full test catalog + recordings live in the 🧪 Tests tab.
+    </div>
+  </div>
+</template>

--- a/frontend/src/views/ExplorerView.vue
+++ b/frontend/src/views/ExplorerView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { api } from '@/composables/useApi'
 import PhoneStreamWidget from '@/components/PhoneStreamWidget.vue'
 
@@ -10,13 +10,23 @@ interface AppState {
   state_id: string; screenshot_path: string; elements: any[]; depth: number; activity: string
   transitions: Record<string, string>
 }
+interface InstalledApp {
+  name: string
+  package: string
+  bundle_id?: string
+  platform?: string
+  verified?: boolean
+  installed?: boolean
+  app_state_name?: string
+  verification_error?: string
+}
 
-const devices = ref<{serial: string; nickname?: string}[]>([])
+const devices = ref<{serial: string; nickname?: string; platform?: string; status?: string}[]>([])
 const runs = ref<ExplorerRun[]>([])
 const pkg = ref('')
 const device = ref('')
-const installedPackages = ref<string[]>([])
-const filteredPackages = ref<string[]>([])
+const installedApps = ref<InstalledApp[]>([])
+const filteredApps = ref<InstalledApp[]>([])
 const showPkgDropdown = ref(false)
 const maxDepth = ref(3)
 const maxStates = ref(20)
@@ -24,6 +34,12 @@ const settle = ref(1.5)
 const running = ref(false)
 const jobId = ref<number | null>(null)
 const progress = ref({ states_found: 0, transitions: 0, current_depth: 0, log_tail: [] as string[] })
+const selectedDeviceIsIos = computed(() => {
+  const selected = devices.value.find(d => d.serial === device.value)
+  return selected?.platform === 'ios' || device.value.startsWith('ios:')
+})
+const packageLabel = computed(() => selectedDeviceIsIos.value ? 'Bundle ID' : 'Package')
+const packagePlaceholder = computed(() => selectedDeviceIsIos.value ? 'com.google.chrome.ios' : 'com.zhiliaoapp.musically')
 
 const cleanLogs = computed(() => {
   return progress.value.log_tail.map(line => {
@@ -43,7 +59,8 @@ async function loadDevices() {
   try {
     const resp = await api('/api/phone/devices')
     devices.value = resp.devices || resp || []
-    if (devices.value.length && !device.value) device.value = devices.value[0].serial
+    const firstDevice = devices.value[0]
+    if (firstDevice && !device.value) device.value = firstDevice.serial
   } catch {}
 }
 
@@ -54,23 +71,40 @@ async function loadRuns() {
 async function loadPackages() {
   if (!device.value) return
   try {
-    const resp = await api(`/api/phone/packages/${device.value}`)
-    installedPackages.value = resp.packages || resp || []
-  } catch { installedPackages.value = [] }
+    const resp = await api(`/api/phone/apps/${encodeURIComponent(device.value)}`)
+    const apps = resp.apps || []
+    const packages = resp.packages || []
+    installedApps.value = apps.length
+      ? apps.map((app: any) => ({
+        ...app,
+        package: app.package || app.bundle_id || '',
+        bundle_id: app.bundle_id || app.package || '',
+        name: app.name || app.package || app.bundle_id || ''
+      }))
+      : packages.map((p: string) => ({ name: p, package: p, bundle_id: p }))
+  } catch { installedApps.value = [] }
+  filteredApps.value = installedApps.value.slice(0, 20)
 }
 
 function onPkgInput() {
   const q = pkg.value.toLowerCase()
   if (!q) {
-    filteredPackages.value = installedPackages.value.slice(0, 20)
+    filteredApps.value = installedApps.value.slice(0, 20)
   } else {
-    filteredPackages.value = installedPackages.value.filter(p => p.toLowerCase().includes(q)).slice(0, 20)
+    filteredApps.value = installedApps.value.filter(app => {
+      const haystack = `${app.name || ''} ${app.package || ''} ${app.bundle_id || ''}`.toLowerCase()
+      return haystack.includes(q)
+    }).slice(0, 20)
   }
-  showPkgDropdown.value = filteredPackages.value.length > 0
+  showPkgDropdown.value = filteredApps.value.length > 0
 }
 
-function selectPkg(p: string) {
-  pkg.value = p
+function appIdentifier(app: InstalledApp) {
+  return selectedDeviceIsIos.value ? (app.bundle_id || app.package || '') : (app.package || app.bundle_id || '')
+}
+
+function selectPkg(app: InstalledApp) {
+  pkg.value = appIdentifier(app)
   showPkgDropdown.value = false
 }
 
@@ -142,6 +176,9 @@ onMounted(async () => {
   await Promise.all([loadDevices(), loadRuns()])
   await loadPackages()
 })
+watch(device, () => {
+  loadPackages()
+})
 onUnmounted(() => {
   if (pollTimer) clearInterval(pollTimer)
 })
@@ -153,7 +190,8 @@ onUnmounted(() => {
     <div style="flex: 3; overflow-y: auto; min-width: 0">
     <div class="flex items-center gap-2 mb-4">
       <h2 class="text-lg font-bold" style="color: var(--text-1)">⛏️ Skill-Miner</h2>
-      <span v-if="installedPackages.length" class="text-xs px-2 py-0.5 rounded-full" style="background: var(--bg-deep); color: var(--text-4); border: 1px solid var(--border)">{{ installedPackages.length }} packages</span>
+      <span v-if="installedApps.length" class="text-xs px-2 py-0.5 rounded-full" style="background: var(--bg-deep); color: var(--text-4); border: 1px solid var(--border)">{{ installedApps.length }} apps</span>
+      <span v-else-if="selectedDeviceIsIos" class="text-xs px-2 py-0.5 rounded-full" style="background: var(--bg-deep); color: var(--text-4); border: 1px solid var(--border)">iOS bundle id</span>
       <span class="text-xs ml-auto flex items-center gap-1.5" :style="{ color: running ? '#f59e0b' : 'var(--text-4)' }">
         <span style="display: inline-block; width: 7px; height: 7px; border-radius: 50%" :style="{ background: running ? '#f59e0b' : '#64748b' }"></span>
         {{ running ? 'exploring...' : 'idle' }}
@@ -164,15 +202,23 @@ onUnmounted(() => {
     <div class="card mb-4">
       <div class="flex gap-3 mb-3 items-end flex-wrap">
         <div style="position: relative; min-width: 200px; max-width: 260px; flex: 1">
-          <label class="block text-xs mb-1" style="color: var(--text-3)">Package</label>
+          <label class="block text-xs mb-1" style="color: var(--text-3)">{{ packageLabel }}</label>
           <input v-model="pkg" @input="onPkgInput" @focus="onPkgInput" @blur="hidePkgDropdown" class="w-full px-3 py-2 rounded-lg text-sm"
             style="background: var(--bg-deep); border: 1px solid var(--border); color: var(--text-1)"
-            placeholder="com.zhiliaoapp.musically" />
+            :placeholder="packagePlaceholder" />
           <div v-if="showPkgDropdown" class="absolute left-0 right-0 mt-1 rounded-lg overflow-auto z-10"
             style="background: var(--bg-card); border: 1px solid var(--border); max-height: 200px; box-shadow: 0 4px 12px rgba(0,0,0,0.3)">
-            <div v-for="p in filteredPackages" :key="p" @mousedown="selectPkg(p)"
-              class="px-3 py-1.5 text-xs cursor-pointer hover:bg-white/5" style="color: var(--text-2)">
-              {{ p }}
+            <div v-for="app in filteredApps" :key="appIdentifier(app)" @mousedown="selectPkg(app)"
+              class="px-3 py-2 text-xs cursor-pointer hover:bg-white/5" style="color: var(--text-2)">
+              <div style="font-weight: 600; color: var(--text-1); overflow: hidden; text-overflow: ellipsis; white-space: nowrap">
+                {{ app.name || appIdentifier(app) }}
+              </div>
+              <div style="font-family: 'JetBrains Mono', 'Fira Code', monospace; color: var(--text-4); overflow: hidden; text-overflow: ellipsis; white-space: nowrap">
+                {{ appIdentifier(app) }}
+              </div>
+              <div v-if="selectedDeviceIsIos && app.verified === false" style="color: #f59e0b; font-size: 10px; margin-top: 2px">
+                unverified
+              </div>
             </div>
           </div>
         </div>
@@ -180,7 +226,9 @@ onUnmounted(() => {
           <label class="block text-xs mb-1" style="color: var(--text-3)">Device</label>
           <select v-model="device" class="w-full px-3 py-2 rounded-lg text-sm"
             style="background: var(--bg-deep); border: 1px solid var(--border); color: var(--text-1)">
-            <option v-for="d in devices" :key="d.serial" :value="d.serial">{{ d.nickname || d.serial }}</option>
+            <option v-for="d in devices" :key="d.serial" :value="d.serial">
+              {{ (d.nickname || d.serial) + ((d.platform === 'ios' || d.serial.startsWith('ios:')) ? ' (iOS)' : ' (Android)') }}
+            </option>
           </select>
         </div>
         <div class="flex gap-2">

--- a/frontend/src/views/PhoneAdminView.vue
+++ b/frontend/src/views/PhoneAdminView.vue
@@ -4,6 +4,9 @@ import { api } from '@/composables/useApi'
 
 const devices = ref<any[]>([])
 const selectedDevice = ref('')
+const selectedIsIos = computed(() => isIosDevice(selectedDevice.value))
+const hasIosDevices = computed(() => devices.value.some(d => isIosDevice(d.serial)))
+const hasAndroidDevices = computed(() => devices.value.some(d => !isIosDevice(d.serial)))
 const streaming = ref(false)
 const subTab = ref<'single' | 'multi'>('single')
 const nickname = ref('')
@@ -44,9 +47,144 @@ interface RtcSession { pc: RTCPeerConnection; sessionId: string; pollTimer: numb
 const rtcSessions = ref<Record<string, RtcSession>>({})
 const rtcStatus = ref<Record<string, string>>({})
 
+interface RecordingResponse {
+  ok?: boolean
+  running?: boolean
+  filename?: string
+  mode?: string
+  url?: string
+  error?: string
+}
+
+type NewsResult = {
+  ok?: boolean
+  error?: string
+  current_url?: string
+  headlines?: any[]
+  articles?: any[]
+  errors?: any[]
+  extraction?: any
+  completion?: any
+  screenshots?: Record<string, string>
+}
+
+type StreamInfo = {
+  ok?: boolean
+  platform?: string
+  requested_mode?: string
+  effective_mode?: string
+  recommended_mode?: string
+  fallback_mode?: string
+  stream_url?: string
+  mjpeg_url?: string
+  mjpeg_settings?: Record<string, unknown>
+  unsupported_actions?: string[]
+  recovery?: Record<string, unknown>
+  error?: string
+}
+
+function isIosSerial(serial: string | null | undefined): boolean {
+  return !!serial && serial.startsWith('ios:')
+}
+
+function devicePlatform(serial: string | null | undefined): 'ios' | 'android' {
+  const row = devices.value.find((d: any) => d.serial === serial)
+  const platform = String(row?.platform || row?.device_platform || '').toLowerCase()
+  if (platform === 'ios' || platform === 'android') return platform
+  return isIosSerial(serial) ? 'ios' : 'android'
+}
+
+function isIosDevice(serial: string | null | undefined): boolean {
+  return devicePlatform(serial) === 'ios'
+}
+
+function mjpegStreamUrl(serial: string): string {
+  const modeParam = isIosDevice(serial) ? '&mode=wda-mjpeg' : ''
+  return `/api/phone/stream?device=${encodeURIComponent(serial)}&fps=5${modeParam}`
+}
+
+function effectiveStreamMode(serial: string, mode: 'rtc' | 'mjpeg'): 'rtc' | 'mjpeg' {
+  return isIosDevice(serial) ? 'mjpeg' : mode
+}
+
+function streamModeText(serial: string, mode: 'rtc' | 'mjpeg'): string {
+  if (mode === 'rtc') return 'WebRTC'
+  return isIosDevice(serial) ? 'WDA MJPEG' : 'MJPEG'
+}
+
+function streamModeTitle(serial: string, mode: 'rtc' | 'mjpeg'): string {
+  if (isIosDevice(serial)) return 'iOS streams through WebDriverAgent MJPEG'
+  return mode === 'rtc' ? 'Android Portal WebRTC stream' : 'Android MJPEG fallback stream'
+}
+
+function multiStreamLabel(serial: string): string {
+  const mode = multiStreamMode.value[serial] || 'mjpeg'
+  if (mode === 'rtc') return rtcStatus.value[serial] || 'RTC'
+  return streamModeText(serial, mode)
+}
+
+function streamFallbackUrl(serial: string, fallback?: any): string {
+  const url = String(fallback?.url || '').trim()
+  return url || mjpegStreamUrl(serial)
+}
+
+const streamInfo = ref<Record<string, StreamInfo>>({})
+const streamInfoStatus = ref<Record<string, string>>({})
+
+function streamInfoModeParam(serial: string, mode: 'rtc' | 'mjpeg'): string {
+  if (isIosDevice(serial)) return 'mjpeg'
+  return mode === 'rtc' ? 'portal' : 'screencap'
+}
+
+function streamInfoTitle(serial: string): string {
+  const info = streamInfo.value[serial]
+  if (!info) return streamModeTitle(serial, multiStreamMode.value[serial] || singleStreamMode.value)
+  const parts = [
+    info.effective_mode ? `mode ${info.effective_mode}` : '',
+    info.fallback_mode ? `fallback ${info.fallback_mode}` : '',
+    info.unsupported_actions?.length ? `unsupported ${info.unsupported_actions.join(', ')}` : '',
+  ].filter(Boolean)
+  return parts.join(' | ') || streamModeTitle(serial, multiStreamMode.value[serial] || singleStreamMode.value)
+}
+
+async function resolveMjpegStreamUrl(serial: string, mode: 'rtc' | 'mjpeg'): Promise<string> {
+  const fallback = mjpegStreamUrl(serial)
+  try {
+    const info = await api<StreamInfo>(
+      `/api/phone/stream-info?device=${encodeURIComponent(serial)}&fps=5&mode=${encodeURIComponent(streamInfoModeParam(serial, mode))}`
+    )
+    streamInfo.value[serial] = info
+    streamInfoStatus.value[serial] = ''
+    return String(info.stream_url || fallback)
+  } catch (error) {
+    streamInfoStatus.value[serial] = error instanceof Error ? error.message.replace(/^API \d+:\s*/, '') : 'Stream metadata unavailable'
+    return fallback
+  }
+}
+
+function applyIosStreamFallback(serial: string, fallback?: any) {
+  rtcStatus.value[serial] = 'WDA MJPEG'
+  if (serial === selectedDevice.value) {
+    singleStreamMode.value = 'mjpeg'
+    singleMjpegUrl.value = streamFallbackUrl(serial, fallback)
+  }
+  if (multiStreaming.value[serial]) {
+    multiStreamMode.value[serial] = 'mjpeg'
+    mjpegUrls.value[serial] = streamFallbackUrl(serial, fallback)
+  }
+}
+
+function blackWarningText(serial: string): string {
+  return isIosDevice(serial) ? 'WDA stream stalled' : 'FLAG_SECURE - switch to MJPEG'
+}
+
+function streamPlaceholderText(serial: string): string {
+  return isIosDevice(serial) ? 'Press play for WDA MJPEG' : 'Press WebRTC or MJPEG'
+}
+
 function uuid(): string {
   return ([1e7] as any + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, (c: any) =>
-    (c ^ (crypto.getRandomValues(new Uint8Array(1))[0] & 15) >> c / 4).toString(16))
+    (c ^ ((crypto.getRandomValues(new Uint8Array(1))[0] ?? 0) & 15) >> c / 4).toString(16))
 }
 
 async function rtcFixPortal(serial: string) {
@@ -59,6 +197,10 @@ async function rtcFixPortal(serial: string) {
 
 async function rtcStart(serial: string, _reconnectAttempt = 0) {
   console.log(`[RTC ${serial}] rtcStart called (attempt=${_reconnectAttempt})`)
+  if (isIosDevice(serial)) {
+    applyIosStreamFallback(serial)
+    return
+  }
   if (rtcSessions.value[serial]) rtcStop(serial)
   const sessionId = uuid()
   const t0 = performance.now()
@@ -71,6 +213,10 @@ async function rtcStart(serial: string, _reconnectAttempt = 0) {
 
   console.log(`[RTC ${serial}] stream/start response:`, JSON.stringify(startRes).substring(0, 100))
   if (!startRes.ok) {
+    if (startRes.platform === 'ios' && startRes.stream_fallback) {
+      applyIosStreamFallback(serial, startRes.stream_fallback)
+      return
+    }
     const err = startRes.error || 'unknown'
     if (err.includes('Accessibility') || err.includes('Portal not')) {
       rtcStatus.value[serial] = 'Portal down — fixing...'
@@ -92,8 +238,9 @@ async function rtcStart(serial: string, _reconnectAttempt = 0) {
   pc.ontrack = (evt) => {
     rtcStatus.value[serial] = 'Streaming'
     const videoEl = document.getElementById(`rtc-video-${serial}`) as HTMLVideoElement
-    if (videoEl) {
-      videoEl.srcObject = evt.streams[0]
+    const stream = evt.streams[0]
+    if (videoEl && stream) {
+      videoEl.srcObject = stream
       videoEl.play().catch(() => {})
     }
     startBlackCheck(serial)
@@ -202,7 +349,7 @@ function rtcStop(serial: string) {
 function sendInput(_serial: string, _msg: object): boolean {
   // DataChannel input disabled — portal can't exec shell "input" commands
   // without root. Will implement via AccessibilityService dispatchGesture() later.
-  // For now, always fall through to HTTP → backend → ADB.
+  // For now, always fall through to HTTP → backend platform control.
   return false
 }
 
@@ -257,6 +404,7 @@ function videoMouseLeave(serial: string) { dragState.value[serial] = null }
 function videoTouchStart(serial: string, e: TouchEvent) {
   if (!e.touches.length) return; e.preventDefault()
   const touch = e.touches[0], video = e.target as HTMLVideoElement, rect = video.getBoundingClientRect()
+  if (!touch) return
   const sx = video.videoWidth / rect.width, sy = video.videoHeight / rect.height
   dragState.value[serial] = { x: Math.round((touch.clientX - rect.left) * sx), y: Math.round((touch.clientY - rect.top) * sy), t: Date.now() }
   dragMoved.value[serial] = false
@@ -265,6 +413,7 @@ function videoTouchMove(serial: string) { if (dragState.value[serial]) dragMoved
 function videoTouchEnd(serial: string, e: TouchEvent) {
   const ds = dragState.value[serial]; if (!ds) return; e.preventDefault()
   const touch = e.changedTouches[0], video = e.target as HTMLVideoElement, rect = video.getBoundingClientRect()
+  if (!touch) return
   const sx = video.videoWidth / rect.width, sy = video.videoHeight / rect.height
   const ex = Math.round((touch.clientX - rect.left) * sx), ey = Math.round((touch.clientY - rect.top) * sy)
   const sw = video.videoWidth, sh = video.videoHeight
@@ -285,6 +434,169 @@ function sendKeyTo(serial: string, key: number | string) {
     api('/api/phone/key', { method: 'POST', body: JSON.stringify({ device: serial, key }) })
   } else {
     api('/api/phone/input', { method: 'POST', body: JSON.stringify({ device: serial, action: 'keyevent', keycode: key }) })
+  }
+}
+
+function hardwareKeys(serial: string): { label: string; key: number | string; title: string }[] {
+  if (isIosDevice(serial)) {
+    return [
+      { label: 'Back', key: 'BACK', title: 'Back' },
+      { label: 'Home', key: 'HOME', title: 'Home' },
+      { label: 'Enter', key: 'ENTER', title: 'Enter' },
+    ]
+  }
+  return [
+    { label: '\u25C0', key: 4, title: 'Back' },
+    { label: '\u2302', key: 3, title: 'Home' },
+    { label: '\u25A6', key: 187, title: 'Recents' },
+    { label: '\u23FB', key: 26, title: 'Power' },
+    { label: 'Vol+', key: 24, title: 'Volume up' },
+    { label: 'Vol-', key: 25, title: 'Volume down' },
+  ]
+}
+
+/* ── screen recording ───────────────────────────────────────────────── */
+const recordingState = ref<Record<string, boolean>>({})
+const recordingBusy = ref<Record<string, boolean>>({})
+const recordingStatus = ref<Record<string, string>>({})
+const recordingUrls = ref<Record<string, string>>({})
+const recordingFilenames = ref<Record<string, string>>({})
+
+function applyRecordingStatus(serial: string, result: RecordingResponse) {
+  recordingState.value[serial] = !!result.running
+  if (result.filename) recordingFilenames.value[serial] = result.filename
+  if (result.url) recordingUrls.value[serial] = result.url
+  if (result.error) {
+    recordingStatus.value[serial] = result.error
+  } else if (result.running) {
+    recordingStatus.value[serial] = result.mode ? `Recording ${result.mode}` : 'Recording'
+  } else if (result.url) {
+    recordingStatus.value[serial] = 'Saved recording'
+  } else {
+    recordingStatus.value[serial] = ''
+  }
+}
+
+function recordingErrorText(error: unknown): string {
+  if (error instanceof Error) return error.message.replace(/^API \d+:\s*/, '')
+  return 'Recording request failed'
+}
+
+async function refreshRecordingStatus(serial: string) {
+  if (!serial) return
+  try {
+    const result = await api<RecordingResponse>(`/api/phone/recording/status/${encodeURIComponent(serial)}`)
+    applyRecordingStatus(serial, result)
+  } catch (error) {
+    recordingStatus.value[serial] = recordingErrorText(error)
+  }
+}
+
+function refreshAllRecordingStatus() {
+  for (const d of devices.value) refreshRecordingStatus(d.serial)
+}
+
+function recordingButtonText(serial: string): string {
+  if (recordingBusy.value[serial]) return '...'
+  return recordingState.value[serial] ? 'Stop Rec' : 'Record'
+}
+
+function recordingTinyText(serial: string): string {
+  if (recordingBusy.value[serial]) return '...'
+  return recordingState.value[serial] ? 'Stop' : 'Rec'
+}
+
+function recordingTitle(serial: string): string {
+  if (recordingState.value[serial]) return 'Stop screen recording and save MP4'
+  return isIosDevice(serial) ? 'Record WDA MJPEG stream to MP4' : 'Record Android screen to MP4'
+}
+
+async function toggleRecording(serial: string) {
+  if (!serial || recordingBusy.value[serial]) return
+  recordingBusy.value[serial] = true
+  recordingStatus.value[serial] = ''
+  try {
+    const endpoint = recordingState.value[serial] ? '/api/phone/recording/stop' : '/api/phone/recording/start'
+    const result = await api<RecordingResponse>(endpoint, {
+      method: 'POST',
+      body: JSON.stringify({ device: serial })
+    })
+    applyRecordingStatus(serial, result)
+  } catch (error) {
+    recordingStatus.value[serial] = recordingErrorText(error)
+  } finally {
+    recordingBusy.value[serial] = false
+  }
+}
+
+/* ── iOS browser/news smoke workflow ────────────────────────────────── */
+const newsUrl = ref('https://text.npr.org/')
+const newsBundleId = ref('com.google.chrome.ios')
+const newsMaxHeadlines = ref(5)
+const newsMaxArticles = ref(3)
+const newsWaitSeconds = ref(2)
+const newsSaveScreenshots = ref(true)
+const newsOutDir = ref('data/ios_chrome_news_smoke')
+const newsRunning = ref(false)
+const newsResult = ref<NewsResult | null>(null)
+const newsError = ref('')
+
+const newsHeadlines = computed(() => Array.isArray(newsResult.value?.headlines) ? newsResult.value!.headlines! : [])
+const newsArticles = computed(() => Array.isArray(newsResult.value?.articles) ? newsResult.value!.articles! : [])
+const newsErrors = computed(() => Array.isArray(newsResult.value?.errors) ? newsResult.value!.errors! : [])
+const newsExtraction = computed(() => newsResult.value?.extraction || {})
+const newsScreenshotEntries = computed(() =>
+  Object.entries(newsResult.value?.screenshots || {}).filter(([, path]) => !!path)
+)
+
+function compactEvidence(evidence: any): string {
+  if (!evidence) return ''
+  const source = evidence.source || 'unknown'
+  const attempts = evidence.attempts !== undefined ? `${evidence.attempts}x` : ''
+  if (evidence.returned !== undefined) return `${source} ${evidence.returned}/${evidence.target} ${attempts}`.trim()
+  if (evidence.returned_lines !== undefined) {
+    return `${source} ${evidence.returned_lines}/${evidence.target_lines} lines ${attempts}`.trim()
+  }
+  return source
+}
+
+function articleEvidence(index: number): any {
+  const items = newsExtraction.value?.articles
+  return Array.isArray(items) ? items[index] || {} : {}
+}
+
+function firstNewsError(): string {
+  if (newsResult.value?.error) return String(newsResult.value.error)
+  const first = newsErrors.value[0]
+  if (!first) return ''
+  return String(first.error || first.back_error || first.stage || first.article || JSON.stringify(first))
+}
+
+async function runNewsSmoke() {
+  if (!selectedDevice.value || newsRunning.value) return
+  newsRunning.value = true
+  newsError.value = ''
+  newsResult.value = null
+  try {
+    const result = await api<NewsResult>('/api/phone/browser/read-news', {
+      method: 'POST',
+      body: JSON.stringify({
+        device: selectedDevice.value,
+        url: newsUrl.value || 'https://text.npr.org/',
+        bundle_id: newsBundleId.value || undefined,
+        max_headlines: Math.max(1, Number(newsMaxHeadlines.value) || 5),
+        max_articles: Math.max(0, Number(newsMaxArticles.value) || 0),
+        wait_s: Math.max(0.5, Number(newsWaitSeconds.value) || 2),
+        save_screenshots: newsSaveScreenshots.value,
+        out_dir: newsOutDir.value || undefined,
+      })
+    })
+    newsResult.value = result
+    if (!result.ok) newsError.value = firstNewsError() || 'News workflow failed'
+  } catch (error) {
+    newsError.value = error instanceof Error ? error.message.replace(/^API \d+:\s*/, '') : 'News workflow failed'
+  } finally {
+    newsRunning.value = false
   }
 }
 
@@ -313,7 +625,7 @@ function startBlackCheck(serial: string) {
       const data = c.getContext('2d')!.getImageData(0, 0, 8, 8).data
       // Simple hash: sum of all pixel values
       let hash = 0
-      for (let i = 0; i < data.length; i += 4) hash += data[i] + data[i+1] + data[i+2]
+      for (let i = 0; i < data.length; i += 4) hash += (data[i] ?? 0) + (data[i+1] ?? 0) + (data[i+2] ?? 0)
       const hashStr = hash.toString()
 
       // Black screen check (first time only)
@@ -344,6 +656,17 @@ function clearBlackCheck(serial: string) {
 
 function reconnectStream(serial: string) {
   streamFrozen.value[serial] = false
+  if (isIosDevice(serial)) {
+    if (streaming.value && serial === selectedDevice.value) {
+      stopStream()
+      singleStreamMode.value = 'mjpeg'
+      setTimeout(() => startStream(), 500)
+    } else {
+      stopMultiStream(serial)
+      setTimeout(() => startMultiStream(serial, 'mjpeg'), 500)
+    }
+    return
+  }
   rtcStop(serial)
   setTimeout(() => rtcStart(serial), 500)
 }
@@ -351,6 +674,7 @@ function reconnectStream(serial: string) {
 /* ── toggle stream mode (switch while streaming) ────────────────────── */
 function toggleMultiMode(serial: string) {
   if (!multiStreaming.value[serial]) return
+  if (isIosDevice(serial)) return
   const newMode = multiStreamMode.value[serial] === 'rtc' ? 'mjpeg' : 'rtc'
   stopMultiStream(serial)
   startMultiStream(serial, newMode)
@@ -358,6 +682,7 @@ function toggleMultiMode(serial: string) {
 
 function toggleSingleMode() {
   if (!streaming.value || !selectedDevice.value) return
+  if (selectedIsIos.value) return
   stopStream()
   singleStreamMode.value = singleStreamMode.value === 'rtc' ? 'mjpeg' : 'rtc'
   startStream()
@@ -367,6 +692,7 @@ function toggleSingleMode() {
 const overlayOn = ref<Record<string, boolean>>({})
 
 async function toggleOverlay(serial: string) {
+  if (isIosDevice(serial)) return
   overlayOn.value[serial] = !overlayOn.value[serial]
   await api(`/api/phone/overlay/${serial}`, {
     method: 'POST', body: JSON.stringify({ visible: overlayOn.value[serial] })
@@ -378,21 +704,29 @@ const multiStreaming = ref<Record<string, boolean>>({})
 const multiStreamMode = ref<Record<string, 'rtc' | 'mjpeg'>>({})
 const mjpegUrls = ref<Record<string, string>>({})
 
-function startMultiStream(serial: string, mode: 'rtc' | 'mjpeg' = 'rtc') {
+async function startMultiStream(serial: string, mode: 'rtc' | 'mjpeg' = 'rtc') {
   // Clean up any existing stream first
   if (multiStreaming.value[serial]) stopMultiStream(serial)
+  const actualMode = effectiveStreamMode(serial, mode)
   multiStreaming.value[serial] = true
-  multiStreamMode.value[serial] = mode
-  if (mode === 'rtc') {
+  multiStreamMode.value[serial] = actualMode
+  if (actualMode === 'rtc') {
     rtcStart(serial)
   } else {
-    mjpegUrls.value[serial] = `/api/phone/stream?device=${encodeURIComponent(serial)}&fps=5`
+    streamFrozen.value[serial] = false
+    mjpegReconnects.value[serial] = 0
+    streamInfoStatus.value[serial] = isIosDevice(serial) ? 'Loading WDA MJPEG...' : ''
+    mjpegUrls.value[serial] = mjpegStreamUrl(serial)
+    mjpegUrls.value[serial] = await resolveMjpegStreamUrl(serial, actualMode)
+    startMjpegWatchdog(serial)
   }
 }
 function stopMultiStream(serial: string) {
   multiStreaming.value[serial] = false
   if (multiStreamMode.value[serial] === 'rtc') rtcStop(serial)
+  stopMjpegWatchdog(serial)
   mjpegUrls.value[serial] = ''
+  streamInfoStatus.value[serial] = ''
   multiStreamMode.value[serial] = 'rtc'
 }
 function startAllStreams(mode: 'rtc' | 'mjpeg' = 'rtc') {
@@ -401,56 +735,241 @@ function startAllStreams(mode: 'rtc' | 'mjpeg' = 'rtc') {
 function stopAllStreams() { for (const d of devices.value) stopMultiStream(d.serial) }
 
 /* ── single device ───────────────────────────────────────────────────── */
-const singleStreamMode = ref<'rtc' | 'mjpeg'>('rtc')
+const singleStreamMode = ref<'rtc' | 'mjpeg' | 'h264'>('rtc')
 const singleMjpegUrl = ref('')
 
-function startStream() {
+/* ── H.264 (GhostAgent WebSocket stream, iOS) ─────────────────────────── */
+const h264Status = ref('')
+const h264ShowMetrics = ref(true)
+const h264M = ref({ recvFps: 0, renderFps: 0, queue: 0, latencyMs: 0, kbps: 0, dropped: 0 })
+let h264Handle: { status: any; recvFps: any; renderFps: any; queue: any; latencyMs: any; kbps: any; dropped: any; stop: () => void } | null = null
+function h264StreamWsUrl(serial: string): string {
+  const proto = location.protocol === 'https:' ? 'wss' : 'ws'
+  return `${proto}://${location.host}/api/phone/h264/${encodeURIComponent(serial)}`
+}
+async function startH264(serial: string) {
+  stopH264()
+  await nextTick()
+  const canvas = document.getElementById(`h264-canvas-${serial}`) as HTMLCanvasElement | null
+  if (!canvas) return
+  const { startH264Stream, h264Supported } = await import('@/composables/useH264Stream')
+  if (!h264Supported()) { h264Status.value = 'WebCodecs unavailable — use MJPEG'; return }
+  h264Handle = startH264Stream(h264StreamWsUrl(serial), canvas)
+  const h = h264Handle
+  watch(h.status, (v: string) => { h264Status.value = v })
+  const sync = () => { h264M.value = { recvFps: h.recvFps.value, renderFps: h.renderFps.value, queue: h.queue.value, latencyMs: h.latencyMs.value, kbps: h.kbps.value, dropped: h.dropped.value } }
+  watch([h.recvFps, h.renderFps, h.queue, h.latencyMs, h.kbps, h.dropped], sync)
+}
+function stopH264() {
+  if (h264Handle) { h264Handle.stop(); h264Handle = null }
+  h264Status.value = ''
+  h264M.value = { recvFps: 0, renderFps: 0, queue: 0, latencyMs: 0, kbps: 0, dropped: 0 }
+}
+
+async function startStream() {
   if (!selectedDevice.value) return
+  const serial = selectedDevice.value
+  if (singleStreamMode.value !== 'h264') singleStreamMode.value = effectiveStreamMode(serial, singleStreamMode.value)
   streaming.value = true
-  if (singleStreamMode.value === 'rtc') {
-    rtcStart(selectedDevice.value)
+  if (singleStreamMode.value === 'h264') {
+    await startH264(serial)
+  } else if (singleStreamMode.value === 'rtc') {
+    rtcStart(serial)
     // Auto-fallback: if RTC doesn't connect within 5s, switch to MJPEG
     setTimeout(() => {
-      if (streaming.value && singleStreamMode.value === 'rtc' && rtcStatus[selectedDevice.value] !== 'Streaming') {
+      if (streaming.value && singleStreamMode.value === 'rtc' && rtcStatus.value[serial] !== 'Streaming') {
         console.log('RTC timeout — falling back to MJPEG')
         singleStreamMode.value = 'mjpeg'
-        singleMjpegUrl.value = `/api/phone/stream?device=${encodeURIComponent(selectedDevice.value)}&fps=5`
+        singleMjpegUrl.value = mjpegStreamUrl(serial)
+        void resolveMjpegStreamUrl(serial, 'mjpeg').then(url => {
+          if (streaming.value && selectedDevice.value === serial && singleStreamMode.value === 'mjpeg') singleMjpegUrl.value = url
+        })
+        startMjpegWatchdog(serial)
       }
     }, 5000)
   } else {
-    singleMjpegUrl.value = `/api/phone/stream?device=${encodeURIComponent(selectedDevice.value)}&fps=5`
+    streamFrozen.value[serial] = false
+    mjpegReconnects.value[serial] = 0
+    streamInfoStatus.value[serial] = isIosDevice(serial) ? 'Loading WDA MJPEG...' : ''
+    singleMjpegUrl.value = mjpegStreamUrl(serial)
+    singleMjpegUrl.value = await resolveMjpegStreamUrl(serial, singleStreamMode.value)
+    startMjpegWatchdog(serial)
   }
 }
 function stopStream() {
-  if (selectedDevice.value) rtcStop(selectedDevice.value)
+  if (selectedDevice.value) { rtcStop(selectedDevice.value); stopMjpegWatchdog(selectedDevice.value) }
+  stopH264()
   singleMjpegUrl.value = ''
+  if (selectedDevice.value) streamInfoStatus.value[selectedDevice.value] = ''
   streaming.value = false
 }
 
 /* ── MJPEG tap/swipe (uses naturalWidth/Height for coordinate scaling) ─ */
+function mjpegImageLoaded(serial: string) {
+  streamFrozen.value[serial] = false
+  blackWarning.value[serial] = false
+  if (streamInfoStatus.value[serial]?.startsWith('Loading ')) streamInfoStatus.value[serial] = ''
+  if (isIosDevice(serial)) rtcStatus.value[serial] = 'WDA MJPEG'
+}
+
+function mjpegImageError(serial: string) {
+  streamFrozen.value[serial] = true
+  streamInfoStatus.value[serial] = isIosDevice(serial)
+    ? 'WDA MJPEG failed — reconnecting…'
+    : 'MJPEG stream failed — reconnecting…'
+  // Hard error → reconnect right away (backoff-limited by the watchdog).
+  reconnectMjpeg(serial)
+}
+
+/* ── MJPEG stall watchdog ─────────────────────────────────────────────────
+ * An <img> streaming multipart-JPEG holds its LAST frame forever if the
+ * connection silently stalls — no 'error' event fires, so health stays green
+ * while the picture is frozen. Sample the frame to a tiny canvas every few
+ * seconds; if it hasn't changed for a while, force a reconnect (cache-busted
+ * src reload). Reconnecting a genuinely-static screen is harmless. */
+const mjpegWatchTimers = ref<Record<string, number>>({})
+const mjpegLastHash = ref<Record<string, string>>({})
+const mjpegStaleCount = ref<Record<string, number>>({})
+const mjpegReconnects = ref<Record<string, number>>({})
+const MJPEG_STALL_CHECKS = 3          // ~3 * 2.5s = ~7.5s frozen → reconnect
+const MJPEG_MAX_RECONNECTS = 20       // safety cap; reset on any fresh frame
+
+function mjpegFrameHash(serial: string): string | null {
+  const img = document.getElementById(`mjpeg-img-${serial}`) as HTMLImageElement | null
+  if (!img || !img.naturalWidth) return null
+  try {
+    const c = document.createElement('canvas')
+    c.width = 16; c.height = 16
+    const ctx = c.getContext('2d')!
+    ctx.drawImage(img, 0, 0, 16, 16)
+    const d = ctx.getImageData(0, 0, 16, 16).data
+    let h = 0
+    for (let i = 0; i < d.length; i += 4) h = (h * 31 + (d[i]! + d[i+1]! * 3 + d[i+2]! * 7)) | 0
+    return String(h)
+  } catch { return null }  // tainted canvas etc. → skip (don't false-reconnect)
+}
+
+function reconnectMjpeg(serial: string) {
+  if ((mjpegReconnects.value[serial] || 0) >= MJPEG_MAX_RECONNECTS) return
+  mjpegReconnects.value[serial] = (mjpegReconnects.value[serial] || 0) + 1
+  mjpegStaleCount.value[serial] = 0
+  const base = mjpegStreamUrl(serial)
+  const sep = base.includes('?') ? '&' : '?'
+  // New URL forces the <img> to drop the dead connection and open a fresh one.
+  const url = `${base}${sep}_r=${mjpegReconnects.value[serial]}`
+  // Route to whichever view is showing this device (multi grid vs single panel).
+  if (multiStreaming.value[serial]) mjpegUrls.value[serial] = url
+  else singleMjpegUrl.value = url
+}
+
+function startMjpegWatchdog(serial: string) {
+  stopMjpegWatchdog(serial)
+  mjpegLastHash.value[serial] = ''
+  mjpegStaleCount.value[serial] = 0
+  mjpegWatchTimers.value[serial] = window.setInterval(() => {
+    // Active if this device is streaming MJPEG in either the single panel or the grid.
+    const singleActive = streaming.value && selectedDevice.value === serial && singleStreamMode.value === 'mjpeg'
+    const multiActive = multiStreaming.value[serial] && multiStreamMode.value[serial] === 'mjpeg'
+    if (!singleActive && !multiActive) return
+    const hash = mjpegFrameHash(serial)
+    if (hash == null) return
+    if (hash === mjpegLastHash.value[serial]) {
+      mjpegStaleCount.value[serial] = (mjpegStaleCount.value[serial] || 0) + 1
+      if (mjpegStaleCount.value[serial] >= MJPEG_STALL_CHECKS) {
+        streamInfoStatus.value[serial] = 'Stream stalled — reconnecting…'
+        reconnectMjpeg(serial)
+      }
+    } else {
+      mjpegLastHash.value[serial] = hash
+      mjpegStaleCount.value[serial] = 0
+      mjpegReconnects.value[serial] = 0   // healthy frames → reset backoff
+      streamFrozen.value[serial] = false
+    }
+  }, 2500)
+}
+
+function stopMjpegWatchdog(serial: string) {
+  if (mjpegWatchTimers.value[serial]) { clearInterval(mjpegWatchTimers.value[serial]); delete mjpegWatchTimers.value[serial] }
+}
+
+function mjpegImagePoint(img: HTMLImageElement | HTMLCanvasElement, clientX: number, clientY: number): { x: number; y: number; width: number; height: number } | null {
+  const rect = img.getBoundingClientRect()
+  // <img> exposes naturalWidth/Height; <canvas> (H.264) exposes width/height.
+  const sw = (img as HTMLImageElement).naturalWidth || (img as HTMLCanvasElement).width
+  const sh = (img as HTMLImageElement).naturalHeight || (img as HTMLCanvasElement).height
+  if (!sw || !sh || !rect.width || !rect.height) return null
+  const sx = sw / rect.width
+  const sy = sh / rect.height
+  return {
+    x: Math.round((clientX - rect.left) * sx),
+    y: Math.round((clientY - rect.top) * sy),
+    width: sw,
+    height: sh,
+  }
+}
+
 function mjpegMouseDown(serial: string, e: MouseEvent) {
   e.preventDefault()
   const img = e.target as HTMLImageElement
-  const rect = img.getBoundingClientRect()
-  const sx = img.naturalWidth / rect.width, sy = img.naturalHeight / rect.height
-  dragState.value[serial] = { x: Math.round((e.clientX - rect.left) * sx), y: Math.round((e.clientY - rect.top) * sy), t: Date.now() }
+  const point = mjpegImagePoint(img, e.clientX, e.clientY)
+  if (!point) return
+  dragState.value[serial] = { x: point.x, y: point.y, t: Date.now() }
   dragMoved.value[serial] = false
 }
+
+function mjpegMove(serial: string) {
+  if (dragState.value[serial]) dragMoved.value[serial] = true
+}
+
 function mjpegMouseUp(serial: string, e: MouseEvent) {
   const ds = dragState.value[serial]; if (!ds) return; e.preventDefault()
   const img = e.target as HTMLImageElement
-  const rect = img.getBoundingClientRect()
-  const sx = img.naturalWidth / rect.width, sy = img.naturalHeight / rect.height
-  const ex = Math.round((e.clientX - rect.left) * sx), ey = Math.round((e.clientY - rect.top) * sy)
-  const sw = img.naturalWidth, sh = img.naturalHeight
-  const dx = ex - ds.x, dy = ey - ds.y, dist = Math.sqrt(dx * dx + dy * dy)
+  const point = mjpegImagePoint(img, e.clientX, e.clientY)
+  if (!point) { dragState.value[serial] = null; return }
+  const dx = point.x - ds.x, dy = point.y - ds.y, dist = Math.sqrt(dx * dx + dy * dy)
   if (!dragMoved.value[serial] || dist < 20) {
-    api('/api/phone/tap', { method: 'POST', body: JSON.stringify({ device: serial, x: ex, y: ey, stream_w: sw, stream_h: sh }) })
+    api('/api/phone/tap', { method: 'POST', body: JSON.stringify({ device: serial, x: point.x, y: point.y, stream_w: point.width, stream_h: point.height }) })
   } else {
-    api('/api/phone/swipe', { method: 'POST', body: JSON.stringify({ device: serial, x1: ds.x, y1: ds.y, x2: ex, y2: ey, stream_w: sw, stream_h: sh }) })
+    api('/api/phone/swipe', { method: 'POST', body: JSON.stringify({ device: serial, x1: ds.x, y1: ds.y, x2: point.x, y2: point.y, stream_w: point.width, stream_h: point.height }) })
   }
   dragState.value[serial] = null
 }
+
+function mjpegTouchStart(serial: string, e: TouchEvent) {
+  if (!e.touches.length) return
+  e.preventDefault()
+  const touch = e.touches[0]
+  if (!touch) return
+  const point = mjpegImagePoint(e.target as HTMLImageElement, touch.clientX, touch.clientY)
+  if (!point) return
+  dragState.value[serial] = { x: point.x, y: point.y, t: Date.now() }
+  dragMoved.value[serial] = false
+}
+
+function mjpegTouchMove(serial: string, e: TouchEvent) {
+  if (!dragState.value[serial]) return
+  e.preventDefault()
+  dragMoved.value[serial] = true
+}
+
+function mjpegTouchEnd(serial: string, e: TouchEvent) {
+  const ds = dragState.value[serial]
+  if (!ds) return
+  e.preventDefault()
+  const touch = e.changedTouches[0]
+  if (!touch) { dragState.value[serial] = null; return }
+  const point = mjpegImagePoint(e.target as HTMLImageElement, touch.clientX, touch.clientY)
+  if (!point) { dragState.value[serial] = null; return }
+  const dx = point.x - ds.x, dy = point.y - ds.y, dist = Math.sqrt(dx * dx + dy * dy)
+  if (!dragMoved.value[serial] || dist < 20) {
+    api('/api/phone/tap', { method: 'POST', body: JSON.stringify({ device: serial, x: point.x, y: point.y, stream_w: point.width, stream_h: point.height }) })
+  } else {
+    api('/api/phone/swipe', { method: 'POST', body: JSON.stringify({ device: serial, x1: ds.x, y1: ds.y, x2: point.x, y2: point.y, stream_w: point.width, stream_h: point.height }) })
+  }
+  dragState.value[serial] = null
+}
+
+function mjpegTouchCancel(serial: string) { dragState.value[serial] = null }
 
 /* ── per-device logs ─────────────────────────────────────────────────── */
 const multiLogs = ref<Record<string, string[]>>({})
@@ -467,11 +986,44 @@ async function pollMultiLogs() {
 /* ── device health ──────────────────────────────────────────────────── */
 const healthData = ref<Record<string, any>>({})
 const healthLoading = ref<Record<string, boolean>>({})
+const healthFixStatus = ref<Record<string, string>>({})
+const showRecoveryDetails = ref<Record<string, boolean>>({})
+function toggleRecoveryDetails(serial: string) {
+  showRecoveryDetails.value[serial] = !showRecoveryDetails.value[serial]
+}
 const showWirelessModal = ref(false)
 const wirelessIp = ref('')
 const wirelessPort = ref('5555')
 const wirelessCode = ref('')
 const wirelessResult = ref('')
+const IOS_AUTO_FIXES = new Set(['start_appium', 'reset_session', 'appium_session', 'wda_session', 'restart_remote_xpc_tunnel'])
+
+// Auto-reset a stale WDA session without the user clicking. Only for session
+// resets (not the heavier tunnel restart), one attempt per distinct dead
+// session, capped so a persistently broken device can't loop (Reset WDA stays
+// available manually). The guard clears once the device is healthy again.
+const AUTO_RESET_ACTIONS = new Set(['reset_session', 'appium_session', 'wda_session'])
+const autoResetGuard = ref<Record<string, { key: string; attempts: number }>>({})
+
+function maybeAutoReset(serial: string) {
+  const h = healthData.value[serial]
+  if (!h) return
+  const state = String(h?.connection?.status || h?.appium?.state || '')
+  if (['available', 'ready', 'connected', 'online'].includes(state)) {
+    delete autoResetGuard.value[serial]
+    return
+  }
+  const action = iosRecoveryAction(serial)
+  if (!AUTO_RESET_ACTIONS.has(action) || !iosRecoveryCanApplyFix(serial) || iosRecoveryFixBusy(serial)) return
+  const key = String(h?.wda?.session || h?.appium?.session_id || state)
+  const g = autoResetGuard.value[serial]
+  if (g && g.key === key) return
+  const attempts = (g?.attempts || 0) + 1
+  if (attempts > 2) return
+  autoResetGuard.value[serial] = { key, attempts }
+  healthFixStatus.value[serial] = 'Auto-resetting WDA…'
+  fixIssue(serial, action)
+}
 
 async function loadHealth(serial: string) {
   healthLoading.value[serial] = true
@@ -479,15 +1031,45 @@ async function loadHealth(serial: string) {
     healthData.value[serial] = await api(`/api/phone/health/${serial}`)
   } catch { healthData.value[serial] = null }
   healthLoading.value[serial] = false
+  maybeAutoReset(serial)
 }
 
 async function loadAllHealth() {
   for (const d of devices.value) loadHealth(d.serial)
 }
 
+function isIosHealthPayload(h: any): boolean {
+  return h?.platform === 'ios' || h?.connection?.type === 'appium-wda'
+}
+
+function iosActiveAppLabel(h: any): string {
+  const active = h?.wda?.active_app || h?.device_info?.active_app || {}
+  return String(active.name || active.bundleId || active.bundle_id || '').trim()
+}
+
+function healthDotColor(c: string): string {
+  return c === 'green' ? '#22c55e' : c === 'yellow' ? '#f59e0b' : c === 'red' ? '#ef4444' : '#475569'
+}
+
 function healthDots(serial: string): string[] {
   const h = healthData.value[serial]
   if (!h) return []
+  if (isIosHealthPayload(h)) {
+    const state = h.connection?.status || h.appium?.state || 'session_error'
+    const appiumReachable = h.appium?.reachable === true
+    const sessionOk = state === 'available' || !!h.wda?.session || !!h.appium?.session_id
+    const screenshotOk = h.wda?.screenshot_ok === true || (h.wda?.checks?.screenshot_bytes || 0) > 0
+    const sourceOk = h.wda?.source_ok === true || (h.wda?.checks?.source_bytes || 0) > 0
+    const activeOk = !!iosActiveAppLabel(h)
+    const reachableMissing = appiumReachable ? 'yellow' : 'red'
+    return [
+      appiumReachable ? 'green' : 'red',
+      sessionOk ? 'green' : reachableMissing,
+      screenshotOk ? 'green' : reachableMissing,
+      sourceOk ? 'green' : reachableMissing,
+      activeOk ? 'green' : 'gray',
+    ]
+  }
   const dots: string[] = []
   dots.push(h.portal?.http_responding ? 'green' : h.portal?.installed ? 'yellow' : 'red')
   dots.push(h.wifi?.connected ? 'green' : 'gray')
@@ -497,9 +1079,135 @@ function healthDots(serial: string): string[] {
   return dots
 }
 
+function healthTitle(serial: string): string {
+  const h = healthData.value[serial]
+  if (!h) return ''
+  if (!isIosHealthPayload(h)) return 'Portal / WiFi / Battery / Storage / Screen'
+  const state = h.connection?.status || h.appium?.state || 'unknown'
+  const message = String(h.appium?.message || h.error || '').trim()
+  const activeApp = iosActiveAppLabel(h)
+  const recovery = iosRecovery(serial)
+  const parts = [`Appium / WDA / Screenshot / Source / Active app: ${state}`]
+  if (activeApp) parts.push(`active ${activeApp}`)
+  if (h.recommended_fix) parts.push(`fix ${h.recommended_fix}`)
+  if (recovery?.summary) parts.push(recovery.summary)
+  if (message) parts.push(message)
+  return parts.join(' | ')
+}
+
+function iosRecovery(serial: string): any | null {
+  const h = healthData.value[serial]
+  if (!isIosHealthPayload(h)) return null
+  return h?.recovery || null
+}
+
+function iosRecoveryVisible(serial: string): boolean {
+  // The tunnel/WDA health probe is synchronous and slow (often >10s), so the
+  // dashboard poll times out and the card flashes "remote_xpc_tunnel_unavailable"
+  // even while a live stream is flowing over that exact tunnel — pure noise. The
+  // stream itself is proof the tunnel works. Suppress this recovery card on the
+  // Phone Agent tab entirely; full, honest diagnostics live in the 🩺 Device
+  // Health tab where a stale reading isn't sitting on top of a working stream.
+  void serial
+  return false
+}
+
+function iosRecoveryState(serial: string): string {
+  const h = healthData.value[serial]
+  return String(h?.connection?.status || h?.appium?.state || iosRecovery(serial)?.state || 'unknown')
+}
+
+function iosRecoveryCode(serial: string): string {
+  return String(iosRecovery(serial)?.code || healthData.value[serial]?.recommended_fix || '')
+}
+
+function iosRecoveryAction(serial: string): string {
+  return iosRecoveryCode(serial) || String(healthData.value[serial]?.recommended_fix || '')
+}
+
+function iosRecoveryCanApplyFix(serial: string): boolean {
+  if (!serial || !isIosDevice(serial)) return false
+  const recovery = iosRecovery(serial)
+  if (recovery?.auto_fixable === false || recovery?.manual_action_required === true) return false
+  return IOS_AUTO_FIXES.has(iosRecoveryAction(serial))
+}
+
+function iosRecoveryFixBusy(serial: string): boolean {
+  return healthFixStatus.value[serial]?.startsWith('Applying ') || false
+}
+
+function iosRecoveryActionLabel(serial: string): string {
+  const action = iosRecoveryAction(serial)
+  if (action === 'start_appium') return 'Start Appium'
+  if (action === 'restart_remote_xpc_tunnel') return 'Restart Tunnel'
+  if (action === 'reset_session' || action === 'appium_session' || action === 'wda_session') return 'Reset WDA'
+  return 'Apply Fix'
+}
+
+function iosRecoveryActionTitle(serial: string): string {
+  const action = iosRecoveryAction(serial)
+  const recovery = iosRecovery(serial)
+  if (recovery?.auto_fixable === false || recovery?.manual_action_required === true) return 'Manual recovery is required; copy the recovery commands below'
+  if (action === 'start_appium') return 'Start local Appium when IOS_APPIUM_URL points to localhost'
+  if (action === 'restart_remote_xpc_tunnel') return 'Restart the XCUITest RemoteXPC tunnel when the process is owned by this user'
+  if (action) return `Apply iOS health fix: ${action}`
+  return 'No automatic iOS health fix is available'
+}
+
+function iosRecoverySummary(serial: string): string {
+  return String(iosRecovery(serial)?.summary || healthData.value[serial]?.appium?.message || '')
+}
+
+function iosRecoverySteps(serial: string): string[] {
+  const steps = iosRecovery(serial)?.steps
+  return Array.isArray(steps) ? steps.slice(0, 3).map(step => String(step)) : []
+}
+
+function iosRecoveryCommands(serial: string): string[] {
+  const commands = iosRecovery(serial)?.commands
+  return Array.isArray(commands) ? commands.map(cmd => String(cmd)).filter(Boolean) : []
+}
+
+function iosHealthDetails(serial: string): { label: string; value: string; ok?: boolean }[] {
+  const h = healthData.value[serial]
+  if (!isIosHealthPayload(h)) return []
+  const wda = h?.wda || {}
+  const appium = h?.appium || {}
+  const rows = [
+    { label: 'Appium', value: appium.reachable ? 'reachable' : 'down', ok: appium.reachable === true },
+    { label: 'WDA', value: wda.ready ? 'ready' : String(appium.state || h?.connection?.status || 'not ready'), ok: wda.ready === true },
+    { label: 'Session', value: String(wda.session || appium.session_id || 'none'), ok: !!(wda.session || appium.session_id) },
+    { label: 'Stream', value: String(wda.mjpeg_url || 'WDA MJPEG'), ok: wda.ready === true },
+  ]
+  return rows.filter(row => row.value)
+}
+
+async function copyIosRecoveryCommand(serial: string, command: string) {
+  try {
+    await navigator.clipboard.writeText(command)
+    healthFixStatus.value[serial] = 'Copied recovery command'
+  } catch {
+    healthFixStatus.value[serial] = 'Copy failed'
+  }
+}
+
 async function fixIssue(serial: string, issue: string) {
-  await api(`/api/phone/health/${serial}/fix`, { method: 'POST', body: JSON.stringify({ issue }) })
-  await loadHealth(serial)
+  if (!serial || !issue) return
+  healthFixStatus.value[serial] = `Applying ${issue}...`
+  try {
+    const result = await api(`/api/phone/health/${serial}/fix`, { method: 'POST', body: JSON.stringify({ issue }) })
+    if (result.ok) {
+      healthFixStatus.value[serial] = result.message || 'Fix applied'
+    } else if (result.manual_action_required) {
+      healthFixStatus.value[serial] = result.message || 'Manual action required'
+    } else {
+      healthFixStatus.value[serial] = result.error || 'Fix failed'
+    }
+  } catch (error) {
+    healthFixStatus.value[serial] = error instanceof Error ? error.message.replace(/^API \d+:\s*/, '') : 'Fix failed'
+  } finally {
+    await loadHealth(serial)
+  }
 }
 
 async function goWireless(serial: string) {
@@ -679,7 +1387,8 @@ async function deleteConversation(cid: string) {
 function onProviderChange() {
   localStorage.setItem('agent_provider', chatProvider.value)
   const p = CHAT_PROVIDERS.value.find(p => p.id === chatProvider.value)
-  if (p?.models.length) { chatModel.value = p.models[0]; localStorage.setItem('agent_model', chatModel.value) }
+  const firstModel = p?.models?.[0]
+  if (firstModel) { chatModel.value = firstModel; localStorage.setItem('agent_model', chatModel.value) }
   chatSessionId.value = '' // reset session on provider change
   if (chatProvider.value === 'ollama') fetchOllamaStatus()
 }
@@ -825,7 +1534,8 @@ async function loadDevices() {
     devices.value = resp.devices || resp || []
     if (devices.value.length && !selectedDevice.value) selectedDevice.value = devices.value[0].serial
     statusText.value = devices.value.length ? `${devices.value.length} device(s)` : 'No devices'
-  } catch (e: any) { statusText.value = e.message || 'ADB error' }
+    refreshAllRecordingStatus()
+  } catch (e: any) { statusText.value = e.message || 'Device load error' }
 }
 
 function updateNicknameRow() {
@@ -862,7 +1572,11 @@ onMounted(async () => {
   multiLogTimer = window.setInterval(pollMultiLogs, 4000)
   pollMultiLogs()
 })
-watch(selectedDevice, () => { loadConversations(); chatClear() })
+watch(selectedDevice, () => {
+  loadConversations()
+  chatClear()
+  refreshRecordingStatus(selectedDevice.value)
+})
 onUnmounted(() => {
   // Clean up all RTC sessions
   for (const serial of Object.keys(rtcSessions.value)) rtcStop(serial)
@@ -1018,16 +1732,148 @@ onUnmounted(() => {
               {{ d.connection === 'wifi' ? '\uD83D\uDCF6' : '\uD83D\uDD0C' }} {{ d.nickname || d.model || d.serial }}
             </option>
           </select>
-          <button v-if="!streaming" class="ctrl-btn ctrl-btn--webrtc" style="font-size:9px;padding:3px 8px" @click="singleStreamMode = 'rtc'; startStream()">&#x26A1; Stream</button>
+          <button v-if="!streaming" class="ctrl-btn" :class="selectedIsIos ? 'ctrl-btn--mjpeg' : 'ctrl-btn--webrtc'"
+            style="font-size:9px;padding:3px 8px"
+            :title="selectedIsIos ? 'Start iOS WDA MJPEG stream' : 'Start Android WebRTC stream'"
+            @click="singleStreamMode = selectedIsIos ? 'mjpeg' : 'rtc'; startStream()">Stream</button>
+          <button v-if="!streaming && selectedIsIos" class="ctrl-btn ctrl-btn--webrtc"
+            style="font-size:9px;padding:3px 8px"
+            title="Start GhostAgent H.264 stream (beta — needs the patched WDA)"
+            @click="singleStreamMode = 'h264'; startStream()">H.264</button>
           <span v-if="streaming" style="font-size:8px;padding:1px 6px;border-radius:10px;white-space:nowrap"
+            :title="streamInfoTitle(selectedDevice)"
             :style="singleStreamMode === 'rtc'
               ? { background: '#22c55e20', color: '#4ade80', border: '1px solid #22c55e40' }
               : { background: '#6366f120', color: '#a5b4fc', border: '1px solid #6366f140' }">
-            {{ singleStreamMode === 'rtc' ? '⚡ WebRTC' : '📷 MJPEG' }}
+            {{ streamModeText(selectedDevice, singleStreamMode) }}
           </span>
+          <span v-if="healthData[selectedDevice]" class="health-dots" :title="healthTitle(selectedDevice)">
+            <span v-for="(c, i) in healthDots(selectedDevice)" :key="i" class="health-dot" :style="{ background: healthDotColor(c) }"></span>
+          </span>
+          <button v-if="iosRecoveryCanApplyFix(selectedDevice)" class="ctrl-btn ctrl-btn--fix"
+            :disabled="iosRecoveryFixBusy(selectedDevice)"
+            @click="fixIssue(selectedDevice, iosRecoveryAction(selectedDevice))"
+            :title="iosRecoveryActionTitle(selectedDevice)">
+            {{ iosRecoveryFixBusy(selectedDevice) ? 'Fixing...' : iosRecoveryActionLabel(selectedDevice) }}
+          </button>
+          <button v-if="selectedDevice" class="ctrl-btn ctrl-btn--record"
+            :class="{ 'ctrl-btn--record-active': recordingState[selectedDevice] }"
+            :disabled="recordingBusy[selectedDevice]"
+            :title="recordingTitle(selectedDevice)"
+            @click="toggleRecording(selectedDevice)">
+            {{ recordingButtonText(selectedDevice) }}
+          </button>
+          <a v-if="recordingUrls[selectedDevice]" class="ctrl-btn ctrl-btn--record-link"
+            :href="recordingUrls[selectedDevice]" target="_blank" rel="noopener"
+            :title="recordingFilenames[selectedDevice] || 'Open recording'">MP4</a>
           <button v-if="streaming" class="ctrl-btn ctrl-btn--stop" style="font-size:9px;padding:3px 8px" @click="stopStream">&#x23F9; Stop</button>
-          <button class="ctrl-btn" style="font-size:9px;padding:3px 6px" @click="toggleOverlay(selectedDevice)"
+          <button v-if="!selectedIsIos" class="ctrl-btn" style="font-size:9px;padding:3px 6px" @click="toggleOverlay(selectedDevice)"
             :style="{ background: overlayOn[selectedDevice] ? '#fbbf24' : '', color: overlayOn[selectedDevice] ? '#000' : '#fbbf24' }">&#x1F522;</button>
+        </div>
+        <div v-if="recordingStatus[selectedDevice]" class="recording-status-line" :title="recordingStatus[selectedDevice]">
+          <span v-if="recordingState[selectedDevice]" class="recording-dot"></span>
+          {{ recordingStatus[selectedDevice] }}
+        </div>
+        <div v-if="streamInfoStatus[selectedDevice]" class="recording-status-line" :title="streamInfoStatus[selectedDevice]">
+          {{ streamInfoStatus[selectedDevice] }}
+        </div>
+        <div v-if="iosRecoveryVisible(selectedDevice)" class="ios-recovery-panel">
+          <div class="ios-recovery-head">
+            <span class="ios-recovery-state">{{ iosRecoveryState(selectedDevice) }}</span>
+            <span class="ios-recovery-summary-inline" :title="iosRecoverySummary(selectedDevice)">{{ iosRecoverySummary(selectedDevice) }}</span>
+            <button v-if="iosRecoveryCanApplyFix(selectedDevice)" class="ios-recovery-link ios-recovery-link--fix"
+              :disabled="iosRecoveryFixBusy(selectedDevice)"
+              @click="fixIssue(selectedDevice, iosRecoveryAction(selectedDevice))"
+              :title="iosRecoveryActionTitle(selectedDevice)">
+              {{ iosRecoveryFixBusy(selectedDevice) ? 'Fixing…' : iosRecoveryActionLabel(selectedDevice) }}
+            </button>
+            <button class="ios-recovery-link" @click="loadHealth(selectedDevice)">Refresh</button>
+            <button class="ios-recovery-link" @click="toggleRecoveryDetails(selectedDevice)">
+              {{ showRecoveryDetails[selectedDevice] ? 'Hide' : 'Details' }}
+            </button>
+          </div>
+          <div v-if="healthFixStatus[selectedDevice]" class="ios-recovery-status">{{ healthFixStatus[selectedDevice] }}</div>
+          <div v-if="showRecoveryDetails[selectedDevice]" class="ios-recovery-details">
+            <div v-if="iosHealthDetails(selectedDevice).length" class="ios-health-details">
+              <span v-for="row in iosHealthDetails(selectedDevice)" :key="row.label"
+                class="ios-health-chip" :class="{ 'ios-health-chip--ok': row.ok }"
+                :title="`${row.label}: ${row.value}`">
+                {{ row.label }} {{ row.value }}
+              </span>
+            </div>
+            <ol v-if="iosRecoverySteps(selectedDevice).length" class="ios-recovery-steps">
+              <li v-for="(step, i) in iosRecoverySteps(selectedDevice)" :key="i">{{ step }}</li>
+            </ol>
+            <div v-if="iosRecoveryCommands(selectedDevice).length" class="ios-recovery-commands">
+              <div v-for="command in iosRecoveryCommands(selectedDevice)" :key="command" class="ios-recovery-command">
+                <code>{{ command }}</code>
+                <button class="ios-copy-btn" @click="copyIosRecoveryCommand(selectedDevice, command)">Copy</button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div v-if="selectedIsIos" class="news-panel">
+          <div class="news-panel-head">
+            <span class="news-title">Chrome News</span>
+            <button class="ctrl-btn ctrl-btn--mjpeg ctrl-btn--tiny" :disabled="newsRunning || !selectedDevice"
+              @click="runNewsSmoke">{{ newsRunning ? 'Reading...' : 'Read News' }}</button>
+          </div>
+          <div class="news-controls">
+            <input v-model="newsUrl" class="news-input news-input--url" title="URL" />
+            <input v-model="newsBundleId" class="news-input" title="iOS bundle id" />
+            <input v-model.number="newsMaxHeadlines" class="news-number" type="number" min="1" max="10" title="Headlines" />
+            <input v-model.number="newsMaxArticles" class="news-number" type="number" min="0" max="5" title="Articles" />
+            <label class="news-toggle" title="Save front-page and article screenshots">
+              <input v-model="newsSaveScreenshots" type="checkbox" />
+              shots
+            </label>
+            <input v-if="newsSaveScreenshots" v-model="newsOutDir" class="news-input news-input--out" title="Screenshot output directory" />
+          </div>
+          <div v-if="newsRunning" class="news-status">Running read_news...</div>
+          <div v-else-if="newsError" class="news-status news-status--error">{{ newsError }}</div>
+          <div v-if="newsResult" class="news-result">
+            <div class="news-summary">
+              <span class="news-pill" :class="newsResult.ok ? 'news-pill--ok' : 'news-pill--error'">
+                {{ newsResult.ok ? 'OK' : 'Fail' }}
+              </span>
+              <span>{{ newsHeadlines.length }} headlines</span>
+              <span>{{ newsArticles.length }} articles</span>
+              <span v-if="newsResult.completion">
+                {{ newsResult.completion.articles_with_body || 0 }}/{{ newsResult.completion.requested_articles || 0 }} bodies
+              </span>
+              <span v-if="newsResult.current_url" :title="newsResult.current_url">{{ newsResult.current_url }}</span>
+            </div>
+            <div class="news-evidence">
+              <span :title="JSON.stringify(newsExtraction.headlines || {})">
+                H {{ compactEvidence(newsExtraction.headlines) }}
+              </span>
+              <span :title="JSON.stringify(newsExtraction.front_page_text || {})">
+                Text {{ compactEvidence(newsExtraction.front_page_text) }}
+              </span>
+            </div>
+            <div v-if="newsScreenshotEntries.length" class="news-artifacts">
+              <span v-for="([name, path]) in newsScreenshotEntries" :key="name" :title="path">
+                {{ name }} {{ path }}
+              </span>
+            </div>
+            <div v-if="newsHeadlines.length" class="news-list">
+              <div v-for="(headline, i) in newsHeadlines.slice(0, 5)" :key="i" class="news-headline">
+                {{ headline.title || headline.text || headline.source_headline }}
+              </div>
+            </div>
+            <div v-if="newsArticles.length" class="news-articles">
+              <div v-for="(article, i) in newsArticles.slice(0, 3)" :key="i" class="news-article">
+                <div class="news-article-title">{{ article.page_title || article.source_headline || `Article ${i + 1}` }}</div>
+                <div class="news-article-meta">
+                  {{ article.open_method || articleEvidence(i).open_method || 'open' }}
+                  <span v-if="articleEvidence(i).text"> · {{ compactEvidence(articleEvidence(i).text) }}</span>
+                </div>
+                <div v-if="article.body_snippet" class="news-article-body">{{ article.body_snippet }}</div>
+                <div v-else-if="article.error" class="news-article-error">{{ article.error }}</div>
+              </div>
+            </div>
+            <div v-if="newsErrors.length" class="news-status news-status--error">{{ firstNewsError() }}</div>
+          </div>
         </div>
         <!-- Stream -->
         <div class="stream-panel" style="flex: 1">
@@ -1042,20 +1888,47 @@ onUnmounted(() => {
             @touchmove="videoTouchMove(selectedDevice)"
             @touchend="videoTouchEnd(selectedDevice, $event)" />
           <img v-else-if="streaming && singleStreamMode === 'mjpeg' && singleMjpegUrl"
+            :id="`mjpeg-img-${selectedDevice}`"
             :src="singleMjpegUrl"
             class="stream-media"
+            crossorigin="anonymous"
             draggable="false"
+            @load="mjpegImageLoaded(selectedDevice)"
+            @error="mjpegImageError(selectedDevice)"
             @mousedown="mjpegMouseDown(selectedDevice, $event)"
-            @mousemove="videoMouseMove(selectedDevice)"
+            @mousemove="mjpegMove(selectedDevice)"
             @mouseup="mjpegMouseUp(selectedDevice, $event)"
             @mouseleave="videoMouseLeave(selectedDevice)"
+            @touchstart="mjpegTouchStart(selectedDevice, $event)"
+            @touchmove="mjpegTouchMove(selectedDevice, $event)"
+            @touchend="mjpegTouchEnd(selectedDevice, $event)"
+            @touchcancel="mjpegTouchCancel(selectedDevice)"
             @dragstart.prevent />
+          <canvas v-show="streaming && singleStreamMode === 'h264'"
+            :id="`h264-canvas-${selectedDevice}`" class="stream-media"
+            style="cursor: pointer; touch-action: none"
+            @mousedown="mjpegMouseDown(selectedDevice, $event)"
+            @mousemove="mjpegMove(selectedDevice)"
+            @mouseup="mjpegMouseUp(selectedDevice, $event)"
+            @mouseleave="videoMouseLeave(selectedDevice)"
+            @touchstart="mjpegTouchStart(selectedDevice, $event)"
+            @touchmove="mjpegTouchMove(selectedDevice, $event)"
+            @touchend="mjpegTouchEnd(selectedDevice, $event)"
+            @touchcancel="mjpegTouchCancel(selectedDevice)"
+            @dragstart.prevent />
+          <div v-if="streaming && singleStreamMode === 'h264' && h264ShowMetrics" class="h264-badge" @click="h264ShowMetrics = false" title="Click to hide">
+            <template v-if="h264M.renderFps || h264M.recvFps">
+              recv {{ h264M.recvFps }} · render {{ h264M.renderFps }}fps · q{{ h264M.queue }} · {{ h264M.latencyMs }}ms · {{ h264M.kbps }}kbps<span v-if="h264M.dropped"> · drop {{ h264M.dropped }}</span>
+            </template>
+            <template v-else>H.264 {{ h264Status }}</template>
+          </div>
+          <button v-if="streaming && singleStreamMode === 'h264' && !h264ShowMetrics" class="h264-badge h264-badge--show" @click="h264ShowMetrics = true" title="Show metrics">ⓘ</button>
           <div v-if="!streaming" class="stream-placeholder">
             Select device &amp; start stream<br/>or chat — auto-starts
           </div>
           <div v-if="blackWarning[selectedDevice]" class="black-warning">
-            FLAG_SECURE — switch to MJPEG
-            <button @click="blackWarning[selectedDevice] = false; toggleSingleMode()" class="black-warning-btn">Switch</button>
+            {{ blackWarningText(selectedDevice) }}
+            <button v-if="!selectedIsIos" @click="blackWarning[selectedDevice] = false; toggleSingleMode()" class="black-warning-btn">Switch</button>
           </div>
           <!-- Frozen stream overlay -->
           <div v-if="streamFrozen[selectedDevice]" class="frozen-overlay" @click="reconnectStream(selectedDevice)">
@@ -1067,12 +1940,10 @@ onUnmounted(() => {
       </div>
         <!-- Bottom: hardware keys -->
         <div style="display: flex; gap: 3px; padding: 4px; justify-content: center; flex-wrap: wrap">
-          <button class="ctrl-btn" style="font-size:9px;padding:3px 8px" @click="sendKeyTo(selectedDevice, 'KEYCODE_BACK')">&#x25C0;</button>
-          <button class="ctrl-btn" style="font-size:9px;padding:3px 8px" @click="sendKeyTo(selectedDevice, 'KEYCODE_HOME')">&#x23FA;</button>
-          <button class="ctrl-btn" style="font-size:9px;padding:3px 8px" @click="sendKeyTo(selectedDevice, 'KEYCODE_APP_SWITCH')">&#x2B1C;</button>
-          <button class="ctrl-btn" style="font-size:9px;padding:3px 8px" @click="sendKeyTo(selectedDevice, 'KEYCODE_POWER')">&#x23FB;</button>
-          <button class="ctrl-btn" style="font-size:9px;padding:3px 8px" @click="sendKeyTo(selectedDevice, 'KEYCODE_VOLUME_UP')">&#x1F50A;</button>
-          <button class="ctrl-btn" style="font-size:9px;padding:3px 8px" @click="sendKeyTo(selectedDevice, 'KEYCODE_VOLUME_DOWN')">&#x1F509;</button>
+          <button v-for="key in hardwareKeys(selectedDevice)" :key="String(key.key)" class="ctrl-btn"
+            style="font-size:9px;padding:3px 8px" :title="key.title" @click="sendKeyTo(selectedDevice, key.key)">
+            {{ key.label }}
+          </button>
         </div>
       </div>
     </div>
@@ -1081,10 +1952,10 @@ onUnmounted(() => {
     <div v-if="subTab === 'multi'">
       <!-- Controls header -->
       <div class="multi-header">
-        <button class="ctrl-btn ctrl-btn--webrtc" @click="startAllStreams('rtc')">&#x26A1; Start All (WebRTC)</button>
-        <button class="ctrl-btn ctrl-btn--mjpeg" @click="startAllStreams('mjpeg')">&#x25B6; Start All (MJPEG)</button>
+        <button v-if="hasAndroidDevices" class="ctrl-btn ctrl-btn--webrtc" @click="startAllStreams('rtc')" title="Android devices use Portal WebRTC; iOS devices use WDA MJPEG automatically">&#x26A1; Start All (Auto)</button>
+        <button class="ctrl-btn ctrl-btn--mjpeg" @click="startAllStreams('mjpeg')" :title="hasIosDevices ? 'Start WDA MJPEG on iOS and MJPEG on Android' : 'Start Android MJPEG streams'">&#x25B6; Start All (MJPEG)</button>
         <button class="ctrl-btn ctrl-btn--stop" @click="stopAllStreams">&#x23F9; Stop All</button>
-        <button class="ctrl-btn" @click="showWirelessModal = true" style="background: #0ea5e922; color: #38bdf8; border-color: #0ea5e955">&#x1F4F6; WiFi Connect</button>
+        <button v-if="hasAndroidDevices" class="ctrl-btn" @click="showWirelessModal = true" style="background: #0ea5e922; color: #38bdf8; border-color: #0ea5e955">&#x1F4F6; WiFi Connect</button>
         <button class="ctrl-btn" @click="loadAllHealth" style="font-size: 10px">Health &#x27F3;</button>
         <span class="device-count">{{ devices.length }} device(s)</span>
       </div>
@@ -1095,41 +1966,66 @@ onUnmounted(() => {
           <!-- Header -->
           <div class="multi-card-header">
             <span class="multi-device-name">{{ d.connection === 'wifi' ? '\uD83D\uDCF6' : '\uD83D\uDD0C' }} {{ d.nickname || d.model || d.serial }}</span>
-            <span v-if="healthData[d.serial]" class="health-dots" :title="'Portal / WiFi / Battery / Storage / Screen'">
-              <span v-for="(c, i) in healthDots(d.serial)" :key="i" class="health-dot" :style="{ background: c === 'green' ? '#22c55e' : c === 'yellow' ? '#f59e0b' : c === 'red' ? '#ef4444' : '#475569' }"></span>
+            <span v-if="healthData[d.serial]" class="health-dots" :title="healthTitle(d.serial)">
+              <span v-for="(c, i) in healthDots(d.serial)" :key="i" class="health-dot" :style="{ background: healthDotColor(c) }"></span>
             </span>
-            <button v-if="healthData[d.serial]?.wifi?.ip && !d.serial.includes(':')" class="hw-key-btn"
+            <button v-if="iosRecoveryCanApplyFix(d.serial)" class="hw-key-btn"
+              :disabled="iosRecoveryFixBusy(d.serial)"
+              @click="fixIssue(d.serial, iosRecoveryAction(d.serial))"
+              :title="iosRecoveryActionTitle(d.serial)">
+              {{ iosRecoveryFixBusy(d.serial) ? '...' : iosRecoveryActionLabel(d.serial) }}
+            </button>
+            <button v-if="healthData[d.serial]?.wifi?.ip && !isIosDevice(d.serial) && d.connection !== 'wifi'" class="hw-key-btn"
               @click="goWireless(d.serial)" title="Go Wireless" style="color: #38bdf8">&#x1F4F6;</button>
             <div class="multi-hw-keys">
-              <button class="hw-key-btn" @click="sendKeyTo(d.serial, 4)" title="Back">&#x25C0;</button>
-              <button class="hw-key-btn" @click="sendKeyTo(d.serial, 3)" title="Home">&#x2302;</button>
-              <button class="hw-key-btn" @click="sendKeyTo(d.serial, 187)" title="Recents">&#x25A6;</button>
-              <button class="hw-key-btn" @click="sendKeyTo(d.serial, 26)" title="Power">&#x23FB;</button>
-              <button class="hw-key-btn" @click="sendKeyTo(d.serial, 24)" title="Vol+">&#x1F50A;</button>
-              <button class="hw-key-btn" @click="sendKeyTo(d.serial, 25)" title="Vol-">&#x1F509;</button>
-              <button class="hw-key-btn" @click="toggleOverlay(d.serial)"
+              <button v-for="key in hardwareKeys(d.serial)" :key="String(key.key)" class="hw-key-btn"
+                @click="sendKeyTo(d.serial, key.key)" :title="key.title">{{ key.label }}</button>
+              <button v-if="!isIosDevice(d.serial)" class="hw-key-btn" @click="toggleOverlay(d.serial)"
                 :style="{ background: overlayOn[d.serial] ? '#fbbf24' : '', color: overlayOn[d.serial] ? '#000' : '#fbbf24' }" title="Toggle UI Grid">&#x1F522;</button>
             </div>
             <div class="multi-stream-btns">
               <span class="multi-mode-badge"
+                :title="streamInfoTitle(d.serial)"
                 :style="multiStreamMode[d.serial] === 'mjpeg' ? { background: '#6366f133', color: '#a5b4fc' } : rtcStatus[d.serial] === 'Streaming' ? { background: '#22c55e22', color: '#4ade80' } : { color: '#475569' }">
-                {{ multiStreaming[d.serial] ? (multiStreamMode[d.serial] === 'mjpeg' ? 'MJPEG' : (rtcStatus[d.serial] || 'RTC')) : '' }}
+                {{ multiStreaming[d.serial] ? multiStreamLabel(d.serial) : '' }}
               </span>
               <button v-if="rtcStatus[d.serial]?.includes('Portal') || rtcStatus[d.serial]?.includes('fix')"
                 class="ctrl-btn ctrl-btn--fix"
                 @click="rtcFixPortal(d.serial)" title="Fix Portal">Fix</button>
+              <button class="ctrl-btn ctrl-btn--record ctrl-btn--tiny"
+                :class="{ 'ctrl-btn--record-active': recordingState[d.serial] }"
+                :disabled="recordingBusy[d.serial]"
+                :title="recordingTitle(d.serial)"
+                @click="toggleRecording(d.serial)">
+                {{ recordingTinyText(d.serial) }}
+              </button>
+              <a v-if="recordingUrls[d.serial]" class="ctrl-btn ctrl-btn--record-link ctrl-btn--tiny"
+                :href="recordingUrls[d.serial]" target="_blank" rel="noopener"
+                :title="recordingFilenames[d.serial] || 'Open recording'">MP4</a>
               <template v-if="!multiStreaming[d.serial]">
-                <button class="ctrl-btn ctrl-btn--webrtc ctrl-btn--tiny" @click="startMultiStream(d.serial, 'rtc')" title="WebRTC">&#x26A1;</button>
+                <button v-if="!isIosDevice(d.serial)" class="ctrl-btn ctrl-btn--webrtc ctrl-btn--tiny" @click="startMultiStream(d.serial, 'rtc')" title="WebRTC">&#x26A1;</button>
                 <button class="ctrl-btn ctrl-btn--mjpeg ctrl-btn--tiny" @click="startMultiStream(d.serial, 'mjpeg')" title="MJPEG">&#x25B6;</button>
               </template>
               <template v-else>
                 <button class="ctrl-btn ctrl-btn--stop ctrl-btn--tiny" @click="stopMultiStream(d.serial)">&#x23F9;</button>
-                <button class="ctrl-btn ctrl-btn--tiny" @click="toggleMultiMode(d.serial)"
+                <button v-if="!isIosDevice(d.serial)" class="ctrl-btn ctrl-btn--tiny" @click="toggleMultiMode(d.serial)"
                   :style="{ background: multiStreamMode[d.serial] === 'rtc' ? '#0ea5e922' : '#6366f122', color: multiStreamMode[d.serial] === 'rtc' ? '#38bdf8' : '#a5b4fc', borderColor: multiStreamMode[d.serial] === 'rtc' ? '#0ea5e955' : '#6366f155' }"
                   :title="'Switch to ' + (multiStreamMode[d.serial] === 'rtc' ? 'MJPEG' : 'WebRTC')">&#x21C4;</button>
               </template>
               <button class="ctrl-btn ctrl-btn--tiny" @click="selectedDevice = d.serial; subTab = 'single'; startStream()" title="Expand">&#x2197;</button>
             </div>
+          </div>
+          <div v-if="iosRecoveryVisible(d.serial)" class="ios-recovery-compact" :title="healthTitle(d.serial)">
+            <span>{{ iosRecoveryState(d.serial) }}</span>
+            <span v-if="iosRecoveryCode(d.serial)">{{ iosRecoveryCode(d.serial) }}</span>
+            <span v-if="healthFixStatus[d.serial]">{{ healthFixStatus[d.serial] }}</span>
+          </div>
+          <div v-if="recordingStatus[d.serial]" class="multi-recording-status" :title="recordingStatus[d.serial]">
+            <span v-if="recordingState[d.serial]" class="recording-dot"></span>
+            {{ recordingStatus[d.serial] }}
+          </div>
+          <div v-if="streamInfoStatus[d.serial]" class="multi-recording-status" :title="streamInfoStatus[d.serial]">
+            {{ streamInfoStatus[d.serial] }}
           </div>
 
           <!-- Stream area -->
@@ -1146,19 +2042,27 @@ onUnmounted(() => {
               @touchend="videoTouchEnd(d.serial, $event)" />
             <!-- MJPEG img -->
             <img v-else-if="multiStreaming[d.serial] && multiStreamMode[d.serial] === 'mjpeg' && mjpegUrls[d.serial]"
+              :id="`mjpeg-img-${d.serial}`"
               :src="mjpegUrls[d.serial]"
               class="multi-stream-media"
+              crossorigin="anonymous"
               draggable="false"
+              @load="mjpegImageLoaded(d.serial)"
+              @error="mjpegImageError(d.serial)"
               @mousedown="mjpegMouseDown(d.serial, $event)"
-              @mousemove="videoMouseMove(d.serial)"
+              @mousemove="mjpegMove(d.serial)"
               @mouseup="mjpegMouseUp(d.serial, $event)"
               @mouseleave="videoMouseLeave(d.serial)"
+              @touchstart="mjpegTouchStart(d.serial, $event)"
+              @touchmove="mjpegTouchMove(d.serial, $event)"
+              @touchend="mjpegTouchEnd(d.serial, $event)"
+              @touchcancel="mjpegTouchCancel(d.serial)"
               @dragstart.prevent />
-            <div v-else class="multi-stream-placeholder">Press &#x26A1; or &#x25B6; to stream</div>
+            <div v-else class="multi-stream-placeholder">{{ streamPlaceholderText(d.serial) }}</div>
             <!-- Black screen warning -->
             <div v-if="blackWarning[d.serial]" class="black-warning black-warning--compact">
-              FLAG_SECURE — switch to MJPEG
-              <button @click="blackWarning[d.serial] = false; toggleMultiMode(d.serial)" class="black-warning-btn">Switch</button>
+              {{ blackWarningText(d.serial) }}
+              <button v-if="!isIosDevice(d.serial)" @click="blackWarning[d.serial] = false; toggleMultiMode(d.serial)" class="black-warning-btn">Switch</button>
             </div>
             <!-- Frozen stream overlay -->
             <div v-if="streamFrozen[d.serial]" class="frozen-overlay" @click="reconnectStream(d.serial)">
@@ -1194,7 +2098,7 @@ onUnmounted(() => {
       </div>
     </div>
     <!-- Wireless connect modal -->
-    <div v-if="showWirelessModal" class="fixed inset-0 bg-black/60 flex items-center justify-center z-50" @click.self="showWirelessModal = false">
+    <div v-if="showWirelessModal && hasAndroidDevices" class="fixed inset-0 bg-black/60 flex items-center justify-center z-50" @click.self="showWirelessModal = false">
       <div class="card" style="width: 360px">
         <h3 class="font-bold text-sm mb-3" style="color: var(--text-1)">Connect WiFi Device</h3>
         <div class="mb-2">
@@ -1339,6 +2243,14 @@ onUnmounted(() => {
   user-select: none;
 }
 
+.h264-badge {
+  position: absolute; top: 6px; left: 6px; z-index: 3;
+  font-size: 9px; padding: 2px 7px; border-radius: 10px;
+  background: rgba(99,102,241,0.85); color: #fff; white-space: nowrap;
+  cursor: pointer; border: none;
+}
+.h264-badge--show { opacity: 0.5; padding: 2px 6px; }
+.h264-badge--show:hover { opacity: 1; }
 .stream-placeholder {
   color: var(--text-4);
   font-size: 13px;
@@ -1429,6 +2341,10 @@ onUnmounted(() => {
   white-space: nowrap;
 }
 .ctrl-btn:hover { border-color: var(--accent); color: var(--text-1); }
+.ctrl-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
 
 .ctrl-btn--webrtc { background: #0ea5e9; color: #fff; border-color: #0ea5e9; }
 .ctrl-btn--webrtc:hover { background: #0284c7; border-color: #0284c7; }
@@ -1437,8 +2353,250 @@ onUnmounted(() => {
 .ctrl-btn--stop { border-color: #475569; color: var(--text-3); }
 .ctrl-btn--confirm { color: #34d399; border-color: #34d399; }
 .ctrl-btn--fix { background: #f59e0b; color: #000; border: none; font-size: 9px; padding: 2px 6px; }
+.ctrl-btn--fix:disabled,
+.hw-key-btn:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+.ctrl-btn--record {
+  border-color: #7f1d1d;
+  color: #fca5a5;
+  background: #1f1118;
+}
+.ctrl-btn--record:hover:not(:disabled) {
+  border-color: #ef4444;
+  color: #fecaca;
+}
+.ctrl-btn--record-active {
+  background: #ef444433;
+  border-color: #ef444466;
+  color: #fecaca;
+}
+.ctrl-btn--record-link {
+  border-color: #164e63;
+  color: #67e8f9;
+  background: #082f49;
+  text-decoration: none;
+}
 
 .ctrl-btn--tiny { font-size: 9px; padding: 2px 6px; }
+
+.recording-status-line,
+.multi-recording-status {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 18px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-3);
+}
+
+.recording-status-line {
+  padding: 0 6px;
+  font-size: 9px;
+}
+
+.multi-recording-status {
+  padding: 2px 6px 0;
+  font-size: 8px;
+}
+
+.recording-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #ef4444;
+  box-shadow: 0 0 0 2px #7f1d1d55;
+  flex-shrink: 0;
+}
+
+.news-panel {
+  margin: 0 4px;
+  padding: 8px;
+  border: 1px solid #1e293b;
+  border-radius: 8px;
+  background: #0a0f16;
+  flex-shrink: 0;
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+.news-panel-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+
+.news-title {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--text-2);
+}
+
+.news-panel-head .ctrl-btn {
+  margin-left: auto;
+}
+
+.news-controls {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr) 42px 42px 48px;
+  gap: 4px;
+}
+
+.news-input,
+.news-number {
+  min-width: 0;
+  padding: 4px 6px;
+  border-radius: 5px;
+  border: 1px solid #1e293b;
+  background: #070b10;
+  color: var(--text-2);
+  font-size: 9px;
+}
+
+.news-input--out {
+  grid-column: 1 / -1;
+}
+
+.news-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  min-width: 0;
+  padding: 4px 5px;
+  border-radius: 5px;
+  border: 1px solid #1e293b;
+  background: #070b10;
+  color: #94a3b8;
+  font-size: 9px;
+  white-space: nowrap;
+}
+
+.news-toggle input {
+  width: 11px;
+  height: 11px;
+  accent-color: #6366f1;
+}
+
+.news-status {
+  margin-top: 6px;
+  padding: 4px 6px;
+  border-radius: 5px;
+  background: #111827;
+  color: #94a3b8;
+  font-size: 9px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.news-status--error {
+  background: #3f1d26;
+  color: #fca5a5;
+  white-space: normal;
+}
+
+.news-result {
+  margin-top: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.news-summary,
+.news-evidence,
+.news-artifacts {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  color: var(--text-3);
+  font-size: 9px;
+}
+
+.news-pill {
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-size: 8px;
+  font-weight: 700;
+}
+
+.news-pill--ok {
+  background: #14532d;
+  color: #86efac;
+}
+
+.news-pill--error {
+  background: #7f1d1d;
+  color: #fecaca;
+}
+
+.news-evidence span {
+  padding: 2px 5px;
+  border: 1px solid #1e293b;
+  border-radius: 4px;
+  background: #070b10;
+  color: #67e8f9;
+}
+
+.news-artifacts span {
+  max-width: 100%;
+  padding: 2px 5px;
+  border: 1px solid #1e293b;
+  border-radius: 4px;
+  background: #111827;
+  color: #a5b4fc;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.news-list,
+.news-articles {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.news-headline,
+.news-article {
+  padding: 5px 6px;
+  border: 1px solid #1e293b;
+  border-radius: 6px;
+  background: #070b10;
+}
+
+.news-headline,
+.news-article-title {
+  color: var(--text-2);
+  font-size: 10px;
+  line-height: 1.35;
+}
+
+.news-article-meta {
+  margin-top: 2px;
+  color: #64748b;
+  font-size: 8px;
+}
+
+.news-article-body,
+.news-article-error {
+  margin-top: 4px;
+  color: var(--text-3);
+  font-size: 9px;
+  line-height: 1.4;
+  max-height: 58px;
+  overflow: hidden;
+  white-space: pre-line;
+}
+
+.news-article-error {
+  color: #fca5a5;
+}
 
 .btn-grid {
   display: grid;
@@ -1642,6 +2800,165 @@ onUnmounted(() => {
   height: 6px;
   border-radius: 50%;
   display: inline-block;
+}
+
+.ios-recovery-panel {
+  margin: 0 4px 4px;
+  padding: 8px 10px;
+  border: 1px solid #f59e0b44;
+  background: #0f172a;
+  border-radius: 6px;
+  color: var(--text-2);
+  font-size: 10px;
+}
+
+.ios-recovery-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 4px;
+  min-width: 0;
+}
+
+.ios-recovery-state {
+  color: #fbbf24;
+  font-weight: 700;
+}
+
+.ios-recovery-code {
+  color: #fed7aa;
+  border: 1px solid #f59e0b55;
+  border-radius: 4px;
+  padding: 1px 5px;
+}
+
+.ios-recovery-link {
+  margin-left: auto;
+  color: #93c5fd;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 10px;
+  padding: 0;
+}
+
+.ios-recovery-summary {
+  color: var(--text-3);
+  line-height: 1.35;
+}
+
+.ios-recovery-summary-inline {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-3);
+  font-size: 11px;
+  opacity: 0.85;
+}
+
+.ios-recovery-link--fix {
+  margin-left: 0;
+  color: #6ee7b7;
+  font-weight: 700;
+}
+
+.ios-recovery-details {
+  margin-top: 6px;
+}
+
+.ios-recovery-status {
+  margin-top: 4px;
+  color: #93c5fd;
+  font-size: 9px;
+  line-height: 1.3;
+}
+
+.ios-health-details {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 6px;
+}
+
+.ios-health-chip {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 2px 5px;
+  border: 1px solid #334155;
+  border-radius: 4px;
+  background: #020617;
+  color: #94a3b8;
+  font-size: 9px;
+}
+
+.ios-health-chip--ok {
+  border-color: #16653466;
+  color: #86efac;
+  background: #052e1622;
+}
+
+.ios-recovery-steps {
+  margin: 5px 0 0;
+  padding-left: 16px;
+  color: var(--text-4);
+  line-height: 1.35;
+}
+
+.ios-recovery-commands {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 6px;
+}
+
+.ios-recovery-command {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 6px;
+  align-items: center;
+}
+
+.ios-recovery-command code {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 4px 6px;
+  border: 1px solid #334155;
+  border-radius: 4px;
+  background: #020617;
+  color: #c4b5fd;
+  font-size: 9px;
+}
+
+.ios-copy-btn {
+  padding: 3px 6px;
+  border: 1px solid #334155;
+  border-radius: 4px;
+  background: #111827;
+  color: #93c5fd;
+  font-size: 9px;
+  cursor: pointer;
+}
+
+.ios-copy-btn:hover {
+  border-color: #60a5fa;
+  color: #bfdbfe;
+}
+
+.ios-recovery-compact {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  padding: 3px 6px;
+  border-top: 1px solid #f59e0b33;
+  background: #f59e0b12;
+  color: #fbbf24;
+  font-size: 9px;
+  line-height: 1.2;
 }
 
 .multi-hw-keys {

--- a/frontend/src/views/SchedulerView.vue
+++ b/frontend/src/views/SchedulerView.vue
@@ -23,6 +23,9 @@ const logPanelTitle = ref('')
 const logPanelLines = ref<string[]>([])
 const logPanelAutoScroll = ref(true)
 const logPanelSource = ref<{ type: 'queue' | 'history'; id: number } | null>(null)
+const logPanelResult = ref<any | null>(null)
+const logPanelResultLoading = ref(false)
+const logPanelResultError = ref('')
 let logPollTimer: number | null = null
 
 /* form state */
@@ -34,10 +37,112 @@ const sf = ref<any>({
   max_duration_s: 900, account: '', config_json: '{}',
 })
 
+type JobTypeOption = {
+  value: string
+  label: string
+  android: boolean
+  ios: boolean
+}
+
+type IosScheduleTemplate = {
+  id: string
+  label: string
+  name: string
+  max_duration_s: number
+  config: Record<string, any>
+}
+
+type ReadNewsItem = {
+  title?: string
+  page_title?: string
+  source_headline?: string
+  url?: string
+  current_url?: string
+  body_snippet?: string
+  text?: string
+}
+
+type ExtractionEvidence = {
+  source?: string
+  attempts?: number
+  returned?: number
+  target?: number
+  returned_lines?: number
+  target_lines?: number
+  text?: ExtractionEvidence
+  open_method?: string
+  [key: string]: any
+}
+
+const DEFAULT_IOS_TEMPLATE_ID = 'chrome_browser_smoke'
+
+const JOB_TYPE_OPTIONS: JobTypeOption[] = [
+  { value: 'post', label: 'Post', android: true, ios: false },
+  { value: 'publish_draft', label: 'Publish Draft', android: true, ios: false },
+  { value: 'skill_workflow', label: 'Skill', android: true, ios: true },
+  { value: 'app_explore', label: 'Explore App', android: true, ios: true },
+]
+
+const IOS_SCHEDULE_TEMPLATES: IosScheduleTemplate[] = [
+  {
+    id: 'chrome_browser_smoke',
+    label: 'Chrome News',
+    name: 'iOS Chrome News',
+    max_duration_s: 600,
+    config: {
+      skill: 'safari',
+      workflow: 'read_news',
+      params: {
+        url: 'https://text.npr.org/',
+        max_headlines: 5,
+        max_articles: 3,
+        wait_s: 2,
+        bundle_id: 'com.google.chrome.ios',
+        save_screenshots: true,
+        out_dir: 'data/ios_chrome_news_smoke',
+      },
+    },
+  },
+  {
+    id: 'tiktok_profile_smoke',
+    label: 'TikTok Profile Smoke',
+    name: 'iOS TikTok Profile Smoke',
+    max_duration_s: 300,
+    config: {
+      skill: 'tiktok_ios',
+      workflow: 'profile_smoke',
+      params: { max_lines: 80 },
+    },
+  },
+  {
+    id: 'tiktok_search_smoke',
+    label: 'TikTok Search Smoke',
+    name: 'iOS TikTok Search Smoke',
+    max_duration_s: 300,
+    config: {
+      skill: 'tiktok_ios',
+      workflow: 'search_smoke',
+      params: { query: '#news' },
+    },
+  },
+  {
+    id: 'tiktok_open_app_smoke',
+    label: 'TikTok Open App Smoke',
+    name: 'iOS TikTok Open App Smoke',
+    max_duration_s: 300,
+    config: {
+      skill: 'tiktok_ios',
+      workflow: 'open_app_smoke',
+      params: {},
+    },
+  },
+]
+
 /* timeline canvas */
 const timelineCanvas = ref<HTMLCanvasElement | null>(null)
-let timelineHits: any[] = []
+let timelineHits: { x: number; y: number; w: number; h: number; data: any }[] = []
 let animFrameId: number | null = null
+const tooltip = ref<{ x: number; y: number; data: any } | null>(null)
 
 const TYPE_COLORS: Record<string, string> = {
   post: '#f59e0b', content_gen: '#22c55e', publish_draft: '#a855f7',
@@ -75,9 +180,13 @@ function openLogPanel(source: { type: 'queue' | 'history'; id: number }, title: 
   logPanelOpen.value = true
   logPanelTitle.value = title
   logPanelLines.value = []
+  logPanelResult.value = null
+  logPanelResultLoading.value = false
+  logPanelResultError.value = ''
   logPanelAutoScroll.value = true
   logPanelSource.value = source
   pollLogPanel()
+  loadLogPanelResult(source)
   if (logPollTimer) clearInterval(logPollTimer)
   logPollTimer = window.setInterval(pollLogPanel, 1500)
 }
@@ -86,7 +195,32 @@ function closeLogPanel() {
   logPanelOpen.value = false
   logPanelSource.value = null
   logPanelLines.value = []
+  logPanelResult.value = null
+  logPanelResultLoading.value = false
+  logPanelResultError.value = ''
   if (logPollTimer) { clearInterval(logPollTimer); logPollTimer = null }
+}
+
+async function loadLogPanelResult(source: { type: 'queue' | 'history'; id: number }) {
+  if (source.type !== 'history') return
+  const stillCurrent = () => logPanelSource.value?.type === source.type && logPanelSource.value?.id === source.id
+  logPanelResultLoading.value = true
+  try {
+    const resp = await api(`/api/scheduler/history/${source.id}/result`)
+    if (!stillCurrent()) return
+    if (resp?.ok && resp.result) {
+      logPanelResult.value = resp
+    } else {
+      logPanelResult.value = null
+      logPanelResultError.value = resp?.error || ''
+    }
+  } catch (e: any) {
+    if (!stillCurrent()) return
+    logPanelResult.value = null
+    logPanelResultError.value = e?.message || 'result unavailable'
+  } finally {
+    if (stillCurrent()) logPanelResultLoading.value = false
+  }
 }
 
 async function pollLogPanel() {
@@ -122,6 +256,45 @@ function phoneName(serial: string | null): string {
   return serial.slice(0, 5)
 }
 
+function isIosSerial(serial: string | null | undefined): boolean {
+  return !!serial && serial.startsWith('ios:')
+}
+
+function platformValue(value: any): 'ios' | 'android' | '' {
+  const platform = String(value || '').toLowerCase()
+  return platform === 'ios' || platform === 'android' ? platform : ''
+}
+
+function platformForSerial(serial: string | null | undefined, ...sources: any[]): 'ios' | 'android' {
+  for (const source of sources) {
+    const platform = platformValue(source?.platform || source?.device_platform)
+    if (platform) return platform
+  }
+  if (isIosSerial(serial)) return 'ios'
+  return 'android'
+}
+
+function schedulerPlatformSource(serial: string): any | null {
+  const collections = [
+    schedules.value,
+    history.value,
+    queue.value,
+    timeline.value.past || [],
+    timeline.value.future || [],
+    timeline.value.content_plan || [],
+  ]
+  for (const collection of collections) {
+    const match = collection.find((item: any) => item.phone_serial === serial && platformValue(item.platform))
+    if (match) return match
+  }
+  return status.value[serial] || null
+}
+
+function deviceOptionLabel(ph: any): string {
+  const platform = ph.platform === 'ios' ? 'iOS' : 'Android'
+  return `${ph.label} (${platform})`
+}
+
 const phoneList = computed(() => {
   // Build phone list from devices + any serials found in data
   const serials = new Set<string>()
@@ -134,7 +307,37 @@ const phoneList = computed(() => {
   return Array.from(serials).map(s => ({
     serial: s,
     label: phoneName(s),
+    platform: platformForSerial(s, devices.value.find((d: any) => d.serial === s), schedulerPlatformSource(s)),
   }))
+})
+
+const selectedScheduleDevice = computed(() =>
+  devices.value.find((p: any) => p.serial === sf.value.phone_serial)
+)
+
+const selectedScheduleIsIos = computed(() =>
+  platformForSerial(sf.value.phone_serial, selectedScheduleDevice.value) === 'ios'
+)
+
+const selectedSchedulePlatform = computed(() =>
+  selectedScheduleIsIos.value ? 'ios' : 'android'
+)
+
+const jobTypeOptions = computed(() =>
+  JOB_TYPE_OPTIONS.filter(option => selectedScheduleIsIos.value ? option.ios : option.android)
+)
+
+const schedulePlatformNotice = computed(() => {
+  if (!selectedScheduleIsIos.value) return ''
+  return 'iOS schedules default to the Chrome/news workflow and can run supported skill workflows or app exploration. TikTok post and publish jobs stay Android-only until the iOS upload flow is ported.'
+})
+
+const currentIosTemplateId = computed(() => {
+  const cfg = parseConfig(sf.value.config_json)
+  const match = IOS_SCHEDULE_TEMPLATES.find(template =>
+    cfg.skill === template.config.skill && cfg.workflow === template.config.workflow
+  )
+  return match?.id || 'custom'
 })
 
 /* ── computed: filtered schedules ───────────────────────────────────────── */
@@ -185,11 +388,145 @@ function parseConfig(json: string): any {
   try { return JSON.parse(json || '{}') } catch { return {} }
 }
 
+function findNestedResult(data: any, predicate: (item: any) => boolean): any | null {
+  if (!data || typeof data !== 'object') return null
+  if (predicate(data)) return data
+  if (data.data && typeof data.data === 'object') {
+    const nested = findNestedResult(data.data, predicate)
+    if (nested) return nested
+  }
+  const steps = Array.isArray(data.step_results) ? data.step_results : []
+  for (const step of steps) {
+    const nested = findNestedResult(step?.data, predicate)
+    if (nested) return nested
+  }
+  return null
+}
+
+const logPanelReadNews = computed(() =>
+  findNestedResult(
+    logPanelResult.value?.result,
+    item => Array.isArray(item?.headlines) && Array.isArray(item?.articles),
+  )
+)
+
+const logPanelGenericResult = computed(() => {
+  const result = logPanelResult.value?.result
+  if (!result || logPanelReadNews.value) return null
+  return result
+})
+
+const logPanelHeadlines = computed<ReadNewsItem[]>(() =>
+  Array.isArray(logPanelReadNews.value?.headlines) ? logPanelReadNews.value.headlines.slice(0, 5) : []
+)
+
+const logPanelArticles = computed<ReadNewsItem[]>(() =>
+  Array.isArray(logPanelReadNews.value?.articles) ? logPanelReadNews.value.articles.slice(0, 3) : []
+)
+
+const logPanelExtraction = computed<Record<string, any>>(() => logPanelReadNews.value?.extraction || {})
+
+const logPanelResultJson = computed(() =>
+  logPanelGenericResult.value ? JSON.stringify(logPanelGenericResult.value, null, 2) : ''
+)
+
+function resultTitle(item: any): string {
+  return String(item?.title || item?.page_title || item?.source_headline || '').trim()
+}
+
+function resultUrl(item: any): string {
+  return String(item?.url || item?.current_url || '').trim()
+}
+
+function resultSnippet(item: any): string {
+  return String(item?.body_snippet || item?.text || '').trim()
+}
+
+function compactEvidence(evidence: any): string {
+  if (!evidence) return ''
+  const source = String(evidence.source || 'unknown')
+  const attempts = evidence.attempts !== undefined ? `${evidence.attempts}x` : ''
+  if (evidence.returned !== undefined) return `${source} ${evidence.returned}/${evidence.target} ${attempts}`.trim()
+  if (evidence.returned_lines !== undefined) {
+    return `${source} ${evidence.returned_lines}/${evidence.target_lines} lines ${attempts}`.trim()
+  }
+  return source
+}
+
+function displayIndex(index: string | number): number {
+  return Number(index) + 1
+}
+
+function articleEvidence(index: string | number): ExtractionEvidence {
+  const items = logPanelExtraction.value?.articles
+  return Array.isArray(items) ? items[Number(index)] || {} : {}
+}
+
+function evidenceTitle(evidence: any): string {
+  return evidence ? JSON.stringify(evidence) : ''
+}
+
+function stringifyConfig(config: Record<string, any>): string {
+  return JSON.stringify(config, null, 2)
+}
+
+function appExploreDefaultConfig(): Record<string, any> {
+  const pkg = selectedSchedulePlatform.value === 'ios'
+    ? 'com.google.chrome.ios'
+    : 'com.zhiliaoapp.musically'
+  return {
+    package: pkg,
+    max_depth: 2,
+    max_states: 8,
+  }
+}
+
+function applyIosScheduleTemplate(templateId: string) {
+  if (templateId === 'custom') return
+  const template = IOS_SCHEDULE_TEMPLATES.find(t => t.id === templateId)
+  if (!template) return
+  const hadTemplateName = IOS_SCHEDULE_TEMPLATES.some(t => t.name === sf.value.name)
+  sf.value.job_type = 'skill_workflow'
+  if (!String(sf.value.name || '').trim() || hadTemplateName) {
+    sf.value.name = template.name
+  }
+  sf.value.max_duration_s = template.max_duration_s
+  sf.value.config_json = stringifyConfig(template.config)
+}
+
+function ensureIosScheduleDefaults() {
+  if (sf.value.job_type === 'app_explore') {
+    const cfg = parseConfig(sf.value.config_json)
+    if (!cfg.package) {
+      sf.value.config_json = stringifyConfig({ ...appExploreDefaultConfig(), ...cfg })
+    }
+    return
+  }
+  if (!selectedScheduleIsIos.value) return
+  const selectedTypeAllowed = jobTypeOptions.value.some(option => option.value === sf.value.job_type)
+  if (!selectedTypeAllowed) {
+    applyIosScheduleTemplate(DEFAULT_IOS_TEMPLATE_ID)
+    return
+  }
+  if (sf.value.job_type === 'skill_workflow') {
+    const cfg = parseConfig(sf.value.config_json)
+    if (!cfg.skill && !cfg.workflow) {
+      applyIosScheduleTemplate(DEFAULT_IOS_TEMPLATE_ID)
+    }
+  }
+}
+
+function onIosTemplateChange(event: Event) {
+  const target = event.target as HTMLSelectElement | null
+  applyIosScheduleTemplate(target?.value || '')
+}
+
 function configDetail(r: any): string {
   const cfg = parseConfig(r.config_json)
   const jt = r.job_type
   let detail = ''
   if (jt === 'post') detail = cfg.action || 'draft'
+  if (jt === 'app_explore') detail = cfg.package || ''
   if (cfg.account) detail += ` @${cfg.account}`
   return detail
 }
@@ -212,6 +549,7 @@ function schedConfigDetail(s: any): string {
   const cfg = parseConfig(s.config_json)
   const jt = s.job_type
   if (jt === 'post') return cfg.action || 'draft'
+  if (jt === 'app_explore') return cfg.package || ''
   return ''
 }
 
@@ -301,6 +639,7 @@ function sfReset() {
 
 async function sfSave() {
   const f = sf.value
+  ensureIosScheduleDefaults()
   // Inject account into config if set
   if (f.account) {
     try {
@@ -439,6 +778,7 @@ function renderTimeline() {
     ctx.globalAlpha = 0.8
     ctx.fillRect(x, ph.y - 5, w, 14)
     ctx.globalAlpha = 1
+    timelineHits.push({ x, y: ph.y - 5, w, h: 14, data: { kind: 'past', run } })
   }
 
   // Currently running - glowing block
@@ -473,6 +813,7 @@ function renderTimeline() {
     const elapsed = Math.max(0, Math.floor((Date.now() - new Date(job.started_at.replace(' ', 'T')).getTime()) / 1000))
     const elStr = elapsed < 60 ? `${elapsed}s` : `${Math.floor(elapsed / 60)}m`
     ctx.fillText(`\u25B6 ${elStr}`, x + 2, ph.y + 5)
+    timelineHits.push({ x, y: ph.y - 6, w, h: 16, data: { kind: 'active', job, elapsed } })
   }
 
   // Future - outlined blocks
@@ -506,6 +847,7 @@ function renderTimeline() {
     if (shortLabel) ctx.fillText(shortLabel, x + w / 2, ph.y + 2)
     ctx.globalAlpha = 1
     ctx.textBaseline = 'alphabetic'
+    timelineHits.push({ x, y: ph.y - 5, w, h: 14, data: { kind: 'future', fut } })
   }
 
   // Legend
@@ -526,6 +868,29 @@ function renderTimeline() {
   }
 }
 
+function onTimelineMove(ev: MouseEvent) {
+  const canvas = timelineCanvas.value
+  if (!canvas) return
+  const rect = canvas.getBoundingClientRect()
+  const x = ev.clientX - rect.left
+  const y = ev.clientY - rect.top
+  const hit = timelineHits.find(h => x >= h.x && x <= h.x + h.w && y >= h.y && y <= h.y + h.h)
+  if (hit) {
+    canvas.style.cursor = 'pointer'
+    // Clamp x so the tooltip never overflows the right edge of the viewport
+    const tx = Math.min(ev.clientX + 14, window.innerWidth - 280)
+    tooltip.value = { x: tx, y: ev.clientY + 14, data: hit.data }
+  } else {
+    canvas.style.cursor = 'default'
+    tooltip.value = null
+  }
+}
+
+function onTimelineLeave() {
+  tooltip.value = null
+  if (timelineCanvas.value) timelineCanvas.value.style.cursor = 'default'
+}
+
 // Rerender timeline when data or window changes
 function handleResize() {
   renderTimeline()
@@ -534,6 +899,11 @@ function handleResize() {
 watch([timeline, queue, devices], () => {
   nextTick(() => renderTimeline())
 })
+
+watch(
+  () => [sf.value.phone_serial, sf.value.job_type],
+  () => ensureIosScheduleDefaults()
+)
 
 onMounted(() => {
   load()
@@ -598,7 +968,69 @@ onUnmounted(() => {
         <span class="section-subtitle">{{ phoneList.length }} device{{ phoneList.length !== 1 ? 's' : '' }}</span>
       </div>
       <div class="timeline-canvas-wrap">
-        <canvas ref="timelineCanvas" height="160" style="width: 100%; cursor: default" />
+        <canvas
+          ref="timelineCanvas"
+          height="160"
+          style="width: 100%; cursor: default"
+          @mousemove="onTimelineMove"
+          @mouseleave="onTimelineLeave"
+        />
+        <!-- Hover tooltip -->
+        <div
+          v-if="tooltip"
+          :style="{
+            position: 'fixed',
+            left: tooltip.x + 'px',
+            top: tooltip.y + 'px',
+            zIndex: 1000,
+            background: 'var(--bg-card, #141e17)',
+            border: '1px solid var(--border, #1e2e22)',
+            borderRadius: '6px',
+            padding: '8px 10px',
+            fontSize: '11px',
+            color: 'var(--text-1, #e8ede9)',
+            maxWidth: '260px',
+            boxShadow: '0 8px 24px rgba(0,0,0,0.6)',
+            pointerEvents: 'none',
+            fontFamily: 'JetBrains Mono, monospace',
+            lineHeight: 1.5,
+          }"
+        >
+          <template v-if="tooltip.data.kind === 'past'">
+            <div style="font-weight: 600; margin-bottom: 4px">
+              {{ tooltip.data.run.schedule_name || tooltip.data.run.job_type }}
+            </div>
+            <div style="opacity: 0.7">type: {{ tooltip.data.run.job_type }}</div>
+            <div style="opacity: 0.7">status:
+              <span :style="{ color: tooltip.data.run.status === 'completed' ? '#22c55e' : tooltip.data.run.status === 'failed' ? '#ef4444' : '#f59e0b' }">
+                {{ tooltip.data.run.status }}
+              </span>
+            </div>
+            <div style="opacity: 0.7">started: {{ tooltip.data.run.started_at }}</div>
+            <div style="opacity: 0.7">duration: {{ fmtDuration(tooltip.data.run.duration_s) }}</div>
+            <div style="opacity: 0.7">phone: {{ tooltip.data.run.phone_serial?.slice(-6) || '—' }}</div>
+            <div v-if="tooltip.data.run.exit_code != null" style="opacity: 0.7">exit: {{ tooltip.data.run.exit_code }}</div>
+            <div v-if="tooltip.data.run.error_msg" style="color: #ef4444; margin-top: 4px">{{ tooltip.data.run.error_msg.slice(0, 100) }}</div>
+          </template>
+          <template v-else-if="tooltip.data.kind === 'active'">
+            <div style="font-weight: 600; margin-bottom: 4px; color: #22c55e">
+              ▶ {{ tooltip.data.job.schedule_name || tooltip.data.job.job_type }} (running)
+            </div>
+            <div style="opacity: 0.7">type: {{ tooltip.data.job.job_type }}</div>
+            <div style="opacity: 0.7">started: {{ tooltip.data.job.started_at }}</div>
+            <div style="opacity: 0.7">elapsed: {{ fmtDuration(tooltip.data.elapsed) }}</div>
+            <div style="opacity: 0.7">phone: {{ tooltip.data.job.phone_serial?.slice(-6) || '—' }}</div>
+          </template>
+          <template v-else-if="tooltip.data.kind === 'future'">
+            <div style="font-weight: 600; margin-bottom: 4px">
+              ⏰ {{ tooltip.data.fut.schedule_name || tooltip.data.fut.job_type }}
+            </div>
+            <div style="opacity: 0.7">type: {{ tooltip.data.fut.job_type }}</div>
+            <div style="opacity: 0.7">scheduled: {{ tooltip.data.fut.time }}</div>
+            <div style="opacity: 0.7">phone: {{ tooltip.data.fut.phone_serial?.slice(-6) || '—' }}</div>
+            <div v-if="tooltip.data.fut.is_past" style="color: #f59e0b">missed (in past)</div>
+          </template>
+        </div>
       </div>
     </div>
 
@@ -616,7 +1048,7 @@ onUnmounted(() => {
           </span>
           <select v-model="schedPhoneFilter" class="filter-select">
             <option value="">All Phones</option>
-            <option v-for="ph in phoneList" :key="ph.serial" :value="ph.serial">{{ ph.label }}</option>
+            <option v-for="ph in phoneList" :key="ph.serial" :value="ph.serial">{{ deviceOptionLabel(ph) }}</option>
           </select>
         </div>
 
@@ -670,18 +1102,30 @@ onUnmounted(() => {
           <div class="form-field">
             <label class="form-label">Type</label>
             <select v-model="sf.job_type" class="form-input">
-              <option value="post">Post</option>
-              <option value="publish_draft">Publish Draft</option>
-              <option value="skill_workflow">Skill</option>
+              <option v-for="option in jobTypeOptions" :key="option.value" :value="option.value">
+                {{ option.label }}
+              </option>
             </select>
           </div>
           <div class="form-field">
             <label class="form-label">Phone</label>
             <select v-model="sf.phone_serial" class="form-input">
               <option value="">None</option>
-              <option v-for="ph in phoneList" :key="ph.serial" :value="ph.serial">{{ ph.label }}</option>
+              <option v-for="ph in phoneList" :key="ph.serial" :value="ph.serial">{{ deviceOptionLabel(ph) }}</option>
             </select>
           </div>
+        </div>
+        <div v-if="schedulePlatformNotice" class="form-hint form-hint--ios">
+          {{ schedulePlatformNotice }}
+        </div>
+        <div v-if="selectedScheduleIsIos && sf.job_type === 'skill_workflow'" class="form-field">
+          <label class="form-label">iOS Skill Template</label>
+          <select :value="currentIosTemplateId" class="form-input" @change="onIosTemplateChange">
+            <option v-for="template in IOS_SCHEDULE_TEMPLATES" :key="template.id" :value="template.id">
+              {{ template.label }}
+            </option>
+            <option value="custom">Custom JSON</option>
+          </select>
         </div>
         <!-- Priority + Schedule -->
         <div class="form-row-2">
@@ -754,13 +1198,15 @@ onUnmounted(() => {
         <div class="runs-filters">
           <select v-model="historyPhoneFilter" class="filter-select">
             <option value="">All Phones</option>
-            <option v-for="ph in phoneList" :key="ph.serial" :value="ph.serial">{{ ph.label }}</option>
+            <option v-for="ph in phoneList" :key="ph.serial" :value="ph.serial">{{ deviceOptionLabel(ph) }}</option>
           </select>
           <select v-model="historyTypeFilter" class="filter-select">
             <option value="">All Types</option>
             <option value="post">&#x1f4f9; post</option>
             <option value="publish_draft">&#x1f4e4; publish_draft</option>
             <option value="content_gen">&#x1f916; content_gen</option>
+            <option value="skill_workflow">skill_workflow</option>
+            <option value="app_explore">app_explore</option>
           </select>
         </div>
       </div>
@@ -844,6 +1290,58 @@ onUnmounted(() => {
           </label>
           <button class="rounded px-2 py-0.5 text-xs" style="background: #1e293b; border: 1px solid #334155; color: #94a3b8; cursor: pointer" @click="closeLogPanel">Close</button>
         </div>
+      </div>
+      <div v-if="logPanelResultLoading" class="run-result-note">Loading structured result...</div>
+      <div v-else-if="logPanelReadNews" class="run-result-section">
+        <div class="run-result-header">
+          <span>Structured Result</span>
+          <span>{{ logPanelResult?.summary || 'read_news result' }}</span>
+        </div>
+        <div class="run-result-metrics">
+          <span>{{ logPanelReadNews.headlines?.length || 0 }} headlines</span>
+          <span>{{ logPanelReadNews.articles?.length || 0 }} articles</span>
+          <span v-if="logPanelReadNews.current_url">{{ logPanelReadNews.current_url }}</span>
+        </div>
+        <div v-if="logPanelExtraction.headlines || logPanelExtraction.front_page_text" class="run-result-evidence">
+          <span v-if="logPanelExtraction.headlines" :title="evidenceTitle(logPanelExtraction.headlines)">
+            Headlines {{ compactEvidence(logPanelExtraction.headlines) }}
+          </span>
+          <span v-if="logPanelExtraction.front_page_text" :title="evidenceTitle(logPanelExtraction.front_page_text)">
+            Page text {{ compactEvidence(logPanelExtraction.front_page_text) }}
+          </span>
+        </div>
+        <div class="run-result-grid">
+          <div>
+            <div class="run-result-subtitle">Headlines</div>
+            <div v-for="(headline, i) in logPanelHeadlines" :key="`headline-${i}`" class="run-result-line">
+              <span class="run-result-index">{{ displayIndex(i) }}</span>
+              <span>{{ resultTitle(headline) || 'Untitled headline' }}</span>
+            </div>
+          </div>
+          <div>
+            <div class="run-result-subtitle">Articles</div>
+            <div v-for="(article, i) in logPanelArticles" :key="`article-${i}`" class="run-result-article">
+              <div class="run-result-article-title">{{ resultTitle(article) || resultTitle({ title: article.source_headline }) || 'Untitled article' }}</div>
+              <div v-if="resultUrl(article)" class="run-result-url">{{ resultUrl(article) }}</div>
+              <div v-if="articleEvidence(i).text || articleEvidence(i).open_method" class="run-result-evidence run-result-evidence--article">
+                <span v-if="articleEvidence(i).open_method" :title="evidenceTitle(articleEvidence(i))">
+                  {{ articleEvidence(i).open_method }}
+                </span>
+                <span v-if="articleEvidence(i).text" :title="evidenceTitle(articleEvidence(i).text)">
+                  Text {{ compactEvidence(articleEvidence(i).text) }}
+                </span>
+              </div>
+              <div v-if="resultSnippet(article)" class="run-result-snippet">{{ resultSnippet(article) }}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div v-else-if="logPanelGenericResult" class="run-result-section">
+        <div class="run-result-header">
+          <span>Structured Result</span>
+          <span>{{ logPanelResult?.summary || 'skill result' }}</span>
+        </div>
+        <pre class="run-result-json">{{ logPanelResultJson }}</pre>
       </div>
       <div id="sched-log-viewer"
         style="height: 320px; overflow-y: auto; background: #070b10; border: 1px solid #1e2438; border-radius: 8px; padding: 10px 12px; font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace; font-size: 11px; line-height: 1.55; color: #94a3b8; white-space: pre-wrap; word-break: break-all">
@@ -1242,6 +1740,17 @@ onUnmounted(() => {
   color: var(--text-4);
 }
 
+.form-hint--ios {
+  margin: -2px 0 8px;
+  padding: 6px 8px;
+  font-size: 11px;
+  line-height: 1.4;
+  color: #93c5fd;
+  background: rgba(37, 99, 235, 0.08);
+  border: 1px solid rgba(59, 130, 246, 0.22);
+  border-radius: 4px;
+}
+
 .form-input {
   width: 100%;
   padding: 4px 8px;
@@ -1275,6 +1784,166 @@ onUnmounted(() => {
 .form-actions .act-btn {
   font-size: 12px;
   padding: 4px 14px;
+}
+
+/* ── Run Result Panel ─────────────────────────────────────────────────── */
+.run-result-note {
+  margin-bottom: 10px;
+  font-size: 11px;
+  color: var(--text-4);
+}
+
+.run-result-section {
+  margin-bottom: 10px;
+  padding: 10px 12px;
+  background: #0b1220;
+  border: 1px solid #1e293b;
+  border-radius: 6px;
+}
+
+.run-result-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+  color: #cbd5e1;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.run-result-header span:last-child {
+  color: #94a3b8;
+  font-size: 11px;
+  font-weight: 500;
+  text-align: right;
+}
+
+.run-result-metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+
+.run-result-metrics span {
+  padding: 2px 6px;
+  color: #93c5fd;
+  background: rgba(37, 99, 235, 0.12);
+  border: 1px solid rgba(59, 130, 246, 0.22);
+  border-radius: 4px;
+  font-size: 10px;
+}
+
+.run-result-evidence {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin: -4px 0 10px;
+}
+
+.run-result-evidence span {
+  padding: 2px 6px;
+  color: #67e8f9;
+  background: rgba(8, 47, 73, 0.5);
+  border: 1px solid rgba(14, 116, 144, 0.35);
+  border-radius: 4px;
+  font-size: 9px;
+  white-space: nowrap;
+}
+
+.run-result-evidence--article {
+  margin: 4px 0 0;
+}
+
+.run-result-evidence--article span {
+  color: #a5b4fc;
+  background: rgba(49, 46, 129, 0.35);
+  border-color: rgba(99, 102, 241, 0.3);
+}
+
+.run-result-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr);
+  gap: 12px;
+}
+
+.run-result-subtitle {
+  margin-bottom: 6px;
+  color: #64748b;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.run-result-line {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr);
+  gap: 6px;
+  align-items: start;
+  padding: 3px 0;
+  color: #dbeafe;
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.run-result-index {
+  color: #64748b;
+  font-family: monospace;
+}
+
+.run-result-article {
+  padding: 6px 0;
+  border-top: 1px solid #1e293b;
+}
+.run-result-article:first-of-type {
+  border-top: none;
+  padding-top: 0;
+}
+
+.run-result-article-title {
+  color: #e2e8f0;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.run-result-url {
+  margin-top: 2px;
+  color: #38bdf8;
+  font-size: 10px;
+  word-break: break-all;
+}
+
+.run-result-snippet {
+  margin-top: 4px;
+  color: #94a3b8;
+  font-size: 11px;
+  line-height: 1.45;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.run-result-json {
+  max-height: 220px;
+  overflow: auto;
+  margin: 0;
+  padding: 8px;
+  background: #070b10;
+  border: 1px solid #1e2438;
+  border-radius: 4px;
+  color: #94a3b8;
+  font-size: 10px;
+  line-height: 1.45;
+}
+
+@media (max-width: 800px) {
+  .run-result-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* ── Recent Runs Section ──────────────────────────────────────────────── */

--- a/frontend/src/views/SkillCreatorView.vue
+++ b/frontend/src/views/SkillCreatorView.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
-import { ref, watch, onMounted, onUnmounted, nextTick } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
 import { api } from '@/composables/useApi'
 import { renderMermaid } from '@/composables/useMermaid'
-import PhoneStreamWidget from '@/components/PhoneStreamWidget.vue'
 
 const devices = ref<any[]>([])
 const selectedDevice = ref('')
+const selectedIsIos = computed(() => selectedDevice.value.startsWith('ios:'))
+const selectedPlatform = computed(() => selectedIsIos.value ? 'ios' : 'android')
+const targetIdLabel = computed(() => selectedIsIos.value ? 'iOS bundle id' : 'Android package')
+const targetIdPlaceholder = computed(() => selectedIsIos.value ? 'com.google.chrome.ios' : 'com.zhiliaoapp.musically')
 const backend = ref(localStorage.getItem('creator_backend') || 'claude-code')
 const model = ref(localStorage.getItem('creator_model') || 'anthropic/claude-sonnet-4')
 const messages = ref<{role: string; content: string; actions?: any[]}[]>([])
@@ -13,6 +16,9 @@ const input = ref('')
 const sending = ref(false)
 const streaming = ref(false)
 const streamImg = ref('')
+const mjpegUrl = ref('')
+const streamStatus = ref('')
+const streamInfo = ref<any | null>(null)
 const overlayOn = ref(false)
 const elements = ref<any[]>([])
 const actionHistory = ref<any[]>([])
@@ -21,6 +27,9 @@ const recording = ref(false)
 const recordedActions = ref<any[]>([])
 const showContextModal = ref(false)
 const overlayCanvas = ref<HTMLCanvasElement | null>(null)
+const streamImageEl = ref<HTMLImageElement | null>(null)
+const streamFrame = ref({ width: 0, height: 0 })
+const elementFrame = ref({ width: 0, height: 0 })
 let streamTimer: number | null = null
 
 const BACKENDS = [
@@ -42,7 +51,8 @@ async function loadDevices() {
   try {
     const resp = await api('/api/phone/devices')
     devices.value = resp.devices || resp || []
-    if (devices.value.length && !selectedDevice.value) selectedDevice.value = devices.value[0].serial
+    const firstDevice = devices.value[0]
+    if (firstDevice && !selectedDevice.value) selectedDevice.value = firstDevice.serial
   } catch {}
 }
 
@@ -56,9 +66,9 @@ async function loadOllamaModels() {
 function onBackendChange() {
   localStorage.setItem('creator_backend', backend.value)
   if (backend.value === 'ollama' && ollamaModels.value.length) {
-    model.value = ollamaModels.value[0]
+    model.value = ollamaModels.value[0] || model.value
   } else if (MODELS[backend.value]?.length) {
-    model.value = MODELS[backend.value][0]
+    model.value = MODELS[backend.value]?.[0] || model.value
   }
 }
 
@@ -71,25 +81,90 @@ function availableModels() {
   return MODELS[backend.value] || []
 }
 
+const streamMode = computed(() => selectedIsIos.value ? 'mjpeg' : 'screenshot')
+const streamSource = computed(() => streamMode.value === 'mjpeg' ? mjpegUrl.value : streamImg.value)
+const streamPlaceholder = computed(() => selectedIsIos.value ? 'Start WDA stream' : 'Select a device and press Stream')
+
 function toggleStream() {
   if (streaming.value) {
-    streaming.value = false
-    if (streamTimer) { clearInterval(streamTimer); streamTimer = null }
+    stopStream()
   } else {
-    streaming.value = true
-    pollFrame()
-    streamTimer = window.setInterval(pollFrame, 200)
+    startStream()
   }
 }
 
+async function resolveMjpegUrl(): Promise<string> {
+  const fallback = `/api/phone/stream?device=${encodeURIComponent(selectedDevice.value)}&fps=5&mode=wda-mjpeg`
+  try {
+    const info = await api(`/api/phone/stream-info?device=${encodeURIComponent(selectedDevice.value)}&fps=5&mode=mjpeg`)
+    streamInfo.value = info
+    streamStatus.value = info.effective_mode ? `${info.effective_mode}` : ''
+    return String(info.stream_url || fallback)
+  } catch (error) {
+    streamStatus.value = error instanceof Error ? error.message.replace(/^API \d+:\s*/, '') : 'Stream metadata unavailable'
+    return fallback
+  }
+}
+
+async function startStream() {
+  if (!selectedDevice.value || streaming.value) return
+  streaming.value = true
+  streamImg.value = ''
+  mjpegUrl.value = ''
+  streamStatus.value = ''
+  streamInfo.value = null
+  if (streamMode.value === 'mjpeg') {
+    streamStatus.value = 'Loading WDA MJPEG...'
+    const url = await resolveMjpegUrl()
+    if (streaming.value && streamMode.value === 'mjpeg') mjpegUrl.value = url
+    return
+  }
+  pollFrame()
+  streamTimer = window.setInterval(pollFrame, 200)
+}
+
+function stopStream() {
+  streaming.value = false
+  if (streamTimer) { clearInterval(streamTimer); streamTimer = null }
+  streamImg.value = ''
+  mjpegUrl.value = ''
+  streamStatus.value = ''
+  streamInfo.value = null
+  streamFrame.value = { width: 0, height: 0 }
+}
+
 async function pollFrame() {
-  if (!selectedDevice.value) return
+  if (!selectedDevice.value || streamMode.value !== 'screenshot') return
   try {
     const resp = await api(`/api/phone/screenshot/${selectedDevice.value}`)
     if (resp.ok && resp.image) {
       streamImg.value = `data:image/jpeg;base64,${resp.image}`
+      streamFrame.value = { width: Number(resp.width || 0), height: Number(resp.height || 0) }
     }
   } catch {}
+}
+
+function updateStreamFrame() {
+  const img = streamImageEl.value
+  if (!img) return
+  streamFrame.value = {
+    width: img.naturalWidth || streamFrame.value.width,
+    height: img.naturalHeight || streamFrame.value.height,
+  }
+  nextTick(drawOverlay)
+}
+
+function handleStreamLoad() {
+  updateStreamFrame()
+  if (streamStatus.value.startsWith('Loading ')) {
+    streamStatus.value = streamInfo.value?.effective_mode ? String(streamInfo.value.effective_mode) : ''
+  }
+}
+
+function handleStreamError() {
+  streamStatus.value = selectedIsIos.value
+    ? 'WDA MJPEG failed — check iOS health or restart the stream'
+    : 'Stream failed — restart the stream'
 }
 
 async function refreshElements() {
@@ -97,6 +172,11 @@ async function refreshElements() {
   try {
     const resp = await api(`/api/phone/elements/${selectedDevice.value}`)
     elements.value = resp.elements || resp || []
+    const size = resp.screen_size || {}
+    elementFrame.value = {
+      width: Number(size.width || 0),
+      height: Number(size.height || 0),
+    }
   } catch {}
 }
 
@@ -160,7 +240,10 @@ async function executeActions(actions: any[]) {
     } else if (step.action === 'back') {
       await api('/api/phone/back', { method: 'POST', body: JSON.stringify({ device: selectedDevice.value }) })
     } else if (step.action === 'launch') {
-      await api('/api/phone/launch', { method: 'POST', body: JSON.stringify({ device: selectedDevice.value, package: step.package }) })
+      await api('/api/phone/launch', {
+        method: 'POST',
+        body: JSON.stringify({ device: selectedDevice.value, package: step.package || step.bundle_id })
+      })
     } else if (step.action === 'swipe') {
       await api('/api/phone/swipe', { method: 'POST', body: JSON.stringify({ device: selectedDevice.value, ...step }) })
     } else if (step.action === 'wait') {
@@ -185,16 +268,38 @@ function sendKey(key: number | string) {
   if (recording.value) recordedActions.value.push(step)
 }
 
-function handleStreamClick(e: MouseEvent) {
-  if (!selectedDevice.value) return
-  const el = e.target as HTMLImageElement
+function streamPoint(el: HTMLImageElement, clientX: number, clientY: number): { x: number; y: number; streamW: number; streamH: number } | null {
   const rect = el.getBoundingClientRect()
-  const x = Math.round((e.clientX - rect.left) / rect.width * 1080)
-  const y = Math.round((e.clientY - rect.top) / rect.height * 2400)
-  api('/api/phone/tap', { method: 'POST', body: JSON.stringify({ device: selectedDevice.value, x, y }) })
-  const step = { action: 'tap', x, y }
+  const streamW = el.naturalWidth || streamFrame.value.width || 540
+  const streamH = el.naturalHeight || streamFrame.value.height || 1200
+  if (!rect.width || !rect.height || !streamW || !streamH) return null
+  return {
+    x: Math.round((clientX - rect.left) / rect.width * streamW),
+    y: Math.round((clientY - rect.top) / rect.height * streamH),
+    streamW,
+    streamH,
+  }
+}
+
+function tapStreamAt(el: HTMLImageElement, clientX: number, clientY: number) {
+  if (!selectedDevice.value) return
+  const point = streamPoint(el, clientX, clientY)
+  if (!point) return
+  api('/api/phone/tap', { method: 'POST', body: JSON.stringify({ device: selectedDevice.value, x: point.x, y: point.y, stream_w: point.streamW, stream_h: point.streamH }) })
+  const step = { action: 'tap', x: point.x, y: point.y }
   actionHistory.value.push(step)
   if (recording.value) recordedActions.value.push(step)
+}
+
+function handleStreamClick(e: MouseEvent) {
+  tapStreamAt(e.target as HTMLImageElement, e.clientX, e.clientY)
+}
+
+function handleStreamTouchEnd(e: TouchEvent) {
+  const touch = e.changedTouches[0]
+  if (!touch) return
+  e.preventDefault()
+  tapStreamAt(e.target as HTMLImageElement, touch.clientX, touch.clientY)
 }
 
 function toggleRecord() {
@@ -209,11 +314,44 @@ function toggleRecord() {
 }
 
 const saveSkillName = ref('')
+const saveSkillTarget = ref('')
 const saveSkillModal = ref(false)
+
+const hardwareKeys = computed(() => {
+  if (selectedIsIos.value) {
+    return [
+      { label: 'Back', key: 'BACK', title: 'Back' },
+      { label: 'Home', key: 'HOME', title: 'Home' },
+      { label: 'Enter', key: 'ENTER', title: 'Enter' },
+    ]
+  }
+  return [
+    { label: '\u25C0', key: 4, title: 'Back' },
+    { label: '\u2302', key: 3, title: 'Home' },
+    { label: '\u25A6', key: 187, title: 'Recents' },
+    { label: '\u23FB', key: 26, title: 'Power' },
+    { label: 'Vol+', key: 24, title: 'Vol+' },
+    { label: 'Vol-', key: 25, title: 'Vol-' },
+  ]
+})
+
+function deviceLabel(d: any): string {
+  const platform = d.platform === 'ios' || String(d.serial || '').startsWith('ios:') ? 'iOS' : 'Android'
+  return `${d.nickname || d.model || d.serial} (${platform})`
+}
+
+function defaultSkillTarget(): string {
+  const launchStep = [...recordedActions.value].reverse().find(step => step.action === 'launch' && (step.package || step.bundle_id))
+  if (launchStep) return launchStep.package || launchStep.bundle_id || ''
+  const dev = devices.value.find(d => d.serial === selectedDevice.value)
+  if (selectedIsIos.value) return dev?.bundle_id || dev?.ios_bundle_id || ''
+  return dev?.package || dev?.app_package || ''
+}
 
 function openSaveSkill() {
   if (!recordedActions.value.length) return
   saveSkillName.value = ''
+  saveSkillTarget.value = defaultSkillTarget()
   saveSkillModal.value = true
 }
 
@@ -221,11 +359,25 @@ async function saveRecordedSkill() {
   const name = saveSkillName.value.trim().toLowerCase().replace(/\s+/g, '_')
   if (!name || !recordedActions.value.length) return
   try {
+    const platform = selectedPlatform.value
+    const target = saveSkillTarget.value.trim()
+    const payload: any = {
+      name,
+      steps: recordedActions.value,
+      platforms: [platform],
+      app_package: platform === 'android' ? target : '',
+      android_package: platform === 'android' ? target : '',
+      ios_bundle_id: platform === 'ios' ? target : '',
+    }
+    if (elements.value.length) {
+      if (platform === 'ios') payload.elements_ios = elements.value
+      else payload.elements_android = elements.value
+    }
     const res = await api('/api/skills/create-from-recording', {
       method: 'POST',
-      body: JSON.stringify({ name, steps: recordedActions.value, app_package: '' })
+      body: JSON.stringify(payload)
     })
-    messages.value.push({ role: 'system', content: `Skill "${name}" saved with ${recordedActions.value.length} steps.` })
+    messages.value.push({ role: 'system', content: `Skill "${name}" saved for ${platform} with ${recordedActions.value.length} steps.` })
     saveSkillModal.value = false
     recordedActions.value = []
   } catch (e: any) {
@@ -236,17 +388,38 @@ async function saveRecordedSkill() {
 function drawOverlay() {
   const canvas = overlayCanvas.value
   if (!canvas) return
+  const cssWidth = Math.max(1, Math.round(canvas.clientWidth || canvas.getBoundingClientRect().width || 360))
+  const cssHeight = Math.max(1, Math.round(canvas.clientHeight || canvas.getBoundingClientRect().height || 800))
+  if (canvas.width !== cssWidth) canvas.width = cssWidth
+  if (canvas.height !== cssHeight) canvas.height = cssHeight
   const ctx = canvas.getContext('2d')
   if (!ctx) return
   ctx.clearRect(0, 0, canvas.width, canvas.height)
   if (!overlayOn.value || !elements.value.length) return
-  // Scale from device coords (1080x2400) to canvas size
-  const scaleX = canvas.width / 1080
-  const scaleY = canvas.height / 2400
+  const image = streamImageEl.value
+  const streamW = image?.naturalWidth || streamFrame.value.width || 540
+  const streamH = image?.naturalHeight || streamFrame.value.height || 1200
+  const coordinateScale = selectedIsIos.value && streamMode.value === 'mjpeg' ? 1 : 2
+  const frameW = elementFrame.value.width || streamW * coordinateScale
+  const frameH = elementFrame.value.height || streamH * coordinateScale
+  let offsetX = 0
+  let offsetY = 0
+  let displayW = canvas.width
+  let displayH = canvas.height
+  if (image) {
+    const canvasRect = canvas.getBoundingClientRect()
+    const imageRect = image.getBoundingClientRect()
+    offsetX = imageRect.left - canvasRect.left
+    offsetY = imageRect.top - canvasRect.top
+    displayW = imageRect.width || displayW
+    displayH = imageRect.height || displayH
+  }
+  const scaleX = displayW / frameW
+  const scaleY = displayH / frameH
   elements.value.forEach((el, i) => {
     if (!el.bounds) return
-    const x = el.bounds.x1 * scaleX
-    const y = el.bounds.y1 * scaleY
+    const x = offsetX + el.bounds.x1 * scaleX
+    const y = offsetY + el.bounds.y1 * scaleY
     const w = (el.bounds.x2 - el.bounds.x1) * scaleX
     const h = (el.bounds.y2 - el.bounds.y1) * scaleY
     ctx.strokeStyle = '#6366f1'
@@ -258,7 +431,16 @@ function drawOverlay() {
   })
 }
 
-watch([overlayOn, elements], () => { nextTick(drawOverlay) })
+watch([overlayOn, elements, streamFrame, elementFrame], () => { nextTick(drawOverlay) })
+watch(selectedDevice, async (newDevice, oldDevice) => {
+  if (newDevice === oldDevice) return
+  const wasStreaming = streaming.value
+  stopStream()
+  elements.value = []
+  elementFrame.value = { width: 0, height: 0 }
+  if (newDevice && overlayOn.value) await refreshElements()
+  if (wasStreaming && newDevice) startStream()
+})
 watch(messages, () => {
   nextTick(() => {
     const el = document.getElementById('creator-messages')
@@ -274,7 +456,7 @@ onMounted(async () => {
     setTimeout(async () => { await loadDevices() }, 3000)
   }
 })
-onUnmounted(() => { if (streamTimer) clearInterval(streamTimer) })
+onUnmounted(() => { stopStream() })
 </script>
 
 <template>
@@ -344,7 +526,7 @@ onUnmounted(() => { if (streamTimer) clearInterval(streamTimer) })
         <span class="sc-status-dot" :style="{ background: streaming ? '#22c55e' : '#475569' }"></span>
         <select v-model="selectedDevice" class="sc-select sc-select--device">
           <option value="">{{ devices.length ? 'Select device' : 'No devices — click ↻' }}</option>
-          <option v-for="d in devices" :key="d.serial" :value="d.serial">{{ d.nickname || d.model || d.serial }}</option>
+          <option v-for="d in devices" :key="d.serial" :value="d.serial">{{ deviceLabel(d) }}</option>
         </select>
         <button class="sc-pill-btn" @click="loadDevices" title="Refresh devices" style="padding: 4px 8px; font-size: 11px">↻</button>
         <div class="sc-device-actions">
@@ -369,21 +551,27 @@ onUnmounted(() => { if (streamTimer) clearInterval(streamTimer) })
 
       <!-- Hardware keys -->
       <div class="sc-hw-keys">
-        <button class="sc-hw-btn" @click="sendKey(4)" title="Back">&#x25C0;</button>
-        <button class="sc-hw-btn" @click="sendKey(3)" title="Home">&#x2302;</button>
-        <button class="sc-hw-btn" @click="sendKey(187)" title="Recents">&#x25A6;</button>
-        <button class="sc-hw-btn" @click="sendKey(26)" title="Power">&#x23FB;</button>
-        <button class="sc-hw-btn" @click="sendKey(24)" title="Vol+">&#x1F50A;</button>
-        <button class="sc-hw-btn" @click="sendKey(25)" title="Vol-">&#x1F509;</button>
+        <button v-for="key in hardwareKeys" :key="String(key.key)" class="sc-hw-btn" @click="sendKey(key.key)" :title="key.title">
+          {{ key.label }}
+        </button>
       </div>
 
       <!-- Stream area -->
       <div class="sc-stream-area">
-        <img v-if="streamImg" :src="streamImg" class="sc-stream-img"
-          @click="handleStreamClick" />
+        <img v-if="streaming && streamSource" ref="streamImageEl" :src="streamSource" class="sc-stream-img"
+          draggable="false"
+          @click="handleStreamClick"
+          @touchstart.prevent
+          @touchend="handleStreamTouchEnd"
+          @load="handleStreamLoad"
+          @error="handleStreamError"
+          @dragstart.prevent />
         <canvas ref="overlayCanvas" width="360" height="800" class="sc-overlay-canvas"></canvas>
-        <div v-if="!streamImg" class="sc-stream-empty">
-          Select a device and press Stream
+        <div v-if="streamStatus" class="sc-stream-status" :title="streamStatus">
+          {{ streamStatus }}
+        </div>
+        <div v-if="!streamSource" class="sc-stream-empty">
+          {{ streamPlaceholder }}
         </div>
       </div>
 
@@ -415,9 +603,9 @@ onUnmounted(() => { if (streamTimer) clearInterval(streamTimer) })
           <div class="sc-modal-meta">Backend: {{ backend }} / {{ model }}</div>
           <div class="sc-modal-meta">Elements: {{ elements.length }}</div>
         </div>
-        <div v-if="streamImg" class="sc-modal-section">
+        <div v-if="streamSource" class="sc-modal-section">
           <div class="sc-modal-section-title">Current Screen</div>
-          <img :src="streamImg" class="sc-modal-screenshot" />
+          <img :src="streamSource" class="sc-modal-screenshot" />
         </div>
         <div v-if="elements.length" class="sc-modal-section">
           <div class="sc-modal-section-title">Elements ({{ elements.length }})</div>
@@ -457,6 +645,15 @@ onUnmounted(() => { if (streamTimer) clearInterval(streamTimer) })
             <input v-model="saveSkillName" placeholder="my_automation"
               style="width: 100%; padding: 8px 12px; font-size: 13px; background: var(--bg-deep); border: 1px solid var(--border); border-radius: 6px; color: var(--text-1); outline: none"
               @keyup.enter="saveRecordedSkill" />
+          </div>
+          <div style="margin-top: 12px">
+            <label style="font-size: 11px; color: var(--text-3); display: block; margin-bottom: 4px">{{ targetIdLabel }}</label>
+            <input v-model="saveSkillTarget" :placeholder="targetIdPlaceholder"
+              style="width: 100%; padding: 8px 12px; font-size: 13px; background: var(--bg-deep); border: 1px solid var(--border); border-radius: 6px; color: var(--text-1); outline: none"
+              @keyup.enter="saveRecordedSkill" />
+            <div style="margin-top: 4px; font-size: 10px; color: var(--text-4)">
+              Saving as {{ selectedIsIos ? 'iOS' : 'Android' }} skill.
+            </div>
           </div>
           <div style="margin-top: 8px; max-height: 200px; overflow-y: auto; font-size: 10px; font-family: monospace; color: var(--text-4)">
             <div v-for="(a, i) in recordedActions" :key="i">
@@ -949,6 +1146,22 @@ onUnmounted(() => { if (streamTimer) clearInterval(streamTimer) })
   text-align: center;
   padding: 48px 24px;
   line-height: 1.6;
+}
+.sc-stream-status {
+  position: absolute;
+  left: 8px;
+  bottom: 8px;
+  max-width: calc(100% - 16px);
+  padding: 4px 8px;
+  border-radius: 6px;
+  background: rgba(2, 6, 23, 0.78);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  color: #cbd5e1;
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  pointer-events: none;
 }
 
 /* ── Element list ────────────────────────────────────────────────── */

--- a/frontend/src/views/SkillHubView.vue
+++ b/frontend/src/views/SkillHubView.vue
@@ -8,8 +8,10 @@ interface SkillWorkflow { name: string; description: string }
 interface PopupDetector { detect: string; button: string; label: string; method?: string; notes?: string }
 interface SkillInfo {
   dir: string; name: string; version: string; app_package: string | null
+  android_package?: string | null; ios_bundle_id?: string | null
+  platforms?: string[]; supports_android?: boolean; supports_ios?: boolean
   description: string; actions: string[] | SkillAction[]; workflows: string[] | SkillWorkflow[]
-  elements_count: number; popup_count?: number; popup_detectors?: PopupDetector[]
+  elements_count: number; elements_ios_count?: number; popup_count?: number; popup_detectors?: PopupDetector[]
   metadata: any; default_params?: Record<string, Record<string, any>>
 }
 interface SkillDetail extends SkillInfo {
@@ -26,10 +28,12 @@ const filteredSkills = computed(() => {
   return skills.value.filter(s =>
     (s.name || s.dir || '').toLowerCase().includes(q) ||
     (s.description || '').toLowerCase().includes(q) ||
-    (s.app_package || '').toLowerCase().includes(q)
+    (s.app_package || '').toLowerCase().includes(q) ||
+    (s.android_package || '').toLowerCase().includes(q) ||
+    (s.ios_bundle_id || '').toLowerCase().includes(q)
   )
 })
-const devices = ref<{serial: string; nickname?: string}[]>([])
+const devices = ref<{serial: string; nickname?: string; platform?: string; status?: string; status_message?: string}[]>([])
 const runModal = ref(false)
 const runTarget = ref({ type: '', name: '' })
 const runDevice = ref('')
@@ -65,10 +69,43 @@ const STATUS_COLORS: Record<string, { bg: string; text: string }> = {
   fail: { bg: '#ef444422', text: '#f87171' },
   partial: { bg: '#f59e0b22', text: '#fbbf24' },
   untested: { bg: '#64748b22', text: '#94a3b8' },
+  unsupported: { bg: '#33415544', text: '#64748b' },
+}
+
+function devicePlatform(device: string | { serial: string; platform?: string } | undefined): 'android' | 'ios' {
+  const serial = typeof device === 'string' ? device : (device?.serial || '')
+  const platform = typeof device === 'string' ? '' : (device?.platform || '')
+  return platform === 'ios' || serial.startsWith('ios:') ? 'ios' : 'android'
+}
+
+function skillSupportsDevice(skill: SkillInfo | null | undefined, device: string | { serial: string; platform?: string } | undefined): boolean {
+  if (!skill || !device) return true
+  const platforms = skill.platforms || []
+  if (!platforms.length) return true
+  return platforms.includes(devicePlatform(device))
+}
+
+function skillTargetLabel(skill: SkillInfo | null | undefined): string {
+  if (!skill) return 'universal'
+  if (skill.supports_ios && !skill.supports_android) return skill.ios_bundle_id || 'iOS app'
+  if (skill.supports_android && !skill.supports_ios) return skill.android_package || skill.app_package || 'Android app'
+  if (skill.supports_android && skill.supports_ios) return 'Android + iOS'
+  return skill.app_package || skill.ios_bundle_id || 'universal'
+}
+
+function platformLabel(skill: SkillInfo | null | undefined): string {
+  const platforms = skill?.platforms || []
+  return platforms.length ? platforms.map(p => p.toUpperCase()).join(' / ') : 'ANDROID'
+}
+
+function skillDeviceStatus(skill: SkillInfo, device: string): string {
+  if (!skillSupportsDevice(skill, device)) return 'unsupported'
+  return compatStatus(skill.dir, device)
 }
 
 async function verifySkill(skillName: string, device: string) {
   if (!device) return
+  if (!skillSupportsDevice(selected.value, device)) return
   verifying.value = true
   verifyLog.value = ''
   runDevice.value = device
@@ -141,7 +178,8 @@ function workflowCount(s: SkillInfo) {
 
 function openRun(type: 'workflow' | 'action', name: string) {
   runTarget.value = { type, name }
-  runDevice.value = devices.value[0]?.serial || ''
+  const compatible = devices.value.find(d => skillSupportsDevice(selected.value, d))
+  runDevice.value = compatible?.serial || devices.value[0]?.serial || ''
   runResult.value = ''
   // Pre-fill default params from skill metadata
   const dp = (selected.value as any)?.default_params as Record<string, any> | undefined
@@ -153,6 +191,10 @@ function openRun(type: 'workflow' | 'action', name: string) {
 
 async function executeRun() {
   const skill = selected.value?.dir || selected.value?.name
+  if (!skillSupportsDevice(selected.value, runDevice.value)) {
+    runResult.value = `Unsupported: ${selected.value?.name || skill} does not support ${devicePlatform(runDevice.value)}`
+    return
+  }
   const endpoint = runTarget.value.type === 'workflow'
     ? `/api/skills/${skill}/run`
     : `/api/skills/${skill}/run-action`
@@ -214,7 +256,9 @@ const filteredRegistry = computed(() => {
   return registry.value.filter((s: any) =>
     (s.name || '').toLowerCase().includes(q) ||
     (s.description || '').toLowerCase().includes(q) ||
-    (s.app_package || '').toLowerCase().includes(q)
+    (s.app_package || '').toLowerCase().includes(q) ||
+    (s.android_package || '').toLowerCase().includes(q) ||
+    (s.ios_bundle_id || '').toLowerCase().includes(q)
   )
 })
 
@@ -255,7 +299,8 @@ onUnmounted(() => {
             <h2 class="sh-detail-name">{{ selected.name }}</h2>
             <div class="sh-detail-meta">
               <span class="sh-version-badge">v{{ selected.version || '1.0.0' }}</span>
-              <span class="sh-pkg">{{ selected.app_package || 'universal' }}</span>
+              <span class="sh-platform-badge">{{ platformLabel(selected) }}</span>
+              <span class="sh-pkg">{{ skillTargetLabel(selected) }}</span>
             </div>
           </div>
         </div>
@@ -310,14 +355,14 @@ onUnmounted(() => {
                 <div class="sh-compat-row-top">
                   <span class="sh-compat-device">{{ d.nickname || d.serial?.slice(0, 10) }}</span>
                   <span class="sh-compat-status"
-                    :style="{ background: STATUS_COLORS[compatStatus(selected.dir, d.serial)]?.bg,
-                              color: STATUS_COLORS[compatStatus(selected.dir, d.serial)]?.text }">
-                    {{ compatStatus(selected.dir, d.serial).toUpperCase() }}
+                    :style="{ background: STATUS_COLORS[skillDeviceStatus(selected, d.serial)]?.bg,
+                              color: STATUS_COLORS[skillDeviceStatus(selected, d.serial)]?.text }">
+                    {{ skillDeviceStatus(selected, d.serial).toUpperCase() }}
                   </span>
                   <div class="sh-compat-actions">
-                    <button class="sh-verify-btn" :disabled="verifying"
+                    <button class="sh-verify-btn" :disabled="verifying || !skillSupportsDevice(selected, d)"
                       @click="verifySkill(selected.dir, d.serial)"
-                      title="Run all workflows on this device to test if they work. Results are saved per-device.">
+                      :title="skillSupportsDevice(selected, d) ? 'Run all workflows on this device to test if they work. Results are saved per-device.' : 'This skill does not support this device platform.'">
                       {{ verifying ? 'Testing...' : 'Verify' }}
                     </button>
                     <button v-if="compatFor(selected.dir, d.serial).length"
@@ -341,6 +386,7 @@ onUnmounted(() => {
           <div class="sh-section" v-if="selected.elements_count">
             <h3 class="sh-section-title">Elements <span class="sh-count-badge">{{ selected.elements_count }}</span></h3>
             <p class="sh-elements-note">UI element definitions with fallback locator chains.</p>
+            <p v-if="selected.elements_ios_count" class="sh-elements-note">{{ selected.elements_ios_count }} iOS element definitions available.</p>
           </div>
 
           <!-- Popup Detectors -->
@@ -441,7 +487,7 @@ onUnmounted(() => {
             </div>
 
             <!-- Package -->
-            <div class="sh-card-pkg">{{ s.app_package || 'universal' }}</div>
+            <div class="sh-card-pkg">{{ skillTargetLabel(s) }}</div>
 
             <!-- Description -->
             <div class="sh-card-desc">{{ s.description }}</div>
@@ -451,6 +497,8 @@ onUnmounted(() => {
               <span class="sh-stat-pill">{{ actionCount(s) }} actions</span>
               <span class="sh-stat-pill">{{ workflowCount(s) }} workflows</span>
               <span class="sh-stat-pill">{{ s.elements_count || 0 }} elements</span>
+              <span class="sh-stat-pill" v-if="s.elements_ios_count">{{ s.elements_ios_count }} iOS elements</span>
+              <span class="sh-platform-badge">{{ platformLabel(s) }}</span>
               <span v-if="s.popup_count" class="sh-stat-pill">{{ s.popup_count }} popups</span>
             </div>
 
@@ -458,10 +506,10 @@ onUnmounted(() => {
             <div v-if="compatFor(s.dir).length" class="sh-card-compat">
               <span v-for="d in devices" :key="d.serial"
                 class="sh-compat-inline-badge"
-                :style="{ background: STATUS_COLORS[compatStatus(s.dir, d.serial)]?.bg,
-                          color: STATUS_COLORS[compatStatus(s.dir, d.serial)]?.text }"
+                :style="{ background: STATUS_COLORS[skillDeviceStatus(s, d.serial)]?.bg,
+                          color: STATUS_COLORS[skillDeviceStatus(s, d.serial)]?.text }"
                 :title="d.nickname || d.serial">
-                {{ (d.nickname || d.serial?.slice(0, 6)) }}: {{ compatStatus(s.dir, d.serial) }}
+                {{ (d.nickname || d.serial?.slice(0, 6)) }}: {{ skillDeviceStatus(s, d.serial) }}
               </span>
             </div>
           </div>
@@ -558,8 +606,8 @@ onUnmounted(() => {
           <label class="block text-xs mb-1" style="color: var(--text-3)">Device</label>
           <select v-model="runDevice" class="w-full px-3 py-2 rounded-lg text-sm"
             style="background: var(--bg-deep); border: 1px solid var(--border); color: var(--text-1)">
-            <option v-for="d in devices" :key="d.serial" :value="d.serial">
-              {{ d.nickname || d.serial }}
+            <option v-for="d in devices" :key="d.serial" :value="d.serial" :disabled="!skillSupportsDevice(selected, d)">
+              {{ (d.nickname || d.serial) + (skillSupportsDevice(selected, d) ? '' : ' (unsupported)') }}
             </option>
           </select>
         </div>
@@ -760,6 +808,15 @@ onUnmounted(() => {
   border-radius: 6px;
   background: color-mix(in srgb, var(--_text-4) 12%, transparent);
   color: var(--_text-3);
+}
+.sh-platform-badge {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0;
+  padding: 3px 8px;
+  border-radius: 6px;
+  background: color-mix(in srgb, #38bdf8 14%, transparent);
+  color: #67e8f9;
 }
 .sh-card-compat {
   display: flex;

--- a/frontend/src/views/TestsView.vue
+++ b/frontend/src/views/TestsView.vue
@@ -10,6 +10,10 @@ interface TestFile {
 interface Recording {
   name: string
   device: string
+  device_ref?: string
+  device_label?: string
+  platform?: string
+  test_name?: string
   date: string
   size_mb: string
   result?: { passed: number; failed: number; skipped: number; errors: number }
@@ -49,8 +53,29 @@ function phoneName(serial: string): string {
   return d ? (d.nickname || d.model || d.label || d.serial) : serial.slice(0, 6)
 }
 
-function recTestName(name: string): string {
-  return name.replace(/^[^_]+_\d{8}_\d{6}_/, '').replace('.mp4', '')
+function testRecordingUrl(name: string): string {
+  return `/api/test-runner/recording/${encodeURIComponent(name)}`
+}
+
+function testRecordingLogUrl(name: string): string {
+  return `/api/test-runner/recording-log/${encodeURIComponent(name)}`
+}
+
+function recDeviceRef(r: Recording): string {
+  return r.device_ref || r.device || ''
+}
+
+function recPhoneName(r: Recording): string {
+  return r.device_label || phoneName(recDeviceRef(r))
+}
+
+function recTestName(r: Recording): string {
+  if (r.test_name) return r.test_name
+  return r.name.replace(/^.+?_\d{8}_\d{6}_/, '').replace('.mp4', '')
+}
+
+function recPlatform(r: Recording): string {
+  return (r.platform || (recDeviceRef(r).startsWith('ios:') ? 'ios' : 'android')).toUpperCase()
 }
 
 function recTime(date: string): string {
@@ -84,8 +109,9 @@ async function load() {
   testCatalog.value = Array.isArray(t) ? t : t.tests || []
   devices.value = d.devices || d || []
   recordings.value = Array.isArray(r) ? r : r.recordings || []
-  if (!selectedTest.value && testCatalog.value.length) {
-    selectedTest.value = testCatalog.value[0].file + '|'
+  const firstTest = testCatalog.value[0]
+  if (!selectedTest.value && firstTest) {
+    selectedTest.value = firstTest.file + '|'
   }
 }
 
@@ -155,9 +181,9 @@ async function viewRecording(rec: Recording) {
   viewingRecLogs.value = []
   highlightedLogIdx.value = -1
   recLogAutoScroll.value = true
-  // Load logs for the recording's device
+  // Load saved logs for this recording. The live logs endpoint only knows active in-memory runs.
   try {
-    const resp = await api(`/api/test-runner/logs?device=${rec.device}&since=0`)
+    const resp = await api(testRecordingLogUrl(rec.name))
     viewingRecLogs.value = resp.lines || []
   } catch {}
 }
@@ -167,7 +193,8 @@ function parseLogTimestamp(line: string): number | null {
   // Matches patterns like "2026-04-01 12:34:56" or "12:34:56" at the start of a log line
   const m = line.match(/(?:^\d{4}-\d{2}-\d{2}\s+)?(\d{2}):(\d{2}):(\d{2})/)
   if (!m) return null
-  return parseInt(m[1]) * 3600 + parseInt(m[2]) * 60 + parseInt(m[3])
+  const [, hh = '0', mm = '0', ss = '0'] = m
+  return parseInt(hh) * 3600 + parseInt(mm) * 60 + parseInt(ss)
 }
 
 function onVideoTimeUpdate() {
@@ -255,7 +282,7 @@ onUnmounted(() => { if (pollTimer) clearInterval(pollTimer) })
 
         <!-- Inline video player (during test execution) -->
         <div v-if="phoneStates[d.serial]?.running && phoneStates[d.serial]?.recording" style="border-radius: 8px; overflow: hidden; background: #000">
-          <video :src="`/api/test-runner/recording/${phoneStates[d.serial].recording}`"
+          <video :src="testRecordingUrl(phoneStates[d.serial].recording)"
             autoplay muted loop
             style="width: 100%; max-height: 200px; object-fit: contain; display: block" />
         </div>
@@ -292,7 +319,7 @@ onUnmounted(() => { if (pollTimer) clearInterval(pollTimer) })
       <div class="grid grid-cols-2 gap-4" style="max-height: 520px">
         <div class="card p-3 flex flex-col" style="max-height: 520px">
           <div class="text-xs font-semibold uppercase tracking-widest mb-2" style="color: var(--text-3)">{{ viewingRec.name }}</div>
-          <video ref="recVideoRef" controls :src="`/api/test-runner/recording/${viewingRec.name}`"
+          <video ref="recVideoRef" controls :src="testRecordingUrl(viewingRec.name)"
             @timeupdate="onVideoTimeUpdate"
             style="width: 100%; max-height: 480px; object-fit: contain; border-radius: 6px; background: #000; display: block"></video>
         </div>
@@ -353,8 +380,8 @@ onUnmounted(() => { if (pollTimer) clearInterval(pollTimer) })
               @mouseenter="($event.currentTarget as HTMLElement).style.background = '#0f1523'"
               @mouseleave="($event.currentTarget as HTMLElement).style.background = 'transparent'">
               <td style="padding: 5px 8px; text-align: center">&#127916;</td>
-              <td style="padding: 5px 8px; color: #a5b4fc">{{ recTestName(r.name) }}</td>
-              <td style="padding: 5px 8px; color: var(--text-3)">{{ phoneName(r.device || '') }}</td>
+              <td style="padding: 5px 8px; color: #a5b4fc">{{ recTestName(r) }}</td>
+              <td style="padding: 5px 8px; color: var(--text-3)">{{ recPhoneName(r) }} <span style="color: var(--text-5)">({{ recPlatform(r) }})</span></td>
               <td style="padding: 5px 8px; color: var(--text-4); font-family: monospace">{{ recTime(r.date) }}</td>
               <td style="padding: 5px 8px; color: var(--text-4)">{{ r.size_mb ? r.size_mb + ' MB' : '' }}</td>
               <td style="padding: 5px 8px">

--- a/frontend/src/views/ToolsHubView.vue
+++ b/frontend/src/views/ToolsHubView.vue
@@ -1,18 +1,27 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { api } from '@/composables/useApi'
 
-interface ToolParam { name: string; type: string; required: boolean; default?: any }
-interface Tool { name: string; description: string; params: ToolParam[]; category: string }
+interface ToolParam { name: string; type: string; required: boolean; default?: any; description?: string; items?: any }
+interface ToolPlatformSupport { support: string; android: boolean; ios: boolean; notes?: string }
+interface Tool { name: string; description: string; params: ToolParam[]; category: string; platform_support?: ToolPlatformSupport }
 interface ToolGroup { category: string; tools: Tool[] }
+interface ToolDevice {
+  serial: string
+  nickname?: string
+  model?: string
+  platform?: string
+  status?: string
+  status_message?: string
+}
 
 const groups = ref<ToolGroup[]>([])
-const devices = ref<{serial: string; nickname?: string}[]>([])
+const devices = ref<ToolDevice[]>([])
 const loading = ref(false)
 const search = ref('')
 const selectedTool = ref<Tool | null>(null)
 const testDevice = ref('')
-const testArgs = ref<Record<string, string>>({})
+const testArgs = ref<Record<string, any>>({})
 const testResult = ref('')
 const testRunning = ref(false)
 const testDuration = ref(0)
@@ -20,7 +29,7 @@ const testDuration = ref(0)
 const CATEGORY_EMOJI: Record<string, string> = {
   'Screen Reading': '👁', 'Input': '👆', 'App Management': '🚀',
   'Shell': '💻', 'Clipboard & Notifications': '📋', 'Skills': '🧩',
-  'Device': '📱', 'System': '⚙️',
+  'Web': '🌐', 'Marketing': '📣', 'Device': '📱', 'System': '⚙️',
 }
 
 const filteredGroups = computed(() => {
@@ -33,6 +42,91 @@ const filteredGroups = computed(() => {
 })
 
 const totalTools = computed(() => groups.value.reduce((sum, g) => sum + g.tools.length, 0))
+const selectedDevicePlatform = computed(() => testDevice.value.startsWith('ios:') ? 'ios' : 'android')
+const selectedToolNeedsDevice = computed(() =>
+  !!selectedTool.value?.params.some(p => p.name === 'device')
+)
+const selectedToolSupportsDevice = computed(() => {
+  if (!selectedTool.value || !selectedToolNeedsDevice.value) return true
+  return toolSupportsPlatform(selectedTool.value, selectedDevicePlatform.value)
+})
+const selectedToolSupportMessage = computed(() => {
+  if (!selectedTool.value || !selectedToolNeedsDevice.value || selectedToolSupportsDevice.value) return ''
+  const platform = selectedDevicePlatform.value === 'ios' ? 'iOS' : 'Android'
+  return `${selectedTool.value.name} does not support ${platform}. ${selectedTool.value.platform_support?.notes || ''}`.trim()
+})
+
+function isIosSerial(serial: string): boolean {
+  return serial.startsWith('ios:')
+}
+
+function devicePlatform(device: ToolDevice): 'ios' | 'android' {
+  const platform = String(device.platform || '').toLowerCase()
+  if (platform === 'ios') return 'ios'
+  return isIosSerial(device.serial) ? 'ios' : 'android'
+}
+
+function deviceLabel(device: ToolDevice): string {
+  const platform = devicePlatform(device) === 'ios' ? 'iOS' : 'Android'
+  const label = device.nickname || device.model || device.serial
+  const status = device.status && device.status !== 'available' ? ` · ${device.status}` : ''
+  return `${label} (${platform}${status})`
+}
+
+function toolSupportsPlatform(tool: Tool, platform: 'android' | 'ios'): boolean {
+  const support = tool.platform_support
+  if (!support) return true
+  return platform === 'ios' ? !!support.ios : !!support.android
+}
+
+function supportLabel(tool: Tool): string {
+  const support = tool.platform_support
+  if (!support) return 'Unaudited'
+  if (support.android && support.ios) return 'Android + iOS'
+  if (support.ios) return 'iOS only'
+  if (support.android) return support.support === 'ios_planned' ? 'Android, iOS planned' : 'Android only'
+  return support.support || 'Unsupported'
+}
+
+function supportBadgeClass(tool: Tool, platform: 'android' | 'ios'): string {
+  return toolSupportsPlatform(tool, platform) ? 'tool-platform-badge--on' : 'tool-platform-badge--off'
+}
+
+function defaultParamValue(param: ToolParam): any {
+  if (param.name === 'device') return testDevice.value
+  if (param.default !== undefined) {
+    if (param.type === 'object' || param.type === 'array') {
+      return JSON.stringify(param.default, null, 2)
+    }
+    return String(param.default)
+  }
+  if (param.type === 'object') return '{}'
+  if (param.type === 'array') return '[]'
+  if (param.type === 'boolean') return 'false'
+  return ''
+}
+
+function parseParamValue(param: ToolParam, value: any): any {
+  if (param.type === 'integer') return Number.parseInt(String(value || '0'), 10) || 0
+  if (param.type === 'number') return Number(value) || 0
+  if (param.type === 'boolean') return value === true || String(value).toLowerCase() === 'true'
+  if (param.type === 'object' || param.type === 'array') {
+    if (typeof value !== 'string') return value
+    const raw = value.trim()
+    if (!raw) return param.type === 'array' ? [] : {}
+    try {
+      const parsed = JSON.parse(raw)
+      if (param.type === 'array' && !Array.isArray(parsed)) throw new Error('expected array')
+      if (param.type === 'object' && (Array.isArray(parsed) || parsed === null || typeof parsed !== 'object')) {
+        throw new Error('expected object')
+      }
+      return parsed
+    } catch (error: any) {
+      throw new Error(`${param.name} must be valid JSON ${param.type}: ${error?.message || error}`)
+    }
+  }
+  return value
+}
 
 async function load() {
   loading.value = true
@@ -40,7 +134,8 @@ async function load() {
     groups.value = await api('/api/tools')
     const devResp = await api('/api/phone/devices')
     devices.value = devResp.devices || devResp || []
-    if (devices.value.length && !testDevice.value) testDevice.value = devices.value[0].serial
+    const firstDevice = devices.value[0]
+    if (firstDevice && !testDevice.value) testDevice.value = firstDevice.serial
   } finally { loading.value = false }
 }
 
@@ -49,23 +144,31 @@ function selectTool(tool: Tool) {
   testResult.value = ''
   testArgs.value = {}
   for (const p of tool.params) {
-    testArgs.value[p.name] = p.name === 'device' ? testDevice.value : (p.default != null ? String(p.default) : '')
+    testArgs.value[p.name] = defaultParamValue(p)
   }
 }
 
 async function runTest() {
   if (!selectedTool.value) return
+  if (!selectedToolSupportsDevice.value) {
+    testDuration.value = 0
+    testResult.value = `ERROR: ${selectedToolSupportMessage.value}`
+    return
+  }
   testRunning.value = true
   testResult.value = ''
   // Update device arg
   if ('device' in testArgs.value) testArgs.value.device = testDevice.value
-  // Parse numeric args
   const args: Record<string, any> = {}
-  for (const [k, v] of Object.entries(testArgs.value)) {
-    const param = selectedTool.value.params.find(p => p.name === k)
-    if (param?.type === 'integer' || param?.type === 'number') args[k] = Number(v) || 0
-    else if (param?.type === 'boolean') args[k] = v === 'true'
-    else args[k] = v
+  try {
+    for (const [k, v] of Object.entries(testArgs.value)) {
+      const param = selectedTool.value.params.find(p => p.name === k)
+      args[k] = param ? parseParamValue(param, v) : v
+    }
+  } catch (error: any) {
+    testRunning.value = false
+    testResult.value = `ERROR: ${error?.message || error}`
+    return
   }
   try {
     const res = await api('/api/tools/test', {
@@ -79,6 +182,12 @@ async function runTest() {
   }
   testRunning.value = false
 }
+
+watch(testDevice, (serial) => {
+  if (selectedTool.value?.params.some(p => p.name === 'device')) {
+    testArgs.value.device = serial
+  }
+})
 
 onMounted(load)
 </script>
@@ -115,6 +224,11 @@ onMounted(load)
                 {{ t.params.filter(p => p.required).length }} req / {{ t.params.length }} params
               </span>
             </div>
+            <div class="tool-platform-row">
+              <span class="tool-platform-badge" :class="supportBadgeClass(t, 'android')">Android</span>
+              <span class="tool-platform-badge" :class="supportBadgeClass(t, 'ios')">iOS</span>
+              <span class="tool-platform-summary">{{ supportLabel(t) }}</span>
+            </div>
             <div style="font-size: 11px; color: var(--text-3); line-height: 1.4">{{ t.description }}</div>
           </div>
         </div>
@@ -133,7 +247,13 @@ onMounted(load)
             {{ selectedTool.name }}
           </div>
           <div style="font-size: 10px; color: #6366f1; margin-bottom: 8px">{{ selectedTool.category }}</div>
+          <div class="tool-platform-row tool-platform-row--detail">
+            <span class="tool-platform-badge" :class="supportBadgeClass(selectedTool, 'android')">Android</span>
+            <span class="tool-platform-badge" :class="supportBadgeClass(selectedTool, 'ios')">iOS</span>
+            <span class="tool-platform-summary">{{ supportLabel(selectedTool) }}</span>
+          </div>
           <div style="font-size: 12px; color: var(--text-2); line-height: 1.5">{{ selectedTool.description }}</div>
+          <div v-if="selectedTool.platform_support?.notes" class="tool-platform-notes">{{ selectedTool.platform_support.notes }}</div>
         </div>
 
         <!-- Parameters -->
@@ -146,12 +266,20 @@ onMounted(load)
               <span style="font-size: 9px; color: var(--text-4); background: var(--bg-deep); padding: 1px 5px; border-radius: 3px">{{ p.type }}</span>
               <span v-if="p.required" style="font-size: 9px; color: #f59e0b">required</span>
             </div>
-            <input v-if="p.name === 'device'"
+            <select v-if="p.name === 'device' && devices.length" v-model="testDevice"
+              style="width: 100%; padding: 6px; font-size: 11px; background: var(--bg-deep); border: 1px solid var(--border); border-radius: 6px; color: var(--text-1)">
+              <option v-for="d in devices" :key="d.serial" :value="d.serial">{{ deviceLabel(d) }}</option>
+            </select>
+            <input v-else-if="p.name === 'device'"
               v-model="testDevice"
               style="width: 100%; padding: 6px 10px; font-size: 11px; background: var(--bg-deep); border: 1px solid var(--border); border-radius: 6px; color: var(--text-1); outline: none; font-family: monospace" />
-            <select v-else-if="p.name === 'device'" v-model="testDevice"
-              style="width: 100%; padding: 6px; font-size: 11px; background: var(--bg-deep); border: 1px solid var(--border); border-radius: 6px; color: var(--text-1)">
-              <option v-for="d in devices" :key="d.serial" :value="d.serial">{{ d.nickname || d.serial }}</option>
+            <textarea v-else-if="p.type === 'object' || p.type === 'array'" v-model="testArgs[p.name]"
+              :placeholder="p.type === 'array' ? '[]' : '{}'"
+              class="tool-param-textarea"
+              rows="5" />
+            <select v-else-if="p.type === 'boolean'" v-model="testArgs[p.name]" class="tool-param-select">
+              <option value="false">false</option>
+              <option value="true">true</option>
             </select>
             <input v-else v-model="testArgs[p.name]"
               :placeholder="p.default != null ? String(p.default) : ''"
@@ -164,13 +292,16 @@ onMounted(load)
             <select v-model="testDevice"
               style="width: 100%; padding: 6px; font-size: 11px; background: var(--bg-deep); border: 1px solid var(--border); border-radius: 6px; color: var(--text-1)"
               @change="testArgs.device = testDevice">
-              <option v-for="d in devices" :key="d.serial" :value="d.serial">{{ d.nickname || d.serial }}</option>
+              <option v-for="d in devices" :key="d.serial" :value="d.serial">{{ deviceLabel(d) }}</option>
             </select>
           </div>
+          <div v-if="selectedToolSupportMessage" class="tool-platform-warning">
+            {{ selectedToolSupportMessage }}
+          </div>
 
-          <button @click="runTest" :disabled="testRunning"
+          <button @click="runTest" :disabled="testRunning || !selectedToolSupportsDevice"
             style="width: 100%; padding: 8px; font-size: 12px; font-weight: 600; background: #6366f1; color: white; border: none; border-radius: 8px; cursor: pointer; margin-top: 4px"
-            :style="{ opacity: testRunning ? 0.5 : 1 }">
+            :style="{ opacity: testRunning || !selectedToolSupportsDevice ? 0.5 : 1 }">
             {{ testRunning ? 'Running...' : '▶ Test Tool' }}
           </button>
         </div>
@@ -188,3 +319,84 @@ onMounted(load)
     </div>
   </div>
 </template>
+
+<style scoped>
+.tool-platform-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  margin: 4px 0 6px;
+}
+
+.tool-platform-row--detail {
+  margin-bottom: 10px;
+}
+
+.tool-platform-badge {
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0;
+  border: 1px solid transparent;
+}
+
+.tool-platform-badge--on {
+  color: #bbf7d0;
+  background: rgba(22, 101, 52, 0.32);
+  border-color: rgba(34, 197, 94, 0.28);
+}
+
+.tool-platform-badge--off {
+  color: #64748b;
+  background: #0f172a;
+  border-color: #1e293b;
+}
+
+.tool-platform-summary {
+  color: var(--text-4);
+  font-size: 9px;
+}
+
+.tool-platform-notes {
+  margin-top: 8px;
+  padding: 8px;
+  color: #94a3b8;
+  background: #0a0e14;
+  border: 1px solid #1e2438;
+  border-radius: 6px;
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.tool-platform-warning {
+  margin-bottom: 8px;
+  padding: 8px;
+  color: #fca5a5;
+  background: rgba(127, 29, 29, 0.22);
+  border: 1px solid rgba(248, 113, 113, 0.28);
+  border-radius: 6px;
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.tool-param-textarea,
+.tool-param-select {
+  width: 100%;
+  padding: 6px 10px;
+  font-size: 11px;
+  background: var(--bg-deep);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-1);
+  outline: none;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.tool-param-textarea {
+  resize: vertical;
+  min-height: 70px;
+  line-height: 1.45;
+}
+</style>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -14,8 +14,9 @@ export default defineConfig({
     port: 6175,
     proxy: {
       '/api': {
-        target: 'http://localhost:5055',
+        target: 'http://localhost:5056',
         changeOrigin: true,
+        ws: true,   // proxy WebSocket upgrades (H.264 stream at /api/phone/h264/*)
         // Required for SSE (Server-Sent Events) — disable response buffering
         configure: (proxy) => {
           proxy.on('proxyRes', (proxyRes) => {

--- a/gitd/app.py
+++ b/gitd/app.py
@@ -16,6 +16,8 @@ from gitd.routers.creator import router as creator_router
 from gitd.routers.emulators import pool_router as emulator_pool_router
 from gitd.routers.emulators import router as emulators_router
 from gitd.routers.explorer import router as explorer_router
+from gitd.routers.h264_stream import router as h264_stream_router
+from gitd.routers.marketing_jobs import router as marketing_jobs_router
 from gitd.routers.misc import router as misc_router
 from gitd.routers.phone import router as phone_router
 from gitd.routers.scheduler import router as scheduler_router
@@ -24,6 +26,7 @@ from gitd.routers.streaming import router as streaming_router
 from gitd.routers.streaming_viewers import router as streaming_viewers_router
 from gitd.routers.tests import router as tests_router
 from gitd.routers.tools_hub import router as tools_hub_router
+from gitd.routers.traces import router as traces_router
 
 logger = logging.getLogger(__name__)
 
@@ -51,8 +54,8 @@ async def lifespan(app: FastAPI):
 
 
 TAGS_METADATA = [
-    {"name": "phone", "description": "ADB device control, tap, swipe, screenshots"},
-    {"name": "streaming", "description": "MJPEG + WebRTC phone screen streaming"},
+    {"name": "phone", "description": "Android/iOS device control, tap, swipe, screenshots"},
+    {"name": "streaming", "description": "Android Portal/WebRTC and iOS WDA MJPEG phone screen streaming"},
     {"name": "skills", "description": "Installed skill packages, run actions/workflows"},
     {"name": "creator", "description": "LLM-assisted skill builder with device stream"},
     {"name": "explorer", "description": "Auto app explorer (BFS state discovery)"},
@@ -72,7 +75,7 @@ def create_app() -> FastAPI:
     """Build and return the FastAPI application."""
     app = FastAPI(
         title="Ghost in the Droid API",
-        description="Open-source Android automation — give any AI agent an Android body",
+        description="Open-source mobile automation for Android ADB and iOS Appium/WDA devices",
         version="1.0.0",
         lifespan=lifespan,
         openapi_tags=TAGS_METADATA,
@@ -102,6 +105,7 @@ def create_app() -> FastAPI:
     app.include_router(misc_router)
     app.include_router(phone_router)
     app.include_router(streaming_router)
+    app.include_router(h264_stream_router)
     app.include_router(streaming_viewers_router)
     app.include_router(skills_router)
     app.include_router(creator_router)
@@ -110,10 +114,12 @@ def create_app() -> FastAPI:
     app.include_router(tools_hub_router)
     app.include_router(bot_router)
     app.include_router(scheduler_router)
+    app.include_router(marketing_jobs_router)
     app.include_router(tests_router)
     app.include_router(emulators_router)
     app.include_router(emulator_pool_router)
     app.include_router(benchmarks_router)
+    app.include_router(traces_router)
 
     # Plugin hook: load premium features if installed
     try:

--- a/gitd/benchmarks/base.py
+++ b/gitd/benchmarks/base.py
@@ -17,10 +17,26 @@ class Task:
     init: dict = field(default_factory=dict)
     eval: dict = field(default_factory=dict)
     teardown: dict | None = None
+    platforms: list[str] = field(default_factory=lambda: ["android"])
 
     @property
     def max_steps(self) -> int:
         return int(self.complexity * 10)
+
+    def supported_platforms(self) -> list[str]:
+        """Return normalized platforms supported by this benchmark task."""
+        raw = self.platforms or ["android"]
+        values = raw if isinstance(raw, (list, tuple, set)) else [raw]
+        result: list[str] = []
+        for value in values:
+            platform = str(value).strip().lower()
+            if platform in {"android", "ios", "all"} and platform not in result:
+                result.append(platform)
+        return result or ["android"]
+
+    def supports_platform(self, platform: str) -> bool:
+        supported = self.supported_platforms()
+        return "all" in supported or platform.strip().lower() in supported
 
 
 @dataclass

--- a/gitd/benchmarks/ghost_bench/evaluators.py
+++ b/gitd/benchmarks/ghost_bench/evaluators.py
@@ -3,9 +3,12 @@
 import subprocess
 
 from gitd.benchmarks.base import Task
+from gitd.bots.common.device import is_ios_ref
 
 
 def _adb(serial: str, *args: str, timeout: int = 10) -> str:
+    if is_ios_ref(serial):
+        raise RuntimeError("Ghost Bench evaluators are Android-only and do not support iOS device refs")
     cmd = ["adb", "-s", serial, "shell", *args]
     r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
     return r.stdout.strip()

--- a/gitd/bots/common/adb.py
+++ b/gitd/bots/common/adb.py
@@ -5,7 +5,88 @@ adb_core.py — Shared ADB + XML primitives for Android automation.
 Single Device class providing tap, swipe, type, screenshot, XML dump,
 and other low-level ADB operations used by skills and bot scripts.
 """
-import hashlib, html, json, re, subprocess, time
+import hashlib, html, json, re, shlex, subprocess, time
+import unicodedata
+from typing import NamedTuple
+
+
+def ascii_typeable(text: str) -> str:
+    """Transliterate text to the closest ASCII `adb shell input text` can send.
+
+    `adb shell input text` is ASCII-only: a single non-ASCII char (e.g. the é in
+    "Sauté") makes the WHOLE command fail and leaves the field blank. NFKD-decompose
+    then drop combining marks so accented letters land as their base letter
+    ("Sauté" -> "Saute", "café" -> "cafe"), which fuzzy-matches the intended value
+    and is the best the device can physically type. For full-fidelity emoji/CJK the
+    caller should use `type_unicode` (ADBKeyboard) instead — this is the graceful
+    degradation for the plain `input text` path only.
+    """
+    if text.isascii():
+        return text
+    return unicodedata.normalize("NFKD", text).encode("ascii", "ignore").decode("ascii")
+
+
+_KEYCODE_RE = re.compile(r"^KEYCODE_[A-Z0-9_]+$")
+
+
+def normalize_keycode(key: str) -> str:
+    """Return a validated Android keycode, adding the ``KEYCODE_`` prefix if absent.
+
+    ``adb shell input keyevent <key>`` re-parses its argument through the *device*
+    shell, so an agent/attacker-controlled value like ``KEYCODE_HOME; reboot`` would
+    otherwise run ``reboot`` on the device. Keycodes are always bare
+    ``KEYCODE_[A-Z0-9_]+`` names, so anything else is rejected outright.
+    """
+    if not key.startswith("KEYCODE_"):
+        key = "KEYCODE_" + key
+    if not _KEYCODE_RE.match(key):
+        raise ValueError(f"invalid keycode {key!r}: expected KEYCODE_[A-Z0-9_]+")
+    return key
+
+
+def input_text_arg(text: str) -> str:
+    """Shell-quote text for ``adb shell input text`` so it types literally.
+
+    ``adb shell`` re-parses its argv through the device shell, so metacharacters
+    (``; & | $ ` ( ) < > \\n`` — including ones NFKD transliteration folds in from
+    fullwidth punctuation) would break out of the ``input text`` call and run on
+    the device. Quoting the whole argument neutralizes that; spaces stay encoded
+    as ``%s`` (input's own space escape) inside the quotes. Pass already-ASCII
+    (``ascii_typeable``) text; the caller keeps the transliterated string for its
+    own reporting.
+    """
+    return shlex.quote(text.replace(" ", "%s"))
+
+
+class ADBError(RuntimeError):
+    """Raised when an adb invocation fails (nonzero exit, timeout, or adb missing).
+
+    Subclasses RuntimeError so the many call sites that already wrap adb calls in
+    ``try/except Exception`` keep degrading gracefully — the only behaviour change
+    is that a failure now carries a real message instead of masquerading as an
+    empty-string success.
+    """
+
+    def __init__(self, args, returncode: int, stderr: str = "", stdout: str = ""):
+        self.cmd_args = tuple(args)
+        self.returncode = returncode
+        self.stderr = stderr or ""
+        self.stdout = stdout or ""
+        detail = self.stderr.strip() or self.stdout.strip() or "no output"
+        cmd = "adb " + " ".join(str(a) for a in args)
+        super().__init__(f"{cmd} failed (exit {returncode}): {detail}")
+
+
+class ADBResult(NamedTuple):
+    """Result of a soft (non-raising) adb call — see ``Device.adb_soft``."""
+
+    returncode: int
+    stdout: str
+    stderr: str
+
+    @property
+    def ok(self) -> bool:
+        return self.returncode == 0
 
 
 def _stable_port(serial: str, base: int = 18000) -> int:
@@ -53,12 +134,47 @@ class Device:
 
     # ── ADB primitives ────────────────────────────────────────────────────────
 
+    def _run(self, args, timeout) -> subprocess.CompletedProcess:
+        """Invoke adb once. Raises ADBError if adb is missing or the call times
+        out — both are hard failures no caller can recover from as a string."""
+        try:
+            return subprocess.run(
+                ["adb", "-s", self.serial, *args],
+                capture_output=True, text=True, timeout=timeout,
+            )
+        except FileNotFoundError as e:
+            raise ADBError(args, 127, "adb executable not found on PATH") from e
+        except subprocess.TimeoutExpired as e:
+            raise ADBError(args, -1, f"timed out after {timeout}s") from e
+
     def adb(self, *args, timeout=30) -> str:
-        r = subprocess.run(
-            ["adb", "-s", self.serial, *args],
-            capture_output=True, text=True, timeout=timeout,
-        )
+        """Run an adb command, returning stripped stdout.
+
+        Raises ADBError on a nonzero exit (device offline/unauthorized/unknown
+        serial, adb transport errors) instead of silently returning "" — that
+        empty string used to read as success and gave every downstream tool a
+        phantom success. Note: app-level tools like ``am``/``pm``/``monkey``
+        usually still exit 0 on their own failures and print the error to
+        stdout, so callers that care about those must still parse stdout; this
+        only surfaces adb-process-level failures. For commands where a nonzero
+        exit is expected and tolerable, use ``adb_soft``.
+        """
+        r = self._run(args, timeout)
+        if r.returncode != 0:
+            raise ADBError(args, r.returncode, r.stderr, r.stdout)
         return r.stdout.strip()
+
+    def adb_soft(self, *args, timeout=30) -> ADBResult:
+        """Run an adb command without raising on a nonzero exit.
+
+        Returns an ADBResult(returncode, stdout, stderr) so the caller can
+        inspect the exit code / stderr itself. Use for calls where a nonzero
+        exit is a normal, expected outcome (e.g. probing an optional feature
+        that may be unavailable on older devices). adb-missing / timeout still
+        raise ADBError — those are never a normal outcome.
+        """
+        r = self._run(args, timeout)
+        return ADBResult(r.returncode, r.stdout.strip(), r.stderr.strip())
 
     def adb_show(self, *args):
         """adb with live output (e.g. for push progress)."""
@@ -88,8 +204,13 @@ class Device:
         time.sleep(delay)
 
     def clipboard_get(self) -> str:
-        """Get clipboard text (requires API 29+)."""
-        return self.adb("shell", "cmd", "clipboard", "get-text") or ''
+        """Get clipboard text (requires API 29+).
+
+        Uses adb_soft — the clipboard service is unavailable on some devices
+        and returns nonzero; that's a normal "no clipboard" outcome, not an
+        error worth raising through every caller.
+        """
+        return self.adb_soft("shell", "cmd", "clipboard", "get-text").stdout or ''
 
     def clipboard_set(self, text: str):
         """Set clipboard text."""
@@ -304,11 +425,12 @@ class Device:
         n = list(map(int, re.findall(r'\d+', bounds_str)))
         return (n[0] + n[2]) // 2, (n[1] + n[3]) // 2
 
-    def find_bounds(self, xml: str, *, text=None, content_desc=None, resource_id=None) -> str | None:
+    def find_bounds(self, xml: str, *, text=None, content_desc=None, resource_id=None, class_name=None) -> str | None:
         """Return bounds string of first node matching the given attribute."""
         if text:          key, val = "text",         text
         elif content_desc: key, val = "content-desc", content_desc
         elif resource_id:  key, val = "resource-id",  resource_id
+        elif class_name:   key, val = "class",        class_name
         else:              return None
         m = re.search(rf'<node[^>]*{key}="{re.escape(val)}"[^>]*>', xml)
         if m:
@@ -388,7 +510,17 @@ class Device:
         time.sleep(0.5)
         self.adb("shell", "am", "force-stop", TIKTOK_PKG)
         time.sleep(1)
-        self.adb("shell", "am", "start", "-n", activity)
+        # Try the canonical MainActivity first; fall back to the LAUNCHER intent
+        # (which is what 'tap the icon' uses — works on Samsung where the
+        # explicit activity start sometimes lands in background only).
+        # adb_soft: a nonzero am-start exit is a normal fallback trigger here,
+        # not an error to raise.
+        r = self.adb_soft("shell", "am", "start", "-n", activity, timeout=10)
+        time.sleep(2)
+        if not r.ok or "Error" in r.stdout or "Activity not started" in r.stdout \
+                or self.screen_type(self.dump_xml()) == "unknown":
+            self.adb("shell", "monkey", "-p", TIKTOK_PKG, "-c",
+                     "android.intent.category.LAUNCHER", "1", timeout=10)
         time.sleep(3)
         # TikTok sometimes restores a previous creation session — back out until home
         for _ in range(8):

--- a/gitd/bots/common/device.py
+++ b/gitd/bots/common/device.py
@@ -1,0 +1,131 @@
+"""Platform-aware device factory.
+
+Bare device refs remain Android ADB serials.  Refs with the ``ios:`` prefix are
+handled by the Appium/WebDriverAgent iOS backend.
+
+iOS support is feature-gated (dev-only for one release cycle): when
+``settings.ios_platform_enabled`` is false and ``GITD_ENABLE_IOS`` is unset,
+``ios:`` refs raise NotImplementedError and iOS devices are excluded from
+discovery. The Android path is unaffected either way.
+"""
+from __future__ import annotations
+
+import os
+
+from gitd.bots.common.adb import Device, list_connected
+from gitd.bots.common.ios import (
+    IOS_PREFIX,
+    IOSDevice,
+    configured_ios_udids,
+    discover_host_ios_devices,
+    ios_config_for_udid,
+    is_ios_ref,
+    probe_ios_device,
+)
+
+
+def ios_enabled() -> bool:
+    """Whether the iOS backend is enabled for this process."""
+    if os.environ.get("GITD_ENABLE_IOS") == "1":
+        return True
+    from gitd.config import settings
+
+    return settings.ios_platform_enabled
+
+
+def _require_ios_enabled(device: str) -> None:
+    if not ios_enabled():
+        raise NotImplementedError(
+            f"iOS device refs are not supported ({device}): iOS support is disabled. "
+            "Set GITD_ENABLE_IOS=1 (or ios_platform_enabled=true in .env) to enable."
+        )
+
+
+def platform_for_device(device: str | None) -> str:
+    return "ios" if is_ios_ref(device) else "android"
+
+
+def get_device(device: str):
+    if is_ios_ref(device):
+        _require_ios_enabled(device)
+        return IOSDevice(device)
+    return Device(device)
+
+
+def require_android_device(device: str, tool_name: str) -> None:
+    if is_ios_ref(device):
+        raise NotImplementedError(f"{tool_name} is Android-only and is not supported for iOS device refs")
+
+
+def ios_refs_from_env() -> list[str]:
+    if not ios_enabled():
+        return []
+    return [f"{IOS_PREFIX}{udid}" for udid in configured_ios_udids()]
+
+
+def ios_refs_from_host() -> list[str]:
+    if not ios_enabled():
+        return []
+    values = configured_ios_udids()
+    values.extend(item["udid"] for item in discover_host_ios_devices(include_simulators=True))
+    refs: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        udid = value.removeprefix(IOS_PREFIX) if isinstance(value, str) else str(value)
+        if udid and udid not in seen:
+            seen.add(udid)
+            refs.append(f"{IOS_PREFIX}{udid}")
+    return refs
+
+
+def list_configured_ios_devices(*, deep_probe: bool = False) -> list[dict]:
+    if not ios_enabled():
+        return []
+    devices: list[dict] = []
+    discovered = {item["udid"]: item for item in discover_host_ios_devices(include_simulators=True)}
+    for ref in ios_refs_from_host():
+        udid = ref.removeprefix(IOS_PREFIX)
+        cfg = ios_config_for_udid(ref)
+        host = discovered.get(udid, {})
+        try:
+            status = probe_ios_device(ref, deep=deep_probe).to_dict()
+        except Exception as e:
+            status = {
+                "platform": "ios",
+                "device": ref,
+                "udid": udid,
+                "state": "session_error",
+                "message": str(e),
+            }
+        devices.append(
+            {
+                "serial": ref,
+                "model": host.get("name") or cfg.device_name or "iOS device",
+                "connection": "appium-wda",
+                "platform": "ios",
+                "source": host.get("source", "configured"),
+                "host_state": host.get("state", ""),
+                "status": status.get("state", "session_error"),
+                "status_message": status.get("message", ""),
+                "appium_url": status.get("appium_url", cfg.appium_url),
+                "device_name": host.get("name") or cfg.device_name,
+                "platform_version": cfg.platform_version or host.get("platform_version", ""),
+                "bundle_id": cfg.bundle_id,
+                "browser_name": cfg.browser_name,
+                "wda_url": cfg.wda_url,
+                "mjpeg_server_port": cfg.mjpeg_server_port,
+                "mjpeg_settings": cfg.mjpeg_settings(),
+                "details": status,
+            }
+        )
+    return devices
+
+
+def list_connected_device_refs() -> list[str]:
+    devices: list[str] = []
+    try:
+        devices.extend(list_connected())
+    except Exception:
+        pass
+    devices.extend(ios_refs_from_host())
+    return devices

--- a/gitd/bots/common/ios.py
+++ b/gitd/bots/common/ios.py
@@ -1,0 +1,3437 @@
+#!/usr/bin/env python3
+"""iOS automation primitives backed by Appium XCUITest/WebDriverAgent.
+
+The public methods mirror the small Android ``Device`` surface used by the
+agent layer: screenshot, XML dump, tap, swipe, type, app launch, and simple XML
+helpers.  The implementation talks directly to Appium's W3C WebDriver HTTP API
+so the first iOS milestone does not need the Python Appium client package.
+"""
+from __future__ import annotations
+
+import base64
+import html
+import contextlib
+import fcntl
+import json
+import os
+import re
+import signal
+import shlex
+import subprocess
+import threading
+import time
+import urllib.parse
+import xml.etree.ElementTree as ET
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import requests
+
+IOS_PREFIX = "ios:"
+
+_CLICKABLE_TYPES = {
+    "XCUIElementTypeButton",
+    "XCUIElementTypeCell",
+    "XCUIElementTypeLink",
+    "XCUIElementTypeTextField",
+    "XCUIElementTypeSecureTextField",
+    "XCUIElementTypeSearchField",
+    "XCUIElementTypeSwitch",
+    "XCUIElementTypeSlider",
+    "XCUIElementTypePickerWheel",
+    "XCUIElementTypeSegmentedControl",
+    "XCUIElementTypeTabBar",
+    "XCUIElementTypeTabBarItem",
+}
+
+_SCROLLABLE_TYPES = {
+    "XCUIElementTypeCollectionView",
+    "XCUIElementTypeScrollView",
+    "XCUIElementTypeTable",
+    "XCUIElementTypeWebView",
+}
+
+_KNOWN_IOS_POPUPS = [
+    {"detect": "Turn on notifications", "button": "Not now", "label": "Notification prompt"},
+    {"detect": "Not now", "button": "Not now", "label": "Not now dialog"},
+    {"detect": "Allow", "button": "Allow", "label": "Permission dialog"},
+    {"detect": "Don\u2019t Allow", "button": "Don\u2019t Allow", "label": "Permission denial dialog"},
+    {"detect": "Don't Allow", "button": "Don't Allow", "label": "Permission denial dialog"},
+    {"detect": "Skip", "button": "Skip", "label": "Skip dialog"},
+    {"detect": "Cancel", "button": "Cancel", "label": "Cancel dialog"},
+    {"detect": "Close", "button": "Close", "label": "Close dialog"},
+]
+_DISMISS_WORDS = {"not now", "skip", "cancel", "dismiss", "later", "close", "done"}
+_DISMISS_EXACT = {"cancel", "dismiss", "close", "done", "not now", "don't allow", "don\u2019t allow"}
+
+_ELEMENT_ID_KEYS = (
+    "element-6066-11e4-a52e-4f735466cecf",
+    "ELEMENT",
+)
+_IOS_DEVICE_NAME_RE = re.compile(r"\b(iPhone|iPad|iPod)\b", re.I)
+_IOS_HARDWARE_UDID_RE = re.compile(r"^(?:[A-F0-9]{40}|[A-F0-9]{8}-[A-F0-9]{16})$", re.I)
+_IOS_SIMULATOR_UDID_RE = re.compile(
+    r"^[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}$",
+    re.I,
+)
+_MAC_HOST_NAME_RE = re.compile(r"\b(Mac|MacBook|iMac|Mac mini|Mac Studio|Laptop|Desktop)\b", re.I)
+_REMOTE_XPC_REGISTRY_PORTS = (42314,)
+
+
+class IOSBackendError(RuntimeError):
+    """Raised when Appium/WDA cannot satisfy a requested iOS operation."""
+
+
+class IOSSessionInvalid(IOSBackendError):
+    """Raised when Appium reports a cached session is no longer valid."""
+
+
+@dataclass(frozen=True)
+class IOSSessionConfig:
+    appium_url: str
+    udid: str
+    bundle_id: str
+    browser_name: str
+    device_name: str
+    platform_version: str
+    wda_url: str
+    capability_items: tuple[tuple[str, Any], ...]
+
+
+@dataclass(frozen=True)
+class IOSDeviceConfig:
+    udid: str
+    appium_url: str = "http://127.0.0.1:4723"
+    bundle_id: str = "com.google.chrome.ios"
+    browser_name: str = ""
+    device_name: str = "iPhone"
+    platform_version: str = ""
+    wda_url: str = ""
+    timeout: float = 120.0
+    mjpeg_server_port: int = 9100
+    mjpeg_screenshot_url: str = ""
+    mjpeg_server_framerate: int = 0
+    mjpeg_scaling_factor: float = 0.0
+    mjpeg_server_screenshot_quality: int = 0
+    mjpeg_fix_orientation: bool | None = None
+    screenshot_quality: int = 0
+    xcode_org_id: str = ""
+    xcode_signing_id: str = ""
+    updated_wda_bundle_id: str = ""
+    derived_data_path: str = ""
+    allow_provisioning_device_registration: bool | None = None
+    show_xcode_log: bool | None = None
+    use_prebuilt_wda: bool | None = None
+    use_preinstalled_wda: bool | None = None
+    wda_launch_timeout: int = 0
+    wda_connection_timeout: int = 0
+    wda_startup_retries: int = 0
+    wda_startup_retry_interval: int = 0
+    known_apps: tuple[tuple[str, str], ...] = ()
+
+    def capabilities(self) -> dict[str, Any]:
+        caps: dict[str, Any] = {}
+        string_caps = {
+            "xcode_org_id": "appium:xcodeOrgId",
+            "xcode_signing_id": "appium:xcodeSigningId",
+            "updated_wda_bundle_id": "appium:updatedWDABundleId",
+            "derived_data_path": "appium:derivedDataPath",
+            "mjpeg_screenshot_url": "appium:mjpegScreenshotUrl",
+        }
+        int_caps = {
+            "wda_launch_timeout": "appium:wdaLaunchTimeout",
+            "wda_connection_timeout": "appium:wdaConnectionTimeout",
+            "wda_startup_retries": "appium:wdaStartupRetries",
+            "wda_startup_retry_interval": "appium:wdaStartupRetryInterval",
+            "mjpeg_server_port": "appium:mjpegServerPort",
+            "screenshot_quality": "appium:screenshotQuality",
+        }
+        bool_caps = {
+            "allow_provisioning_device_registration": "appium:allowProvisioningDeviceRegistration",
+            "show_xcode_log": "appium:showXcodeLog",
+            "use_prebuilt_wda": "appium:usePrebuiltWDA",
+            "use_preinstalled_wda": "appium:usePreinstalledWDA",
+        }
+        for field_name, cap_name in string_caps.items():
+            value = getattr(self, field_name)
+            if value:
+                caps[cap_name] = value
+        for field_name, cap_name in int_caps.items():
+            value = getattr(self, field_name)
+            if value:
+                caps[cap_name] = int(value)
+        for field_name, cap_name in bool_caps.items():
+            value = getattr(self, field_name)
+            if value is not None:
+                caps[cap_name] = bool(value)
+        for setting_name, value in self.mjpeg_settings().items():
+            caps[f"appium:settings[{setting_name}]"] = value
+        return caps
+
+    def mjpeg_settings(self) -> dict[str, Any]:
+        settings: dict[str, Any] = {}
+        if self.mjpeg_server_framerate:
+            settings["mjpegServerFramerate"] = int(self.mjpeg_server_framerate)
+        if self.mjpeg_scaling_factor:
+            settings["mjpegScalingFactor"] = float(self.mjpeg_scaling_factor)
+        if self.mjpeg_server_screenshot_quality:
+            settings["mjpegServerScreenshotQuality"] = int(self.mjpeg_server_screenshot_quality)
+        if self.mjpeg_fix_orientation is not None:
+            settings["mjpegFixOrientation"] = bool(self.mjpeg_fix_orientation)
+        return settings
+
+
+@dataclass
+class IOSDeviceStatus:
+    device: str
+    udid: str
+    state: str
+    message: str
+    appium_url: str
+    session_id: str = ""
+    active_app: dict[str, Any] | None = None
+    screen_size: dict[str, int] | None = None
+    checks: dict[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["platform"] = "ios"
+        return data
+
+
+_CONFIG_ENV_FIELDS = {
+    "IOS_APPIUM_URL": "appium_url",
+    "IOS_BUNDLE_ID": "bundle_id",
+    "IOS_BROWSER_NAME": "browser_name",
+    "IOS_DEVICE_NAME": "device_name",
+    "IOS_PLATFORM_VERSION": "platform_version",
+    "IOS_WDA_URL": "wda_url",
+    "IOS_WEBDRIVERAGENT_URL": "wda_url",
+    "IOS_APPIUM_TIMEOUT": "timeout",
+    "IOS_MJPEG_SERVER_PORT": "mjpeg_server_port",
+    "IOS_MJPEG_SCREENSHOT_URL": "mjpeg_screenshot_url",
+    "IOS_MJPEG_SERVER_FRAMERATE": "mjpeg_server_framerate",
+    "IOS_MJPEG_SCALING_FACTOR": "mjpeg_scaling_factor",
+    "IOS_MJPEG_SERVER_SCREENSHOT_QUALITY": "mjpeg_server_screenshot_quality",
+    "IOS_MJPEG_FIX_ORIENTATION": "mjpeg_fix_orientation",
+    "IOS_SCREENSHOT_QUALITY": "screenshot_quality",
+    "IOS_XCODE_ORG_ID": "xcode_org_id",
+    "IOS_XCODE_SIGNING_ID": "xcode_signing_id",
+    "IOS_UPDATED_WDA_BUNDLE_ID": "updated_wda_bundle_id",
+    "IOS_DERIVED_DATA_PATH": "derived_data_path",
+    "IOS_ALLOW_PROVISIONING_DEVICE_REGISTRATION": "allow_provisioning_device_registration",
+    "IOS_SHOW_XCODE_LOG": "show_xcode_log",
+    "IOS_USE_PREBUILT_WDA": "use_prebuilt_wda",
+    "IOS_USE_PREINSTALLED_WDA": "use_preinstalled_wda",
+    "IOS_WDA_LAUNCH_TIMEOUT": "wda_launch_timeout",
+    "IOS_WDA_CONNECTION_TIMEOUT": "wda_connection_timeout",
+    "IOS_WDA_STARTUP_RETRIES": "wda_startup_retries",
+    "IOS_WDA_STARTUP_RETRY_INTERVAL": "wda_startup_retry_interval",
+    "IOS_KNOWN_APPS_JSON": "known_apps",
+    "IOS_APPS_JSON": "known_apps",
+}
+
+_INT_CONFIG_FIELDS = {
+    "mjpeg_server_port",
+    "wda_launch_timeout",
+    "wda_connection_timeout",
+    "wda_startup_retries",
+    "wda_startup_retry_interval",
+    "mjpeg_server_framerate",
+    "mjpeg_server_screenshot_quality",
+    "screenshot_quality",
+}
+_FLOAT_CONFIG_FIELDS = {"timeout", "mjpeg_scaling_factor"}
+_BOOL_CONFIG_FIELDS = {
+    "allow_provisioning_device_registration",
+    "show_xcode_log",
+    "use_prebuilt_wda",
+    "use_preinstalled_wda",
+    "mjpeg_fix_orientation",
+}
+
+_BROWSER_CONTROL_TEXT = {
+    "chrome",
+    "address",
+    "tabs",
+    "tab switcher",
+    "share",
+    "menu",
+    "reload",
+    "back",
+    "forward",
+    "new tab",
+    "done",
+    "cancel",
+    "search or type web address",
+    "search your screen with google lens",
+}
+
+_BROWSER_FIRST_RUN_ACTIONS = {
+    "accept",
+    "accept & continue",
+    "accept and continue",
+    "agree",
+    "continue",
+    "done",
+    "got it",
+    "no thanks",
+    "not now",
+    "skip",
+    "start browsing",
+    "use without an account",
+}
+
+
+def _looks_like_address_bar_text(value: str) -> bool:
+    label = re.sub(r"\s+", " ", str(value or "").strip().lower())
+    if not label:
+        return False
+    if "address" in label or "url" in label or "web address" in label:
+        return True
+    return "search" in label and ("type" in label or "enter" in label or "web" in label)
+
+
+_LOW_VALUE_ARTICLE_TERMS = {
+    "advertisement",
+    "cookie",
+    "donate",
+    "email",
+    "newsletter",
+    "notifications",
+    "privacy",
+    "profile",
+    "sign in",
+    "sign up",
+    "subscribe",
+    "terms",
+}
+
+_ARTICLE_URL_HINTS = (
+    "article",
+    "story",
+    "news",
+    "world",
+    "politics",
+    "business",
+    "economy",
+    "science",
+    "health",
+    "culture",
+    "sports",
+)
+
+_COMMON_IOS_APPS: tuple[tuple[str, str], ...] = (
+    ("Chrome", "com.google.chrome.ios"),
+    ("Safari", "com.apple.mobilesafari"),
+    ("Settings", "com.apple.Preferences"),
+    ("Camera", "com.apple.camera"),
+    ("Photos", "com.apple.mobileslideshow"),
+    ("Messages", "com.apple.MobileSMS"),
+    ("Phone", "com.apple.mobilephone"),
+    ("Mail", "com.apple.mobilemail"),
+    ("App Store", "com.apple.AppStore"),
+    ("Gmail", "com.google.Gmail"),
+    ("Google Maps", "com.google.Maps"),
+    ("Google Photos", "com.google.photos"),
+    ("YouTube", "com.google.ios.youtube"),
+    ("TikTok", "com.zhiliaoapp.musically"),
+    ("Instagram", "com.burbn.instagram"),
+    ("Facebook", "com.facebook.Facebook"),
+    ("Messenger", "com.facebook.Messenger"),
+    ("WhatsApp", "net.whatsapp.WhatsApp"),
+    ("X", "com.atebits.Tweetie2"),
+    ("Reddit", "com.reddit.Reddit"),
+    ("Spotify", "com.spotify.client"),
+)
+
+_IOS_APP_STATE_NAMES = {
+    0: "not_installed",
+    1: "not_running",
+    2: "running_background_suspended",
+    3: "running_background",
+    4: "running_foreground",
+}
+
+_IOS_NOTIFICATION_SKIP_TEXT = {
+    "clear",
+    "clear all",
+    "notification center",
+    "notifications",
+    "no notifications",
+    "no older notifications",
+    "scheduled summary",
+    "today",
+    "earlier",
+}
+
+_WEB_TEXT_JS = r"""
+const maxEntries = arguments[0] || 300;
+const clean = (value) => String(value || '').replace(/\s+/g, ' ').trim();
+const visible = (el) => {
+  const style = window.getComputedStyle(el);
+  if (!style || style.visibility === 'hidden' || style.display === 'none') return false;
+  const rect = el.getBoundingClientRect();
+  if (rect.width <= 0 || rect.height <= 0) return false;
+  if (rect.bottom < 0 || rect.right < 0) return false;
+  if (rect.top > window.innerHeight || rect.left > window.innerWidth) return false;
+  return true;
+};
+const nodes = Array.from(document.querySelectorAll(
+  'article h1, article h2, article h3, h1, h2, h3, [role="heading"], a, p'
+));
+const seen = new Set();
+const entries = [];
+for (const el of nodes) {
+  if (!visible(el)) continue;
+  const text = clean(el.innerText || el.textContent);
+  if (!text || text.length < 2) continue;
+  const rect = el.getBoundingClientRect();
+  const key = `${text}:${Math.round(rect.top)}:${Math.round(rect.left)}`;
+  if (seen.has(key)) continue;
+  seen.add(key);
+  const anchor = el.closest('a') || (el.tagName === 'A' ? el : null);
+  entries.push({
+    text,
+    tag: String(el.tagName || '').toLowerCase(),
+    role: el.getAttribute('role') || '',
+    href: anchor ? anchor.href || '' : '',
+    bounds: {
+      x1: Math.round(rect.left),
+      y1: Math.round(rect.top),
+      x2: Math.round(rect.right),
+      y2: Math.round(rect.bottom),
+    },
+    provenance: 'web_context',
+  });
+  if (entries.length >= maxEntries) break;
+}
+return {
+  url: window.location ? window.location.href : '',
+  title: document.title || '',
+  bodyText: document.body ? clean(document.body.innerText || document.body.textContent) : '',
+  viewport: {width: window.innerWidth, height: window.innerHeight},
+  entries,
+};
+"""
+
+
+def strip_ios_prefix(device: str) -> str:
+    return device[len(IOS_PREFIX) :] if device.startswith(IOS_PREFIX) else device
+
+
+def is_ios_ref(device: str | None) -> bool:
+    return bool(device and device.startswith(IOS_PREFIX))
+
+
+def _as_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).lower() in {"1", "true", "yes"}
+
+
+def _clean_config_value(field_name: str, value: Any) -> Any:
+    if value in ("", None):
+        return None
+    if field_name == "known_apps":
+        return _normalize_ios_app_inventory(value)
+    if field_name in _BOOL_CONFIG_FIELDS:
+        return _as_bool(value)
+    if field_name in _INT_CONFIG_FIELDS:
+        return _intish(value)
+    if field_name in _FLOAT_CONFIG_FIELDS:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+    return str(value)
+
+
+def _looks_like_bundle_id(value: str) -> bool:
+    return "." in value and not any(ch.isspace() for ch in value)
+
+
+def _guess_ios_app_name(bundle_id: str) -> str:
+    for name, known_bundle_id in _COMMON_IOS_APPS:
+        if known_bundle_id == bundle_id:
+            return name
+    parts = [p for p in re.split(r"[.\-_]+", bundle_id) if p]
+    ignored = {"ios", "iphone", "ipad", "client", "app", "mobile"}
+    token = next((part for part in reversed(parts) if part.lower() not in ignored), bundle_id)
+    if token.isupper():
+        return token
+    return token.replace("_", " ").replace("-", " ").title()
+
+
+def _normalize_ios_app_inventory(value: Any) -> tuple[tuple[str, str], ...]:
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return ()
+        if raw.startswith("{") or raw.startswith("["):
+            try:
+                value = json.loads(raw)
+            except json.JSONDecodeError:
+                return ()
+        else:
+            value = [item.strip() for item in raw.split(",") if item.strip()]
+
+    rows: list[tuple[str, str]] = []
+    if isinstance(value, dict):
+        items = value.items()
+        for raw_name, raw_bundle_id in items:
+            if isinstance(raw_bundle_id, dict):
+                name = str(raw_bundle_id.get("name") or raw_name or "").strip()
+                bundle_id = str(
+                    raw_bundle_id.get("bundle_id")
+                    or raw_bundle_id.get("bundleId")
+                    or raw_bundle_id.get("package")
+                    or raw_bundle_id.get("app_package")
+                    or raw_bundle_id.get("id")
+                    or ""
+                ).strip()
+            else:
+                left = str(raw_name or "").strip()
+                right = str(raw_bundle_id or "").strip()
+                if _looks_like_bundle_id(left) and not _looks_like_bundle_id(right):
+                    name, bundle_id = right or _guess_ios_app_name(left), left
+                else:
+                    name, bundle_id = left, right
+            if bundle_id:
+                rows.append((name or _guess_ios_app_name(bundle_id), bundle_id))
+    elif isinstance(value, list | tuple):
+        for item in value:
+            if isinstance(item, dict):
+                bundle_id = str(
+                    item.get("bundle_id")
+                    or item.get("bundleId")
+                    or item.get("package")
+                    or item.get("app_package")
+                    or item.get("id")
+                    or ""
+                ).strip()
+                name = str(item.get("name") or item.get("label") or "").strip()
+            else:
+                bundle_id = str(item or "").strip()
+                name = ""
+            if bundle_id:
+                rows.append((name or _guess_ios_app_name(bundle_id), bundle_id))
+
+    out: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for name, bundle_id in rows:
+        if bundle_id in seen:
+            continue
+        seen.add(bundle_id)
+        out.append((name, bundle_id))
+    return tuple(out)
+
+
+def _skill_ios_app_inventory() -> tuple[tuple[str, str], ...]:
+    """Return iOS bundle ids declared by local skill metadata."""
+    try:
+        import yaml
+    except Exception:
+        return ()
+
+    skills_dir = Path(__file__).resolve().parents[2] / "skills"
+    rows: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for meta_path in sorted(skills_dir.glob("*/skill.yaml")):
+        try:
+            meta = yaml.safe_load(meta_path.read_text(encoding="utf-8")) or {}
+        except Exception:
+            continue
+        bundle_id = str(meta.get("ios_bundle_id") or "").strip()
+        if not bundle_id or bundle_id in seen:
+            continue
+        raw_platforms = meta.get("platforms") or []
+        platforms = raw_platforms if isinstance(raw_platforms, (list, tuple, set)) else [raw_platforms]
+        explicit_platforms = {str(platform).strip().lower() for platform in platforms if str(platform).strip()}
+        if explicit_platforms and "ios" not in explicit_platforms:
+            continue
+        seen.add(bundle_id)
+        rows.append((_guess_ios_app_name(bundle_id), bundle_id))
+    return tuple(rows)
+
+
+def _load_ios_devices_blob() -> dict[str, Any]:
+    raw = os.getenv("IOS_DEVICES_JSON", "").strip()
+    if not raw and os.getenv("IOS_CONFIG_FILE"):
+        try:
+            with open(os.environ["IOS_CONFIG_FILE"], encoding="utf-8") as fh:
+                raw = fh.read()
+        except OSError:
+            raw = ""
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    if isinstance(data, dict) and isinstance(data.get("devices"), dict):
+        return data["devices"]
+    if isinstance(data, dict):
+        return data
+    return {}
+
+
+def _host_device_config_for_udid(udid: str) -> dict[str, str]:
+    if not (_IOS_HARDWARE_UDID_RE.match(udid) or _IOS_SIMULATOR_UDID_RE.match(udid)):
+        return {}
+    try:
+        devices = discover_host_ios_devices(include_simulators=True)
+    except Exception:
+        return {}
+    return next((item for item in devices if item.get("udid") == udid), {})
+
+
+def _appium_url_is_loopback(appium_url: str) -> bool:
+    parsed = urllib.parse.urlparse(appium_url)
+    host = parsed.hostname or "127.0.0.1"
+    return host in {"127.0.0.1", "localhost", "::1"}
+
+
+def _requires_host_device_visibility(appium_url: str, udid: str) -> bool:
+    return _appium_url_is_loopback(appium_url) and (
+        _IOS_HARDWARE_UDID_RE.match(udid) is not None or _IOS_SIMULATOR_UDID_RE.match(udid) is not None
+    )
+
+
+def _ios_major_version(version: str) -> int:
+    match = re.search(r"\d+", str(version or ""))
+    return int(match.group(0)) if match else 0
+
+
+def _remote_xpc_registry_ports() -> tuple[int, ...]:
+    raw = os.getenv("IOS_REMOTE_XPC_REGISTRY_PORTS", "") or os.getenv("IOS_REMOTE_XPC_REGISTRY_PORT", "")
+    if not raw.strip():
+        return _REMOTE_XPC_REGISTRY_PORTS
+    ports: list[int] = []
+    seen: set[int] = set()
+    for part in re.split(r"[,\s]+", raw):
+        try:
+            port = int(part)
+        except ValueError:
+            continue
+        if 0 < port <= 65535 and port not in seen:
+            seen.add(port)
+            ports.append(port)
+    return tuple(ports) or _REMOTE_XPC_REGISTRY_PORTS
+
+
+def _remote_xpc_tunnel_start_timeout() -> float:
+    raw = os.getenv("IOS_REMOTE_XPC_TUNNEL_START_TIMEOUT", "10")
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        return 10.0
+
+
+def _appium_command_base() -> tuple[list[str], str]:
+    try:
+        command = shlex.split(os.getenv("IOS_APPIUM_COMMAND", "appium"))
+    except ValueError as e:
+        return [], f"IOS_APPIUM_COMMAND is not parseable: {e}"
+    if not command:
+        return [], "IOS_APPIUM_COMMAND is empty."
+    return command, ""
+
+
+def _appium_command_display() -> str:
+    command, error = _appium_command_base()
+    if error:
+        command = ["appium"]
+    return shlex.join(command)
+
+
+def _remote_xpc_tunnel_processes(udid: str) -> list[dict[str, Any]]:
+    clean_udid = strip_ios_prefix(udid)
+    try:
+        output = subprocess.check_output(["ps", "-eo", "pid=,uid=,command="], text=True, timeout=5)
+    except (OSError, subprocess.SubprocessError):
+        return []
+    rows: list[dict[str, Any]] = []
+    for raw_line in output.splitlines():
+        parts = raw_line.strip().split(None, 2)
+        if len(parts) < 3:
+            continue
+        pid_raw, uid_raw, command = parts
+        if "tunnel-creation" not in command or clean_udid not in command:
+            continue
+        try:
+            pid = int(pid_raw)
+            uid = int(uid_raw)
+        except ValueError:
+            continue
+        rows.append({"pid": pid, "uid": uid, "command": command})
+    return rows
+
+
+def remote_xpc_manual_recovery(udid: str, tunnel: dict[str, Any] | None = None) -> dict[str, Any]:
+    clean_udid = strip_ios_prefix(udid)
+    processes = _remote_xpc_tunnel_processes(clean_udid)
+    current_uid = os.getuid()
+    foreign = [proc for proc in processes if proc["uid"] != current_uid]
+    stale = foreign or processes
+    auto_fixable = not foreign
+    registry_ports = tunnel.get("checked_ports") if isinstance(tunnel, dict) else None
+    ports = registry_ports or list(_remote_xpc_registry_ports())
+    registry_port = ports[0] if ports else _REMOTE_XPC_REGISTRY_PORTS[0]
+    verify_url = f"http://127.0.0.1:{registry_port}/remotexpc/tunnels/{clean_udid}"
+    steps: list[str] = []
+    if stale:
+        prefix = "Stop the stale process ids with sudo" if foreign else "Stop the stale process ids"
+        steps.append(f"{prefix}: {', '.join(str(proc['pid']) for proc in stale)}")
+    else:
+        steps.append("Stop any stale XCUITest tunnel process for this device.")
+    kill_command = ""
+    if stale:
+        kill_prefix = "sudo kill" if foreign else "kill"
+        kill_command = f"{kill_prefix} {' '.join(str(proc['pid']) for proc in stale)}"
+    start_command = f"sudo {_appium_command_display()} driver run xcuitest tunnel-creation --udid {clean_udid}"
+    verify_command = f"curl -s {verify_url}"
+    summary = (
+        "Ghost can restart the stale XCUITest tunnel; manual commands are provided as a fallback."
+        if auto_fixable
+        else "Stop the stale XCUITest tunnel process with sudo, then start a fresh tunnel."
+    )
+    steps.extend(
+        [
+            f"Run: {start_command}",
+            f"Verify: {verify_url}",
+        ]
+    )
+    return {
+        "code": "restart_remote_xpc_tunnel",
+        "state": "remote_xpc_tunnel_unavailable",
+        "summary": summary,
+        "auto_fixable": auto_fixable,
+        "manual_action_required": not auto_fixable,
+        "requires_sudo": bool(foreign),
+        "steps": steps,
+        "processes": processes,
+        "foreign_processes": foreign,
+        "verify_url": verify_url,
+        "registry_port": registry_port,
+        "commands": [cmd for cmd in [kill_command, start_command, verify_command] if cmd],
+        "kill_command": kill_command,
+        "start_command": start_command,
+        "verify_command": verify_command,
+    }
+
+
+def _parse_devicectl_details(output: str) -> dict[str, str]:
+    fields = {
+        "identifier": "identifier",
+        "name": "name",
+        "osVersionNumber": "os_version",
+        "bootState": "boot_state",
+        "developerModeStatus": "developer_mode",
+        "pairingState": "pairing_state",
+        "transportType": "transport_type",
+        "tunnelState": "tunnel_state",
+        "tunnelIPAddress": "tunnel_ip_address",
+        "tunnelTransportProtocol": "tunnel_transport_protocol",
+    }
+    details: dict[str, str] = {}
+    for raw_line in output.splitlines():
+        line = raw_line.strip().lstrip("•").strip()
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        field = fields.get(key.strip())
+        if field and value.strip():
+            details[field] = value.strip()
+    return details
+
+
+def devicectl_device_details(udid: str) -> dict[str, str]:
+    try:
+        output = subprocess.check_output(
+            ["xcrun", "devicectl", "device", "info", "details", "--device", strip_ios_prefix(udid)],
+            stderr=subprocess.STDOUT,
+            timeout=10,
+            text=True,
+        )
+    except (OSError, subprocess.SubprocessError) as e:
+        return {"error": str(e)}
+    return _parse_devicectl_details(output)
+
+
+def remote_xpc_tunnel_status(udid: str, *, platform_version: str = "", host: dict | None = None) -> dict[str, Any]:
+    host = host if host is not None else _host_device_config_for_udid(udid)
+    platform_version = platform_version or host.get("platform_version", "")
+    required = host.get("source") == "host" and _ios_major_version(platform_version) >= 18
+    registry_ports = _remote_xpc_registry_ports()
+    status: dict[str, Any] = {
+        "required": required,
+        "state": "not_required",
+        "ok": True,
+        "checked_ports": list(registry_ports),
+        "registry": {},
+        "devicectl": {},
+    }
+    if not required:
+        return status
+
+    registry: dict[str, Any] = {}
+    for port in registry_ports:
+        url = f"http://127.0.0.1:{port}/remotexpc/tunnels/{strip_ios_prefix(udid)}"
+        try:
+            resp = requests.request("GET", url, timeout=1)
+            registry = {"port": port, "status_code": resp.status_code, "url": url}
+            if resp.status_code < 400:
+                try:
+                    body = resp.json()
+                except ValueError:
+                    body = {}
+                if isinstance(body, dict):
+                    registry.update(body)
+                break
+        except requests.RequestException as e:
+            registry = {"port": port, "url": url, "error": str(e)}
+    status["registry"] = registry
+
+    if registry.get("status") != "OK":
+        status.update(
+            {
+                "ok": False,
+                "state": "missing",
+                "message": "RemoteXPC tunnel registry is missing the device entry.",
+            }
+        )
+        return status
+
+    devicectl = devicectl_device_details(udid)
+    status["devicectl"] = devicectl
+    registry_address = str(registry.get("address") or "")
+    current_address = str(devicectl.get("tunnel_ip_address") or "")
+    tunnel_state = str(devicectl.get("tunnel_state") or "").lower()
+    if devicectl.get("error"):
+        status.update(
+            {
+                "ok": False,
+                "state": "stale",
+                "message": "RemoteXPC tunnel registry cannot be validated because devicectl details are unavailable.",
+                "registry_address": registry_address,
+                "current_address": current_address,
+                "devicectl_connected": False,
+                "stale_reason": "devicectl_unavailable",
+            }
+        )
+        return status
+    if tunnel_state and tunnel_state != "connected":
+        status.update(
+            {
+                "ok": False,
+                "state": "stale",
+                "message": "RemoteXPC tunnel is not connected according to devicectl.",
+                "registry_address": registry_address,
+                "current_address": current_address,
+                "devicectl_connected": False,
+                "stale_reason": "devicectl_tunnel_disconnected",
+            }
+        )
+        return status
+    if not current_address:
+        status.update(
+            {
+                "ok": False,
+                "state": "stale",
+                "message": "RemoteXPC tunnel registry cannot be validated because devicectl has no tunnel IP address.",
+                "registry_address": registry_address,
+                "current_address": current_address,
+                "devicectl_connected": tunnel_state == "connected",
+                "stale_reason": "devicectl_address_missing",
+            }
+        )
+        return status
+    # The registry (pymobiledevice3 RemoteXPC tunnel) and devicectl (Apple
+    # CoreDevice tunnel) are INDEPENDENT tunnels to the same device and normally
+    # report different addresses, so an address mismatch is NOT a staleness signal
+    # — matching them false-flags a healthy dual-tunnel setup as stale and breaks
+    # iOS streaming. Genuine staleness (devicectl error / not-connected / missing
+    # address) is handled above; a connected tunnel is available regardless of the
+    # address match. Ratified lenient by core-dev for v1.3.0.
+    status.update(
+        {
+            "state": "available",
+            "ok": True,
+            "registry_address": registry_address,
+            "current_address": current_address,
+            "devicectl_connected": tunnel_state == "connected",
+        }
+    )
+    return status
+
+
+def _config_dict_for_udid(udid: str) -> dict[str, Any]:
+    clean_udid = strip_ios_prefix(udid)
+    cfg: dict[str, Any] = {"udid": clean_udid}
+    for env_name, field_name in _CONFIG_ENV_FIELDS.items():
+        if env_name in os.environ:
+            value = _clean_config_value(field_name, os.getenv(env_name))
+            if value is not None:
+                cfg[field_name] = value
+
+    for key, raw_value in _load_ios_devices_blob().items():
+        if strip_ios_prefix(str(key)) != clean_udid or not isinstance(raw_value, dict):
+            continue
+        for raw_field, raw_value_item in raw_value.items():
+            field_name = _CONFIG_ENV_FIELDS.get(raw_field, raw_field)
+            if field_name not in IOSDeviceConfig.__dataclass_fields__ or field_name == "udid":
+                continue
+            value = _clean_config_value(field_name, raw_value_item)
+            if value is not None:
+                cfg[field_name] = value
+
+    host = _host_device_config_for_udid(clean_udid)
+    if host.get("name") and not cfg.get("device_name"):
+        cfg["device_name"] = host["name"]
+    if host.get("platform_version") and not cfg.get("platform_version"):
+        cfg["platform_version"] = host["platform_version"]
+    return cfg
+
+
+def ios_config_for_udid(udid: str) -> IOSDeviceConfig:
+    return IOSDeviceConfig(**_config_dict_for_udid(udid))
+
+
+def configured_ios_udids() -> list[str]:
+    values: list[str] = []
+    single = os.getenv("IOS_DEVICE_UDID", "").strip()
+    if single:
+        values.append(single)
+    multi = os.getenv("IOS_DEVICE_UDIDS", "").strip()
+    if multi:
+        values.extend(v.strip() for v in multi.split(",") if v.strip())
+    values.extend(str(k) for k in _load_ios_devices_blob().keys())
+
+    out: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        udid = strip_ios_prefix(value)
+        if udid and udid not in seen:
+            seen.add(udid)
+            out.append(udid)
+    return out
+
+
+def _xctrace_line_device(line: str, section: str) -> dict[str, str] | None:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("=="):
+        return None
+    groups = re.findall(r"\(([^()]*)\)", stripped)
+    if len(groups) < 2:
+        return None
+    state = ""
+    udid = groups[-1].strip()
+    if section == "simulators" and groups[-1] in {"Booted", "Shutdown", "Creating", "Shutting Down"}:
+        state = groups[-1]
+        udid = groups[-2].strip()
+    if section == "simulators" and state != "Booted":
+        return None
+    if not udid or "unavailable" in stripped.lower():
+        return None
+    name = stripped.split(" (", 1)[0].strip()
+    if section == "devices":
+        if _MAC_HOST_NAME_RE.search(name):
+            return None
+        if not (_IOS_DEVICE_NAME_RE.search(name) or _IOS_HARDWARE_UDID_RE.match(udid)):
+            return None
+    elif not _IOS_DEVICE_NAME_RE.search(name):
+        return None
+    version = groups[0].strip()
+    return {
+        "udid": strip_ios_prefix(udid),
+        "name": name,
+        "platform_version": version,
+        "source": "simulator" if section == "simulators" else "host",
+        "state": state or "connected",
+    }
+
+
+def _parse_xctrace_devices(output: str, *, include_simulators: bool = True) -> list[dict[str, str]]:
+    section = ""
+    rows: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if line == "== Devices ==":
+            section = "devices"
+            continue
+        if line == "== Simulators ==":
+            section = "simulators"
+            continue
+        if line.startswith("=="):
+            section = ""
+            continue
+        if section == "simulators" and not include_simulators:
+            continue
+        if section not in {"devices", "simulators"}:
+            continue
+        item = _xctrace_line_device(line, section)
+        if not item or item["udid"] in seen:
+            continue
+        seen.add(item["udid"])
+        rows.append(item)
+    return rows
+
+
+def _simctl_runtime_version(runtime_id: str) -> str:
+    match = re.search(r"iOS-(\d+(?:-\d+)*)$", runtime_id)
+    return match.group(1).replace("-", ".") if match else ""
+
+
+def _parse_simctl_booted_devices(output: str) -> list[dict[str, str]]:
+    try:
+        payload = json.loads(output)
+    except (TypeError, ValueError):
+        return []
+
+    rows: list[dict[str, str]] = []
+    seen: set[str] = set()
+    devices = payload.get("devices") if isinstance(payload, dict) else None
+    if not isinstance(devices, dict):
+        return rows
+    for runtime_id, runtime_devices in devices.items():
+        if not isinstance(runtime_devices, list):
+            continue
+        version = _simctl_runtime_version(str(runtime_id))
+        for item in runtime_devices:
+            if not isinstance(item, dict):
+                continue
+            udid = strip_ios_prefix(str(item.get("udid") or ""))
+            state = str(item.get("state") or "")
+            name = str(item.get("name") or "").strip()
+            if not udid or udid in seen or state != "Booted":
+                continue
+            if not _IOS_DEVICE_NAME_RE.search(name):
+                continue
+            seen.add(udid)
+            rows.append(
+                {
+                    "udid": udid,
+                    "name": name,
+                    "platform_version": version,
+                    "source": "simulator",
+                    "state": "Booted",
+                }
+            )
+    return rows
+
+
+def _discover_booted_simulators() -> list[dict[str, str]]:
+    try:
+        output = subprocess.check_output(
+            ["xcrun", "simctl", "list", "devices", "booted", "--json"],
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+            text=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    return _parse_simctl_booted_devices(output)
+
+
+def discover_host_ios_devices(*, include_simulators: bool = True) -> list[dict[str, str]]:
+    """Discover connected iOS devices and booted simulators through Xcode tools.
+
+    Discovery is best-effort: hosts without Xcode/xcrun simply return no rows.
+    Explicit IOS_DEVICE_UDID/IOS_DEVICES_JSON config remains the source for
+    Appium details such as ports and signing capabilities.
+    """
+    rows: list[dict[str, str]] = []
+    try:
+        output = subprocess.check_output(
+            ["xcrun", "xctrace", "list", "devices"],
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+            text=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        output = ""
+    if output:
+        rows.extend(_parse_xctrace_devices(output, include_simulators=include_simulators))
+    if include_simulators:
+        seen = {item["udid"] for item in rows}
+        for item in _discover_booted_simulators():
+            if item["udid"] not in seen:
+                seen.add(item["udid"])
+                rows.append(item)
+    return rows
+
+
+def known_ios_udids(*, include_host: bool = True, include_simulators: bool = True) -> list[str]:
+    values = configured_ios_udids()
+    if include_host:
+        values.extend(device["udid"] for device in discover_host_ios_devices(include_simulators=include_simulators))
+    out: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        udid = strip_ios_prefix(value)
+        if udid and udid not in seen:
+            seen.add(udid)
+            out.append(udid)
+    return out
+
+
+def _env_capabilities() -> dict[str, Any]:
+    udid = os.getenv("IOS_DEVICE_UDID", "")
+    return ios_config_for_udid(udid).capabilities() if udid else {}
+
+
+def _intish(value: str | float | int | None) -> int:
+    try:
+        return int(round(float(value or 0)))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _png_size(data: bytes) -> tuple[int, int] | None:
+    if len(data) >= 24 and data[:8] == b"\x89PNG\r\n\x1a\n":
+        return int.from_bytes(data[16:20], "big"), int.from_bytes(data[20:24], "big")
+    return None
+
+
+def _safe_attr(value: Any) -> str:
+    return "" if value is None else str(value)
+
+
+def _looks_like_ios_identifier(s: str) -> bool:
+    """True for accessibility-identifier / type strings that are not human text.
+
+    WDA exposes the ``accessibilityIdentifier`` as a node's ``name``; on many apps
+    that is a developer string — module paths, generics, mangled Swift, snake_case
+    view ids (e.g. ``BaseCell<FeedStackSliceViewModel>``, ``_TtGC8SliceKit…``,
+    ``reddit_feed__content_view_home_loaded``, ``Home_Impl.HomeScreenView``) —
+    rather than the visible label. Such strings should never surface as extracted
+    page text. Applied only to the ``name`` fallback, so real ``label``/``value``
+    text is never filtered.
+    """
+    if not s or any(ch.isspace() for ch in s):
+        return False
+    if "<" in s or ">" in s:              # generics: BaseCell<...>
+        return True
+    if s.startswith("_Tt"):               # mangled Swift type
+        return True
+    if "__" in s:                         # snake view id: a__b__c
+        return True
+    if re.search(r"[a-z][A-Z]", s):       # camelCase/PascalCase hump: HomeScreenView
+        return True
+    if "." in s and any(c.isupper() for c in s) and any(c.islower() for c in s):
+        return True                       # mixed-case module path: Home_Impl.HomeScreenView
+    return False
+
+
+def _label_for_ios_node(node: ET.Element) -> tuple[str, str, str]:
+    """Return Android-shaped text/content-desc/resource-id values."""
+    value = _safe_attr(node.get("value")).strip()
+    label = _safe_attr(node.get("label")).strip()
+    name = _safe_attr(node.get("name")).strip()
+    node_type = _safe_attr(node.get("type") or node.tag).strip()
+
+    # `name` is the accessibilityIdentifier: keep dev identifiers out of the
+    # human-readable text/desc, but resource-id still uses it for element location.
+    name_text = "" if _looks_like_ios_identifier(name) else name
+    text = value or label or name_text
+    if node_type in _SCROLLABLE_TYPES and text == node_type:
+        text = ""
+    desc = label or name_text
+    rid = name
+    return text, desc, rid
+
+
+def _node_bounds(node: ET.Element, scale_x: float, scale_y: float) -> tuple[str, str, bool]:
+    x = float(node.get("x") or 0)
+    y = float(node.get("y") or 0)
+    w = float(node.get("width") or 0)
+    h = float(node.get("height") or 0)
+    if w <= 0 or h <= 0:
+        return "[0,0][0,0]", "[0,0][0,0]", False
+
+    px1 = _intish(x * scale_x)
+    py1 = _intish(y * scale_y)
+    px2 = _intish((x + w) * scale_x)
+    py2 = _intish((y + h) * scale_y)
+    point_bounds = f"[{_intish(x)},{_intish(y)}][{_intish(x + w)},{_intish(y + h)}]"
+    return f"[{px1},{py1}][{px2},{py2}]", point_bounds, True
+
+
+def normalize_wda_xml(source_xml: str, scale_x: float = 1.0, scale_y: float = 1.0) -> str:
+    """Convert Appium/WDA XML into Android uiautomator-shaped XML."""
+    if not source_xml:
+        return ""
+    try:
+        src_root = ET.fromstring(source_xml)
+    except ET.ParseError:
+        return source_xml
+
+    root = ET.Element("hierarchy", {"rotation": "0", "platform": "ios"})
+
+    def walk(src: ET.Element, dst_parent: ET.Element, index: int = 0):
+        node_type = _safe_attr(src.get("type") or src.tag)
+        text, desc, rid = _label_for_ios_node(src)
+        bounds, point_bounds, has_bounds = _node_bounds(src, scale_x, scale_y)
+        visible = src.get("visible")
+        enabled = src.get("enabled")
+        clickable = (
+            has_bounds
+            and node_type in _CLICKABLE_TYPES
+            and (visible is None or _as_bool(visible))
+            and (enabled is None or _as_bool(enabled))
+        )
+        scrollable = has_bounds and node_type in _SCROLLABLE_TYPES
+
+        dst = ET.SubElement(
+            dst_parent,
+            "node",
+            {
+                "index": str(index),
+                "text": text,
+                "resource-id": rid,
+                "class": node_type,
+                "content-desc": desc,
+                "clickable": str(clickable).lower(),
+                "scrollable": str(scrollable).lower(),
+                "enabled": str(enabled if enabled is not None else "").lower(),
+                "visible": str(visible if visible is not None else "").lower(),
+                "bounds": bounds,
+                "ios-point-bounds": point_bounds,
+            },
+        )
+        for child_index, child in enumerate(list(src)):
+            walk(child, dst, child_index)
+
+    top_nodes = list(src_root) if src_root.tag == "AppiumAUT" else [src_root]
+    for child_index, child in enumerate(top_nodes):
+        walk(child, root, child_index)
+
+    return '<?xml version="1.0" encoding="UTF-8"?>' + ET.tostring(root, encoding="unicode")
+
+
+def ios_xml_to_elements(xml: str, interactive_only: bool = True) -> list[dict]:
+    """Parse normalized iOS XML into the same element list shape as Android."""
+    normalized = normalize_wda_xml(xml) if "<hierarchy" not in xml else xml
+    try:
+        root = ET.fromstring(normalized)
+    except ET.ParseError:
+        return []
+
+    elements: list[dict] = []
+    for node in root.iter("node"):
+        text = node.get("text", "") or ""
+        desc = node.get("content-desc", "") or ""
+        rid = node.get("resource-id", "") or ""
+        cls = (node.get("class", "") or "").split(".")[-1]
+        clickable = node.get("clickable", "") == "true"
+        scrollable = node.get("scrollable", "") == "true"
+        if interactive_only and not clickable and not scrollable and not text and not desc:
+            continue
+        bounds = IOSDevice.node_bounds_static(ET.tostring(node, encoding="unicode"))
+        if not bounds:
+            continue
+        x1, y1, x2, y2 = bounds
+        elements.append(
+            {
+                "idx": len(elements),
+                "text": text,
+                "content_desc": desc,
+                "resource_id": rid.split("/")[-1] if "/" in rid else rid,
+                "class": cls,
+                "bounds": {"x1": x1, "y1": y1, "x2": x2, "y2": y2},
+                "center": {"x": (x1 + x2) // 2, "y": (y1 + y2) // 2},
+                "clickable": clickable,
+                "scrollable": scrollable,
+            }
+        )
+    return elements
+
+
+_WDA_LAUNCH_LOCK_PATH = "/tmp/ghost-ios/wda-launch.lock"
+
+
+def _reap_stale_wda_builds() -> None:
+    """Kill leftover WDA xcodebuild launch processes. Only safe to call when WDA
+    is NOT up — a live session's xcodebuild hosts the running WebDriverAgent, so
+    these are hung/dead attempts from a flaky device."""
+    with contextlib.suppress(Exception):
+        subprocess.run(
+            ["pkill", "-9", "-f", "xcodebuild.*WebDriverAgent"],
+            timeout=5, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+
+
+@contextlib.contextmanager
+def _wda_launch_guard(wda_up):
+    """Serialize WDA session launches across ALL processes (backend, MCP, agent).
+
+    Appium spawns one `xcodebuild test-without-building` per POST /session to host
+    WebDriverAgent. On a flaky device those hang (~1-2 min each) and, without a
+    lock, every caller/retry spawns its own -> a pile-up of stacked xcodebuilds
+    that jams the device so none ever succeed. A cross-process file lock lets only
+    ONE launch run at a time; others block until it finishes (then reuse the live
+    WDA). If WDA isn't up when we take the lock, reap any hung/stale build first so
+    we never stack (the "kill the old guy if a new one spawns" behaviour)."""
+    fh = None
+    try:
+        with contextlib.suppress(Exception):
+            os.makedirs(os.path.dirname(_WDA_LAUNCH_LOCK_PATH), exist_ok=True)
+            fh = open(_WDA_LAUNCH_LOCK_PATH, "w")  # noqa: SIM115
+            fcntl.flock(fh, fcntl.LOCK_EX)  # released on POST timeout, so no forever-block
+        with contextlib.suppress(Exception):
+            if not wda_up():
+                _reap_stale_wda_builds()
+        yield
+    finally:
+        if fh is not None:
+            with contextlib.suppress(Exception):
+                fcntl.flock(fh, fcntl.LOCK_UN)
+                fh.close()
+
+
+class IOSDevice:
+    """One iOS device/simulator controlled through Appium XCUITest."""
+
+    _sessions: dict[IOSSessionConfig, str] = {}
+    _sessions_lock = threading.RLock()
+
+    def __init__(
+        self,
+        serial: str,
+        *,
+        appium_url: str | None = None,
+        bundle_id: str | None = None,
+        browser_name: str | None = None,
+        timeout: float | None = None,
+    ):
+        self.serial = serial if serial.startswith(IOS_PREFIX) else f"{IOS_PREFIX}{serial}"
+        self.udid = strip_ios_prefix(serial)
+        self.config = ios_config_for_udid(self.udid)
+        self.appium_url = (appium_url or self.config.appium_url).rstrip("/")
+        self.bundle_id = bundle_id if bundle_id is not None else self.config.bundle_id
+        self.browser_name = browser_name if browser_name is not None else self.config.browser_name
+        self.device_name = self.config.device_name
+        self.platform_version = self.config.platform_version
+        self.wda_url = self.config.wda_url
+        self.timeout = float(timeout if timeout is not None else self.config.timeout)
+        self.mjpeg_server_port = self.config.mjpeg_server_port
+        self.mjpeg_screenshot_url = self.config.mjpeg_screenshot_url
+        self.mjpeg_server_framerate = self.config.mjpeg_server_framerate
+        self.mjpeg_scaling_factor = self.config.mjpeg_scaling_factor
+        self.mjpeg_server_screenshot_quality = self.config.mjpeg_server_screenshot_quality
+        self.mjpeg_fix_orientation = self.config.mjpeg_fix_orientation
+        self.screenshot_quality = self.config.screenshot_quality
+        self.appium_capabilities = self.config.capabilities()
+        self._session_id: str | None = None
+        self._scale: tuple[float, float] | None = None
+        self._screen_size: tuple[int, int] | None = None
+        self._window_rect_cache: dict | None = None
+        # Direct-WDA transport (IOS_WDA_DIRECT=1): talk to WebDriverAgent over its
+        # own HTTP API — resolving the tunnel address fresh from the RemoteXPC
+        # registry — and skip Appium (and its CoreDevice device-lookup, which
+        # wedges as "Could not find the expected device") entirely. Opt-in; the
+        # Appium path is left completely untouched when this is off.
+        self._direct = os.environ.get("IOS_WDA_DIRECT") == "1"
+        self._wda_base_cache: str | None = None
+
+    @property
+    def platform(self) -> str:
+        return "ios"
+
+    @property
+    def _config(self) -> IOSSessionConfig:
+        return IOSSessionConfig(
+            self.appium_url,
+            self.udid,
+            self.bundle_id,
+            self.browser_name,
+            self.device_name,
+            self.platform_version,
+            self.wda_url,
+            tuple(sorted(self.appium_capabilities.items())),
+        )
+
+    def _wda_base(self) -> str:
+        """WebDriverAgent base URL for direct mode (cached per IOSDevice instance).
+
+        Prefers a fixed ``wda_url`` if configured; otherwise resolves the tunnel
+        address FRESH from the RemoteXPC registry. That address changes on every
+        tunnel restart, so it must never be cached across restarts — a new
+        IOSDevice re-resolves. IPv6 addresses are bracketed for the URL.
+
+        Durable wireless path (no USB): run WDA on the device, reach it over
+        Tailscale, and set ``IOS_WDA_URL=http://<tailscale-ip>:8100`` — that fixed
+        URL is preferred here and survives USB drops and LAN power-save. The
+        RemoteXPC registry is the USB-tunnel path; it does not apply over Tailscale.
+        """
+        if self._wda_base_cache:
+            return self._wda_base_cache
+        base = self.wda_url.rstrip("/") if self.wda_url else self._resolve_wda_base_from_registry()
+        if not base:
+            raise IOSBackendError(
+                "IOS_WDA_DIRECT=1 but no WDA base URL could be determined: set IOS_WDA_URL, "
+                "or ensure the RemoteXPC tunnel registry is reachable "
+                "(IOS_REMOTEXPC_REGISTRY, default http://127.0.0.1:42314)."
+            )
+        self._wda_base_cache = base
+        return base
+
+    def _resolve_wda_base_from_registry(self) -> str:
+        registry = os.environ.get("IOS_REMOTEXPC_REGISTRY", "http://127.0.0.1:42314").rstrip("/")
+        try:
+            resp = requests.get(f"{registry}/remotexpc/tunnels/{self.udid}", timeout=self.timeout)
+            addr = (resp.json() or {}).get("address", "") if resp.ok else ""
+        except (requests.RequestException, ValueError):
+            addr = ""
+        if not addr:
+            return ""
+        if ":" in addr and not addr.startswith("["):
+            addr = f"[{addr}]"  # bracket IPv6 (fdxx::1 → [fdxx::1])
+        return f"http://{addr}:8100"
+
+    def _url(self, path: str) -> str:
+        return (self._wda_base() if self._direct else self.appium_url) + path
+
+    @staticmethod
+    def _invalid_session_message(status_code: int, value: Any, text: str = "") -> bool:
+        message = ""
+        if isinstance(value, dict):
+            message = f"{value.get('error', '')} {value.get('message', '')}"
+        else:
+            message = str(value or "")
+        message = f"{message} {text}".lower()
+        return status_code in {404, 410} and (
+            "invalid session" in message
+            or "session not found" in message
+            or "no such driver" in message
+            or "does not exist" in message
+        )
+
+    def _evict_session(self, session_id: str | None = None) -> None:
+        with IOSDevice._sessions_lock:
+            sid = session_id or self._session_id
+            if sid and IOSDevice._sessions.get(self._config) == sid:
+                IOSDevice._sessions.pop(self._config, None)
+            if self._session_id == sid or session_id is None:
+                self._session_id = None
+            self._scale = None
+            self._screen_size = None
+            self._window_rect_cache = None
+
+    def _clear_instance_session(self) -> None:
+        self._session_id = None
+        self._scale = None
+        self._screen_size = None
+        self._window_rect_cache = None
+
+    def set_target_app(self, *, bundle_id: str | None = None, browser_name: str | None = None) -> None:
+        """Switch the Appium session target without reusing the wrong session.
+
+        A bundle-id override is a concrete app target, so it intentionally clears
+        any configured ``browserName`` capability.  Existing class-level cached
+        sessions for the old target are left intact for other IOSDevice objects.
+        """
+        new_bundle_id = self.bundle_id if bundle_id is None else bundle_id
+        new_browser_name = self.browser_name if browser_name is None and bundle_id is None else (browser_name or "")
+        if new_bundle_id == self.bundle_id and new_browser_name == self.browser_name:
+            return
+        with IOSDevice._sessions_lock:
+            self.bundle_id = new_bundle_id
+            self.browser_name = new_browser_name
+            self._clear_instance_session()
+
+    def _rewrite_session_path(self, path: str, new_session_id: str) -> str:
+        return re.sub(r"^/session/[^/]+", f"/session/{new_session_id}", path, count=1)
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        payload: dict | None = None,
+        timeout: float | None = None,
+        *,
+        retry_stale_session: bool = True,
+    ) -> Any:
+        try:
+            resp = requests.request(
+                method,
+                self._url(path),
+                json=payload,
+                timeout=timeout or self.timeout,
+            )
+        except requests.RequestException as e:
+            raise IOSBackendError(f"Appium request failed: {e}") from e
+
+        try:
+            data = resp.json()
+        except ValueError:
+            data = {}
+
+        value = data.get("value", data)
+        if resp.status_code >= 400:
+            if retry_stale_session and path.startswith("/session/") and method.upper() != "DELETE":
+                if self._invalid_session_message(resp.status_code, value, resp.text):
+                    self._evict_session()
+                    new_path = self._rewrite_session_path(path, self._ensure_session())
+                    return self._request(method, new_path, payload, timeout, retry_stale_session=False)
+            msg = value.get("message") if isinstance(value, dict) else resp.text
+            raise IOSBackendError(f"Appium {method} {path} failed ({resp.status_code}): {msg}")
+        if isinstance(value, dict) and value.get("error"):
+            raise IOSBackendError(f"Appium {method} {path} failed: {value.get('message', value['error'])}")
+        return value
+
+    def _validate_session_id(self, session_id: str) -> bool:
+        # WDA implements /window/size, not /window/rect (Appium adds the latter);
+        # probe the endpoint each backend actually serves so a live session isn't
+        # thrown away and needlessly recreated.
+        probe = "/window/size" if self._direct else "/window/rect"
+        try:
+            resp = requests.request(
+                "GET",
+                self._url(f"/session/{session_id}{probe}"),
+                timeout=min(5, self.timeout),
+            )
+        except requests.RequestException:
+            return False
+        try:
+            data = resp.json()
+        except ValueError:
+            data = {}
+        value = data.get("value", data)
+        if self._invalid_session_message(resp.status_code, value, resp.text):
+            return False
+        return resp.status_code < 400
+
+    def _wda_is_up(self) -> bool:
+        """True if WebDriverAgent already has a live session (Appium forwards it to
+        localhost:8100). When up, the launch guard must NOT reap xcodebuilds — the
+        running WDA is hosted by one."""
+        try:
+            return requests.get("http://127.0.0.1:8100/status", timeout=2).ok
+        except requests.RequestException:
+            return False
+
+    def _ensure_session(self) -> str:
+        with IOSDevice._sessions_lock:
+            if self._session_id:
+                return self._session_id
+            cached = IOSDevice._sessions.get(self._config)
+            if cached:
+                if self._validate_session_id(cached):
+                    self._session_id = cached
+                    return cached
+                self._evict_session(cached)
+
+            if self._direct:
+                # Direct WDA: minimal W3C caps only. WDA ignores appium:* and does
+                # no device lookup (the tunnel address already targets one device),
+                # so appium_capabilities (all appium:*, e.g. mjpegServerPort) are
+                # deliberately not merged here — they belong to the Appium contract.
+                always_match: dict[str, Any] = {"platformName": "iOS"}
+            else:
+                always_match = {
+                    "platformName": "iOS",
+                    "appium:automationName": "XCUITest",
+                    "appium:udid": self.udid,
+                    "appium:deviceName": self.device_name,
+                    "appium:noReset": True,
+                    "appium:newCommandTimeout": 300,
+                    # WDA waits for the app to be "idle" after every interaction and
+                    # times out at ~2.7s/tap when the app never quiesces (animations,
+                    # a live screen stream, etc.). That dominates iOS tap latency and
+                    # makes tap-to-control feel frozen. Disable it for responsiveness;
+                    # the per-action delays already provide settle. Override via
+                    # IOS_WAIT_FOR_QUIESCENCE=1 if a flow needs idle-waiting.
+                    "appium:shouldWaitForQuiescence": os.getenv("IOS_WAIT_FOR_QUIESCENCE", "").strip().lower() in ("1", "true", "yes"),
+                }
+                if self.platform_version:
+                    always_match["appium:platformVersion"] = self.platform_version
+                if self.wda_url:
+                    always_match["appium:webDriverAgentUrl"] = self.wda_url
+                if self.browser_name:
+                    always_match["browserName"] = self.browser_name
+                elif self.bundle_id and os.getenv("IOS_LAUNCH_BUNDLE_ON_SESSION", "").strip().lower() not in ("0", "false", "no"):
+                    # main's contract: appium:bundleId is present in the session
+                    # caps by default, which makes Appium FOREGROUND that app on
+                    # session (re)creation. On-device, that auto-launch can yank a
+                    # live-streamed phone to another app mid-interaction, so set
+                    # IOS_LAUNCH_BUNDLE_ON_SESSION=0 (explicit opt-out) to suppress
+                    # bundleId and just attach to whatever is on screen. Default
+                    # (flag unset) keeps main's behavior.
+                    always_match["appium:bundleId"] = self.bundle_id
+                always_match.update(self.appium_capabilities)
+
+            backend = "WDA" if self._direct else "Appium"
+            try:
+                if self._direct:
+                    # Direct WDA is already running (no Appium xcodebuild spawn), so
+                    # the launch guard's xcodebuild reaping does not apply here.
+                    resp = requests.request(
+                        "POST",
+                        self._url("/session"),
+                        json={"capabilities": {"alwaysMatch": always_match, "firstMatch": [{}]}},
+                        timeout=self.timeout,
+                    )
+                else:
+                    # Serialize the WDA launch across all processes so hung launches
+                    # on a flaky device can't pile up into a stack of xcodebuilds.
+                    with _wda_launch_guard(self._wda_is_up):
+                        resp = requests.request(
+                            "POST",
+                            self._url("/session"),
+                            json={"capabilities": {"alwaysMatch": always_match, "firstMatch": [{}]}},
+                            timeout=self.timeout,
+                        )
+            except requests.RequestException as e:
+                raise IOSBackendError(f"Could not create {backend} iOS session: {e}") from e
+            try:
+                data = resp.json()
+            except ValueError as e:
+                raise IOSBackendError(f"{backend} did not return JSON for session creation: {resp.text[:200]}") from e
+            if resp.status_code >= 400:
+                value = data.get("value", {})
+                msg = value.get("message") if isinstance(value, dict) else resp.text
+                raise IOSBackendError(f"Could not create {backend} iOS session ({resp.status_code}): {msg}")
+
+            value = data.get("value", {})
+            sid = data.get("sessionId") or value.get("sessionId")
+            if not sid:
+                raise IOSBackendError(f"{backend} session response did not include sessionId: {data}")
+            self._session_id = sid
+            IOSDevice._sessions[self._config] = sid
+            # WDA *settings* (not session caps) that zero WDA's idle/animation
+            # waits — measured ~2733ms -> ~713ms per tap. main sends this
+            # appium/settings POST ONLY on the direct-WDA path; the Appium path
+            # sends no such POST during session creation. Preserve that contract:
+            # apply on direct-WDA (honoring the IOS_WAIT_FOR_QUIESCENCE opt-out),
+            # and on the Appium path only when explicitly opted in via
+            # IOS_APPLY_WDA_SETTINGS so the default matches main.
+            if self._direct:
+                if os.getenv("IOS_WAIT_FOR_QUIESCENCE", "").strip().lower() not in ("1", "true", "yes"):
+                    self._apply_wda_settings(sid)
+            elif os.getenv("IOS_APPLY_WDA_SETTINGS", "").strip().lower() in ("1", "true", "yes"):
+                self._apply_wda_settings(sid)
+            return sid
+
+    def _apply_wda_settings(self, sid: str) -> None:
+        """Zero WDA's idle/animation waits for snappy, deterministic control.
+
+        Best-effort: control still works with WDA defaults if this fails, so a
+        settings hiccup must not abort session creation.
+        """
+        try:
+            requests.request(
+                "POST",
+                self._url(f"/session/{sid}/appium/settings"),
+                json={"settings": {"animationCoolOffTimeout": 0, "waitForIdleTimeout": 0}},
+                timeout=self.timeout,
+            )
+        except requests.RequestException:
+            pass  # non-fatal — session still usable, just slower taps
+
+    def _session_path(self, suffix: str) -> str:
+        return f"/session/{self._ensure_session()}{suffix}"
+
+    def _execute_mobile(self, command: str, args: dict | None = None) -> Any:
+        if self._direct:
+            return self._execute_mobile_direct(command, args or {})
+        return self._request("POST", self._session_path("/execute/sync"), {"script": command, "args": [args or {}]})
+
+    def _execute_mobile_direct(self, command: str, args: dict) -> Any:
+        """WDA-native equivalents of the Appium ``mobile:`` execute-script commands.
+
+        Callers (launch_app/app_state/press_key/terminate_app/…) are unchanged —
+        this one override maps their ``mobile:`` verbs onto WDA's own endpoints so
+        the whole tool surface works with no Appium in the loop.
+        """
+        name = command.split(":", 1)[1].strip() if ":" in command else command.strip()
+        bundle = args.get("bundleId") or args.get("appId")
+        if name in ("launchApp", "activateApp"):
+            return self._request("POST", self._session_path("/wda/apps/launch"), {"bundleId": bundle})
+        if name == "terminateApp":
+            return self._request("POST", self._session_path("/wda/apps/terminate"), {"bundleId": bundle})
+        if name == "queryAppState":
+            return self._request("POST", self._session_path("/wda/apps/state"), {"bundleId": bundle})
+        if name == "activeAppInfo":
+            return self._request("GET", self._session_path("/wda/activeAppInfo"))
+        if name == "pressButton":
+            return self._request("POST", self._session_path("/wda/pressButton"), {"name": args.get("name")})
+        raise IOSBackendError(
+            f"mobile: {name} has no WDA-native equivalent in direct mode (IOS_WDA_DIRECT=1)"
+        )
+
+    def _execute_script(self, script: str, args: list[Any] | None = None) -> Any:
+        return self._request("POST", self._session_path("/execute/sync"), {"script": script, "args": args or []})
+
+    def _set_context(self, name: str) -> None:
+        # WDA is native-only: /context (like /contexts) is an Appium endpoint that
+        # 404s on WDA. Native is the only context in direct mode, so this is a no-op.
+        if self._direct:
+            return
+        self._request("POST", self._session_path("/context"), {"name": name})
+
+    def get_contexts(self) -> list[str]:
+        # WDA has no webview-automation contexts and no /contexts endpoint (it 404s
+        # as "Unhandled endpoint"). Report the native context only so web-context
+        # probing skips cleanly and callers fall back to native /source parsing.
+        if self._direct:
+            return ["NATIVE_APP"]
+        value = self._request("GET", self._session_path("/contexts"))
+        return [str(v) for v in value] if isinstance(value, list) else []
+
+    def get_web_contexts(self) -> list[str]:
+        return [ctx for ctx in self.get_contexts() if ctx.upper().startswith("WEBVIEW")]
+
+    def _return_to_native_context(self) -> None:
+        try:
+            self._set_context("NATIVE_APP")
+        except IOSBackendError:
+            pass
+
+    def _window_rect(self) -> dict:
+        if self._window_rect_cache is None:
+            value = self._request("GET", self._session_path("/window/rect"))
+            self._window_rect_cache = value if isinstance(value, dict) else {}
+        return self._window_rect_cache
+
+    def _coordinate_scale(self) -> tuple[float, float]:
+        if self._scale is not None:
+            return self._scale
+        try:
+            raw = self.take_screenshot()
+            size = _png_size(raw)
+            rect = self._window_rect()
+            if size and rect.get("width") and rect.get("height"):
+                self._screen_size = size
+                self._scale = (size[0] / float(rect["width"]), size[1] / float(rect["height"]))
+                return self._scale
+        except Exception:
+            pass
+        self._scale = (1.0, 1.0)
+        return self._scale
+
+    def _to_wda_point(self, x: int | float, y: int | float) -> tuple[int, int]:
+        sx, sy = self._coordinate_scale()
+        return _intish(float(x) / sx), _intish(float(y) / sy)
+
+    @property
+    def mjpeg_url(self) -> str:
+        if self.mjpeg_screenshot_url:
+            return self.mjpeg_screenshot_url
+        # Direct mode: MJPEG streams off the WDA host (tunnel address), not Appium.
+        base = self._wda_base() if self._direct else self.appium_url
+        parsed = urllib.parse.urlparse(base)
+        scheme = parsed.scheme or "http"
+        host = parsed.hostname or "127.0.0.1"
+        if ":" in host and not host.startswith("["):
+            host = f"[{host}]"
+        return f"{scheme}://{host}:{self.mjpeg_server_port}"
+
+    @property
+    def mjpeg_settings(self) -> dict[str, Any]:
+        return self.config.mjpeg_settings()
+
+    # -- Device operations -------------------------------------------------
+
+    def _wda_base_url(self) -> str:
+        """Base URL of the WebDriverAgent HTTP server (device :8100 forwarded local)."""
+        if self.wda_url:
+            return self.wda_url.rstrip("/")
+        parsed = urllib.parse.urlparse(self.appium_url)
+        scheme = parsed.scheme or "http"
+        host = parsed.hostname or "127.0.0.1"
+        if ":" in host and not host.startswith("["):
+            host = f"[{host}]"
+        return f"{scheme}://{host}:8100"
+
+    def speak(self, text: str, rate: float = 1.0, language: str = "") -> str:
+        """Speak text aloud on-device via WDA's /wda/speak (AVSpeechSynthesizer).
+
+        Requires a GhostAgent-patched WebDriverAgent. Posts directly to WDA's
+        HTTP server (the `.withoutSession` route) because Appium's command
+        router does not proxy custom /wda/* paths. Ensures a session first so
+        WDA is running and its :8100 port is forwarded — but WITHOUT foregrounding
+        an app (so it does not launch Chrome/the default bundle).
+        """
+        prev_bundle, prev_browser = self.bundle_id, self.browser_name
+        self.bundle_id, self.browser_name = "", ""
+        try:
+            self._ensure_session()
+        finally:
+            self.bundle_id, self.browser_name = prev_bundle, prev_browser
+        payload: dict[str, Any] = {"text": text, "rate": rate}
+        if language:
+            payload["language"] = language
+        url = f"{self._wda_base_url()}/wda/speak"
+        try:
+            resp = requests.request("POST", url, json=payload, timeout=max(self.timeout, 15))
+        except requests.RequestException as e:
+            raise IOSBackendError(f"WDA /wda/speak request failed: {e}") from e
+        if resp.status_code == 404:
+            raise IOSBackendError(
+                "WDA has no /wda/speak route — rebuild the GhostAgent-patched WebDriverAgent on the device"
+            )
+        if resp.status_code >= 400:
+            raise IOSBackendError(f"WDA /wda/speak failed ({resp.status_code}): {resp.text[:200]}")
+        try:
+            body = resp.json()
+        except ValueError:
+            body = {}
+        value = body.get("value") if isinstance(body, dict) else None
+        if isinstance(value, dict) and value.get("status"):
+            return str(value["status"])
+        return "speaking"
+
+    def take_screenshot(self) -> bytes:
+        value = self._request("GET", self._session_path("/screenshot"), timeout=max(self.timeout, 60))
+        if not isinstance(value, str):
+            raise IOSBackendError("Appium screenshot response was not base64 text")
+        return base64.b64decode(value)
+
+    def dump_xml(self) -> str:
+        try:
+            self._set_context("NATIVE_APP")
+        except IOSBackendError:
+            pass
+        value = self._request("GET", self._session_path("/source"), timeout=max(self.timeout, 60))
+        source = value if isinstance(value, str) else str(value or "")
+        sx, sy = self._coordinate_scale()
+        return normalize_wda_xml(source, sx, sy)
+
+    def dump_ui(self) -> list[dict]:
+        return ios_xml_to_elements(self.dump_xml())
+
+    def get_screen_size(self) -> tuple[int, int]:
+        if self._screen_size:
+            return self._screen_size
+        try:
+            raw = self.take_screenshot()
+            size = _png_size(raw)
+            if size:
+                self._screen_size = size
+                return size
+        except Exception:
+            pass
+        rect = self._window_rect()
+        return _intish(rect.get("width")), _intish(rect.get("height"))
+
+    def tap(self, x, y, delay=0.6):
+        px, py = self._to_wda_point(x, y)
+        payload = {
+            "actions": [
+                {
+                    "type": "pointer",
+                    "id": "finger1",
+                    "parameters": {"pointerType": "touch"},
+                    "actions": [
+                        {"type": "pointerMove", "duration": 0, "x": px, "y": py, "origin": "viewport"},
+                        {"type": "pointerDown", "button": 0},
+                        {"type": "pause", "duration": 50},
+                        {"type": "pointerUp", "button": 0},
+                    ],
+                }
+            ]
+        }
+        self._request("POST", self._session_path("/actions"), payload)
+        time.sleep(delay)
+
+    def swipe(self, x1, y1, x2, y2, ms=500, delay=0.5):
+        px1, py1 = self._to_wda_point(x1, y1)
+        px2, py2 = self._to_wda_point(x2, y2)
+        payload = {
+            "actions": [
+                {
+                    "type": "pointer",
+                    "id": "finger1",
+                    "parameters": {"pointerType": "touch"},
+                    "actions": [
+                        {"type": "pointerMove", "duration": 0, "x": px1, "y": py1, "origin": "viewport"},
+                        {"type": "pointerDown", "button": 0},
+                        {"type": "pointerMove", "duration": int(ms), "x": px2, "y": py2, "origin": "viewport"},
+                        {"type": "pointerUp", "button": 0},
+                    ],
+                }
+            ]
+        }
+        self._request("POST", self._session_path("/actions"), payload)
+        time.sleep(delay)
+
+    def long_press(self, x, y, duration_ms=1000, delay=0.5):
+        px, py = self._to_wda_point(x, y)
+        payload = {
+            "actions": [
+                {
+                    "type": "pointer",
+                    "id": "finger1",
+                    "parameters": {"pointerType": "touch"},
+                    "actions": [
+                        {"type": "pointerMove", "duration": 0, "x": px, "y": py, "origin": "viewport"},
+                        {"type": "pointerDown", "button": 0},
+                        {"type": "pause", "duration": int(duration_ms)},
+                        {"type": "pointerUp", "button": 0},
+                    ],
+                }
+            ]
+        }
+        self._request("POST", self._session_path("/actions"), payload)
+        time.sleep(delay)
+
+    def type_text(self, text: str, delay=0.3):
+        payload = {"text": text, "value": list(text)}
+        try:
+            self._request("POST", self._session_path("/keys"), payload)
+        except IOSBackendError:
+            active = self._request("GET", self._session_path("/element/active"))
+            elem_id = _element_id(active)
+            if not elem_id:
+                raise
+            self._request("POST", self._session_path(f"/element/{elem_id}/value"), payload)
+        time.sleep(delay)
+
+    def _clear_active_element(self) -> bool:
+        try:
+            active = self._request("GET", self._session_path("/element/active"))
+            elem_id = _element_id(active)
+            if not elem_id:
+                return False
+            self._request("POST", self._session_path(f"/element/{elem_id}/clear"), {})
+            return True
+        except IOSBackendError:
+            return False
+
+    def back(self, delay=1.0):
+        try:
+            self._request("POST", self._session_path("/back"), {})
+        except IOSBackendError:
+            self.press_key("HOME", delay=delay)
+        time.sleep(delay)
+
+    def browser_back(self, delay=1.0):
+        try:
+            self._request("POST", self._session_path("/back"), {})
+        except IOSBackendError:
+            self._tap_browser_back_fallback(delay=delay)
+            return
+        time.sleep(delay)
+
+    def press_enter(self, delay=0.5):
+        self.press_key("ENTER", delay=delay)
+
+    def press_key(self, key: str, delay=0.5):
+        normalized = key.replace("KEYCODE_", "").upper()
+        if normalized in {"HOME", "HOMEPAGE"}:
+            self._execute_mobile("mobile: pressButton", {"name": "home"})
+        elif normalized in {"ENTER", "RETURN"}:
+            self._request("POST", self._session_path("/keys"), {"text": "\n", "value": ["\n"]})
+        elif normalized in {"BACK", "ESCAPE"}:
+            self.back(delay=0)
+        else:
+            raise IOSBackendError(f"iOS key '{key}' is not supported through WDA")
+        time.sleep(delay)
+
+    def launch_app(self, bundle_id: str | None = None, delay=2.0) -> str:
+        target = bundle_id or self.bundle_id
+        if not target:
+            raise IOSBackendError("No iOS bundle id supplied")
+        self._ensure_session()
+        try:
+            self._execute_mobile("mobile: launchApp", {"bundleId": target})
+        except IOSBackendError:
+            self._execute_mobile("mobile: activateApp", {"bundleId": target})
+        time.sleep(delay)
+        return target
+
+    def terminate_app(self, bundle_id: str, delay=0.5) -> str:
+        self._execute_mobile("mobile: terminateApp", {"bundleId": bundle_id})
+        time.sleep(delay)
+        return bundle_id
+
+    def _candidate_apps(self) -> list[dict[str, str]]:
+        candidates: list[dict[str, str]] = []
+        seen: set[str] = set()
+
+        def add(name: str, bundle_id: str, source: str) -> None:
+            if not bundle_id or bundle_id in seen:
+                return
+            seen.add(bundle_id)
+            candidates.append(
+                {
+                    "name": name or _guess_ios_app_name(bundle_id),
+                    "package": bundle_id,
+                    "bundle_id": bundle_id,
+                    "platform": "ios",
+                    "source": source,
+                }
+            )
+
+        for name, bundle_id in self.config.known_apps:
+            add(name, bundle_id, "configured")
+        add(_guess_ios_app_name(self.bundle_id), self.bundle_id, "default")
+        for name, bundle_id in _skill_ios_app_inventory():
+            add(name, bundle_id, "skill")
+        for name, bundle_id in _COMMON_IOS_APPS:
+            add(name, bundle_id, "common")
+        return candidates
+
+    def app_state(self, bundle_id: str) -> int:
+        value = self._execute_mobile("mobile: queryAppState", {"bundleId": bundle_id})
+        if isinstance(value, dict):
+            value = value.get("state", value.get("appState", value.get("value", 0)))
+        return _intish(value)
+
+    def is_app_installed(self, bundle_id: str) -> bool:
+        return self.app_state(bundle_id) > 0
+
+    def list_apps(self, query: str = "", *, verify: bool = True) -> list[dict[str, Any]]:
+        """Return known iOS apps, verifying installation through Appium when possible.
+
+        iOS does not expose Android-style arbitrary package enumeration to a host
+        controller.  This method combines user-configured bundle IDs and common
+        bundle IDs, then uses Appium's queryAppState extension to filter installed
+        apps when WDA is available.
+        """
+        needle = (query or "").strip().lower()
+        apps: list[dict[str, Any]] = []
+        verification_error = ""
+
+        for candidate in self._candidate_apps():
+            searchable = " ".join([candidate["name"], candidate["package"], candidate["bundle_id"]]).lower()
+            if needle and needle not in searchable:
+                continue
+
+            app = dict(candidate)
+            app["verified"] = False
+            app["installed"] = None
+
+            if verify:
+                if verification_error:
+                    app["verification_error"] = verification_error
+                else:
+                    try:
+                        state = self.app_state(candidate["bundle_id"])
+                        if state <= 0:
+                            continue
+                        app["verified"] = True
+                        app["installed"] = True
+                        app["app_state"] = state
+                        app["app_state_name"] = _IOS_APP_STATE_NAMES.get(state, "unknown")
+                    except Exception as e:
+                        verification_error = str(e)
+                        app["verification_error"] = verification_error
+            apps.append(app)
+
+        source_order = {"configured": 0, "default": 1, "skill": 2, "common": 3}
+        apps.sort(key=lambda item: (source_order.get(str(item.get("source")), 9), str(item.get("name", "")).lower()))
+        return apps
+
+    def _tap_labeled_control(self, targets: tuple[str, ...], *, xml: str | None = None, delay=0.8) -> bool:
+        target_patterns = [re.compile(rf"\b{re.escape(target.lower())}\b") for target in targets if target]
+        if not target_patterns:
+            return False
+        xml = xml or self.dump_xml()
+        for node in self.nodes(xml):
+            labels = [
+                self.node_text(node).lower(),
+                self.node_content_desc(node).lower(),
+                self.node_rid(node).lower(),
+            ]
+            combined = " ".join(label for label in labels if label)
+            if any(pattern.search(combined) for pattern in target_patterns):
+                if self.tap_node(node, delay=delay):
+                    return True
+        return False
+
+    def open_camera(self, mode: str = "photo", timer_s: int = 0, delay=1.5) -> dict[str, Any]:
+        normalized_mode = (mode or "photo").lower()
+        if normalized_mode not in {"photo", "video", "selfie", "selfie_video"}:
+            normalized_mode = "photo"
+
+        self.launch_app("com.apple.camera", delay=delay)
+
+        needs_video = normalized_mode in {"video", "selfie_video"}
+        needs_front = normalized_mode in {"selfie", "selfie_video"}
+        selected_mode = True
+        switched_camera = False
+        timer_set = False
+        selected_timer = 0
+
+        if needs_video:
+            selected_mode = self._tap_labeled_control(("video",), delay=0.6)
+        elif normalized_mode in {"photo", "selfie"}:
+            self._tap_labeled_control(("photo",), delay=0.4)
+
+        if needs_front:
+            switched_camera = self._tap_labeled_control(
+                ("switch camera", "camera chooser", "flip camera", "front camera"),
+                delay=0.8,
+            )
+
+        if timer_s > 0:
+            selected_timer = 3 if int(timer_s) <= 3 else 10
+            if self._tap_labeled_control(("timer",), delay=0.5):
+                timer_set = self._tap_labeled_control(
+                    (f"{selected_timer}s", f"{selected_timer} s", f"{selected_timer} seconds", str(selected_timer)),
+                    delay=0.5,
+                )
+
+        return {
+            "platform": "ios",
+            "bundle_id": "com.apple.camera",
+            "mode": normalized_mode,
+            "opened": True,
+            "selected_mode": selected_mode,
+            "switched_camera": switched_camera if needs_front else None,
+            "timer_s": selected_timer,
+            "timer_set": timer_set if selected_timer else None,
+        }
+
+    def clipboard_get(self) -> str:
+        value = self._request(
+            "POST",
+            self._session_path("/appium/device/get_clipboard"),
+            {"contentType": "plaintext"},
+        )
+        if not value:
+            return ""
+        if isinstance(value, str):
+            try:
+                return base64.b64decode(value, validate=True).decode("utf-8")
+            except Exception:
+                return value
+        return str(value)
+
+    def clipboard_set(self, text: str) -> bool:
+        content = base64.b64encode(text.encode("utf-8")).decode("ascii")
+        self._request(
+            "POST",
+            self._session_path("/appium/device/set_clipboard"),
+            {
+                "content": content,
+                "contentType": "plaintext",
+                "label": "Ghost in the Droid",
+            },
+        )
+        return True
+
+    def paste_text(self, text: str, delay=0.3) -> bool:
+        self.clipboard_set(text)
+        self.type_text(text, delay=delay)
+        return True
+
+    def open_url(self, url: str, delay=2.0) -> dict[str, Any]:
+        normalized_url = _normalize_url(url)
+        errors: list[dict[str, str]] = []
+        try:
+            self._request("POST", self._session_path("/url"), {"url": normalized_url})
+            status = self.wait_for_url(normalized_url, timeout=delay)
+            status["method"] = "webdriver_url"
+            if status.get("ok"):
+                return status
+            errors.append(
+                {
+                    "method": "webdriver_url",
+                    "state": str(status.get("state") or ""),
+                    "error": str(status.get("error") or "URL navigation was not verified"),
+                }
+            )
+        except IOSBackendError as exc:
+            errors.append({"method": "webdriver_url", "error": str(exc)})
+
+        if self._open_url_in_web_context(normalized_url, delay=delay):
+            status = self.wait_for_url(normalized_url, timeout=delay)
+            status["method"] = "web_context"
+            status["errors"] = errors
+            if status.get("ok"):
+                return status
+            errors.append(
+                {
+                    "method": "web_context",
+                    "state": str(status.get("state") or ""),
+                    "error": str(status.get("error") or "URL navigation was not verified"),
+                }
+            )
+        address_method = self._open_url_via_address_bar(normalized_url, delay=delay)
+        status = self.wait_for_url(normalized_url, timeout=delay)
+        status["method"] = "address_bar"
+        if address_method:
+            status["address_bar_source"] = address_method
+        status["errors"] = errors
+        return status
+
+    def _open_url_in_web_context(self, url: str, delay=2.0) -> bool:
+        try:
+            for ctx in self.get_web_contexts():
+                self._set_context(ctx)
+                self._request("POST", self._session_path("/url"), {"url": url})
+                time.sleep(delay)
+                self._return_to_native_context()
+                return True
+        except IOSBackendError:
+            self._return_to_native_context()
+        return False
+
+    def _open_url_via_address_bar(self, url: str, delay=2.0) -> str:
+        self.launch_app(self.bundle_id, delay=0.8)
+        self._dismiss_browser_first_run_prompts()
+        xml = self.dump_xml()
+        node = self._find_address_bar_node(xml)
+        if node:
+            if not self.tap_node(node, delay=0.5):
+                raise IOSBackendError("Could not tap iOS browser address field")
+            method = "address_bar_xml"
+        elif self._tap_address_bar_from_ocr(delay=0.5):
+            method = "address_bar_ocr"
+        else:
+            raise IOSBackendError("Could not find an iOS browser address field for URL fallback")
+        self._clear_active_element()
+        self.type_text(url, delay=0.2)
+        self.press_enter(delay=delay)
+        return method
+
+    def _tap_address_bar_from_ocr(self, delay=0.5) -> bool:
+        try:
+            from gitd.services.device_context import ocr_screen
+
+            entries = ocr_screen(self.serial)
+        except Exception:
+            return False
+        for entry in entries:
+            if not _looks_like_address_bar_text(str(entry.get("text") or "")):
+                continue
+            try:
+                conf = float(entry.get("conf") or 0)
+            except (TypeError, ValueError):
+                conf = 0
+            if conf and conf < 0.35:
+                continue
+            x = _intish(entry.get("x")) + max(1, _intish(entry.get("w"))) // 2
+            y = _intish(entry.get("y")) + max(1, _intish(entry.get("h"))) // 2
+            self.tap(x, y, delay=delay)
+            return True
+        return False
+
+    def _dismiss_browser_first_run_prompts(self, max_rounds: int = 3) -> int:
+        tapped = 0
+        for _ in range(max(0, int(max_rounds))):
+            xml = self.dump_xml()
+            node = self._find_browser_prompt_action_node(xml)
+            if not node:
+                break
+            if not self.tap_node(node, delay=0.6):
+                break
+            tapped += 1
+        return tapped
+
+    def _find_browser_prompt_action_node(self, xml: str) -> str | None:
+        for node in self.nodes(xml):
+            label = re.sub(
+                r"\s+",
+                " ",
+                f"{self.node_text(node)} {self.node_content_desc(node)} {self.node_rid(node)}",
+            ).strip().lower()
+            if not label:
+                continue
+            cls = _node_attr(node, "class").lower()
+            if cls not in {"xcuielementtypebutton", "xcuielementtypestatictext"}:
+                continue
+            if any(action in label for action in _BROWSER_FIRST_RUN_ACTIONS):
+                return node
+        return None
+
+    def _find_address_bar_node(self, xml: str) -> str | None:
+        for node in self.nodes(xml):
+            text = (self.node_text(node) or "").lower()
+            desc = (self.node_content_desc(node) or "").lower()
+            rid = (self.node_rid(node) or "").lower()
+            cls = _node_attr(node, "class").lower()
+            combined = " ".join([text, desc, rid])
+            if cls in {"xcuielementtypetextfield", "xcuielementtypesearchfield"} and _looks_like_address_bar_text(
+                combined
+            ):
+                return node
+        return None
+
+    def _tap_browser_back_fallback(self, delay=1.0) -> None:
+        xml = self.dump_xml()
+        for node in self.nodes(xml):
+            label = f"{self.node_text(node)} {self.node_content_desc(node)} {self.node_rid(node)}".lower()
+            if "back" in label:
+                if self.tap_node(node, delay=delay):
+                    return
+        raise IOSBackendError("Could not find browser back control")
+
+    def get_current_url(self) -> str:
+        current = self._current_url_from_webdriver()
+        if current:
+            return current
+        snapshot = self.web_text_snapshot(max_entries=1)
+        if snapshot.get("url"):
+            return str(snapshot["url"])
+        return self._current_url_from_native_text()
+
+    def _current_url_from_webdriver(self) -> str:
+        try:
+            value = self._request("GET", self._session_path("/url"))
+            if isinstance(value, str):
+                return value.strip()
+        except IOSBackendError:
+            pass
+        return ""
+
+    def _current_url_from_native_text(self) -> str:
+        for entry in self.visible_text_entries(include_controls=True):
+            text = entry["text"]
+            if "." in text and " " not in text and len(text) > 3:
+                return text
+        return ""
+
+    def wait_for_url(self, expected_url: str, timeout=8.0, interval=0.5) -> dict[str, Any]:
+        expected = _normalize_url(expected_url)
+        deadline = time.time() + max(0.0, float(timeout))
+        last_url = ""
+        last_error = ""
+        saw_page_text = False
+        while True:
+            try:
+                current = self._current_url_from_webdriver()
+                if current:
+                    last_url = current
+                    if _urls_match(current, expected):
+                        return {"ok": True, "expected_url": expected, "url": current, "state": "url_matched"}
+                snapshot = self.web_text_snapshot(max_entries=12)
+                snapshot_url = str(snapshot.get("url") or "").strip() if isinstance(snapshot, dict) else ""
+                if snapshot_url:
+                    last_url = snapshot_url
+                    if _urls_match(snapshot_url, expected):
+                        return {"ok": True, "expected_url": expected, "url": snapshot_url, "state": "url_matched"}
+                if not current and not snapshot_url:
+                    native_url = self._current_url_from_native_text()
+                    if native_url:
+                        last_url = native_url
+                        if _urls_match(native_url, expected):
+                            return {
+                                "ok": True,
+                                "expected_url": expected,
+                                "url": native_url,
+                                "state": "url_matched_native",
+                            }
+                entries = snapshot.get("entries") if isinstance(snapshot, dict) else []
+                body_text = str(snapshot.get("bodyText") or "").strip() if isinstance(snapshot, dict) else ""
+                saw_page_text = bool(body_text or entries)
+                if saw_page_text and not last_url:
+                    return {
+                        "ok": True,
+                        "expected_url": expected,
+                        "url": "",
+                        "state": "page_text_available",
+                        "verified_url": False,
+                    }
+            except Exception as exc:
+                last_error = str(exc)
+            if time.time() >= deadline:
+                break
+            time.sleep(interval)
+        return {
+            "ok": False,
+            "expected_url": expected,
+            "url": last_url,
+            "state": "timeout",
+            "verified_url": False,
+            "page_text_available": saw_page_text,
+            "error": last_error,
+        }
+
+    def web_text_snapshot(self, max_entries: int = 300) -> dict[str, Any]:
+        """Return visible DOM text when Appium exposes a WebView context."""
+        for ctx in self.get_web_contexts():
+            try:
+                self._set_context(ctx)
+                value = self._execute_script(_WEB_TEXT_JS, [max_entries])
+                if isinstance(value, dict):
+                    value["context"] = ctx
+                    return value
+            except IOSBackendError:
+                continue
+            finally:
+                self._return_to_native_context()
+        return {}
+
+    def web_text_entries(self, max_entries: int = 300) -> list[dict[str, Any]]:
+        snapshot = self.web_text_snapshot(max_entries=max_entries)
+        return web_text_entries_from_snapshot(snapshot, max_entries=max_entries)
+
+    def native_text_entries(self, *, include_controls: bool = False, max_entries: int = 300) -> list[dict[str, Any]]:
+        return visible_text_entries_from_xml(
+            self.dump_xml(),
+            screen_size=self.get_screen_size(),
+            include_controls=include_controls,
+            max_entries=max_entries,
+        )
+
+    def wait_for_text(self, text: str, timeout=12, interval=1.0) -> str:
+        needle = text.lower()
+        deadline = time.time() + timeout
+        while time.time() <= deadline:
+            try:
+                visible_text = self.extract_visible_text(max_lines=300)
+            except Exception:
+                last_xml = self.dump_xml()
+                visible_text = "\n".join(e["text"] for e in visible_text_entries_from_xml(last_xml))
+                if needle in last_xml.lower():
+                    return visible_text
+            if needle in visible_text.lower():
+                return visible_text
+            time.sleep(interval)
+        raise TimeoutError(f"Timed out ({timeout}s) waiting for visible text: {text!r}")
+
+    def visible_text_entries(self, *, include_controls: bool = False, max_entries: int = 300) -> list[dict[str, Any]]:
+        snapshot = self.web_text_snapshot(max_entries=max_entries)
+        web_entries = web_text_entries_from_snapshot(snapshot, max_entries=max_entries)
+        if web_entries:
+            if include_controls:
+                return web_entries[:max_entries]
+            return [e for e in web_entries if not _looks_like_browser_control(e["text"])][:max_entries]
+        body_entries = web_body_text_entries_from_snapshot(
+            snapshot,
+            include_controls=include_controls,
+            max_entries=max_entries,
+        )
+        if body_entries:
+            return body_entries
+        return self.native_text_entries(include_controls=include_controls, max_entries=max_entries)
+
+    def extract_visible_text(self, *, include_controls: bool = False, max_lines: int = 200) -> str:
+        lines = [entry["text"] for entry in self.visible_text_entries(include_controls=include_controls)]
+        return "\n".join(lines[:max_lines])
+
+    def extract_articles(self, max_items: int = 5) -> list[dict[str, Any]]:
+        web_entries = self.web_text_entries(max_entries=300)
+        # WebView snapshots often contain a mix of linked promos/nav items and
+        # real headline headings. Score all visible WebView text first so an
+        # unlinked h2 can beat a newsletter/account link.
+        entries = web_entries or self.native_text_entries(include_controls=False, max_entries=300)
+        candidates: dict[str, tuple[int, dict[str, Any]]] = {}
+        for entry in entries:
+            text = entry["text"].strip()
+            if not _looks_like_article_title(text):
+                continue
+            candidate = {
+                "title": text,
+                "url": entry.get("url", ""),
+                "bounds": entry["bounds"],
+                "center": entry["center"],
+                "class": entry["class"],
+                "provenance": entry.get("provenance", "native"),
+            }
+            score = _article_candidate_score({**entry, **candidate})
+            if score < 0:
+                continue
+            key = _article_candidate_key(candidate)
+            existing = candidates.get(key)
+            if not existing or score > existing[0]:
+                candidates[key] = (score, candidate)
+
+        ranked = sorted(
+            candidates.values(),
+            key=lambda item: (
+                -item[0],
+                item[1]["bounds"]["y1"],
+                item[1]["bounds"]["x1"],
+                item[1]["title"].lower(),
+            ),
+        )
+        return [candidate for _, candidate in ranked[:max_items]]
+
+    def open_notifications(self, delay=1.0) -> bool:
+        width, height = self.get_screen_size()
+        x = max(1, width // 2)
+        self.swipe(x, max(1, int(height * 0.02)), x, int(height * 0.62), ms=650, delay=delay)
+        return True
+
+    def close_notifications(self, delay=0.5) -> bool:
+        width, height = self.get_screen_size()
+        x = max(1, width // 2)
+        self.swipe(x, int(height * 0.78), x, int(height * 0.08), ms=450, delay=delay)
+        return True
+
+    def get_notifications(self) -> list[dict[str, Any]]:
+        self.open_notifications(delay=0.8)
+        lines: list[str] = []
+        seen: set[str] = set()
+        for entry in self.native_text_entries(include_controls=True, max_entries=120):
+            text = re.sub(r"\s+", " ", str(entry.get("text") or "")).strip()
+            if not text:
+                continue
+            key = text.lower()
+            if key in _IOS_NOTIFICATION_SKIP_TEXT or key in seen:
+                continue
+            seen.add(key)
+            lines.append(text)
+
+        notifications: list[dict[str, Any]] = []
+        for idx in range(0, len(lines), 2):
+            notifications.append(
+                {
+                    "package": "",
+                    "title": lines[idx],
+                    "text": lines[idx + 1] if idx + 1 < len(lines) else "",
+                    "time": "",
+                    "platform": "ios",
+                    "source": "notification_center",
+                }
+            )
+        return notifications
+
+    def clear_notifications(self, delay=0.8) -> bool:
+        self.open_notifications(delay=0.5)
+        xml = self.dump_xml()
+        for node in self.nodes(xml):
+            parts = [self.node_text(node), self.node_content_desc(node), self.node_rid(node)]
+            labels = {part.strip().lower() for part in parts if part.strip()}
+            label = " ".join(parts).strip().lower()
+            if labels & {"clear", "clear all"} or "clear all" in label:
+                if not self.tap_node(node, delay=delay):
+                    continue
+                try:
+                    updated_xml = self.dump_xml()
+                    for confirm_node in self.nodes(updated_xml):
+                        confirm_parts = [
+                            self.node_text(confirm_node),
+                            self.node_content_desc(confirm_node),
+                            self.node_rid(confirm_node),
+                        ]
+                        confirm_labels = {part.strip().lower() for part in confirm_parts if part.strip()}
+                        confirm = " ".join(confirm_parts).strip().lower()
+                        if confirm_labels & {"clear", "clear all"} or "clear all" in confirm:
+                            self.tap_node(confirm_node, delay=delay)
+                            break
+                except Exception:
+                    pass
+                return True
+        return False
+
+    def get_phone_state(self) -> dict:
+        rect = self._window_rect()
+        width, height = self.get_screen_size()
+        target_bundle = self.bundle_id
+        state = {
+            "platform": "ios",
+            "device": self.serial,
+            "udid": self.udid,
+            "appiumUrl": self.appium_url,
+            "sessionId": self._session_id or IOSDevice._sessions.get(self._config),
+            "bundleId": target_bundle,
+            "bundle_id": target_bundle,
+            "packageName": target_bundle,
+            "activityName": target_bundle,
+            "currentApp": _guess_ios_app_name(target_bundle),
+            "keyboardVisible": False,
+            "focusedElement": {},
+            "screenSize": {"width": width, "height": height},
+            "windowRect": rect,
+        }
+        try:
+            active = self._execute_mobile("mobile: activeAppInfo", {})
+            if isinstance(active, dict):
+                active_bundle = str(active.get("bundleId") or active.get("bundle_id") or target_bundle)
+                state["activeApp"] = active
+                state["bundleId"] = active_bundle
+                state["bundle_id"] = active_bundle
+                state["packageName"] = active_bundle
+                state["activityName"] = active_bundle
+                state["currentApp"] = active.get("name", active_bundle)
+        except Exception:
+            pass
+        try:
+            xml = self.dump_xml()
+            state["keyboardVisible"] = ios_keyboard_visible_from_xml(xml)
+            focused = ios_focused_element_from_xml(xml, keyboard_visible=state["keyboardVisible"])
+            if focused:
+                state["focusedElement"] = focused
+        except Exception:
+            pass
+        return state
+
+    def probe(self, *, deep: bool = True) -> IOSDeviceStatus:
+        checks: dict[str, Any] = {}
+        try:
+            resp = requests.request("GET", self._url("/status"), timeout=min(5, self.timeout))
+            checks["appium_status_code"] = resp.status_code
+            if resp.status_code >= 400:
+                return IOSDeviceStatus(
+                    self.serial,
+                    self.udid,
+                    "appium_down",
+                    f"Appium status returned {resp.status_code}",
+                    self.appium_url,
+                    checks=checks,
+                )
+        except requests.RequestException as e:
+            return IOSDeviceStatus(
+                self.serial,
+                self.udid,
+                "appium_down",
+                f"Appium is unreachable: {e}",
+                self.appium_url,
+                checks=checks,
+            )
+
+        host_device = _host_device_config_for_udid(self.udid)
+        if _requires_host_device_visibility(self.appium_url, self.udid) and not host_device:
+            checks["host_device"] = {
+                "visible": False,
+                "source": "xcrun xctrace list devices",
+            }
+            return IOSDeviceStatus(
+                self.serial,
+                self.udid,
+                "configured_unreachable",
+                "Configured iOS device is not visible to local Xcode device discovery.",
+                self.appium_url,
+                self._session_id or IOSDevice._sessions.get(self._config, ""),
+                checks=checks,
+            )
+        if host_device:
+            checks["host_device"] = host_device
+
+        tunnel = remote_xpc_tunnel_status(
+            self.udid,
+            platform_version=self.platform_version,
+            host=host_device,
+        )
+        if tunnel.get("required"):
+            checks["remote_xpc_tunnel"] = tunnel
+        if tunnel.get("required") and not tunnel.get("ok"):
+            return IOSDeviceStatus(
+                self.serial,
+                self.udid,
+                "remote_xpc_tunnel_unavailable",
+                str(tunnel.get("message") or "RemoteXPC tunnel is unavailable"),
+                self.appium_url,
+                self._session_id or IOSDevice._sessions.get(self._config, ""),
+                checks=checks,
+            )
+
+        if not deep:
+            return IOSDeviceStatus(
+                self.serial,
+                self.udid,
+                "available",
+                "Appium is reachable",
+                self.appium_url,
+                self._session_id or IOSDevice._sessions.get(self._config, ""),
+                checks=checks,
+            )
+
+        try:
+            state = self.get_phone_state()
+            checks["active_app"] = state.get("activeApp") or {}
+            screenshot = self.take_screenshot()
+            checks["screenshot_bytes"] = len(screenshot)
+            xml = self.dump_xml()
+            checks["source_bytes"] = len(xml)
+            return IOSDeviceStatus(
+                self.serial,
+                self.udid,
+                "available",
+                "iOS Appium/WDA session is usable",
+                self.appium_url,
+                self._session_id or IOSDevice._sessions.get(self._config, ""),
+                active_app=state.get("activeApp"),
+                screen_size=state.get("screenSize"),
+                checks=checks,
+            )
+        except Exception as e:
+            state, message = classify_ios_error(e)
+            checks["error"] = str(e)
+            return IOSDeviceStatus(
+                self.serial,
+                self.udid,
+                state,
+                message,
+                self.appium_url,
+                self._session_id or IOSDevice._sessions.get(self._config, ""),
+                checks=checks,
+            )
+
+    def get_app_version(self, package: str) -> str:
+        return "unknown"
+
+    def dismiss_popups(self, xml: str | None = None, popups: list[dict] | None = None) -> bool:
+        """Dismiss known iOS prompts from normalized WDA XML.
+
+        Skill-specific popup detectors use the same {"detect", "button"} shape
+        as Android.  The generic fallback only taps compact, visible controls
+        with dismissal-like labels to avoid tapping article/content text.
+        """
+        if xml is None:
+            xml = self.dump_xml()
+        if not xml:
+            return False
+
+        popup_list = popups if popups is not None else _KNOWN_IOS_POPUPS
+        for popup in popup_list:
+            detect = str(popup.get("detect", "")).strip()
+            if detect and detect not in xml:
+                continue
+            if popup.get("method") == "back":
+                self.back(delay=1.0)
+                return True
+            button = str(popup.get("button", "")).strip()
+            if not button:
+                continue
+            matches = self.find_nodes(xml, text=button)
+            matches.sort(key=lambda node: (self.node_bounds(node) or (0, 0, 0, 0))[1])
+            for node in matches:
+                if self.tap_node(node, delay=1.0):
+                    return True
+
+        for node in self.nodes(xml):
+            label = f"{self.node_text(node)} {self.node_content_desc(node)}".strip().lower()
+            if not label:
+                continue
+            bounds = self.node_bounds(node)
+            if not bounds:
+                continue
+            width = bounds[2] - bounds[0]
+            height = bounds[3] - bounds[1]
+            if width > 500 or height > 120:
+                continue
+            cls = _node_attr(node, "class")
+            clickable = 'clickable="true"' in node
+            if not clickable and cls not in {"XCUIElementTypeButton", "XCUIElementTypeStaticText"}:
+                continue
+            words = set(label.split())
+            if label in _DISMISS_EXACT or label in _DISMISS_WORDS or words & _DISMISS_WORDS:
+                return self.tap_node(node, delay=1.0)
+        return False
+
+    def close(self):
+        sid = self._session_id or IOSDevice._sessions.get(self._config)
+        if not sid:
+            return
+        try:
+            self._request("DELETE", f"/session/{sid}", {}, retry_stale_session=False)
+        finally:
+            self._evict_session(sid)
+
+    def reset_session(self):
+        sid = self._session_id or IOSDevice._sessions.get(self._config)
+        if sid:
+            try:
+                self._request("DELETE", f"/session/{sid}", {}, retry_stale_session=False)
+            except Exception:
+                pass
+        self._evict_session(sid)
+
+    def start_appium_server(self) -> dict[str, Any]:
+        parsed = urllib.parse.urlparse(self.appium_url)
+        scheme = parsed.scheme or "http"
+        host = parsed.hostname or "127.0.0.1"
+        port = parsed.port or (443 if scheme == "https" else 4723)
+        if scheme != "http" or host not in {"127.0.0.1", "localhost", "::1"}:
+            return {
+                "ok": False,
+                "platform": "ios",
+                "issue": "start_appium",
+                "manual_action_required": True,
+                "message": "Configured Appium URL is not a local HTTP server Ghost can start safely.",
+                "appium_url": self.appium_url,
+                "recovery": {
+                    "code": "start_appium",
+                    "state": "appium_down",
+                    "summary": "Start Appium at the configured URL.",
+                    "steps": [
+                        f"Start Appium so {self.appium_url} responds to /status.",
+                        "Verify IOS_APPIUM_URL points to the running server.",
+                        f"Re-run /api/phone/health/{self.serial}.",
+                    ],
+                },
+            }
+        try:
+            resp = requests.request("GET", self._url("/status"), timeout=1)
+            if resp.status_code < 400:
+                return {
+                    "ok": True,
+                    "platform": "ios",
+                    "issue": "start_appium",
+                    "message": "Appium is already running.",
+                    "appium_url": self.appium_url,
+                    "status_code": resp.status_code,
+                }
+        except requests.RequestException:
+            pass
+
+        command, command_error = _appium_command_base()
+        if command_error:
+            return {
+                "ok": False,
+                "platform": "ios",
+                "issue": "start_appium",
+                "manual_action_required": True,
+                "message": command_error,
+                "appium_url": self.appium_url,
+            }
+        bind_host = "127.0.0.1" if host == "localhost" else host
+        command = [*command, "--address", bind_host, "--port", str(port), "--log-level", "info"]
+        log_path = os.getenv("IOS_APPIUM_LOG", f"/tmp/gitd-appium-{port}.log")
+        try:
+            log_fh = open(log_path, "a", encoding="utf-8")
+            try:
+                proc = subprocess.Popen(
+                    command,
+                    stdin=subprocess.DEVNULL,
+                    stdout=log_fh,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+            finally:
+                log_fh.close()
+        except OSError as e:
+            return {
+                "ok": False,
+                "platform": "ios",
+                "issue": "start_appium",
+                "manual_action_required": True,
+                "message": f"Could not start Appium: {e}",
+                "command": command,
+                "log_path": log_path,
+                "appium_url": self.appium_url,
+            }
+
+        status_code = 0
+        reachable = False
+        last_error = ""
+        for _ in range(20):
+            try:
+                resp = requests.request("GET", self._url("/status"), timeout=1)
+                status_code = resp.status_code
+                if resp.status_code < 400:
+                    reachable = True
+                    break
+            except requests.RequestException as e:
+                last_error = str(e)
+            time.sleep(0.25)
+        return {
+            "ok": reachable,
+            "platform": "ios",
+            "issue": "start_appium",
+            "message": "Appium started." if reachable else "Appium start command was launched but /status is not reachable yet.",
+            "pid": proc.pid,
+            "command": command,
+            "log_path": log_path,
+            "appium_url": self.appium_url,
+            "status_code": status_code,
+            "error": "" if reachable else last_error,
+        }
+
+    def restart_remote_xpc_tunnel(self) -> dict[str, Any]:
+        tunnel_before = remote_xpc_tunnel_status(
+            self.udid,
+            platform_version=self.platform_version,
+            host=_host_device_config_for_udid(self.udid),
+        )
+        processes = _remote_xpc_tunnel_processes(self.udid)
+        current_uid = os.getuid()
+        foreign = [proc for proc in processes if proc["uid"] != current_uid]
+        if foreign:
+            recovery = remote_xpc_manual_recovery(self.udid, tunnel_before)
+            return {
+                "ok": False,
+                "platform": "ios",
+                "issue": "restart_remote_xpc_tunnel",
+                "manual_action_required": True,
+                "message": "Existing XCUITest tunnel process is owned by another user and cannot be restarted here.",
+                "processes": processes,
+                "tunnel": tunnel_before,
+                "recovery": recovery,
+            }
+
+        killed: list[dict[str, Any]] = []
+        kill_errors: list[dict[str, Any]] = []
+        for proc in processes:
+            try:
+                os.kill(proc["pid"], signal.SIGTERM)
+                killed.append(proc)
+            except OSError as e:
+                kill_errors.append({**proc, "error": str(e)})
+        if kill_errors:
+            return {
+                "ok": False,
+                "platform": "ios",
+                "issue": "restart_remote_xpc_tunnel",
+                "manual_action_required": True,
+                "message": "Could not stop existing XCUITest tunnel process.",
+                "processes": processes,
+                "killed": killed,
+                "errors": kill_errors,
+                "tunnel": tunnel_before,
+                "recovery": remote_xpc_manual_recovery(self.udid, tunnel_before),
+            }
+
+        registry_port = _remote_xpc_registry_ports()[0]
+        command, command_error = _appium_command_base()
+        if command_error:
+            return {
+                "ok": False,
+                "platform": "ios",
+                "issue": "restart_remote_xpc_tunnel",
+                "manual_action_required": True,
+                "message": command_error,
+                "tunnel": tunnel_before,
+                "recovery": remote_xpc_manual_recovery(self.udid, tunnel_before),
+            }
+        command = [*command, "driver", "run", "xcuitest", "tunnel-creation", "--udid", self.udid]
+        if registry_port != _REMOTE_XPC_REGISTRY_PORTS[0]:
+            command.extend(["--tunnel-registry-port", str(registry_port)])
+        log_path = os.getenv("IOS_REMOTE_XPC_TUNNEL_LOG", f"/tmp/gitd-xcuitest-tunnel-{self.udid}.log")
+        try:
+            log_fh = open(log_path, "a", encoding="utf-8")
+            try:
+                proc = subprocess.Popen(
+                    command,
+                    stdin=subprocess.DEVNULL,
+                    stdout=log_fh,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+            finally:
+                log_fh.close()
+        except OSError as e:
+            return {
+                "ok": False,
+                "platform": "ios",
+                "issue": "restart_remote_xpc_tunnel",
+                "manual_action_required": True,
+                "message": f"Could not start XCUITest tunnel process: {e}",
+                "command": command,
+                "log_path": log_path,
+                "tunnel": tunnel_before,
+            }
+
+        wait_timeout = _remote_xpc_tunnel_start_timeout()
+        deadline = time.time() + wait_timeout
+        tunnel_after: dict[str, Any] = {}
+        attempts = 0
+        while True:
+            attempts += 1
+            tunnel_after = remote_xpc_tunnel_status(
+                self.udid,
+                platform_version=self.platform_version,
+                host=_host_device_config_for_udid(self.udid),
+            )
+            if tunnel_after.get("ok"):
+                return {
+                    "ok": True,
+                    "platform": "ios",
+                    "issue": "restart_remote_xpc_tunnel",
+                    "message": "XCUITest RemoteXPC tunnel is available.",
+                    "pid": proc.pid,
+                    "command": command,
+                    "log_path": log_path,
+                    "killed": killed,
+                    "tunnel_before": tunnel_before,
+                    "tunnel_after": tunnel_after,
+                    "attempts": attempts,
+                }
+            if time.time() >= deadline:
+                break
+            time.sleep(0.5)
+
+        return {
+            "ok": False,
+            "platform": "ios",
+            "issue": "restart_remote_xpc_tunnel",
+            "message": "XCUITest RemoteXPC tunnel restart started but did not become available before timeout.",
+            "manual_action_required": True,
+            "pid": proc.pid,
+            "command": command,
+            "log_path": log_path,
+            "killed": killed,
+            "tunnel_before": tunnel_before,
+            "tunnel_after": tunnel_after,
+            "attempts": attempts,
+            "recovery": remote_xpc_manual_recovery(self.udid, tunnel_after or tunnel_before),
+        }
+
+    # -- Android-compatible XML parsing helpers ---------------------------
+
+    def bounds_center(self, bounds_str: str) -> tuple[int, int]:
+        nums = list(map(int, re.findall(r"\d+", bounds_str)))
+        return (nums[0] + nums[2]) // 2, (nums[1] + nums[3]) // 2
+
+    def find_bounds(self, xml: str, *, text=None, content_desc=None, resource_id=None, class_name=None) -> str | None:
+        if text:
+            key, val = "text", text
+        elif content_desc:
+            key, val = "content-desc", content_desc
+        elif resource_id:
+            key, val = "resource-id", resource_id
+        elif class_name:
+            key, val = "class", class_name
+        else:
+            return None
+        m = re.search(rf'<node[^>]*{key}="{re.escape(val)}"[^>]*>', xml)
+        if m:
+            bm = re.search(r'bounds="([^"]+)"', m.group())
+            return bm.group(1) if bm else None
+        return None
+
+    def tap_text(self, xml: str, text: str, fallback_xy=None, delay=0.8) -> bool:
+        b = self.find_bounds(xml, text=text)
+        if b:
+            self.tap(*self.bounds_center(b), delay)
+            return True
+        if fallback_xy:
+            self.tap(*fallback_xy, delay)
+            return True
+        raise RuntimeError(f"Could not find '{text}' on screen")
+
+    def wait_for(self, text: str, timeout=12, interval=1.0) -> str:
+        for _ in range(int(timeout / interval) + 1):
+            xml = self.dump_xml()
+            if text in xml:
+                return xml
+            time.sleep(interval)
+        raise TimeoutError(f"Timed out ({timeout}s) waiting for: {text!r}")
+
+    def nodes(self, xml: str) -> list[str]:
+        return re.findall(r"<node[^>]+/?>", xml)
+
+    def node_text(self, node: str) -> str:
+        m = re.search(r'\btext="([^"]*)"', node)
+        return html.unescape(m.group(1).strip()) if m else ""
+
+    def node_content_desc(self, node: str) -> str:
+        m = re.search(r'content-desc="([^"]*)"', node)
+        return html.unescape(m.group(1).strip()) if m else ""
+
+    def node_rid(self, node: str) -> str:
+        m = re.search(r'resource-id="([^"]*)"', node)
+        return html.unescape(m.group(1)) if m else ""
+
+    @staticmethod
+    def node_bounds_static(node: str) -> tuple[int, int, int, int] | None:
+        m = re.search(r'bounds="\[(\d+),(\d+)\]\[(\d+),(\d+)\]"', node)
+        return (int(m.group(1)), int(m.group(2)), int(m.group(3)), int(m.group(4))) if m else None
+
+    def node_bounds(self, node: str) -> tuple[int, int, int, int] | None:
+        return self.node_bounds_static(node)
+
+    def node_center(self, b: tuple) -> tuple[int, int]:
+        return (b[0] + b[2]) // 2, (b[1] + b[3]) // 2
+
+    def find_nodes(self, xml: str, rid: str | None = None, text: str | None = None) -> list[str]:
+        out = []
+        for node in self.nodes(xml):
+            if rid and self.node_rid(node) != rid:
+                continue
+            if text and text.lower() not in (self.node_text(node) + self.node_content_desc(node)).lower():
+                continue
+            out.append(node)
+        return out
+
+    def tap_node(self, node: str, delay=0.8) -> bool:
+        b = self.node_bounds(node)
+        if b:
+            self.tap(*self.node_center(b), delay)
+            return True
+        return False
+
+
+def _element_id(value: Any) -> str:
+    if not isinstance(value, dict):
+        return ""
+    for key in _ELEMENT_ID_KEYS:
+        if value.get(key):
+            return str(value[key])
+    return ""
+
+
+def _node_attr(node: str, attr: str) -> str:
+    m = re.search(rf'\b{re.escape(attr)}="([^"]*)"', node)
+    return html.unescape(m.group(1).strip()) if m else ""
+
+
+_IOS_INPUT_CLASSES = {
+    "xcuielementtypesearchfield",
+    "xcuielementtypesecuretextfield",
+    "xcuielementtypetextfield",
+    "xcuielementtypetextview",
+}
+
+
+def _node_visible(node: str) -> bool:
+    return _node_attr(node, "visible").lower() != "false"
+
+
+def ios_keyboard_visible_from_xml(xml: str) -> bool:
+    for node in re.findall(r"<node[^>]+/?>", xml or ""):
+        if not _node_visible(node):
+            continue
+        cls = _node_attr(node, "class").lower()
+        if cls in {"xcuielementtypekeyboard", "xcuielementtypekey"} or "keyboard" in cls:
+            return True
+    return False
+
+
+def _ios_element_payload(node: str) -> dict[str, Any]:
+    bounds = IOSDevice.node_bounds_static(node)
+    payload: dict[str, Any] = {
+        "text": _node_attr(node, "text"),
+        "content_desc": _node_attr(node, "content-desc"),
+        "resource_id": _node_attr(node, "resource-id"),
+        "class": _node_attr(node, "class"),
+        "bounds": {},
+        "center": {},
+    }
+    if bounds:
+        x1, y1, x2, y2 = bounds
+        payload["bounds"] = {"x1": x1, "y1": y1, "x2": x2, "y2": y2}
+        payload["center"] = {"x": (x1 + x2) // 2, "y": (y1 + y2) // 2}
+    return payload
+
+
+def ios_focused_element_from_xml(xml: str, *, keyboard_visible: bool = False) -> dict[str, Any]:
+    input_nodes: list[str] = []
+    for node in re.findall(r"<node[^>]+/?>", xml or ""):
+        if not _node_visible(node):
+            continue
+        cls = _node_attr(node, "class").lower()
+        if _node_attr(node, "focused").lower() == "true":
+            return _ios_element_payload(node)
+        if cls in _IOS_INPUT_CLASSES:
+            input_nodes.append(node)
+    if keyboard_visible and input_nodes:
+        return _ios_element_payload(input_nodes[0])
+    return {}
+
+
+def _normalize_url(url: str) -> str:
+    cleaned = url.strip()
+    if cleaned and "://" not in cleaned:
+        cleaned = "https://" + cleaned
+    return cleaned
+
+
+def _host_without_www(hostname: str) -> str:
+    host = hostname.lower().strip(".")
+    return host[4:] if host.startswith("www.") else host
+
+
+def _urls_match(current_url: str, expected_url: str) -> bool:
+    current = _normalize_url(current_url)
+    expected = _normalize_url(expected_url)
+    try:
+        current_parts = urllib.parse.urlparse(current)
+        expected_parts = urllib.parse.urlparse(expected)
+    except Exception:
+        return False
+    current_host = _host_without_www(current_parts.hostname or "")
+    expected_host = _host_without_www(expected_parts.hostname or "")
+    if not current_host or not expected_host or current_host != expected_host:
+        return False
+
+    current_path = (current_parts.path or "/").rstrip("/") or "/"
+    expected_path = (expected_parts.path or "/").rstrip("/") or "/"
+    if current_path != expected_path:
+        return False
+
+    expected_query = urllib.parse.parse_qs(expected_parts.query, keep_blank_values=True)
+    if expected_query:
+        current_query = urllib.parse.parse_qs(current_parts.query, keep_blank_values=True)
+        for key, values in expected_query.items():
+            if key not in current_query:
+                return False
+            for value in values:
+                if value not in current_query[key]:
+                    return False
+    return True
+
+
+def _looks_like_browser_control(text: str) -> bool:
+    cleaned = text.strip().lower()
+    if not cleaned:
+        return True
+    if cleaned in _BROWSER_CONTROL_TEXT:
+        return True
+    if "google lens" in cleaned:
+        return True
+    if "." in cleaned and "secure" in cleaned:
+        return True
+    if cleaned.startswith("tab ") or cleaned.endswith(" tabs"):
+        return True
+    return False
+
+
+def _looks_like_article_title(text: str) -> bool:
+    cleaned = text.strip()
+    if len(cleaned) < 18:
+        return False
+    lower = cleaned.lower()
+    if _looks_like_browser_control(cleaned):
+        return False
+    if lower.startswith("npr :") or lower == "npr national public radio":
+        return False
+    page_date_pattern = (
+        r"(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday),?"
+        r"\s+[a-z]+\s+\d{1,2},\s+20\d{2}"
+    )
+    if re.fullmatch(page_date_pattern, lower):
+        return False
+    if lower.startswith(("http://", "https://", "www.")):
+        return False
+    if lower in {"home", "menu", "sections", "search", "sponsor message"}:
+        return False
+    words = re.findall(r"[A-Za-z0-9]+", cleaned)
+    return len(words) >= 4
+
+
+def _article_url_score(url: str) -> int:
+    if not url:
+        return 0
+    try:
+        parsed = urllib.parse.urlparse(url)
+    except Exception:
+        return -10
+    if parsed.scheme and parsed.scheme not in {"http", "https"}:
+        return -20
+
+    path = (parsed.path or "/").lower()
+    query = (parsed.query or "").lower()
+    score = 20
+    if path in {"", "/"}:
+        score -= 18
+    path_segments = [segment for segment in re.split(r"[^a-z0-9]+", path) if segment]
+    if any(hint in path_segments for hint in _ARTICLE_URL_HINTS):
+        score += 16
+    if re.search(r"/(?:20\d{2}|\d{4,}|[a-z]+-\d+)", path):
+        score += 12
+    if query:
+        score -= 4
+    if any(term.replace(" ", "-") in path for term in _LOW_VALUE_ARTICLE_TERMS):
+        score -= 30
+    return score
+
+
+def _article_candidate_score(entry: dict[str, Any]) -> int:
+    text = re.sub(r"\s+", " ", str(entry.get("text") or "")).strip()
+    lower = text.lower()
+    bounds = entry.get("bounds") if isinstance(entry.get("bounds"), dict) else {}
+    y1 = _intish(bounds.get("y1"))
+    tag = str(entry.get("class") or "").lower()
+    role = str(entry.get("role") or "").lower()
+    url = str(entry.get("url") or "")
+
+    words = re.findall(r"[A-Za-z0-9]+", text)
+    score = min(len(words), 12)
+    score += _article_url_score(url)
+    if entry.get("provenance") == "web_context":
+        score += 8
+    if tag in {"h1", "h2", "h3"} or role == "heading":
+        score += 12
+    if tag == "a" and url:
+        score += 8
+    if 35 <= y1 <= 1200:
+        score += max(0, 12 - y1 // 160)
+    if len(text) > 180:
+        score -= 10
+    if any(term in lower for term in _LOW_VALUE_ARTICLE_TERMS):
+        score -= 35
+    if entry.get("provenance") == "native" and tag == "xcuielementtypebutton" and y1 < 330:
+        score -= 80
+    return score
+
+
+def _article_candidate_key(entry: dict[str, Any]) -> str:
+    url = str(entry.get("url") or "").strip()
+    if url:
+        parsed = urllib.parse.urlparse(url)
+        return f"url:{parsed.netloc.lower()}{parsed.path.rstrip('/').lower()}"
+    text = re.sub(r"\W+", "", str(entry.get("title") or entry.get("text") or "").lower())
+    return f"text:{text}"
+
+
+def web_text_entries_from_snapshot(snapshot: dict[str, Any], *, max_entries: int = 300) -> list[dict[str, Any]]:
+    limit = max(0, int(max_entries))
+    if limit <= 0:
+        return []
+    entries = snapshot.get("entries") if isinstance(snapshot, dict) else None
+    if not isinstance(entries, list):
+        return []
+    out: list[dict[str, Any]] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        text = str(entry.get("text") or "").strip()
+        if not text:
+            continue
+        bounds = entry.get("bounds") if isinstance(entry.get("bounds"), dict) else {}
+        x1 = _intish(bounds.get("x1"))
+        y1 = _intish(bounds.get("y1"))
+        x2 = _intish(bounds.get("x2"))
+        y2 = _intish(bounds.get("y2"))
+        out.append(
+            {
+                "text": text,
+                "bounds": {"x1": x1, "y1": y1, "x2": x2, "y2": y2},
+                "center": {"x": (x1 + x2) // 2, "y": (y1 + y2) // 2},
+                "class": entry.get("tag", ""),
+                "resource_id": "",
+                "content_desc": "",
+                "provenance": "web_context",
+                "url": str(entry.get("href") or ""),
+                "role": str(entry.get("role") or ""),
+            }
+        )
+        if len(out) >= limit:
+            break
+    return out
+
+
+def web_body_text_entries_from_snapshot(
+    snapshot: dict[str, Any],
+    *,
+    include_controls: bool = False,
+    max_entries: int = 300,
+) -> list[dict[str, Any]]:
+    limit = max(0, int(max_entries))
+    if limit <= 0:
+        return []
+    if not isinstance(snapshot, dict):
+        return []
+    body_text = re.sub(r"\s+", " ", str(snapshot.get("bodyText") or "")).strip()
+    if not body_text:
+        return []
+    if not include_controls and _looks_like_browser_control(body_text):
+        return []
+    viewport = snapshot.get("viewport") if isinstance(snapshot.get("viewport"), dict) else {}
+    width = max(1, _intish(viewport.get("width")))
+    height = max(1, _intish(viewport.get("height")))
+    return [
+        {
+            "text": body_text,
+            "bounds": {"x1": 0, "y1": 0, "x2": width, "y2": height},
+            "center": {"x": width // 2, "y": height // 2},
+            "class": "body",
+            "resource_id": "",
+            "content_desc": "",
+            "provenance": "web_context_body",
+            "url": str(snapshot.get("url") or ""),
+            "role": "document",
+        }
+    ][:limit]
+
+
+def visible_text_entries_from_xml(
+    xml: str,
+    *,
+    screen_size: tuple[int, int] | None = None,
+    include_controls: bool = False,
+    max_entries: int = 300,
+) -> list[dict[str, Any]]:
+    try:
+        root = ET.fromstring(xml)
+    except ET.ParseError:
+        return []
+    max_w, max_h = screen_size or (0, 0)
+    entries: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for node in root.iter("node"):
+        visible = (node.get("visible") or "").lower()
+        if visible == "false":
+            continue
+        text = (node.get("text") or node.get("content-desc") or "").strip()
+        if not text:
+            continue
+        if not include_controls and _looks_like_browser_control(text):
+            continue
+        bounds = IOSDevice.node_bounds_static(ET.tostring(node, encoding="unicode"))
+        if not bounds:
+            continue
+        x1, y1, x2, y2 = bounds
+        if x2 <= x1 or y2 <= y1:
+            continue
+        if max_w and (x2 < 0 or x1 > max_w):
+            continue
+        if max_h and (y2 < 0 or y1 > max_h):
+            continue
+        key = f"{text}\0{x1}:{y1}:{x2}:{y2}"
+        if key in seen:
+            continue
+        seen.add(key)
+        entries.append(
+            {
+                "text": text,
+                "bounds": {"x1": x1, "y1": y1, "x2": x2, "y2": y2},
+                "center": {"x": (x1 + x2) // 2, "y": (y1 + y2) // 2},
+                "class": node.get("class", ""),
+                "resource_id": node.get("resource-id", ""),
+                "content_desc": node.get("content-desc", ""),
+                "provenance": "native",
+            }
+        )
+        if len(entries) >= max_entries:
+            break
+    entries.sort(key=lambda e: (e["bounds"]["y1"], e["bounds"]["x1"], e["text"]))
+    return entries
+
+
+def classify_ios_error(exc: Exception) -> tuple[str, str]:
+    message = str(exc)
+    lower = message.lower()
+    if (
+        "developer app certificate" in lower
+        or "webdriveragentrunner" in lower
+        or "xctrunner" in lower
+        or "invalid code signature" in lower
+        or "development team" in lower
+    ) and (
+        "not trusted" in lower
+        or "code sign" in lower
+        or "code signature" in lower
+        or "signing" in lower
+        or "provision" in lower
+        or "xcodebuild" in lower
+        or "development team" in lower
+    ):
+        return "wda_signing_failed", f"WebDriverAgent signing/provisioning failed: {message}"
+    if (
+        "unlock" in lower
+        or "locked" in lower
+        or "passcode" in lower
+        or "not trusted" in lower
+        or "trust this computer" in lower
+        or "developer mode" in lower
+        or "ui automation" in lower
+    ):
+        return "locked", f"Device is locked, not trusted, or blocked by iOS automation permissions: {message}"
+    if (
+        "remote xpc" in lower
+        or "remotexpc" in lower
+        or "could not find the expected device" in lower
+    ):
+        return "remote_xpc_tunnel_unavailable", f"RemoteXPC tunnel or usbmux device listing is unavailable: {message}"
+    if (
+        "could not create appium ios session" in lower
+        and ("read timed out" in lower or "timed out" in lower)
+    ):
+        return "wda_launch_timeout", f"WebDriverAgent session creation timed out: {message}"
+    if "connection refused" in lower or "failed to establish" in lower or "timed out" in lower:
+        return "appium_down", f"Appium is unreachable: {message}"
+    if "code sign" in lower or "signing" in lower or "provision" in lower or "xcodebuild" in lower:
+        return "wda_signing_failed", f"WebDriverAgent signing/provisioning failed: {message}"
+    if "invalid session" in lower or "session not found" in lower or "no such driver" in lower:
+        return "session_error", f"Appium session is invalid: {message}"
+    if "could not create appium ios session" in lower:
+        return "configured_unreachable", message
+    return "session_error", message
+
+
+def probe_ios_device(device: str, *, deep: bool = True) -> IOSDeviceStatus:
+    return IOSDevice(device).probe(deep=deep)

--- a/gitd/bots/tiktok/scraper.py
+++ b/gitd/bots/tiktok/scraper.py
@@ -1,0 +1,8 @@
+"""Compatibility shim — re-export TikTok scraper helpers from premium."""
+
+try:
+    from ghost_premium.bots.tiktok.scraper import *  # noqa: F401, F403
+except ImportError as e:
+    raise ImportError(
+        "gitd.bots.tiktok.scraper requires the premium plugin to be installed."
+    ) from e

--- a/gitd/bots/tiktok/upload.py
+++ b/gitd/bots/tiktok/upload.py
@@ -1,0 +1,18 @@
+"""Compatibility shim — re-export TikTok upload helpers from premium.
+
+The actual implementation lives at internal/ghost_premium/bots/tiktok/upload.py.
+This shim exists so scripts that import from gitd.bots.tiktok.upload (the
+pre-split path) keep working after the public/premium split, without each
+script needing to fall back manually.
+
+If premium isn't installed, importing this module raises a clear ImportError
+instead of pretending things work.
+"""
+
+try:
+    from ghost_premium.bots.tiktok.upload import *  # noqa: F401, F403
+except ImportError as e:
+    raise ImportError(
+        "gitd.bots.tiktok.upload requires the premium plugin to be installed. "
+        "If you have premium, ensure internal/ghost_premium is on PYTHONPATH."
+    ) from e

--- a/gitd/cli.py
+++ b/gitd/cli.py
@@ -1,6 +1,7 @@
 """CLI entry point: android-agent skill install/list/update/remove/validate/search"""
 
 import argparse
+import json
 import logging
 import os
 import re
@@ -506,8 +507,318 @@ def cmd_search(args):
 # ── Main ──────────────────────────────────────────────────────────────────
 
 
-def main():
+def cmd_up(args):
+    """Boot the server + dashboard (replaces `python3 run.py`)."""
+    from pathlib import Path as _Path
+
+    # Load .env from the current working dir if present (uvx/pipx runs from
+    # anywhere, so we can't assume the repo layout run.py relied on).
+    try:
+        from dotenv import load_dotenv
+
+        env = _Path.cwd() / ".env"
+        if env.exists():
+            load_dotenv(env)
+    except Exception:
+        pass
+
+    try:
+        import uvicorn
+
+        from gitd.app import app
+        from gitd.config import settings
+    except Exception as e:
+        print(f"✗ Could not start server: {e}")
+        print("  Run `android-agent doctor` to check your install.")
+        return 1
+
+    # Default to localhost — this server shells into a physical phone, so it
+    # must NOT be exposed to the whole LAN on first run. Opt into LAN access
+    # explicitly with `--host 0.0.0.0`. (settings.host stays 0.0.0.0 for the
+    # container/run.py path, which is deliberately behind other controls.)
+    host = args.host or "127.0.0.1"
+    port = args.port or settings.port
+    shown_host = "localhost" if host in ("0.0.0.0", "127.0.0.1") else host
+    print(f"Ghost in the Droid → http://{shown_host}:{port}  (dashboard + API)")
+    if host == "0.0.0.0":
+        print("⚠  Bound to 0.0.0.0 — reachable by anyone on your network. This server controls your phone.")
+    print("Press Ctrl+C to stop.")
+    uvicorn.run(app, host=host, port=port)
+    return 0
+
+
+# ── doctor ───────────────────────────────────────────────────────────────────
+
+_DOCTOR_ICON = {"ok": "✓", "warn": "!", "fail": "✗"}
+
+
+def _port_in_use(port: int, host: str = "127.0.0.1") -> bool:
+    import socket
+
+    probe_host = "127.0.0.1" if host in ("0.0.0.0", "") else host
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(0.5)
+        return s.connect_ex((probe_host, port)) == 0
+
+
+def collect_doctor_checks() -> list[dict]:
+    """Preflight environment checks. Returns a list of
+    {name, status: ok|warn|fail, detail, hint} dicts — no printing, so it's
+    unit-testable. `cmd_doctor` renders and sets the exit code from these.
+    """
+    checks: list[dict] = []
+
+    # Python version
+    py = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+    py_ok = sys.version_info >= (3, 10)
+    checks.append(
+        {
+            "name": "Python >= 3.10",
+            "status": "ok" if py_ok else "fail",
+            "detail": py,
+            "hint": "" if py_ok else "Ghost requires Python 3.10+.",
+        }
+    )
+
+    # adb on PATH — the #1 first-run failure
+    adb = shutil.which("adb")
+    checks.append(
+        {
+            "name": "adb on PATH",
+            "status": "ok" if adb else "fail",
+            "detail": adb or "not found",
+            "hint": "" if adb else "Install Android platform-tools and add `adb` to PATH.",
+        }
+    )
+
+    # Connected devices (only meaningful if adb exists)
+    if adb:
+        try:
+            from gitd.bots.common.adb import list_connected
+
+            devices = list_connected()
+        except Exception as e:
+            devices = []
+            checks.append({"name": "adb devices", "status": "warn", "detail": f"could not query: {e}", "hint": ""})
+        else:
+            checks.append(
+                {
+                    "name": "adb devices",
+                    "status": "ok" if devices else "warn",
+                    "detail": ", ".join(devices) if devices else "no devices connected",
+                    "hint": "" if devices else "Plug in a device / start an emulator and enable USB debugging.",
+                }
+            )
+
+    # Server port
+    try:
+        from gitd.config import settings
+
+        port = settings.port
+        host = settings.host
+    except Exception:
+        port, host = 5055, "0.0.0.0"
+    in_use = _port_in_use(port, host)
+    checks.append(
+        {
+            "name": f"server port {port}",
+            "status": "warn" if in_use else "ok",
+            "detail": "already in use (server running?)" if in_use else "free",
+            "hint": f"Another process holds port {port}; stop it or set a different port." if in_use else "",
+        }
+    )
+
+    # LLM backend configured — a key OR the claude CLI (subscription auth)
+    try:
+        from gitd.config import settings as _s
+
+        keys = {
+            "anthropic": bool(_s.anthropic_api_key),
+            "openai": bool(_s.openai_api_key),
+            "openrouter": bool(_s.openrouter_api_key),
+        }
+    except Exception:
+        keys = {}
+    claude_cli = shutil.which("claude") is not None
+    configured = [k for k, v in keys.items() if v] + (["claude-code CLI"] if claude_cli else [])
+    checks.append(
+        {
+            "name": "LLM backend",
+            "status": "ok" if configured else "warn",
+            "detail": ", ".join(configured) if configured else "none configured",
+            "hint": "" if configured else "Set an API key (e.g. ANTHROPIC_API_KEY) or install the `claude` CLI.",
+        }
+    )
+
+    # Claude subscription sign-in (the no-API-key path). Only surfaced when the
+    # claude CLI is present but not signed in — otherwise the LLM-backend check
+    # above already covers it.
+    if claude_cli:
+        signed_in = _claude_auth_state() == "logged_in"
+        checks.append(
+            {
+                "name": "Claude subscription",
+                "status": "ok" if signed_in else "warn",
+                "detail": "signed in (no API key needed)" if signed_in else "claude CLI present, not signed in",
+                "hint": "" if signed_in else "Run `android-agent login` to use your Claude Max/Pro subscription.",
+            }
+        )
+
+    return checks
+
+
+def cmd_doctor(args):
+    """Print a green/red preflight checklist and exit non-zero on any failure."""
+    checks = collect_doctor_checks()
+    print("Ghost in the Droid — doctor\n")
+    for c in checks:
+        icon = _DOCTOR_ICON.get(c["status"], "?")
+        line = f"  {icon} {c['name']}: {c['detail']}"
+        print(line)
+        if c["hint"] and c["status"] != "ok":
+            print(f"      → {c['hint']}")
+    failed = [c for c in checks if c["status"] == "fail"]
+    warned = [c for c in checks if c["status"] == "warn"]
+    print()
+    if failed:
+        print(f"{len(failed)} problem(s) must be fixed before Ghost will run.")
+        return 1
+    if warned:
+        print(f"Ready, with {len(warned)} warning(s).")
+    else:
+        print("All checks passed. Run `android-agent up` to start.")
+    return 0
+
+
+# ── login (Claude subscription, no API key) ──────────────────────────────────
+
+
+def _claude_status_logged_in(timeout: int = 10) -> bool:
+    """Ask the claude CLI whether it's signed in, via `claude auth status`.
+
+    Storage-agnostic — respects wherever the CLI keeps creds (plain file on
+    Linux, the login Keychain on macOS), so it fixes the false-negative when the
+    file check misses on a Mac. Still NEVER reads the token itself; we only look
+    at the CLI's own yes/no. Best-effort: any failure → treat as not-signed-in.
+    """
+    try:
+        r = subprocess.run(
+            ["claude", "auth", "status"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except Exception:
+        return False
+    out = (r.stdout or "").strip()
+    try:
+        data = json.loads(out)
+        if isinstance(data, dict) and "loggedIn" in data:
+            return bool(data["loggedIn"])
+    except Exception:
+        pass
+    # Older/plain-text CLIs: fall back to the exit code.
+    return r.returncode == 0
+
+
+def _claude_auth_state() -> str:
+    """Check Claude subscription sign-in.
+
+    Returns 'not_installed' | 'logged_out' | 'logged_in'. NEVER reads the token
+    value — only whether the CLI is signed in. Ghost does not store or manage
+    the token; the claude CLI owns it (and its refresh).
+
+    Fast path: the plain-file credential (Linux, and macOS when the CLI uses the
+    file) — no subprocess. If that's absent the CLI may keep creds elsewhere
+    (e.g. the macOS Keychain), so we ask `claude auth status`, which respects its
+    own storage. On Linux this only costs a subprocess when NOT signed in.
+    """
+    if shutil.which("claude") is None:
+        return "not_installed"
+    creds = Path.home() / ".claude" / ".credentials.json"
+    try:
+        if creds.exists() and json.loads(creds.read_text()).get("claudeAiOauth"):
+            return "logged_in"
+    except Exception:
+        pass
+    # File missing/unreadable — ask the CLI itself (catches macOS Keychain).
+    if _claude_status_logged_in():
+        return "logged_in"
+    return "logged_out"
+
+
+def _record_default_provider(provider: str) -> None:
+    """Best-effort upsert of DEFAULT_PROVIDER in ./.env (records the preference;
+    auth is the real work, so failures here are non-fatal)."""
+    env_path = Path.cwd() / ".env"
+    key = "DEFAULT_PROVIDER"
+    try:
+        lines, found = [], False
+        if env_path.exists():
+            for line in env_path.read_text().splitlines():
+                if line.strip().startswith(f"{key}="):
+                    lines.append(f"{key}={provider}")
+                    found = True
+                else:
+                    lines.append(line)
+        if not found:
+            lines.append(f"{key}={provider}")
+        env_path.write_text("\n".join(lines) + "\n")
+    except Exception:
+        pass
+
+
+def cmd_login(args):
+    """Sign in Ghost's LLM backend via your Claude Max/Pro subscription — no API key.
+
+    Ghost's `claude-code` provider runs through the `claude` CLI, which signs in
+    with your Claude subscription via Anthropic's own OAuth flow. This command
+    delegates to `claude auth login` and confirms the result — Ghost never
+    handles or stores the token; the claude CLI owns it, refresh included.
+    """
+    state = _claude_auth_state()
+    if state == "not_installed":
+        print("✗ The `claude` CLI (Claude Code) is not installed.")
+        print("  Ghost uses your Claude Max/Pro subscription through it — no API key needed.")
+        print("  Install: https://docs.claude.com/claude-code, then re-run `android-agent login`.")
+        return 1
+
+    if state == "logged_out" or getattr(args, "relogin", False):
+        print("Opening Anthropic sign-in via the claude CLI…")
+        try:
+            rc = subprocess.run(["claude", "auth", "login"]).returncode
+        except Exception as e:
+            print(f"✗ Could not launch `claude auth login`: {e}")
+            return 1
+        if rc != 0:
+            print("✗ Sign-in didn't complete. Re-run `android-agent login` after finishing in the browser.")
+            return 1
+        state = _claude_auth_state()
+
+    if state == "logged_in":
+        _record_default_provider("claude-code")
+        print("✓ Signed in to your Claude subscription.")
+        print("  No API key needed — Ghost will use the `claude-code` provider by default.")
+        print("  Start it: android-agent up")
+        return 0
+
+    print("! Could not confirm sign-in. Check `claude auth status`.")
+    return 1
+
+
+def main(argv=None):
     logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    # Deprecation notice when invoked via a legacy bin name. `ghost` is primary;
+    # these aliases keep working for one release cycle. (No warning when `ghost`
+    # delegates here — the invoked bin is still `ghost`.)
+    _bin = os.path.basename(sys.argv[0]) if sys.argv and sys.argv[0] else ""
+    if _bin in ("gitd", "android-agent", "ghost-in-the-droid"):
+        print(
+            f"⚠  '{_bin}' is deprecated — use 'ghost' instead "
+            "(this alias will be removed in a future release).",
+            file=sys.stderr,
+        )
 
     parser = argparse.ArgumentParser(
         prog="android-agent",
@@ -544,11 +855,32 @@ def main():
     search_p = skill_sub.add_parser("search", help="Search registry by name/description")
     search_p.add_argument("query", help="Search query")
 
-    args = parser.parse_args()
+    # ── up subcommand — boot the server + dashboard ──
+    up_p = sub.add_parser("up", help="Start the Ghost server + dashboard")
+    up_p.add_argument("--host", default=None, help="Bind host (default 127.0.0.1; use 0.0.0.0 to expose on your LAN)")
+    up_p.add_argument("--port", type=int, default=None, help="Bind port (default from settings)")
+
+    # ── doctor subcommand — environment preflight ──
+    sub.add_parser("doctor", help="Check your environment (adb, ports, deps, LLM keys)")
+
+    # ── login subcommand — Claude subscription sign-in (no API key) ──
+    login_p = sub.add_parser("login", help="Sign in via your Claude subscription (no API key needed)")
+    login_p.add_argument("--relogin", action="store_true", help="Force re-authentication even if already signed in")
+
+    args = parser.parse_args(argv)
 
     if args.command is None:
         parser.print_help()
         return 0
+
+    if args.command == "login":
+        return cmd_login(args)
+
+    if args.command == "up":
+        return cmd_up(args)
+
+    if args.command == "doctor":
+        return cmd_doctor(args)
 
     if args.command == "skill":
         if args.skill_command is None:

--- a/gitd/config.py
+++ b/gitd/config.py
@@ -1,10 +1,15 @@
 """
 Pydantic-settings configuration — reads from .env / environment variables.
+Compatible with both pydantic v1 and v2.
 """
 
 from pathlib import Path
 
-from pydantic_settings import BaseSettings
+try:
+    from pydantic_settings import BaseSettings
+except ImportError:
+    # pydantic v1 fallback — BaseSettings was in pydantic directly
+    from pydantic import BaseSettings
 
 
 class Settings(BaseSettings):
@@ -21,6 +26,27 @@ class Settings(BaseSettings):
     # ── Devices ──────────────────────────────────────────────────────────────
     default_device: str = ""  # ADB serial of primary phone (auto-detected if empty)
 
+    # ── iOS (feature-gated) ──────────────────────────────────────────────────
+    # iOS support (Appium/WebDriverAgent) ships dev-only for one release cycle:
+    # OFF by default, so `ios:` device refs surface "not supported" errors and
+    # iOS devices are excluded from discovery. Enable with GITD_ENABLE_IOS=1
+    # (or ios_platform_enabled=true in .env). Flip the default once device
+    # testing passes.
+    ios_platform_enabled: bool = False
+
+    # ── Perception ───────────────────────────────────────────────────────────
+    # After a UI action, append a before/after accessibility-tree diff to the
+    # tool result so the model sees what its action changed (additive perception
+    # aid). ON by default; set A11Y_DIFF_ENABLED=false to disable (kill-switch) —
+    # the diff costs one extra UI-tree dump per UI action.
+    a11y_diff_enabled: bool = True
+
+    # ── LLM ──────────────────────────────────────────────────────────────────
+    # Provider used when a session is created without an explicit one. Defaults
+    # to claude-code (Claude subscription, no API key) — `android-agent login`
+    # records this in .env.
+    default_provider: str = "claude-code"
+
     # ── API keys (optional, loaded from env) ─────────────────────────────────
     openai_api_key: str = ""
     anthropic_api_key: str = ""
@@ -29,11 +55,18 @@ class Settings(BaseSettings):
     # ── Ollama ──────────────────────────────────────────────────────────────
     ollama_base_url: str = "http://localhost:11434"
 
-    model_config = {
-        "env_file": ".env",
-        "env_file_encoding": "utf-8",
-        "extra": "ignore",
-    }
+    # ── vLLM (OpenAI-compatible, remote GPU) ────────────────────────────────────
+    # Default assumes a chained tunnel:
+    #   phone:8000 → adb reverse → mac:8000 → ssh -L 8000:localhost:8000 <your-gpu-host>
+    # On the Mac dev backend, the same URL works directly because the ssh
+    # tunnel is already on `localhost`. Override via env GITD_VLLM_BASE_URL.
+    vllm_base_url: str = "http://127.0.0.1:8000/v1"
+    vllm_api_key: str = "EMPTY"  # vLLM doesn't enforce auth; placeholder for OpenAI client
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+        extra = "ignore"
 
 
 settings = Settings()

--- a/gitd/db.py
+++ b/gitd/db.py
@@ -1,0 +1,784 @@
+"""Compatibility shim: gitd.db — raw SQLite helpers for TikTok bots.
+
+The bots in internal/ghost_premium/bots/tiktok/ were written against the old
+gitd.db module (Flask era). This shim re-exposes the same function signatures
+so those bots can import without modification.
+
+Only the functions actually imported by the bots are included. Do not add more
+unless a new bot import requires it.
+"""
+
+import json
+import re
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+DEFAULT_DB = Path(__file__).resolve().parents[1] / "data" / "gitd.db"
+
+
+def get_connection(db_path: Path = DEFAULT_DB) -> sqlite3.Connection:
+    db_path = Path(db_path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+    return conn
+
+
+def create_tables(conn: sqlite3.Connection):
+    conn.executescript("""
+    CREATE TABLE IF NOT EXISTS influencers (
+        id              INTEGER PRIMARY KEY AUTOINCREMENT,
+        handle          TEXT    NOT NULL UNIQUE,
+        display_name    TEXT,
+        platform        TEXT    DEFAULT 'TikTok',
+        profile_url     TEXT,
+        followers       INTEGER,
+        following       INTEGER,
+        total_likes     INTEGER,
+        bio             TEXT,
+        niche           TEXT,
+        pet_focus       TEXT,
+        caption         TEXT,
+        top_views       TEXT,
+        avg_views       TEXT,
+        num_videos      TEXT,
+        screenshot_path TEXT,
+        source_query    TEXT,
+        scraped_at      TEXT,
+        created_at      TEXT    DEFAULT (datetime('now')),
+        updated_at      TEXT    DEFAULT (datetime('now'))
+    );
+
+    CREATE TABLE IF NOT EXISTS outreach_strategies (
+        id               INTEGER PRIMARY KEY AUTOINCREMENT,
+        name             TEXT    NOT NULL,
+        description      TEXT,
+        message_template TEXT,
+        is_active        INTEGER DEFAULT 1,
+        created_at       TEXT    DEFAULT (datetime('now'))
+    );
+
+    CREATE TABLE IF NOT EXISTS outreach_log (
+        id              INTEGER PRIMARY KEY AUTOINCREMENT,
+        influencer_id   INTEGER NOT NULL REFERENCES influencers(id),
+        strategy_id     INTEGER REFERENCES outreach_strategies(id),
+        status          TEXT    DEFAULT 'not_contacted',
+        deal_status     TEXT,
+        contacted_at    TEXT,
+        notes           TEXT,
+        source          TEXT    DEFAULT 'bot',
+        source_account  TEXT,
+        created_at      TEXT    DEFAULT (datetime('now')),
+        updated_at      TEXT    DEFAULT (datetime('now'))
+    );
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_outreach_influencer
+        ON outreach_log(influencer_id);
+
+    CREATE TABLE IF NOT EXISTS crawl_runs (
+        id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+        run_hex             TEXT,
+        name                TEXT,
+        labels              TEXT    DEFAULT '[]',
+        query               TEXT,
+        tab                 TEXT    DEFAULT 'top',
+        started_at          TEXT,
+        ended_at            TEXT,
+        tiles_processed     INTEGER DEFAULT 0,
+        influencers_new     INTEGER DEFAULT 0,
+        influencers_known   INTEGER DEFAULT 0
+    );
+
+    CREATE TABLE IF NOT EXISTS influencer_labels (
+        influencer_id   INTEGER NOT NULL REFERENCES influencers(id) ON DELETE CASCADE,
+        label           TEXT    NOT NULL,
+        PRIMARY KEY (influencer_id, label)
+    );
+
+    CREATE TABLE IF NOT EXISTS content_videos (
+        id              INTEGER PRIMARY KEY AUTOINCREMENT,
+        video_id        INTEGER UNIQUE,
+        filename        TEXT    NOT NULL UNIQUE,
+        original_path   TEXT,
+        source          TEXT    DEFAULT 'other',
+        video_type      TEXT,
+        template_key    TEXT,
+        handle          TEXT,
+        prompt_name     TEXT,
+        input_image     TEXT,
+        pet_type        TEXT,
+        pet_name        TEXT,
+        account_vibe    TEXT,
+        follower_tier   TEXT,
+        followers       INTEGER,
+        width           INTEGER,
+        height          INTEGER,
+        orientation     TEXT,
+        file_size_mb    REAL,
+        file_mtime      TEXT,
+        content_plan_id INTEGER,
+        agent_run_id    INTEGER,
+        source_account  TEXT,
+        status          TEXT    DEFAULT 'ready',
+        created_at      TEXT    DEFAULT (datetime('now')),
+        updated_at      TEXT    DEFAULT (datetime('now'))
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_cv_handle  ON content_videos(handle);
+    CREATE INDEX IF NOT EXISTS idx_cv_status  ON content_videos(status);
+
+    CREATE TABLE IF NOT EXISTS content_posts (
+        id              INTEGER PRIMARY KEY AUTOINCREMENT,
+        video_id        INTEGER NOT NULL REFERENCES content_videos(id) ON DELETE CASCADE,
+        action          TEXT    NOT NULL,
+        caption_used    TEXT,
+        hashtags_used   TEXT,
+        device          TEXT,
+        source_account  TEXT,
+        inject_tts      INTEGER DEFAULT 0,
+        status          TEXT    DEFAULT 'uploading',
+        draft_upload_at TEXT,
+        draft_position  INTEGER,
+        draft_tag       TEXT,
+        published_at    TEXT,
+        tiktok_video_id TEXT,
+        tiktok_url      TEXT,
+        views           INTEGER,
+        likes           INTEGER,
+        comments        INTEGER,
+        shares          INTEGER,
+        last_scraped_at TEXT,
+        notes           TEXT,
+        created_at      TEXT    DEFAULT (datetime('now')),
+        updated_at      TEXT    DEFAULT (datetime('now'))
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_cp_video_id ON content_posts(video_id);
+    CREATE INDEX IF NOT EXISTS idx_cp_status   ON content_posts(status);
+
+    CREATE TABLE IF NOT EXISTS tiktok_accounts (
+        handle          TEXT PRIMARY KEY,
+        display_name    TEXT,
+        phone_serial    TEXT,
+        niche           TEXT,
+        is_default      INTEGER DEFAULT 0,
+        is_active       INTEGER DEFAULT 1,
+        notes           TEXT,
+        created_at      TEXT DEFAULT (datetime('now'))
+    );
+
+    CREATE TABLE IF NOT EXISTS inbox_snapshots (
+        id              INTEGER PRIMARY KEY AUTOINCREMENT,
+        scanned_at      TEXT NOT NULL,
+        total           INTEGER DEFAULT 0,
+        reply_count     INTEGER DEFAULT 0,
+        seen_count      INTEGER DEFAULT 0,
+        sent_count      INTEGER DEFAULT 0,
+        failed_count    INTEGER DEFAULT 0,
+        new_replies     INTEGER DEFAULT 0,
+        device          TEXT,
+        account         TEXT
+    );
+
+    CREATE TABLE IF NOT EXISTS inbox_replies (
+        id              INTEGER PRIMARY KEY AUTOINCREMENT,
+        handle          TEXT NOT NULL UNIQUE,
+        last_msg        TEXT,
+        status          TEXT DEFAULT 'reply',
+        unread          INTEGER DEFAULT 0,
+        influencer_id   INTEGER REFERENCES influencers(id),
+        outreach_updated INTEGER DEFAULT 0,
+        needs_reply     INTEGER DEFAULT 1,
+        first_seen_at   TEXT NOT NULL,
+        last_seen_at    TEXT NOT NULL,
+        snapshot_id     INTEGER REFERENCES inbox_snapshots(id)
+    );
+
+    CREATE TABLE IF NOT EXISTS post_analytics (
+        id               INTEGER PRIMARY KEY AUTOINCREMENT,
+        content_post_id  INTEGER REFERENCES content_posts(id),
+        account          TEXT,
+        post_index       INTEGER,
+        posted_on        TEXT,
+        video_views      INTEGER,
+        likes            INTEGER,
+        comments         INTEGER,
+        shares           INTEGER,
+        bookmarks        INTEGER,
+        avg_watch_time   TEXT,
+        watched_full_pct TEXT,
+        new_followers    INTEGER,
+        traffic_sources_json TEXT,
+        viewers_json     TEXT,
+        engagement_json  TEXT,
+        scraped_at       TEXT NOT NULL,
+        UNIQUE(content_post_id, scraped_at)
+    );
+    """)
+    conn.commit()
+
+    # Soft migrations — ignore if column already exists
+    for migration in [
+        "ALTER TABLE outreach_log ADD COLUMN source TEXT DEFAULT 'bot'",
+        "ALTER TABLE outreach_log ADD COLUMN source_account TEXT",
+        "ALTER TABLE content_videos ADD COLUMN content_plan_id INTEGER",
+        "ALTER TABLE content_videos ADD COLUMN agent_run_id INTEGER",
+        "ALTER TABLE content_videos ADD COLUMN source_account TEXT",
+        "ALTER TABLE content_posts ADD COLUMN source_account TEXT",
+        "ALTER TABLE content_posts ADD COLUMN draft_tag TEXT",
+        "ALTER TABLE inbox_snapshots ADD COLUMN account TEXT",
+    ]:
+        try:
+            conn.execute(migration)
+            conn.commit()
+        except sqlite3.OperationalError:
+            pass
+
+
+# ── Internal helpers ──────────────────────────────────────────────────────────
+
+def _now() -> str:
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _parse_int(val) -> int | None:
+    if val is None or str(val).strip() in ("", "-"):
+        return None
+    s = str(val).strip().upper().replace(",", "")
+    try:
+        if s.endswith("K"):
+            return int(float(s[:-1]) * 1_000)
+        if s.endswith("M"):
+            return int(float(s[:-1]) * 1_000_000)
+        if s.endswith("B"):
+            return int(float(s[:-1]) * 1_000_000_000)
+        return int(float(s))
+    except (ValueError, TypeError):
+        return None
+
+
+def _parse_metric(val) -> int | None:
+    if not val:
+        return None
+    val = str(val).replace(",", "").strip()
+    if not val:
+        return None
+    m = re.match(r"^([\d.]+)([KMB]?)$", val, re.IGNORECASE)
+    if not m:
+        return _parse_int(val)
+    num = float(m.group(1))
+    suffix = m.group(2).upper()
+    if suffix == "K":
+        return int(num * 1_000)
+    if suffix == "M":
+        return int(num * 1_000_000)
+    if suffix == "B":
+        return int(num * 1_000_000_000)
+    return int(num)
+
+
+# ── Influencers ───────────────────────────────────────────────────────────────
+
+def get_influencer_id(conn: sqlite3.Connection, handle: str) -> int | None:
+    row = conn.execute(
+        "SELECT id FROM influencers WHERE handle = ?", (handle.strip(),)
+    ).fetchone()
+    return row["id"] if row else None
+
+
+def upsert_influencer(conn: sqlite3.Connection, row: dict,
+                      labels: list | None = None) -> int | None:
+    handle = (row.get("handle") or "").strip()
+    if not handle:
+        return None
+    followers = _parse_int(row.get("followers") or row.get("followers_n"))
+    following = _parse_int(row.get("following") or row.get("following_n"))
+    total_likes = _parse_int(row.get("total_likes") or row.get("likes") or row.get("likes_n"))
+    conn.execute("""
+        INSERT INTO influencers
+            (handle, display_name, platform, profile_url,
+             followers, following, total_likes,
+             bio, niche, pet_focus, caption, top_views,
+             avg_views, num_videos, screenshot_path,
+             source_query, scraped_at, updated_at)
+        VALUES
+            (:handle, :display_name, :platform, :profile_url,
+             :followers, :following, :total_likes,
+             :bio, :niche, :pet_focus, :caption, :top_views,
+             :avg_views, :num_videos, :screenshot_path,
+             :source_query, :scraped_at, :updated_at)
+        ON CONFLICT(handle) DO UPDATE SET
+            display_name    = COALESCE(excluded.display_name,    display_name),
+            followers       = COALESCE(excluded.followers,       followers),
+            following       = COALESCE(excluded.following,       following),
+            total_likes     = COALESCE(excluded.total_likes,     total_likes),
+            bio             = COALESCE(excluded.bio,             bio),
+            niche           = COALESCE(excluded.niche,           niche),
+            pet_focus       = COALESCE(excluded.pet_focus,       pet_focus),
+            caption         = COALESCE(excluded.caption,         caption),
+            top_views       = COALESCE(excluded.top_views,       top_views),
+            avg_views       = COALESCE(excluded.avg_views,       avg_views),
+            num_videos      = COALESCE(excluded.num_videos,      num_videos),
+            screenshot_path = COALESCE(excluded.screenshot_path, screenshot_path),
+            source_query    = COALESCE(excluded.source_query,    source_query),
+            scraped_at      = COALESCE(excluded.scraped_at,      scraped_at),
+            updated_at      = :updated_at
+    """, {
+        "handle":          handle,
+        "display_name":    row.get("display_name") or None,
+        "platform":        row.get("platform") or "TikTok",
+        "profile_url":     row.get("profile_url") or None,
+        "followers":       followers,
+        "following":       following,
+        "total_likes":     total_likes,
+        "bio":             row.get("bio") or None,
+        "niche":           row.get("niche") or None,
+        "pet_focus":       row.get("pet_focus") or None,
+        "caption":         row.get("caption") or None,
+        "top_views":       row.get("top_views") or None,
+        "avg_views":       row.get("avg_views") or None,
+        "num_videos":      row.get("num_videos") or None,
+        "screenshot_path": row.get("screenshot") or row.get("screenshot_path") or None,
+        "source_query":    row.get("query") or row.get("source_query") or None,
+        "scraped_at":      row.get("scraped_at") or None,
+        "updated_at":      _now(),
+    })
+    conn.commit()
+    inf_id = get_influencer_id(conn, handle)
+    if inf_id and labels:
+        for label in labels:
+            try:
+                conn.execute(
+                    "INSERT OR IGNORE INTO influencer_labels (influencer_id, label) VALUES (?, ?)",
+                    (inf_id, label),
+                )
+            except sqlite3.Error:
+                pass
+        conn.commit()
+    return inf_id
+
+
+# ── Outreach ──────────────────────────────────────────────────────────────────
+
+def upsert_outreach(conn: sqlite3.Connection, influencer_id: int,
+                    status: str = "not_contacted",
+                    strategy_id: int | None = None,
+                    deal_status: str | None = None,
+                    notes: str | None = None,
+                    contacted_at: str | None = None,
+                    source: str = "bot",
+                    source_account: str | None = None):
+    now = _now()
+    existing = conn.execute(
+        "SELECT id FROM outreach_log WHERE influencer_id = ?", (influencer_id,)
+    ).fetchone()
+    if existing:
+        conn.execute("""
+            UPDATE outreach_log SET
+                status         = ?,
+                strategy_id    = COALESCE(?, strategy_id),
+                deal_status    = COALESCE(?, deal_status),
+                notes          = COALESCE(?, notes),
+                contacted_at   = COALESCE(?, contacted_at),
+                source         = ?,
+                source_account = COALESCE(?, source_account),
+                updated_at     = ?
+            WHERE influencer_id = ?
+        """, (status, strategy_id, deal_status, notes, contacted_at,
+              source, source_account, now, influencer_id))
+    else:
+        conn.execute("""
+            INSERT INTO outreach_log
+                (influencer_id, strategy_id, status, deal_status, notes,
+                 contacted_at, source, source_account, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """, (influencer_id, strategy_id, status, deal_status, notes,
+              contacted_at, source, source_account, now, now))
+    conn.commit()
+
+
+def get_all_strategies(conn: sqlite3.Connection) -> list[dict]:
+    rows = conn.execute(
+        "SELECT * FROM outreach_strategies WHERE is_active = 1 ORDER BY id"
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def seed_default_strategies(conn: sqlite3.Connection):
+    existing = conn.execute("SELECT COUNT(*) FROM outreach_strategies").fetchone()[0]
+    if existing:
+        return
+    conn.executemany(
+        "INSERT INTO outreach_strategies (name, description, message_template) VALUES (?, ?, ?)",
+        [
+            ("Generic friendly",
+             "Friendly intro template — customize for your use case",
+             "Hi {name}! Reaching out about a collab — let me know if interested."),
+            ("Generic collab",
+             "Direct collaboration ask — replace with your own messaging",
+             "Hey {name}! Would you be open to a small collab? Happy to share details."),
+        ],
+    )
+    conn.commit()
+
+
+# ── Crawl runs ────────────────────────────────────────────────────────────────
+
+def create_crawl_run(conn: sqlite3.Connection, run_hex: str,
+                     name: str | None, labels: list,
+                     query: str, tab: str) -> int:
+    cur = conn.execute("""
+        INSERT INTO crawl_runs (run_hex, name, labels, query, tab, started_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+    """, (run_hex, name or None, json.dumps(labels or []), query, tab, _now()))
+    conn.commit()
+    return cur.lastrowid
+
+
+def update_crawl_run(conn: sqlite3.Connection, run_id: int,
+                     tiles_processed: int = 0,
+                     influencers_new: int = 0,
+                     influencers_known: int = 0):
+    conn.execute("""
+        UPDATE crawl_runs
+        SET ended_at=?, tiles_processed=?, influencers_new=?, influencers_known=?
+        WHERE id=?
+    """, (_now(), tiles_processed, influencers_new, influencers_known, run_id))
+    conn.commit()
+
+
+# ── Content posts ─────────────────────────────────────────────────────────────
+
+def create_content_post(conn: sqlite3.Connection, video_id: int, action: str,
+                        caption: str = "", hashtags: str = "", device: str = "",
+                        inject_tts: bool = False,
+                        draft_position: int | None = None) -> int:
+    cur = conn.execute("""
+        INSERT INTO content_posts
+            (video_id, action, caption_used, hashtags_used, device, inject_tts,
+             status, draft_position)
+        VALUES (?, ?, ?, ?, ?, ?, 'uploading', ?)
+    """, (video_id, action, caption or None, hashtags or None,
+          device or None, 1 if inject_tts else 0, draft_position))
+    conn.commit()
+    return cur.lastrowid
+
+
+def update_content_post(conn: sqlite3.Connection, post_id: int, **kwargs):
+    kwargs["updated_at"] = _now()
+    sets = ", ".join(f"{k} = :{k}" for k in kwargs)
+    kwargs["post_id"] = post_id
+    conn.execute(f"UPDATE content_posts SET {sets} WHERE id = :post_id", kwargs)
+    conn.commit()
+
+
+def update_content_video_status(conn: sqlite3.Connection, vid_id: int, status: str):
+    conn.execute(
+        "UPDATE content_videos SET status = ?, updated_at = ? WHERE id = ?",
+        (status, _now(), vid_id),
+    )
+    conn.commit()
+
+
+# ── Post analytics ────────────────────────────────────────────────────────────
+
+def save_post_analytics(conn: sqlite3.Connection, post_data: dict,
+                        account: str | None = None,
+                        post_index: int | None = None) -> int:
+    now = _now()
+    posted_on = post_data.get("posted_on", "")
+
+    cp_id = None
+    if posted_on:
+        _clean = posted_on.replace("Posted on", "").strip()
+        iso_prefix = None
+        for fmt in ("%b %d, %Y, %I:%M %p", "%b %d,%Y,%I:%M%p",
+                    "%b %d, %Y, %I:%M%p", "%b %d,%Y, %I:%M %p"):
+            try:
+                dt = datetime.strptime(_clean, fmt)
+                iso_prefix = dt.strftime("%Y-%m-%d %H:%M")
+                break
+            except ValueError:
+                continue
+        if iso_prefix:
+            acct_clause = "AND source_account = ?" if account else ""
+            params = (f"{iso_prefix}%",) + ((account,) if account else ())
+            row = conn.execute(
+                f"SELECT id FROM content_posts WHERE published_at LIKE ? {acct_clause} ORDER BY id DESC LIMIT 1",
+                params,
+            ).fetchone()
+            if row:
+                cp_id = row[0]
+                conn.execute("""
+                    UPDATE content_posts SET
+                        views=?, likes=?, comments=?, shares=?, last_scraped_at=?
+                    WHERE id=?
+                """, (_parse_metric(post_data.get("video_views")),
+                      _parse_metric(post_data.get("likes")),
+                      _parse_metric(post_data.get("comments")),
+                      _parse_metric(post_data.get("shares")),
+                      now, cp_id))
+
+    cur = conn.execute("""
+        INSERT INTO post_analytics
+            (posted_on, post_index, content_post_id, account,
+             video_views, likes, comments, shares, bookmarks,
+             avg_watch_time, watched_full_pct, new_followers,
+             traffic_sources_json, viewers_json, engagement_json, scraped_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    """, (posted_on, post_index, cp_id, account,
+          _parse_metric(post_data.get("video_views")),
+          _parse_metric(post_data.get("likes")),
+          _parse_metric(post_data.get("comments")),
+          _parse_metric(post_data.get("shares")),
+          _parse_metric(post_data.get("bookmarks")),
+          post_data.get("avg_watch_time"),
+          post_data.get("watched_full_pct"),
+          _parse_metric(post_data.get("new_followers")),
+          json.dumps(post_data.get("traffic_sources", {})),
+          json.dumps(post_data.get("viewers", {})),
+          json.dumps(post_data.get("engagement", {})),
+          now))
+    conn.commit()
+    return cur.lastrowid
+
+
+# ── Inbox snapshots ──────────────────────────────────────────────────────────
+
+def save_inbox_snapshot(conn: sqlite3.Connection, result: dict,
+                        device: str | None = None,
+                        account: str | None = None) -> int:
+    """Persist inbox scan results. Returns snapshot_id.
+
+    result = {replies: [{handle, last_msg, unread, time_str}],
+              seen: [...], sent: int, failed: int, total: int}
+    """
+    now = _now()
+    new_replies = 0
+
+    cur = conn.execute("""
+        INSERT INTO inbox_snapshots
+            (scanned_at, total, reply_count, seen_count, sent_count, failed_count, device, account)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    """, (now, result["total"], len(result["replies"]), len(result.get("seen", [])),
+          result["sent"], result["failed"], device, account))
+    snap_id = cur.lastrowid
+
+    for entry in result["replies"]:
+        handle = entry["handle"]
+        existing = conn.execute(
+            "SELECT id FROM inbox_replies WHERE handle = ?", (handle,)
+        ).fetchone()
+
+        inf_id = get_influencer_id(conn, handle)
+        outreach_upd = 0
+        if inf_id:
+            try:
+                upsert_outreach(conn, inf_id, status="replied", source="inbox_scan")
+                outreach_upd = 1
+            except Exception:
+                pass
+
+        if existing:
+            conn.execute("""
+                UPDATE inbox_replies SET last_msg=?, status='reply', unread=?,
+                    last_seen_at=?, snapshot_id=?, influencer_id=COALESCE(?, influencer_id),
+                    outreach_updated=MAX(outreach_updated, ?)
+                WHERE handle=?
+            """, (entry["last_msg"], entry.get("unread", 0), now, snap_id,
+                  inf_id, outreach_upd, handle))
+        else:
+            new_replies += 1
+            conn.execute("""
+                INSERT INTO inbox_replies
+                    (handle, last_msg, status, unread, influencer_id, outreach_updated,
+                     needs_reply, first_seen_at, last_seen_at, snapshot_id)
+                VALUES (?, ?, 'reply', ?, ?, ?, 1, ?, ?, ?)
+            """, (handle, entry["last_msg"], entry.get("unread", 0),
+                  inf_id, outreach_upd, now, now, snap_id))
+
+    for entry in result.get("seen", []):
+        handle = entry["handle"]
+        existing = conn.execute(
+            "SELECT id, status FROM inbox_replies WHERE handle = ?", (handle,)
+        ).fetchone()
+        inf_id = get_influencer_id(conn, handle)
+
+        if existing:
+            if existing["status"] != "reply":
+                conn.execute("""
+                    UPDATE inbox_replies SET last_msg=?, unread=?,
+                        last_seen_at=?, snapshot_id=?, influencer_id=COALESCE(?, influencer_id)
+                    WHERE handle=?
+                """, (entry["last_msg"], entry.get("unread", 0), now, snap_id, inf_id, handle))
+        else:
+            conn.execute("""
+                INSERT INTO inbox_replies
+                    (handle, last_msg, status, unread, influencer_id, outreach_updated,
+                     needs_reply, first_seen_at, last_seen_at, snapshot_id)
+                VALUES (?, ?, 'seen', ?, ?, 0, 0, ?, ?, ?)
+            """, (handle, entry["last_msg"], entry.get("unread", 0),
+                  inf_id, now, now, snap_id))
+
+    conn.execute("UPDATE inbox_snapshots SET new_replies=? WHERE id=?", (new_replies, snap_id))
+    conn.commit()
+    print(f"[db] Inbox snapshot #{snap_id}: {result['total']} total, "
+          f"{len(result['replies'])} replies ({new_replies} new), "
+          f"{len(result.get('seen', []))} seen")
+    return snap_id
+
+# ─────────────────────────────────────────────────────────────────────
+# Marketing agent / content plan / styles support (added 2026-05-28)
+# ─────────────────────────────────────────────────────────────────────
+
+def generate_themes_catalog(conn: sqlite3.Connection) -> list[dict]:
+    """Generate compact catalog for agent context (no full prompts)."""
+    rows = conn.execute(
+        'SELECT id, display_name, category, description '
+        'FROM styles WHERE is_active=1 ORDER BY id'
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def generate_images_catalog(conn: sqlite3.Connection) -> list[dict]:
+    """Compact catalog for agent context."""
+    rows = conn.execute(
+        'SELECT id, pet_type, pet_name, description, source_handle '
+        'FROM input_images WHERE is_active=1 AND public_url IS NOT NULL AND public_url <> "" '
+        'ORDER BY id'
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def get_style(conn: sqlite3.Connection, style_id: str) -> dict | None:
+    row = conn.execute('SELECT * FROM styles WHERE id=?', (style_id,)).fetchone()
+    return dict(row) if row else None
+
+
+def create_content_plan(conn: sqlite3.Connection, **kwargs) -> int:
+    now = _now()
+    kwargs.setdefault('created_at', now)
+    kwargs.setdefault('updated_at', now)
+    kwargs.setdefault('status', 'planned')
+    cols = ', '.join(kwargs.keys())
+    placeholders = ', '.join(f':{k}' for k in kwargs.keys())
+    cur = conn.execute(f'INSERT INTO content_plan ({cols}) VALUES ({placeholders})', kwargs)
+    conn.commit()
+    return cur.lastrowid
+
+
+def update_content_plan(conn: sqlite3.Connection, plan_id: int, **kwargs):
+    if not kwargs:
+        return
+    kwargs['updated_at'] = _now()
+    sets = ', '.join(f'{k}=?' for k in kwargs)
+    conn.execute(f'UPDATE content_plan SET {sets} WHERE id=?', (*kwargs.values(), plan_id))
+    conn.commit()
+
+
+def create_agent_run(conn: sqlite3.Connection, **kwargs) -> int:
+    now = _now()
+    kwargs.setdefault('created_at', now)
+    kwargs.setdefault('status', 'running')
+    cols = ', '.join(kwargs.keys())
+    placeholders = ', '.join(f':{k}' for k in kwargs.keys())
+    cur = conn.execute(f'INSERT INTO agent_runs ({cols}) VALUES ({placeholders})', kwargs)
+    conn.commit()
+    return cur.lastrowid
+
+
+def update_agent_run(conn: sqlite3.Connection, run_id: int, **kwargs):
+    if not kwargs:
+        return
+    sets = ', '.join(f'{k}=?' for k in kwargs)
+    conn.execute(f'UPDATE agent_runs SET {sets} WHERE id=?', (*kwargs.values(), run_id))
+    conn.commit()
+
+
+def sync_styles_from_prompts_ts(conn: sqlite3.Connection,
+                                prompts_ts_path: str | Path | None = None):
+    """Parse prompts.ts and upsert all templates into styles table.
+    Preserves manual edits to description/category/tags — only updates
+    prompt_text + inputs on sync."""
+    import re as _re
+    if prompts_ts_path is None:
+        prompts_ts_path = Path(__file__).resolve().parent / 'functions' / 'src' / 'prompts.ts'
+    content = Path(prompts_ts_path).read_text()
+    now = _now()
+    count = 0
+
+    for m in _re.finditer(r'\[GenerationTemplateName\.(\w+)\]:\s*\{', content):
+        enum_name = m.group(1)
+        start = m.end()
+        depth = 1; pos = start
+        while pos < len(content) and depth > 0:
+            if   content[pos] == '{': depth += 1
+            elif content[pos] == '}': depth -= 1
+            pos += 1
+        block = content[start:pos - 1]
+
+        pm = _re.search(r'prompt:\s*"((?:[^"\\]|\\.)*)"', block)
+        prompt = pm.group(1).replace('\\"', '"') if pm else ''
+
+        inputs = []
+        if 'inputs:' in block:
+            for im in _re.finditer(
+                r'\{[^}]*?label:\s*[\'"](\w+)[\'"]'
+                r'(?:[^}]*?templateString:\s*[\'"]([^\'"]*)[\'"])?'
+                r'(?:[^}]*?fallbackString:\s*[\'"]([^\'"]*)[\'"])?[^}]*?\}',
+                block, _re.DOTALL
+            ):
+                inputs.append({
+                    'label':          im.group(1),
+                    'templateString': im.group(2) or '',
+                    'fallbackString': im.group(3) or '',
+                })
+            seen: set = set()
+            inputs = [i for i in inputs if not (i['label'] in seen or seen.add(i['label']))]
+
+        key = _enum_to_key(enum_name)
+        display = _enum_to_display(enum_name)
+        inputs_json = json.dumps(inputs) if inputs else '[]'
+
+        conn.execute("""
+            INSERT INTO styles (id, display_name, prompt_text, inputs_json, synced_from_website_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                prompt_text = excluded.prompt_text,
+                inputs_json = excluded.inputs_json,
+                display_name = CASE WHEN styles.display_name = '' OR styles.display_name IS NULL
+                                    THEN excluded.display_name ELSE styles.display_name END,
+                synced_from_website_at = excluded.synced_from_website_at,
+                updated_at = excluded.updated_at
+        """, (key, display, prompt, inputs_json, now, now))
+        count += 1
+
+    conn.commit()
+    print(f'[db] Synced {count} styles from prompts.ts')
+    return count
+
+
+def upsert_gen_job(conn: sqlite3.Connection, task_id: str, *,
+                   template_key: str = '', image_url: str = '',
+                   prompt_used: str = '', aspect: str = '9:16',
+                   status: str = 'pending', output_url: str | None = None,
+                   output_filename: str | None = None,
+                   error_msg: str | None = None) -> None:
+    now = _now()
+    conn.execute("""
+        INSERT INTO gen_jobs
+            (task_id, template_key, image_url, prompt_used, aspect,
+             status, output_url, output_filename, error_msg, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(task_id) DO UPDATE SET
+            status          = excluded.status,
+            output_url      = COALESCE(excluded.output_url,      output_url),
+            output_filename = COALESCE(excluded.output_filename, output_filename),
+            error_msg       = COALESCE(excluded.error_msg,       error_msg),
+            updated_at      = excluded.updated_at
+    """, (task_id, template_key, image_url, prompt_used, aspect,
+          status, output_url, output_filename, error_msg, now, now))
+    conn.commit()

--- a/gitd/ghost_cli.py
+++ b/gitd/ghost_cli.py
@@ -1,0 +1,209 @@
+"""The ``ghost`` CLI entry point — task-first dispatch.
+
+Grammar: a **bare positional** is an agent task (``ghost "check reddit" --device
+asus``); a **reserved first token** is a subcommand (``ghost devices``, ``ghost
+skill run …``). Reserved wins, so quote a task whose first word is a reserved verb
+(``ghost "record my day"``). ``--`` forces prompt mode.
+
+Kept thin: legacy subcommands (``up``/``doctor``/``login``/``skill``) delegate to
+the existing ``gitd.cli`` handlers; the prompt path delegates to
+``agent_chat.chat_turn`` via :mod:`gitd.ghostcli.run`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from gitd.ghostcli import config as gcfg
+from gitd.ghostcli import devices as gdev
+from gitd.ghostcli import mcp as gmcp
+from gitd.ghostcli import resolve as gres
+from gitd.ghostcli import run as grun
+from gitd.ghostcli import wizard as gwiz
+
+# Subcommands whose first token routes away from the prompt path.
+_LEGACY = ("up", "doctor", "login", "skill")  # handled by gitd.cli
+_LOCAL = ("devices", "setup", "configure", "config", "mcp")  # handled here
+RESERVED = (*_LEGACY, *_LOCAL, "help")
+
+
+def _split_leading(argv: list[str]) -> list[str]:
+    """Tokens before the first ``-``-prefixed flag."""
+    out: list[str] = []
+    for tok in argv:
+        if tok.startswith("-"):
+            break
+        out.append(tok)
+    return out
+
+
+# ── local subcommand handlers ────────────────────────────────────────────────
+
+
+def _cmd_devices(_rest: list[str]) -> int:
+    rows = gdev.list_for_display()
+    if not rows:
+        print("No devices connected.")
+        return 0
+    aliases = gcfg.load_devices()
+    width = max((len(r["ref"]) for r in rows), default=0)
+    for r in rows:
+        alias = f"  ({r['alias']})" if r["alias"] else ""
+        model = f"  {r['model']}" if r["model"] else ""
+        print(f"{r['ref']:<{width}}{model}{alias}  [{r['platform']}]")
+    if aliases:
+        print(f"\nAliases in {gcfg.devices_path()}: " + ", ".join(f"{k}→{v}" for k, v in aliases.items()))
+    return 0
+
+
+def _cmd_setup(rest: list[str]) -> int:
+    p = argparse.ArgumentParser(prog="ghost setup", add_help=True)
+    p.add_argument("--backend")
+    p.add_argument("--model", default="")
+    p.add_argument("--mode", default="fast")
+    p.add_argument("--device", default="")
+    args = p.parse_args(rest)
+    if args.backend:  # non-interactive
+        cfg = gwiz.apply_noninteractive(backend=args.backend, model=args.model, mode=args.mode, device=args.device)
+        print(f"✓ Wrote {gcfg.config_path()} (backend={cfg['backend']['name']}, mode={cfg['defaults']['mode']}).")
+        return 0
+    if not gwiz.is_interactive():
+        print("ghost setup needs a terminal, or pass --backend (see 'ghost setup --help').", file=sys.stderr)
+        return 2
+    return 0 if gwiz.run_interactive() is not None else 0
+
+
+def _cmd_config(rest: list[str]) -> int:
+    if not rest:
+        print("usage: ghost config <get <key> | set <key>=<val> | path>", file=sys.stderr)
+        return 2
+    sub, *tail = rest
+    if sub == "path":
+        print(gcfg.config_path())
+        return 0
+    if sub == "get":
+        if not tail:
+            print("usage: ghost config get <key>", file=sys.stderr)
+            return 2
+        try:
+            val = gcfg.get_value(tail[0])
+        except KeyError:
+            print(f"Unknown key '{tail[0]}'. Known: {', '.join(gcfg.known_keys())}", file=sys.stderr)
+            return 2
+        print("" if val is None else val)
+        return 0
+    if sub == "set":
+        if not tail or "=" not in tail[0]:
+            print("usage: ghost config set <key>=<value>", file=sys.stderr)
+            return 2
+        key, value = tail[0].split("=", 1)
+        try:
+            gcfg.set_value(key, value)
+        except KeyError:
+            print(f"Unknown key '{key}'. Known: {', '.join(gcfg.known_keys())}", file=sys.stderr)
+            return 2
+        except ValueError as e:
+            print(str(e), file=sys.stderr)
+            return 2
+        print(f"{key} = {value}")
+        return 0
+    print(f"Unknown config subcommand '{sub}'.", file=sys.stderr)
+    return 2
+
+
+def _cmd_mcp(rest: list[str]) -> int:
+    p = argparse.ArgumentParser(prog="ghost mcp install")
+    p.add_argument("action", choices=["install"])
+    p.add_argument("--client", required=True, choices=list(gmcp.SUPPORTED_CLIENTS))
+    args = p.parse_args(rest)
+    try:
+        print(gmcp.install(args.client))
+    except gmcp.McpInstallError as e:
+        print(str(e), file=sys.stderr)
+        return 1
+    return 0
+
+
+def _delegate_legacy(argv: list[str]) -> int:
+    from gitd import cli as legacy
+
+    return int(legacy.main(argv) or 0)
+
+
+# ── prompt path ──────────────────────────────────────────────────────────────
+
+
+def _run_prompt(prompt: str, flag_argv: list[str]) -> int:
+    p = argparse.ArgumentParser(prog="ghost", add_help=False)
+    p.add_argument("--device", "-d", "--udid", dest="device", default=None)
+    p.add_argument("--mode", default=None)
+    p.add_argument("--backend", default=None)
+    p.add_argument("--model", default=None)
+    try:
+        args, _unknown = p.parse_known_args(flag_argv)
+    except SystemExit:
+        return 2
+
+    # First run with no config + no env + no explicit backend → wizard, then resume.
+    if gres.unconfigured() and not args.backend and gwiz.is_interactive():
+        gwiz.run_interactive()
+
+    try:
+        provider, model = gres.resolve_backend_or_error(args.backend, args.model)
+        mode = gres.resolve_mode(args.mode)
+        device = gdev.resolve_device(args.device)
+        picked = gdev.auto_picked(args.device)
+    except (gres.GhostConfigError, gdev.DeviceError) as e:
+        print(str(e), file=sys.stderr)
+        return 2
+    return grun.run_task(prompt, device, provider, model, mode, auto_picked=picked)
+
+
+_HELP = """ghost — give any AI agent an Android/iOS body.
+
+  ghost "<task>" [--device D] [--mode fast|vision|reason] [--backend B]
+      Run an agent task on a device. Quote the task.
+
+  ghost devices                 List connected devices + aliases
+  ghost setup                   First-run wizard (or --backend for non-interactive)
+  ghost config get|set|path     Read/write ~/.ghost/config.toml
+  ghost mcp install --client claude-code|cursor|codex|opencode|agy
+  ghost up | doctor | login | skill …    (existing commands)
+"""
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if not argv or argv[0] in ("-h", "--help", "help"):
+        print(_HELP)
+        return 0
+
+    # `--` forces prompt mode for a task that starts with a reserved word.
+    if argv[0] == "--":
+        rest = argv[1:]
+        leading = _split_leading(rest)
+        return _run_prompt(" ".join(leading), rest[len(leading) :])
+
+    first = argv[0]
+    if first in _LEGACY:
+        return _delegate_legacy(argv)
+    if first == "devices":
+        return _cmd_devices(argv[1:])
+    if first in ("setup", "configure"):
+        return _cmd_setup(argv[1:])
+    if first == "config":
+        return _cmd_config(argv[1:])
+    if first == "mcp":
+        return _cmd_mcp(argv[1:])
+
+    # Bare positional → agent task.
+    leading = _split_leading(argv)
+    if not leading:
+        print(_HELP)
+        return 0
+    return _run_prompt(" ".join(leading), argv[len(leading) :])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/gitd/ghostcli/config.py
+++ b/gitd/ghostcli/config.py
@@ -1,0 +1,163 @@
+"""``~/.ghost/`` config + device-alias store for the ``ghost`` CLI.
+
+Thin layer over two TOML files, with a strict precedence chain so a flag always
+beats an env var beats the config file beats the built-in default:
+
+    explicit flag  >  GHOST_* env  >  ~/.ghost/config.toml  >  detected default
+
+Files (dir overridable with ``GHOST_CONFIG_DIR`` for tests / non-default homes):
+
+    ~/.ghost/config.toml   [backend] name/model · [defaults] mode/device · [dashboard] port
+    ~/.ghost/devices.toml  [devices] <alias> = "<serial-or-ref>"
+
+Read uses stdlib ``tomllib`` (3.11+); we hand-write TOML on save (the schema is
+flat, so a real TOML writer isn't worth a dependency).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+try:
+    import tomllib  # py3.11+
+except ModuleNotFoundError:  # pragma: no cover - py3.10 fallback
+    import tomli as tomllib  # type: ignore
+
+VALID_MODES = ("fast", "vision", "reason")
+
+
+def ghost_dir() -> Path:
+    """The ``~/.ghost`` directory (overridable via ``GHOST_CONFIG_DIR``)."""
+    override = os.environ.get("GHOST_CONFIG_DIR")
+    return Path(override) if override else Path.home() / ".ghost"
+
+
+def config_path() -> Path:
+    return ghost_dir() / "config.toml"
+
+
+def devices_path() -> Path:
+    return ghost_dir() / "devices.toml"
+
+
+def skills_dir() -> Path:
+    return ghost_dir() / "skills"
+
+
+def logs_dir() -> Path:
+    return ghost_dir() / "logs"
+
+
+def _read_toml(path: Path) -> dict:
+    try:
+        with open(path, "rb") as fh:
+            return tomllib.load(fh)
+    except (FileNotFoundError, ValueError):
+        return {}
+
+
+def load_config() -> dict:
+    return _read_toml(config_path())
+
+
+def load_devices() -> dict[str, str]:
+    """Return the ``{alias: serial}`` map from devices.toml.
+
+    Accepts both the canonical ``[devices]`` section and a bare ``alias = "serial"``
+    file with no header (a common hand-edit) — the latter parses to top-level keys,
+    which would otherwise be silently ignored.
+    """
+    data = _read_toml(devices_path())
+    section = data.get("devices")
+    if not isinstance(section, dict):
+        # No [devices] header: treat top-level string entries as aliases.
+        section = {k: v for k, v in data.items() if isinstance(v, str)}
+    return {str(k): str(v) for k, v in section.items()}
+
+
+def config_exists() -> bool:
+    return config_path().exists()
+
+
+# ── writing ──────────────────────────────────────────────────────────────────
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _dump_toml(data: dict) -> str:
+    """Serialize a shallow ``{section: {key: scalar}}`` dict to TOML text."""
+    lines: list[str] = []
+    for section, body in data.items():
+        if not isinstance(body, dict):
+            continue
+        lines.append(f"[{section}]")
+        for key, value in body.items():
+            if value is None or value == "":
+                continue
+            if isinstance(value, bool):
+                lines.append(f"{key} = {'true' if value else 'false'}")
+            elif isinstance(value, (int, float)):
+                lines.append(f"{key} = {value}")
+            else:
+                lines.append(f'{key} = "{_toml_escape(str(value))}"')
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def save_config(data: dict) -> Path:
+    path = config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_dump_toml(data), encoding="utf-8")
+    return path
+
+
+def save_devices(devices: dict[str, str]) -> Path:
+    path = devices_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_dump_toml({"devices": devices}), encoding="utf-8")
+    return path
+
+
+def set_device_alias(alias: str, serial: str) -> None:
+    devices = load_devices()
+    devices[alias] = serial
+    save_devices(devices)
+
+
+# ── flat get/set for `ghost config get/set <dotted.key>` ─────────────────────
+
+# Whitelisted dotted keys → (section, key, coercer). Keeps `config set` from
+# writing arbitrary junk into the file.
+_KEYS: dict[str, tuple[str, str, type]] = {
+    "backend.name": ("backend", "name", str),
+    "backend.model": ("backend", "model", str),
+    "defaults.mode": ("defaults", "mode", str),
+    "defaults.device": ("defaults", "device", str),
+    "dashboard.port": ("dashboard", "port", int),
+}
+
+
+def get_value(dotted: str):
+    if dotted not in _KEYS:
+        raise KeyError(dotted)
+    section, key, _ = _KEYS[dotted]
+    return load_config().get(section, {}).get(key)
+
+
+def set_value(dotted: str, raw: str) -> None:
+    if dotted not in _KEYS:
+        raise KeyError(dotted)
+    section, key, coerce = _KEYS[dotted]
+    value = coerce(raw)
+    if dotted == "defaults.mode" and value not in VALID_MODES:
+        raise ValueError(f"mode must be one of {VALID_MODES}")
+    cfg = load_config()
+    cfg.setdefault(section, {})[key] = value
+    save_config(cfg)
+
+
+def known_keys() -> tuple[str, ...]:
+    return tuple(_KEYS)

--- a/gitd/ghostcli/detect.py
+++ b/gitd/ghostcli/detect.py
@@ -1,0 +1,118 @@
+"""Backend / environment detection for the first-run wizard and ``ghost doctor``.
+
+Print-free probes — each returns data so callers (wizard, tests) render it.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+
+
+def _claude_available() -> tuple[bool, str]:
+    path = shutil.which("claude")
+    if not path:
+        return False, "not installed"
+    try:
+        from gitd.cli import _claude_auth_state
+
+        state = _claude_auth_state()
+    except Exception:
+        state = "unknown"
+    if state == "logged_in":
+        return True, path
+    if state == "logged_out":
+        return False, f"{path} (logged out — run 'ghost login')"
+    return bool(path), path
+
+
+def _ollama_models() -> list[str]:
+    try:
+        import requests
+
+        from gitd.config import settings
+
+        base = os.environ.get("OLLAMA_BASE_URL") or settings.ollama_base_url
+        r = requests.get(f"{base.rstrip('/')}/api/tags", timeout=2)
+        if r.ok:
+            return [m["name"] for m in r.json().get("models", []) if m.get("name")]
+    except Exception:
+        pass
+    return []
+
+
+def _api_key(*names: str) -> bool:
+    for n in names:
+        if os.environ.get(n):
+            return True
+    try:
+        from gitd.config import settings
+
+        field = {
+            "ANTHROPIC_API_KEY": "anthropic_api_key",
+            "OPENROUTER_API_KEY": "openrouter_api_key",
+            "OPENAI_API_KEY": "openai_api_key",
+        }
+        for n in names:
+            if n in field and getattr(settings, field[n], ""):
+                return True
+    except Exception:
+        pass
+    return False
+
+
+def detect_backends() -> list[dict]:
+    """Detected LLM backends, in recommended order.
+
+    Each: ``{key, label, available, detail, models}``. ``key`` is a valid
+    provider name (see ``PROVIDERS``) except ``opencode`` (an MCP-client only).
+    """
+    claude_ok, claude_detail = _claude_available()
+    ollama_models = _ollama_models()
+    return [
+        {"key": "claude-code", "label": "Claude Code", "available": claude_ok, "detail": claude_detail, "models": []},
+        {
+            "key": "ollama",
+            "label": "Ollama",
+            "available": bool(ollama_models),
+            "detail": (f"{len(ollama_models)} local models" if ollama_models else "not detected"),
+            "models": ollama_models,
+        },
+        {
+            "key": "openrouter",
+            "label": "OpenRouter",
+            "available": _api_key("OPENROUTER_API_KEY"),
+            "detail": ("$OPENROUTER_API_KEY set" if _api_key("OPENROUTER_API_KEY") else "set $OPENROUTER_API_KEY"),
+            "models": [],
+        },
+        {
+            "key": "anthropic",
+            "label": "Anthropic API",
+            "available": _api_key("ANTHROPIC_API_KEY"),
+            "detail": ("$ANTHROPIC_API_KEY set" if _api_key("ANTHROPIC_API_KEY") else "set $ANTHROPIC_API_KEY"),
+            "models": [],
+        },
+        {
+            "key": "codex",
+            "label": "Codex CLI",
+            "available": bool(shutil.which("codex")),
+            "detail": (shutil.which("codex") or "not detected"),
+            "models": [],
+        },
+        {
+            "key": "opencode",
+            "label": "OpenCode (MCP client)",
+            "available": bool(shutil.which("opencode")),
+            "detail": (shutil.which("opencode") or "not detected"),
+            "models": [],
+        },
+    ]
+
+
+def detect_devices() -> list[str]:
+    try:
+        from gitd.bots.common.device import list_connected_device_refs
+
+        return list(list_connected_device_refs())
+    except Exception:
+        return []

--- a/gitd/ghostcli/devices.py
+++ b/gitd/ghostcli/devices.py
@@ -1,0 +1,94 @@
+"""Device selection for the ``ghost`` CLI.
+
+``--device`` (aka ``-d`` / ``--udid``) accepts a **human alias** (resolved via
+``~/.ghost/devices.toml``) or a **raw serial / ref**. With no flag: auto-pick the
+sole connected device (with a warning), or error listing candidates when several
+are connected — never silently pick one of many.
+"""
+
+from __future__ import annotations
+
+from gitd.ghostcli import config as gcfg
+
+
+class DeviceError(Exception):
+    """No device could be selected (none / ambiguous / unknown alias)."""
+
+
+def _connected_refs() -> list[str]:
+    try:
+        from gitd.bots.common.device import list_connected_device_refs
+
+        return list(list_connected_device_refs())
+    except Exception:
+        return []
+
+
+def resolve_device(cli_device: str | None) -> str:
+    """Resolve a device ref to act on. Raises :class:`DeviceError` on failure.
+
+    Order: explicit ``--device`` (alias→serial, else raw) → configured default
+    alias → sole connected device (auto-pick + warning).
+    """
+    aliases = gcfg.load_devices()
+
+    requested = cli_device or gcfg.load_config().get("defaults", {}).get("device")
+    if requested:
+        # alias wins; otherwise it is a raw serial/ref used verbatim
+        return aliases.get(requested, requested)
+
+    refs = _connected_refs()
+    if len(refs) == 1:
+        # caller prints the warning (keeps this layer print-free / testable)
+        return refs[0]
+    if not refs:
+        raise DeviceError("No device connected. Connect one, or configure an alias with 'ghost setup'.")
+    listing = ", ".join(refs)
+    raise DeviceError(
+        f"Multiple devices connected ({listing}). Pick one with --device <alias-or-serial> "
+        "(set aliases in ~/.ghost/devices.toml or via 'ghost setup')."
+    )
+
+
+def auto_picked(cli_device: str | None) -> bool:
+    """True when :func:`resolve_device` would auto-pick a lone device (for the warning)."""
+    if cli_device or gcfg.load_config().get("defaults", {}).get("device"):
+        return False
+    return len(_connected_refs()) == 1
+
+
+def _android_model(serial: str) -> str:
+    try:
+        from gitd.bots.common.adb import Device
+
+        return Device(serial).adb("shell", "getprop", "ro.product.model", timeout=3).strip().replace("_", " ")
+    except Exception:
+        return ""
+
+
+def list_for_display() -> list[dict]:
+    """Rows for ``ghost devices``: ``{ref, alias, model, platform}``."""
+    aliases = gcfg.load_devices()
+    serial_to_alias = {v: k for k, v in aliases.items()}
+    rows: list[dict] = []
+
+    ios_details: dict[str, dict] = {}
+    try:
+        from gitd.bots.common.device import list_configured_ios_devices
+
+        ios_details = {d["serial"]: d for d in list_configured_ios_devices(deep_probe=False)}
+    except Exception:
+        pass
+
+    for ref in _connected_refs():
+        is_ios = ref in ios_details
+        model = ios_details[ref].get("model", "") if is_ios else _android_model(ref)
+        rows.append(
+            {
+                "ref": ref,
+                "alias": serial_to_alias.get(ref, ""),
+                "model": model or ("iOS device" if is_ios else ""),
+                "platform": "ios" if is_ios else "android",
+            }
+        )
+    return rows

--- a/gitd/ghostcli/mcp.py
+++ b/gitd/ghostcli/mcp.py
@@ -1,0 +1,131 @@
+"""``ghost mcp install --client <name>`` — register Ghost's MCP server with a client.
+
+All clients register the same stdio server (``android-agent-mcp``, name
+``android-agent``), so the tool surface is identical everywhere. JSON clients are
+merged (never clobbered); claude-code prefers its own ``claude mcp add`` CLI.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+SERVER_NAME = "android-agent"
+SERVER_CMD = "android-agent-mcp"  # console-script from pyproject; == `python3 -m gitd.mcp_server`
+
+SUPPORTED_CLIENTS = ("claude-code", "cursor", "codex", "opencode", "agy", "antigravity")
+
+
+class McpInstallError(Exception):
+    pass
+
+
+def _home() -> Path:
+    override = os.environ.get("GHOST_HOME_OVERRIDE")  # tests point this at a tmp home
+    return Path(override) if override else Path.home()
+
+
+def _merge_json(path: Path, mutate) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data: dict = {}
+    if path.exists():
+        text = path.read_text(encoding="utf-8")
+        if text.strip():  # agy ships a 0-byte mcp_config.json on first run
+            try:
+                data = json.loads(text) or {}
+            except json.JSONDecodeError as e:
+                raise McpInstallError(f"{path} is not valid JSON ({e}); fix or remove it first.") from e
+    mutate(data)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def _install_cursor() -> str:
+    path = _home() / ".cursor" / "mcp.json"
+
+    def mutate(data: dict) -> None:
+        data.setdefault("mcpServers", {})[SERVER_NAME] = {"command": SERVER_CMD}
+
+    _merge_json(path, mutate)
+    return f"Registered '{SERVER_NAME}' in {path} (Cursor)."
+
+
+def _install_opencode() -> str:
+    path = _home() / ".config" / "opencode" / "opencode.json"
+
+    def mutate(data: dict) -> None:
+        data.setdefault("$schema", "https://opencode.ai/config.json")
+        data.setdefault("mcp", {})[SERVER_NAME] = {
+            "type": "local",
+            "command": [SERVER_CMD],
+            "enabled": True,
+        }
+
+    _merge_json(path, mutate)
+    return f"Registered '{SERVER_NAME}' in {path} (OpenCode)."
+
+
+def _install_codex() -> str:
+    # Codex CLI reads ~/.codex/config.toml with a [mcp_servers.<name>] table.
+    path = _home() / ".codex" / "config.toml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing = path.read_text(encoding="utf-8") if path.exists() else ""
+    if f"[mcp_servers.{SERVER_NAME}]" in existing:
+        return f"'{SERVER_NAME}' already present in {path} (Codex) — left unchanged."
+    block = f'\n[mcp_servers.{SERVER_NAME}]\ncommand = "{SERVER_CMD}"\n'
+    path.write_text(existing.rstrip("\n") + "\n" + block if existing else block.lstrip("\n"), encoding="utf-8")
+    return f"Registered '{SERVER_NAME}' in {path} (Codex)."
+
+
+def _install_agy() -> str:
+    # Antigravity CLI (agy) reads ~/.gemini/config/mcp_config.json — a global
+    # {"mcpServers": {<name>: {command, args?, env?}}} map (stdio transport).
+    path = _home() / ".gemini" / "config" / "mcp_config.json"
+
+    def mutate(data: dict) -> None:
+        data.setdefault("mcpServers", {})[SERVER_NAME] = {"command": SERVER_CMD}
+
+    _merge_json(path, mutate)
+    return f"Registered '{SERVER_NAME}' in {path} (Antigravity/agy)."
+
+
+def _install_claude_code() -> str:
+    # Prefer the official CLI; fall back to a project-local .mcp.json.
+    if shutil.which("claude"):
+        try:
+            subprocess.run(
+                ["claude", "mcp", "add", SERVER_NAME, "--", SERVER_CMD],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            return f"Registered '{SERVER_NAME}' with Claude Code (claude mcp add)."
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+            pass  # fall through to file
+    path = Path.cwd() / ".mcp.json"
+
+    def mutate(data: dict) -> None:
+        data.setdefault("mcpServers", {})[SERVER_NAME] = {"command": SERVER_CMD}
+
+    _merge_json(path, mutate)
+    return f"'claude' CLI unavailable — wrote project-local {path} instead (Claude Code / any .mcp.json reader)."
+
+
+_INSTALLERS = {
+    "claude-code": _install_claude_code,
+    "cursor": _install_cursor,
+    "codex": _install_codex,
+    "opencode": _install_opencode,
+    "agy": _install_agy,
+    "antigravity": _install_agy,  # alias — early docs used this spelling
+}
+
+
+def install(client: str) -> str:
+    if client not in _INSTALLERS:
+        raise McpInstallError(f"Unknown client '{client}'. Supported: {', '.join(SUPPORTED_CLIENTS)}.")
+    return _INSTALLERS[client]()

--- a/gitd/ghostcli/resolve.py
+++ b/gitd/ghostcli/resolve.py
@@ -1,0 +1,119 @@
+"""Resolve backend / model / mode / device for a ``ghost`` run.
+
+Precedence everywhere: explicit flag > ``GHOST_*`` env > ``~/.ghost/config.toml``
+> built-in default. Heavy modules (``agent_chat``, ``anthropic``) are imported
+lazily so ``ghost --help`` and ``ghost devices`` stay fast.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+
+from gitd.ghostcli import config as gcfg
+
+VALID_MODES = gcfg.VALID_MODES
+_DEFAULT_PROVIDER = "claude-code"
+
+
+class GhostConfigError(Exception):
+    """Raised when there is no usable backend to run a task."""
+
+
+def _providers() -> dict:
+    from gitd.services.agent_chat import PROVIDERS
+
+    return PROVIDERS
+
+
+def valid_providers() -> tuple[str, ...]:
+    return tuple(_providers().keys())
+
+
+def resolve_backend(cli_backend: str | None = None, cli_model: str | None = None) -> tuple[str, str]:
+    """Return ``(provider, model)`` by precedence. Does not validate usability."""
+    cfg = gcfg.load_config().get("backend", {})
+    provider = (
+        cli_backend
+        or os.environ.get("GHOST_BACKEND")
+        or cfg.get("name")
+        or _settings_default_provider()
+        or _DEFAULT_PROVIDER
+    )
+    providers = _providers()
+    model = cli_model or os.environ.get("GHOST_MODEL") or cfg.get("model")
+    if not model:
+        models = providers.get(provider, {}).get("models") or [""]
+        model = models[0]
+    return provider, model
+
+
+def _settings_default_provider() -> str:
+    try:
+        from gitd.config import settings
+
+        return settings.default_provider
+    except Exception:
+        return ""
+
+
+def is_provider_usable(provider: str) -> bool:
+    """Best-effort check that ``provider`` can actually run right now.
+
+    Used to decide whether an unconfigured user can be sent straight into a run
+    (they have ``claude`` on PATH, or an API key) vs. shown the setup hint.
+    """
+    if provider == "claude-code":
+        if not shutil.which("claude"):
+            return False
+        try:
+            from gitd.cli import _claude_auth_state
+
+            return _claude_auth_state() == "logged_in"
+        except Exception:
+            return True  # claude present; assume usable if we can't probe auth
+    try:
+        from gitd.config import settings
+
+        if provider == "anthropic":
+            return bool(settings.anthropic_api_key or os.environ.get("ANTHROPIC_API_KEY"))
+        if provider == "openrouter":
+            return bool(settings.openrouter_api_key or os.environ.get("OPENROUTER_API_KEY"))
+        if provider in ("openai",):
+            return bool(settings.openai_api_key or os.environ.get("OPENAI_API_KEY"))
+    except Exception:
+        pass
+    # ollama / vllm / on-device: assume the endpoint is up (the run surfaces a
+    # clear connection error otherwise).
+    return provider in ("ollama", "vllm", "on-device")
+
+
+def unconfigured() -> bool:
+    """True when the user has no config file and no GHOST_* backend env set."""
+    return not gcfg.config_exists() and not os.environ.get("GHOST_BACKEND")
+
+
+def resolve_backend_or_error(cli_backend: str | None, cli_model: str | None) -> tuple[str, str]:
+    """Resolve, but raise :class:`GhostConfigError` when nothing usable exists.
+
+    An explicit ``--backend`` / ``GHOST_BACKEND`` is trusted (the run will surface
+    its own error if wrong). Otherwise, if the user is unconfigured and the default
+    provider is not usable, send them to ``ghost setup``.
+    """
+    provider, model = resolve_backend(cli_backend, cli_model)
+    explicit = bool(cli_backend or os.environ.get("GHOST_BACKEND"))
+    if provider not in _providers():
+        raise GhostConfigError(f"Unknown backend '{provider}'. Valid: {', '.join(valid_providers())}.")
+    if not explicit and unconfigured() and not is_provider_usable(provider):
+        raise GhostConfigError(
+            "No backend configured. Run 'ghost setup' to configure, or pass "
+            "--backend <name> (e.g. --backend ollama), or set GHOST_BACKEND."
+        )
+    return provider, model
+
+
+def resolve_mode(cli_mode: str | None) -> str:
+    mode = cli_mode or os.environ.get("GHOST_MODE") or gcfg.load_config().get("defaults", {}).get("mode") or "fast"
+    if mode not in VALID_MODES:
+        raise GhostConfigError(f"Invalid --mode '{mode}'. Choose one of: {', '.join(VALID_MODES)}.")
+    return mode

--- a/gitd/ghostcli/run.py
+++ b/gitd/ghostcli/run.py
@@ -1,0 +1,112 @@
+"""The bare-positional prompt path: ``ghost "<prompt>" --device asus``.
+
+Thin driver — creates a chat session and streams :func:`chat_turn` events to the
+terminal. All the real work (provider dispatch, tools, the agent loop) lives in
+``gitd.services.agent_chat``; this only renders.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+
+# mode → whether to attach screenshots to the model's perception. `reason` also
+# gets vision today; effort-scaling is a later refinement.
+_MODE_AUTOSHOT = {"fast": False, "vision": True, "reason": True}
+
+# Per-tool emoji for the streamed tool-call line. Without this every call renders
+# the same generic 🧰 and a demo reads as a flat wall; a distinct glyph per action
+# makes the agent's moves legible at a glance. Unmapped tools fall back to 🧰.
+_TOOL_EMOJI = {
+    # input / interaction
+    "tap": "👆", "tap_element": "👆", "long_press": "🤏",
+    "type_text": "⌨️", "type_unicode": "⌨️", "paste_text": "📋",
+    "press_key": "🎹", "press_back": "🔙", "press_home": "🏠", "browser_back": "🔙",
+    "swipe": "📜",
+    # screen / vision
+    "screenshot": "📸", "screenshot_annotated": "📸", "screenshot_cropped": "📸",
+    "screenshot_sequence": "🎞️", "get_screen_tree": "🌲", "get_screen_xml": "📄",
+    "get_elements": "🔲", "classify_screen": "🧠", "find_on_screen": "🔍",
+    "ocr_screen": "🔠", "ocr_region": "🔠",
+    "extract_visible_text": "📃", "extract_articles": "📰", "read_news": "📰",
+    # apps / navigation
+    "launch_app": "🚀", "launch_intent": "🚀", "force_stop": "🛑",
+    "list_apps": "📱", "list_packages": "📦", "search_apps": "🔎", "app_state": "ℹ️",
+    "open_url": "🌐", "get_current_url": "🔗",
+    # device / system
+    "list_devices": "📱", "device_health": "🩺", "fix_device_health": "🔧",
+    "get_phone_state": "📊", "shell": "⚙️", "wait": "⏳", "wait_for_text": "⏳",
+    "speak_text": "🔊", "open_camera": "📷",
+    # notifications / clipboard
+    "get_notifications": "🔔", "open_notifications": "🔔", "clear_notifications": "🔕",
+    "clipboard_get": "📋", "clipboard_set": "📋",
+    # recording / stream
+    "start_screen_recording": "⏺️", "stop_screen_recording": "⏹️",
+    "screen_recording_status": "📹", "get_stream_info": "📡",
+    # web / search
+    "web_search": "🔎",
+    # skills / agent orchestration
+    "list_skills": "🧩", "create_skill": "✨", "run_action": "▶️", "explore_app": "🧭",
+    "chain": "⛓️", "sub_agent": "🤖", "run_flow": "🔀", "run_workflow": "🔀",
+    "toggle_overlay": "🖼️",
+    # crashes
+    "list_crashes": "💥", "get_crash": "💥",
+    # crm / leads
+    "lookup_lead": "🔎", "list_unread_leads": "📥",
+    "crm_lookup_contact": "🔎", "crm_list_unread_messages": "📥",
+}
+
+
+def _tool_emoji(name: str) -> str:
+    """Emoji for a tool-call line; 🧰 for anything unmapped."""
+    return _TOOL_EMOJI.get(name, "🧰")
+
+
+def _emit(text: str, *, end: str = "") -> None:
+    sys.stdout.write(text + end)
+    sys.stdout.flush()
+
+
+def run_task(prompt: str, device_ref: str, provider: str, model: str, mode: str, *, auto_picked: bool = False) -> int:
+    """Run one NL task end-to-end. Returns a process exit code."""
+    from gitd.services.agent_chat import chat_turn, create_session
+
+    if auto_picked:
+        _emit(f"⚠️  using the only connected device: {device_ref}\n")
+    _emit(f"⚡  Model:   {model} (via {provider})\n")
+    _emit(f"📱  Device:  {device_ref}\n\n")
+
+    session = create_session(device=device_ref, provider=provider, model=model)
+    session.auto_screenshot = _MODE_AUTOSHOT.get(mode, False)
+
+    started = time.monotonic()
+    tool_calls = 0
+    had_error = False
+    try:
+        for event in chat_turn(session, prompt):
+            etype = event.get("type")
+            if etype == "text":
+                _emit(str(event.get("content") or event.get("text") or ""))
+            elif etype == "tool_call":
+                tool_calls += 1
+                name = event.get("name") or event.get("tool") or "tool"
+                _emit(f"\n  {_tool_emoji(name)}  {name}\n")
+            elif etype == "thinking":
+                pass  # keep the terminal clean; thinking is not surfaced
+            elif etype == "error":
+                had_error = True
+                _emit(f"\n✗ {event.get('content') or event.get('error') or 'error'}\n")
+            elif etype == "done":
+                break
+    except KeyboardInterrupt:
+        _emit("\n⏹  interrupted\n")
+        return 130
+    except Exception as e:  # noqa: BLE001 — surface any run failure as a clean CLI error
+        _emit(f"\n✗ run failed: {e}\n")
+        return 1
+
+    elapsed = time.monotonic() - started
+    _emit(
+        f"\n\n{'✗' if had_error else '✓'} done in {elapsed:.0f}s · {tool_calls} tool call{'s' if tool_calls != 1 else ''}\n"
+    )
+    return 1 if had_error else 0

--- a/gitd/ghostcli/wizard.py
+++ b/gitd/ghostcli/wizard.py
@@ -1,0 +1,104 @@
+"""First-run onboarding wizard for the ``ghost`` CLI.
+
+Detect available backends → let the user pick → capture a model + a device alias
++ a default mode → write ``~/.ghost/config.toml``. The caller then **resumes the
+original command** so the user never re-types. Fully scriptable via
+``ghost setup --backend ... --model ... --mode ... --device alias:serial`` and via
+``GHOST_*`` env (which bypasses the wizard entirely).
+"""
+
+from __future__ import annotations
+
+import sys
+
+from gitd.ghostcli import config as gcfg
+from gitd.ghostcli import detect
+from gitd.ghostcli.resolve import VALID_MODES
+
+
+def build_and_save(*, backend: str, model: str, mode: str, device_alias: str = "", device_serial: str = "") -> dict:
+    """Assemble + persist config.toml (and a device alias); return the config dict."""
+    if mode not in VALID_MODES:
+        raise ValueError(f"mode must be one of {VALID_MODES}")
+    cfg: dict = {"backend": {"name": backend}, "defaults": {"mode": mode}}
+    if model:
+        cfg["backend"]["model"] = model
+    if device_alias and device_serial:
+        gcfg.set_device_alias(device_alias, device_serial)
+        cfg["defaults"]["device"] = device_alias
+    gcfg.save_config(cfg)
+    return cfg
+
+
+def apply_noninteractive(*, backend: str, model: str = "", mode: str = "fast", device: str = "") -> dict:
+    """`ghost setup --backend ... --device alias:serial` — no prompts."""
+    alias, serial = "", ""
+    if device:
+        if ":" in device:
+            alias, serial = device.split(":", 1)
+        else:
+            alias, serial = device, device  # bare serial: alias == serial
+    return build_and_save(backend=backend, model=model, mode=mode, device_alias=alias, device_serial=serial)
+
+
+def is_interactive() -> bool:
+    return sys.stdin.isatty() and sys.stdout.isatty()
+
+
+def _ask(prompt: str, default: str = "") -> str:
+    suffix = f" [{default}]" if default else ""
+    try:
+        ans = input(f"{prompt}{suffix}: ").strip()
+    except EOFError:
+        return default
+    return ans or default
+
+
+def run_interactive() -> dict | None:
+    """Drive the menu-based wizard. Returns the written config, or None if skipped."""
+    backends = detect.detect_backends()
+    print("\nGhost setup — pick your LLM backend\n")
+    for i, b in enumerate(backends, 1):
+        mark = "" if b["available"] else "  (unavailable)"
+        rec = "   ← recommended" if b["available"] and i == 1 else ""
+        print(f"  [{i}] {b['label']:<22} {b['detail']}{mark}{rec}")
+    skip_n = len(backends) + 1
+    print(f"  [{skip_n}] Skip — configure later\n")
+
+    default_choice = next((str(i) for i, b in enumerate(backends, 1) if b["available"]), str(skip_n))
+    choice = _ask("Choose", default_choice)
+    if not choice.isdigit() or not (1 <= int(choice) <= skip_n):
+        print("Not a valid choice; skipping setup.")
+        return None
+    if int(choice) == skip_n:
+        return None
+
+    chosen = backends[int(choice) - 1]
+    backend = chosen["key"]
+
+    model = ""
+    if chosen["models"]:  # ollama — pick a local model
+        model = _ask(f"Which model? ({', '.join(chosen['models'][:6])})", chosen["models"][0])
+    elif backend in ("claude-code", "anthropic", "openrouter", "openai"):
+        model = _ask("Default model (blank = backend default)", "")
+
+    device_alias, device_serial = "", ""
+    devices = detect.detect_devices()
+    if devices:
+        device_serial = devices[0]
+        device_alias = _ask(f"Nickname for device {device_serial}", "phone")
+
+    mode = _ask(f"Default mode ({'/'.join(VALID_MODES)})", "fast")
+    if mode not in VALID_MODES:
+        mode = "fast"
+
+    cfg = build_and_save(
+        backend=backend, model=model, mode=mode, device_alias=device_alias, device_serial=device_serial
+    )
+    print(
+        f"\n✓ Wrote {gcfg.config_path()}  (backend={backend}"
+        + (f", model={model}" if model else "")
+        + (f", device={device_alias}" if device_alias else "")
+        + f", mode={mode})\n"
+    )
+    return cfg

--- a/gitd/mcp_server.py
+++ b/gitd/mcp_server.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python3
-"""MCP Server — expose Android automation as tools for any LLM agent.
+"""MCP Server - expose mobile automation as tools for any LLM agent.
 
 Usage:
   stdio:  python3 -m gitd.mcp_server
   HTTP:   python3 -m gitd.mcp_server  (port 8002)
 """
 
-import base64
 import importlib
 import json
 import re
@@ -18,7 +17,20 @@ from mcp.server.fastmcp import FastMCP
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from gitd.bots.common.adb import Device, list_connected
+from gitd.bots.common.adb import Device
+from gitd.bots.common.device import (
+    get_device,
+    is_ios_ref,
+    list_configured_ios_devices,
+    list_connected_device_refs,
+)
+from gitd.services.agent_tools import SAFE_DEVICE_TOOLS
+from gitd.services.tool_platforms import platform_error_text, supports_platform
+from gitd.skills.platforms import (
+    skill_platform_error_text,
+    skill_platform_summary,
+    skill_supports_device,
+)
 
 mcp = FastMCP(
     "android-agent",
@@ -30,32 +42,104 @@ mcp = FastMCP(
 )
 
 
-# ── Tier 1: Raw Android Control ──────────────────────────────────────────
+def _ios_unsupported(tool_name: str) -> str:
+    return platform_error_text(tool_name, "ios")
+
+
+def _device_platform(device: str) -> str:
+    return "ios" if is_ios_ref(device) else "android"
+
+
+def _platform_unsupported(tool_name: str, device: str) -> str:
+    return platform_error_text(tool_name, _device_platform(device))
+
+
+def _load_skill_metadata(skill: str) -> dict:
+    import yaml
+
+    meta_path = Path(__file__).parent / "skills" / skill / "skill.yaml"
+    if not meta_path.exists():
+        return {}
+    return yaml.safe_load(meta_path.read_text()) or {}
+
+
+def _ios_device_details_by_serial() -> dict[str, dict]:
+    try:
+        return {item["serial"]: item for item in list_configured_ios_devices(deep_probe=False)}
+    except Exception:
+        return {}
+
+
+def _format_ios_device(serial: str, details: dict | None) -> str:
+    if not details:
+        return f"{serial} (iOS via Appium/WDA)"
+
+    label = details.get("model") or details.get("device_name") or "iOS device"
+    parts = [label, "iOS"]
+
+    status = details.get("status")
+    if status:
+        parts.append(f"status={status}")
+
+    source = details.get("source")
+    host_state = details.get("host_state")
+    if source and host_state:
+        parts.append(f"host={source}/{host_state}")
+    elif source:
+        parts.append(f"source={source}")
+
+    appium_url = details.get("appium_url")
+    if appium_url:
+        parts.append(f"appium={appium_url}")
+
+    message = details.get("status_message")
+    if message:
+        parts.append(f"hint={message}")
+
+    return f"{serial} ({'; '.join(parts)})"
+
+
+# ── Tier 1: Device Control ────────────────────────────────────────────────
 
 
 @mcp.tool()
 def list_devices() -> str:
-    """List all connected Android devices with serial numbers and models.
+    """List connected Android ADB devices and configured iOS Appium devices.
     Call this first to get the device serial you need for other tools."""
-    devices = list_connected()
+    devices = list_connected_device_refs()
     if not devices:
-        return "No devices connected. Check USB cables and ADB authorization."
+        return (
+            "No devices connected. Check ADB authorization, connect an iPhone visible to xcrun/xctrace, "
+            "or set IOS_DEVICE_UDID for iOS."
+        )
+    ios_details = _ios_device_details_by_serial()
     result = []
     for serial in devices:
-        try:
-            model = Device(serial).adb("shell", "getprop", "ro.product.model", timeout=3).strip()
-        except Exception:
-            model = "unknown"
+        if is_ios_ref(serial):
+            result.append(_format_ios_device(serial, ios_details.get(serial)))
+            continue
+        else:
+            try:
+                model = Device(serial).adb("shell", "getprop", "ro.product.model", timeout=3).strip()
+            except Exception:
+                model = "unknown"
         result.append(f"{serial} ({model})")
     return "\n".join(result)
 
 
 @mcp.tool()
 def screenshot(device: str) -> str:
-    """Take a screenshot of the device screen. Returns base64-encoded PNG.
-    Use this to SEE what's on screen before deciding what to tap."""
-    raw = subprocess.check_output(["adb", "-s", device, "exec-out", "screencap", "-p"], timeout=10)
-    return base64.b64encode(raw).decode()
+    """Take a screenshot of the device screen. Returns a base64-encoded JPEG.
+    Use this to SEE what's on screen before deciding what to tap.
+
+    Routes through the shared compressed screenshot path (half-resolution JPEG,
+    cross-platform) instead of a raw full-res PNG: a raw PNG base64 string
+    overflows the MCP tool-result token cap on content-heavy screens, so the
+    client falls back to text/OCR and never sees the pixels. The downscale cuts
+    the payload ~4-8x so most screens stay under the cap. (The lasting fix is
+    returning an MCP image-content block; tracked as feature #8.)"""
+    from gitd.services.device_context import screenshot as _screenshot
+    return _screenshot(device)["image"]
 
 
 @mcp.tool()
@@ -63,51 +147,14 @@ def get_elements(device: str, interactive_only: bool = True) -> str:
     """Get all UI elements on the current screen as a JSON array.
     Each element has: idx, text, content_desc, resource_id, class, bounds, center, clickable, scrollable.
     Use element idx with tap_element(). Call this to understand the screen layout before acting."""
-    dev = Device(device)
-    xml = dev.dump_xml()
-    if not xml:
-        return "[]"
-
-    elements = []
-    for node in dev.nodes(xml):
-        text = dev.node_text(node) or ""
-        desc = dev.node_content_desc(node) or ""
-        rid = dev.node_rid(node) or ""
-        cls_m = re.search(r'class="([^"]*)"', node)
-        cls = cls_m.group(1).split(".")[-1] if cls_m else ""
-        clickable = 'clickable="true"' in node
-        scrollable = 'scrollable="true"' in node
-
-        if interactive_only and not clickable and not scrollable and not text and not desc:
-            continue
-
-        bounds = dev.node_bounds(node)
-        if not bounds:
-            continue
-        x1, y1, x2, y2 = bounds
-        cx, cy = (x1 + x2) // 2, (y1 + y2) // 2
-
-        elements.append(
-            {
-                "idx": len(elements),
-                "text": text,
-                "content_desc": desc,
-                "resource_id": rid.split("/")[-1] if "/" in rid else rid,
-                "class": cls,
-                "bounds": {"x1": x1, "y1": y1, "x2": x2, "y2": y2},
-                "center": {"x": cx, "y": cy},
-                "clickable": clickable,
-                "scrollable": scrollable,
-            }
-        )
-
-    return json.dumps(elements, indent=2)
+    from gitd.services.device_context import get_interactive_elements
+    return json.dumps(get_interactive_elements(device, interactive_only=interactive_only), indent=2)
 
 
 @mcp.tool()
 def tap(device: str, x: int, y: int) -> str:
     """Tap at exact pixel coordinates (x, y) on the device screen."""
-    Device(device).tap(x, y)
+    get_device(device).tap(x, y)
     return f"Tapped ({x}, {y})"
 
 
@@ -115,30 +162,15 @@ def tap(device: str, x: int, y: int) -> str:
 def tap_element(device: str, idx: int) -> str:
     """Tap a UI element by its index from get_elements().
     Call get_elements() first to see what's on screen and get element indices."""
-    dev = Device(device)
-    xml = dev.dump_xml()
-    if not xml:
-        return "Error: could not dump UI"
-
-    elements = []
-    for node in dev.nodes(xml):
-        text = dev.node_text(node) or ""
-        desc = dev.node_content_desc(node) or ""
-        clickable = 'clickable="true"' in node
-        scrollable = 'scrollable="true"' in node
-        if not clickable and not scrollable and not text and not desc:
-            continue
-        bounds = dev.node_bounds(node)
-        if not bounds:
-            continue
-        elements.append({"node": node, "bounds": bounds})
+    from gitd.services.device_context import get_interactive_elements
+    elements = get_interactive_elements(device)
 
     if idx < 0 or idx >= len(elements):
         return f"Error: element idx {idx} out of range (0-{len(elements) - 1})"
 
-    x1, y1, x2, y2 = elements[idx]["bounds"]
-    cx, cy = (x1 + x2) // 2, (y1 + y2) // 2
-    dev.tap(cx, cy)
+    center = elements[idx]["center"]
+    cx, cy = center["x"], center["y"]
+    get_device(device).tap(cx, cy)
     return f"Tapped element #{idx} at ({cx}, {cy})"
 
 
@@ -147,61 +179,149 @@ def swipe(device: str, x1: int, y1: int, x2: int, y2: int, duration_ms: int = 50
     """Swipe from (x1,y1) to (x2,y2). Use for scrolling, pulling down notifications, etc.
     Common patterns: scroll down = swipe(dev, 540, 1400, 540, 600)
                      scroll up   = swipe(dev, 540, 600, 540, 1400)"""
-    Device(device).swipe(x1, y1, x2, y2, ms=duration_ms)
+    get_device(device).swipe(x1, y1, x2, y2, ms=duration_ms)
     return f"Swiped ({x1},{y1}) -> ({x2},{y2}) in {duration_ms}ms"
 
 
 @mcp.tool()
 def type_text(device: str, text: str) -> str:
-    """Type ASCII text into the currently focused input field.
+    """Type text into the currently focused input field.
     Tap an input field first to focus it. Spaces are supported.
-    For emoji/unicode, use type_unicode() instead."""
-    Device(device).adb("shell", "input", "text", text.replace(" ", "%s"))
-    return f"Typed: {text}"
+    Non-ASCII input is transliterated to the closest ASCII (adb input text is
+    ASCII-only); for full-fidelity emoji/CJK use type_unicode() instead."""
+    if is_ios_ref(device):
+        get_device(device).type_text(text)
+        return f"Typed: {text}"
+    from gitd.bots.common.adb import ascii_typeable, input_text_arg
+
+    typed = ascii_typeable(text)
+    Device(device).adb("shell", "input", "text", input_text_arg(typed))
+    if typed != text:
+        return f"Typed (transliterated non-ASCII): {text!r} -> {typed!r}"
+    return f"Typed: {typed}"
 
 
 @mcp.tool()
 def type_unicode(device: str, text: str) -> str:
-    """Type unicode text (emoji, CJK, accented chars) via ADBKeyboard broadcast.
-    Requires ADBKeyboard APK installed. Use type_text() for plain ASCII."""
-    Device(device).type_unicode(text)
+    """Type unicode text into the focused field.
+    Android uses ADBKeyboard when configured; iOS uses WDA text entry.
+    Use type_text() for plain ASCII."""
+    if is_ios_ref(device):
+        get_device(device).type_text(text)
+    else:
+        Device(device).type_unicode(text)
     return f"Typed (unicode): {text}"
 
 
 @mcp.tool()
 def press_back(device: str) -> str:
-    """Press the Android Back button."""
-    Device(device).back()
+    """Press Back on Android or the best available iOS browser/navigation back action."""
+    get_device(device).back()
     return "Pressed Back"
 
 
 @mcp.tool()
 def press_home(device: str) -> str:
-    """Press the Android Home button. Returns to home screen."""
-    Device(device).adb("shell", "input", "keyevent", "KEYCODE_HOME")
+    """Press the platform Home button. Returns to the home screen."""
+    if is_ios_ref(device):
+        get_device(device).press_key("HOME")
+    else:
+        Device(device).adb("shell", "input", "keyevent", "KEYCODE_HOME")
     return "Pressed Home"
 
 
 @mcp.tool()
 def press_key(device: str, key: str) -> str:
-    """Send a key event. key examples: POWER, VOLUME_UP, VOLUME_DOWN, ENTER, TAB, MENU.
-    Full list: KEYCODE_ prefix is added automatically if missing."""
-    if not key.startswith("KEYCODE_"):
-        key = "KEYCODE_" + key
+    """Send a platform key event.
+    Android accepts KEYCODE_* names, with the KEYCODE_ prefix added automatically.
+    iOS supports WDA-backed HOME, ENTER/RETURN, and BACK/ESCAPE."""
+    if is_ios_ref(device):
+        get_device(device).press_key(key)
+        return f"Sent {key}"
+    from gitd.bots.common.adb import normalize_keycode
+
+    key = normalize_keycode(key)
     Device(device).adb("shell", "input", "keyevent", key)
     return f"Sent {key}"
 
 
 @mcp.tool()
-def launch_app(device: str, package: str) -> str:
-    """Launch an Android app by package name. Use search_apps() to find the package name."""
-    Device(device).adb("shell", "monkey", "-p", package, "-c", "android.intent.category.LAUNCHER", "1")
-    return f"Launched {package}"
+def launch_app(device: str, package: str, fresh: bool = False) -> str:
+    """Launch an app by Android package name or iOS bundle id. Use search_apps() to find it.
+
+    Args:
+        device: ADB serial or ios:<udid>.
+        package: App package name or iOS bundle id, e.g. "com.android.chrome" or "com.google.chrome.ios".
+        fresh: If True, force-stop the app first (cold start, clears in-memory
+            state — back stack, unsaved drafts, login flow position, etc.).
+            If False (default), reuses any existing background instance (warm
+            start — resumes wherever the user left off).
+            Use fresh=True for benchmarks, fresh start of a flow, or when the
+            current app state would interfere with the task.
+    """
+    from gitd.services.agent_tools import execute_tool
+    return execute_tool("launch_app", {"device": device, "package": package, "fresh": fresh})
+
+
+@mcp.tool()
+def force_stop(device: str, package: str) -> str:
+    """Force-stop an Android package or terminate an iOS bundle id."""
+    from gitd.services.agent_tools import execute_tool
+
+    return execute_tool("force_stop", {"device": device, "package": package})
+
+
+@mcp.tool()
+def app_state(device: str, package: str) -> str:
+    """Check whether an Android package or iOS bundle id is installed, running, or foreground."""
+    from gitd.services.device_context import app_state as _app_state
+
+    return json.dumps(_app_state(device, package), indent=2)
+
+
+@mcp.tool()
+def open_camera(device: str, mode: str = "photo", timer_s: int = 0) -> str:
+    """Open the platform camera app in a specific mode.
+
+    Android uses launcher/UI automation; iOS uses the Camera bundle and WDA UI
+    controls. No package or bundle id is required.
+
+    Args:
+        device: ADB serial or ios:<udid>.
+        mode: One of:
+            "photo"        — rear camera, photo mode (default)
+            "video"        — rear camera, video/record mode
+            "selfie"       — front camera, photo mode
+            "selfie_video" — front camera, video mode
+        timer_s: Self-timer delay in seconds. Supported: 0 (off), 2, 3, 5, 10.
+                 Uses UI automation — snaps to the closest value the device supports
+                 (ASUS: 3s/10s, Samsung: 2s/5s/10s). 0 = no timer (default).
+    """
+    from gitd.services.agent_tools import execute_tool
+    return execute_tool("open_camera", {"device": device, "mode": mode, "timer_s": timer_s})
+
+
+@mcp.tool()
+def speak_text(device: str, text: str, rate: float = 1.0) -> str:
+    """Make the phone speak text aloud using its built-in TTS engine.
+
+    Works whether the agent runs on the phone or on a PC — the call always
+    goes through the Ghost portal app running on the device.
+
+    Args:
+        device: ADB serial. This tool is Android-only.
+        text:   Text to speak.
+        rate:   Speech rate multiplier (0.5 = slow, 1.0 = normal, 1.5 = fast).
+    """
+    if is_ios_ref(device):
+        return _ios_unsupported("speak_text")
+    from gitd.services.device_context import speak_text as _speak
+    return _speak(device, text, rate)
 
 
 @mcp.tool()
 def search_apps(device: str, query: str) -> str:
-    """Search installed apps by name. Case-insensitive. Returns matching apps with package names.
+    """Search installed apps by name. Case-insensitive. Returns Android packages or iOS bundle ids.
     Example: search_apps('tiktok') → [{"name": "TikTok", "package": "com.zhiliaoapp.musically"}]"""
     from gitd.services.agent_tools import execute_tool
     return execute_tool("search_apps", {"device": device, "query": query})
@@ -209,16 +329,24 @@ def search_apps(device: str, query: str) -> str:
 
 @mcp.tool()
 def list_apps(device: str) -> str:
-    """List all installed apps with human-readable names and package names.
-    Returns [{name, package}] sorted alphabetically. Use search_apps() for faster lookup."""
+    """List installed apps with human-readable names and package names or bundle ids.
+    iOS is limited to configured/common bundle ids verified through Appium."""
     from gitd.services.agent_tools import execute_tool
     return execute_tool("list_apps", {"device": device})
 
 
 @mcp.tool()
+def list_packages(device: str) -> str:
+    """List raw Android package names or iOS bundle ids. Prefer list_apps() for display names."""
+    from gitd.services.agent_tools import execute_tool
+
+    return execute_tool("list_packages", {"device": device})
+
+
+@mcp.tool()
 def long_press(device: str, x: int, y: int, duration_ms: int = 1000) -> str:
     """Long press at coordinates. Use for context menus, drag initiation, etc."""
-    Device(device).long_press(x, y, duration_ms=duration_ms)
+    get_device(device).long_press(x, y, duration_ms=duration_ms)
     return f"Long pressed ({x}, {y}) for {duration_ms}ms"
 
 
@@ -228,6 +356,22 @@ def get_phone_state(device: str) -> str:
     Quick way to check what app/screen the device is on without parsing full elements."""
     from gitd.services.device_context import get_phone_state as _get_state
     return json.dumps(_get_state(device), indent=2)
+
+
+@mcp.tool()
+def device_health(device: str) -> str:
+    """Run a comprehensive device health check.
+    iOS includes Appium/WDA status, active session details, and recovery steps."""
+    from gitd.services.device_context import device_health as _device_health
+    return json.dumps(_device_health(device), indent=2)
+
+
+@mcp.tool()
+def fix_device_health(device: str, issue: str) -> str:
+    """Apply a recovery action returned by device_health.recommended_fix."""
+    from gitd.services.device_context import fix_device_health as _fix_device_health
+
+    return json.dumps(_fix_device_health(device, issue), indent=2)
 
 
 # ── Tier 1.5: Context Extraction ────────────────────────────────────────
@@ -245,7 +389,8 @@ def get_screen_tree(device: str) -> str:
 
 @mcp.tool()
 def get_screen_xml(device: str) -> str:
-    """Get the raw UI XML dump from the device (uiautomator).
+    """Get the raw normalized UI XML dump from the device.
+    Android returns uiautomator XML; iOS returns normalized Appium/WDA XML.
     Use get_screen_tree() instead for a readable summary.
     Use this only when you need exact attribute values or the full hierarchy."""
     from gitd.services.device_context import get_screen_xml as _xml
@@ -271,6 +416,45 @@ def screenshot_cropped(device: str, x1: int, y1: int, x2: int, y2: int) -> str:
     from gitd.services.device_context import screenshot_cropped as _crop
     result = _crop(device, x1, y1, x2, y2)
     return result.get("image", "")
+
+
+@mcp.tool()
+def start_screen_recording(device: str, filename: str = "") -> str:
+    """Start recording the device screen.
+
+    iOS uses WDA MJPEG captured through ffmpeg. Android uses adb screenrecord.
+    """
+    from gitd.services.phone_recording import start_recording
+
+    return json.dumps(start_recording(device, filename=filename), indent=2)
+
+
+@mcp.tool()
+def stop_screen_recording(device: str) -> str:
+    """Stop a running device screen recording and save the MP4."""
+    from gitd.services.phone_recording import stop_recording
+
+    return json.dumps(stop_recording(device), indent=2)
+
+
+@mcp.tool()
+def screen_recording_status(device: str) -> str:
+    """Return active screen recording status for a device."""
+    from gitd.services.phone_recording import recording_status
+
+    return json.dumps(recording_status(device), indent=2)
+
+
+@mcp.tool()
+def get_stream_info(device: str, mode: str = "mjpeg", fps: int = 5, quality: int = 8) -> str:
+    """Return effective stream metadata without opening the stream.
+
+    iOS reports WDA MJPEG URL/settings, screenshot fallback, and unsupported
+    Portal/WebRTC actions. Android reports Portal/H264/screencap metadata.
+    """
+    from gitd.routers.streaming import phone_stream_info
+
+    return json.dumps(phone_stream_info(device=device, mode=mode, fps=fps, quality=quality), indent=2)
 
 
 @mcp.tool()
@@ -306,6 +490,8 @@ def toggle_overlay(device: str, visible: bool = True) -> str:
     """Toggle the numbered element overlay on the device screen.
     When on, interactive elements get visible numbered labels that match get_elements() indices.
     Useful for visual debugging or when sending screenshots to a vision model."""
+    if is_ios_ref(device):
+        return _ios_unsupported("toggle_overlay")
     from gitd.services.device_context import toggle_overlay as _toggle
     ok = _toggle(device, visible)
     return f"Overlay {'enabled' if visible else 'disabled'}" if ok else "Failed — Portal not available"
@@ -322,7 +508,23 @@ def clipboard_get(device: str) -> str:
 def clipboard_set(device: str, text: str) -> str:
     """Set clipboard text on the device. Use with press_key(PASTE) to paste into fields."""
     from gitd.services.device_context import clipboard_set as _set
-    return f"Clipboard set" if _set(device, text) else "Failed"
+    return "Clipboard set" if _set(device, text) else "Failed"
+
+
+@mcp.tool()
+def paste_text(device: str, text: str) -> str:
+    """Set clipboard text and immediately paste it into the currently focused field.
+    Equivalent to clipboard_set + press_key(PASTE) in one call.
+    Tap the target input field first to focus it, then call this."""
+    if is_ios_ref(device):
+        get_device(device).paste_text(text)
+        return f"Inserted text on iOS: {text[:60]}{'...' if len(text) > 60 else ''}"
+    from gitd.bots.common.adb import Device
+    from gitd.services.device_context import clipboard_set as _set
+    if not _set(device, text):
+        return "Failed to set clipboard"
+    Device(device).adb("shell", "input", "keyevent", "KEYCODE_PASTE")
+    return f"Pasted: {text[:60]}{'…' if len(text) > 60 else ''}"
 
 
 @mcp.tool()
@@ -334,9 +536,135 @@ def get_notifications(device: str) -> str:
 
 @mcp.tool()
 def open_notifications(device: str) -> str:
-    """Pull down the notification shade."""
+    """Pull down the notification shade or iOS Notification Center."""
     from gitd.services.device_context import open_notifications as _open
-    return "Notification shade opened" if _open(device) else "Failed"
+    if not _open(device):
+        return "Failed"
+    return "Notification Center opened" if is_ios_ref(device) else "Notification shade opened"
+
+
+@mcp.tool()
+def clear_notifications(device: str) -> str:
+    """Dismiss visible notifications when the platform exposes a clear control."""
+    from gitd.services.device_context import clear_notifications as _clear
+    return "Notifications cleared" if _clear(device) else "Failed"
+
+
+@mcp.tool()
+def web_search(device: str, query: str, engine: str = "google", bundle_id: str = "") -> str:
+    """Open a web search in whatever browser is on the device.
+
+    Faster than: launch Chrome → tap address bar → type → submit. Useful when
+    the user asks "search for X" or you need to look up info that's not on the
+    current screen. Picks the first installed browser from a fallback chain
+    (Chrome → Firefox → Samsung Internet → Edge → Brave → Opera → Vivaldi →
+    DuckDuckGo Browser → system default), so it works even if Chrome is missing.
+
+    Args:
+        device: ADB serial or ios:<udid>.
+        query: Free-text search terms (don't pre-escape — handled here).
+        engine: "google" (default), "ddg" / "duckduckgo", "bing", or "brave".
+        bundle_id: Optional iOS browser bundle id override, e.g. com.google.chrome.ios.
+    """
+    if is_ios_ref(device):
+        from gitd.services.browser import dumps
+        from gitd.services.browser import web_search as _web_search
+
+        return dumps(_web_search(device, query, engine=engine, bundle_id=bundle_id or None))
+    from gitd.services.web_search import open_search
+    return open_search(device, query, engine=engine)
+
+
+@mcp.tool()
+def open_url(device: str, url: str, bundle_id: str = "") -> str:
+    """Open a URL in the platform browser.
+
+    On iOS this uses Appium/WDA and defaults to the configured browser bundle
+    id, usually com.google.chrome.ios or com.apple.mobilesafari.
+    """
+    from gitd.services.browser import dumps
+    from gitd.services.browser import open_url as _open_url
+
+    return dumps(_open_url(device, url, bundle_id=bundle_id or None))
+
+
+@mcp.tool()
+def browser_back(device: str) -> str:
+    """Navigate back in the current browser/app context."""
+    from gitd.services.browser import browser_back as _browser_back
+    from gitd.services.browser import dumps
+
+    return dumps(_browser_back(device))
+
+
+@mcp.tool()
+def get_current_url(device: str) -> str:
+    """Get the current browser URL when the platform exposes it."""
+    if not supports_platform("get_current_url", _device_platform(device)):
+        return _platform_unsupported("get_current_url", device)
+    from gitd.services.browser import dumps
+    from gitd.services.browser import get_current_url as _get_current_url
+
+    return dumps(_get_current_url(device))
+
+
+@mcp.tool()
+def wait_for_text(device: str, text: str, timeout: float = 12.0) -> str:
+    """Wait until text appears on screen and return visible text context."""
+    from gitd.services.browser import dumps
+    from gitd.services.browser import wait_for_text as _wait_for_text
+
+    return dumps(_wait_for_text(device, text, timeout=timeout))
+
+
+@mcp.tool()
+def extract_visible_text(device: str, max_lines: int = 200, include_controls: bool = False) -> str:
+    """Extract visible text from the current screen with browser chrome filtered by default."""
+    from gitd.services.browser import dumps
+    from gitd.services.browser import extract_visible_text as _extract_visible_text
+
+    return dumps(_extract_visible_text(device, max_lines=max_lines, include_controls=include_controls))
+
+
+@mcp.tool()
+def extract_articles(device: str, max_items: int = 5) -> str:
+    """Extract likely visible article/headline candidates from the current browser page."""
+    from gitd.services.browser import dumps
+    from gitd.services.browser import extract_articles as _extract_articles
+
+    return dumps(_extract_articles(device, max_items=max_items))
+
+
+@mcp.tool()
+def read_news(
+    device: str,
+    url: str = "https://text.npr.org/",
+    max_headlines: int = 5,
+    max_articles: int = 3,
+    bundle_id: str = "",
+    wait_s: float = 2.0,
+    save_screenshots: bool = False,
+) -> str:
+    """Open a news page and return structured headlines plus article snippets.
+
+    This is the iOS Chrome/WebDriver smoke workflow exposed as a single tool.
+    """
+    if not supports_platform("read_news", _device_platform(device)):
+        return _platform_unsupported("read_news", device)
+    from gitd.services.browser import dumps
+    from gitd.services.browser import read_news as _read_news
+
+    return dumps(
+        _read_news(
+            device,
+            url,
+            max_headlines=max_headlines,
+            max_articles=max_articles,
+            bundle_id=bundle_id or None,
+            wait_s=wait_s,
+            save_screenshots=save_screenshots,
+        )
+    )
 
 
 @mcp.tool()
@@ -347,6 +675,8 @@ def launch_intent(device: str, action: str = "", data: str = "",
       Open a URL: action="android.intent.action.VIEW" data="https://google.com"
       Open Settings: package="com.android.settings"
       Share text: action="android.intent.action.SEND" extras='{"android.intent.extra.TEXT": "hello"}'"""
+    if is_ios_ref(device):
+        return _ios_unsupported("launch_intent")
     from gitd.services.device_context import launch_intent as _intent
     parsed_extras = json.loads(extras) if extras and extras != "{}" else None
     return _intent(device, action=action, data=data, package=package, extras=parsed_extras)
@@ -367,8 +697,8 @@ def find_on_screen(device: str, text: str) -> str:
 
 
 @mcp.tool()
-def list_skills() -> str:
-    """List all installed Android automation skills with their actions and workflows.
+def list_skills(device: str = "", supported_only: bool = False) -> str:
+    """List all installed mobile automation skills with their actions, workflows, and platform support.
     Use this to discover what high-level automations are available.
     Prefer using run_workflow() over raw tap/swipe when a skill exists for the task."""
     import yaml
@@ -379,11 +709,24 @@ def list_skills() -> str:
         meta_path = d / "skill.yaml"
         if d.is_dir() and meta_path.exists() and not d.name.startswith("__"):
             meta = yaml.safe_load(meta_path.read_text()) or {}
+            platform_summary = skill_platform_summary(meta)
+            supported = skill_supports_device(meta, device) if device else None
+            if supported_only and supported is False:
+                continue
             info = {
                 "name": meta.get("name", d.name),
-                "app_package": meta.get("app_package"),
+                "app_package": platform_summary["app_package"],
+                "android_package": platform_summary["android_package"],
+                "ios_bundle_id": platform_summary["ios_bundle_id"],
+                "platforms": platform_summary["platforms"],
+                "supports_android": platform_summary["supports_android"],
+                "supports_ios": platform_summary["supports_ios"],
+                "platform_limitations": platform_summary["platform_limitations"],
+                "default_params": meta.get("default_params", {}),
                 "description": meta.get("description", ""),
             }
+            if supported is not None:
+                info["supported_on_device"] = supported
             # Try loading runtime actions/workflows
             try:
                 mod = importlib.import_module(f"gitd.skills.{d.name}")
@@ -417,11 +760,14 @@ def run_workflow(device: str, skill: str, workflow: str, params: str = "{}") -> 
       run_workflow("SERIAL", "send_gmail_email", "recorded", '{"subject": "Hello", "body": "Test"}')
 
     params is a JSON string of keyword arguments for the workflow."""
+    meta = _load_skill_metadata(skill)
+    if not skill_supports_device(meta, device):
+        return skill_platform_error_text(skill, meta, device)
     parsed_params = json.loads(params)
     runner = Path(__file__).parent / "skills" / "_run_skill.py"
     result = subprocess.run(
         [
-            "python3",
+            sys.executable,
             "-u",
             str(runner),
             "--skill",
@@ -454,11 +800,14 @@ def run_action(device: str, skill: str, action: str, params: str = "{}") -> str:
     Examples:
       run_action("SERIAL", "tiktok", "open_app", '{}')
       run_action("SERIAL", "tiktok", "type_and_search", '{"query": "cats"}')"""
+    meta = _load_skill_metadata(skill)
+    if not skill_supports_device(meta, device):
+        return skill_platform_error_text(skill, meta, device)
     parsed_params = json.loads(params)
     runner = Path(__file__).parent / "skills" / "_run_skill.py"
     result = subprocess.run(
         [
-            "python3",
+            sys.executable,
             "-u",
             str(runner),
             "--skill",
@@ -482,19 +831,284 @@ def run_action(device: str, skill: str, action: str, params: str = "{}") -> str:
     return f"SUCCESS:\n{output}"
 
 
+# ── Batch flow ──────────────────────────────────────────────────────────
+# Execute a whole sequence of tool calls in ONE MCP round-trip. Today every
+# action is its own round-trip, so the LLM re-sends the schema + a screenshot +
+# history per step; batching collapses that into one call with a single final
+# screenshot — the token/latency win.
+
+MAX_FLOW_STEPS = 50
+
+# ALLOW-list of tools permitted inside a batched flow. A batch is exactly where
+# an injected instruction would smuggle arbitrary execution, so run_flow is
+# fail-CLOSED: only explicitly-vetted read/UI tools may run. Anything not on the
+# list — a dangerous tool (shell, run_skill) OR any tool added to execute_tool
+# in the future — is refused. Shared with the framework adapters (one source of
+# truth, so the two can't drift): gitd.services.agent_tools.SAFE_DEVICE_TOOLS.
+FLOW_ALLOWED_TOOLS = SAFE_DEVICE_TOOLS
+
+
+def _run_flow(device: str, steps: object) -> dict:
+    """Core of run_flow (kept import-light + side-effect-free to unit test).
+
+    Validates the whole batch first (shape + allow-list), then executes each
+    step, aborting on the first error. Returns a consolidated dict with per-step
+    results and ONE final screenshot.
+
+    Dispatches via _execute_tool_inner (not the wrapped execute_tool): the
+    wrapper appends a fresh screen tree and sleeps 0.5s after every UI action,
+    which for a 50-step flow would add ~25s of latency and 50 inflated results —
+    exactly the per-step overhead batching exists to remove. We take one final
+    screenshot for the whole batch instead.
+    """
+    from gitd.services.agent_tools import _execute_tool_inner, get_screenshot_b64
+
+    if not isinstance(steps, list):
+        return {"error": "steps must be a JSON list of {tool, args} objects"}
+    if not steps:
+        return {"error": "steps is empty"}
+    if len(steps) > MAX_FLOW_STEPS:
+        return {"error": f"too many steps ({len(steps)} > {MAX_FLOW_STEPS})"}
+
+    # Fail closed: validate EVERY step before running ANY of them, so a flow
+    # that hides a disallowed action after some benign steps executes nothing.
+    for i, step in enumerate(steps):
+        if not isinstance(step, dict) or "tool" not in step:
+            return {"error": f"step {i} must be an object with a 'tool' field"}
+        if step["tool"] not in FLOW_ALLOWED_TOOLS:
+            return {
+                "error": f"step {i}: tool '{step['tool']}' is not allowed inside run_flow (injection guard)",
+                "blocked": step["tool"],
+            }
+
+    results = []
+    stopped_early = False
+    for i, step in enumerate(steps):
+        tool = step["tool"]
+        args = dict(step.get("args") or {})
+        args.setdefault("device", device)
+        try:
+            out = _execute_tool_inner(tool, args)
+            results.append({"step": i, "tool": tool, "ok": True, "result": str(out)[:800]})
+        except Exception as e:
+            results.append({"step": i, "tool": tool, "ok": False, "error": f"{type(e).__name__}: {e}"[:800]})
+            stopped_early = True
+            break  # phase 1: abort on first error (on_error/if_not_found is phase 2)
+
+    final_screenshot = ""
+    try:
+        final_screenshot = get_screenshot_b64(device) or ""
+    except Exception:
+        pass
+
+    return {
+        "steps_total": len(steps),
+        "steps_run": len(results),
+        "stopped_early": stopped_early,
+        "results": results,
+        "final_screenshot": final_screenshot,  # ONE shot for the whole batch
+    }
+
+
+@mcp.tool()
+def run_flow(device: str, steps: str) -> str:
+    """Run an ordered batch of tool calls server-side in ONE round-trip.
+
+    `steps` is a JSON list of {"tool": "<name>", "args": {...}} — the same tool
+    names execute_tool exposes (tap, tap_element, type_text, launch_app, etc.).
+    Steps run in order and stop at the first error. Returns a JSON object with
+    per-step results and a SINGLE final screenshot (not one per step) — far
+    fewer tokens/round-trips than calling each tool separately. Steps do NOT
+    auto-settle between UI actions; if a step needs the screen to update before
+    the next one reads it, insert an explicit {"tool":"wait","args":{...}} step.
+
+    Example:
+      run_flow("SERIAL", '[{"tool":"launch_app","args":{"package":"com.android.settings"}},
+                           {"tool":"find_on_screen","args":{"text":"Wi-Fi"}},
+                           {"tool":"tap","args":{"x":540,"y":300}}]')
+
+    Security: fail-closed allow-list — only vetted read/UI tools may run inside
+    a flow. Anything else (raw `shell`, `run_skill`, or any unknown tool) makes
+    the whole flow be refused before any step runs, since a batch is exactly
+    where an injected instruction would smuggle a shell command. Max 50 steps.
+    """
+    try:
+        parsed = json.loads(steps)
+    except (ValueError, TypeError) as e:
+        return json.dumps({"error": f"steps must be valid JSON: {e}"})
+    return json.dumps(_run_flow(device, parsed))
+
+
+# ── Crash reports ────────────────────────────────────────────────────────
+# Read app crashes/ANRs from the logcat `crash` buffer — works WITHOUT root
+# (unlike /data/tombstones or /data/anr, which need it). Parser is a pure
+# function so it's unit-testable against captured logcat text.
+
+_CRASH_TS_RE = re.compile(r"^(\d\d-\d\d \d\d:\d\d:\d\d\.\d+)")
+
+
+def _run_logcat_crash(device: str, timeout: int = 10) -> str:
+    """Dump the crash + events ring buffers (`-d` = dump and exit).
+
+    Reads the `crash` buffer (Java FATAL EXCEPTIONs) AND the `events` buffer,
+    which is where ANRs land as `am_anr` events — the crash buffer has none.
+
+    Raises on any adb failure so callers surface a real error instead of a
+    phantom "no crashes": an offline/unauthorized device makes adb exit nonzero
+    with empty stdout, which would otherwise parse to zero crashes and read as
+    "the app is fine".
+    """
+    try:
+        r = subprocess.run(
+            ["adb", "-s", device, "logcat", "-b", "crash", "-b", "events", "-d"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError as e:
+        raise RuntimeError("adb not found on PATH") from e
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError(f"adb logcat timed out after {timeout}s (device unresponsive?)") from e
+    if r.returncode != 0:
+        raise RuntimeError(f"adb exited {r.returncode}: {(r.stderr or '').strip() or 'device offline/unauthorized?'}")
+    return r.stdout
+
+
+def _parse_crashes(logcat_text: str) -> list[dict]:
+    """Parse the crash buffer into crash events, most-recent first.
+
+    Handles Java `FATAL EXCEPTION` blocks (with process + first exception line)
+    and `ANR in <pkg>` lines. Native tombstones need root and are out of scope.
+    """
+    lines = logcat_text.splitlines()
+    crashes: list[dict] = []
+    i, n = 0, len(lines)
+    while i < n:
+        line = lines[i]
+        if "FATAL EXCEPTION" in line and "AndroidRuntime:" in line:
+            ts_m = _CRASH_TS_RE.match(line)
+            ts = ts_m.group(1) if ts_m else ""
+            block, process, summary = [], "", ""
+            j = i
+            while j < n and "AndroidRuntime:" in lines[j]:
+                content = lines[j].split("AndroidRuntime:", 1)[1].strip()
+                block.append(lines[j])
+                pm = re.search(r"Process:\s*([^,]+)", content)
+                if pm and not process:
+                    process = pm.group(1).strip()
+                if not summary and "FATAL EXCEPTION" not in content and ("Exception" in content or "Error" in content):
+                    summary = content
+                j += 1
+            crashes.append(
+                {
+                    "type": "java",
+                    "timestamp": ts,
+                    "process": process,
+                    "summary": summary or "FATAL EXCEPTION",
+                    "raw": "\n".join(block),
+                }
+            )
+            i = j
+            continue
+        if "ANR in " in line:
+            ts_m = _CRASH_TS_RE.match(line)
+            am = re.search(r"ANR in ([^\s(]+)", line)
+            crashes.append(
+                {
+                    "type": "anr",
+                    "timestamp": ts_m.group(1) if ts_m else "",
+                    "process": am.group(1) if am else "",
+                    "summary": line.split("ANR in ", 1)[1].strip() if "ANR in " in line else line.strip(),
+                    "raw": line,
+                }
+            )
+        elif "am_anr" in line:
+            # events-buffer ANR: `... I am_anr : [userId,pid,packageName,flags,reason]`
+            ts_m = _CRASH_TS_RE.match(line)
+            bm = re.search(r"\[([^\]]*)\]", line)
+            fields = [f.strip() for f in bm.group(1).split(",")] if bm else []
+            if len(fields) >= 3:
+                crashes.append(
+                    {
+                        "type": "anr",
+                        "timestamp": ts_m.group(1) if ts_m else "",
+                        "process": fields[2],
+                        "summary": "ANR: " + ", ".join(fields[4:]) if len(fields) > 4 else "ANR",
+                        "raw": line,
+                    }
+                )
+        i += 1
+    crashes.reverse()  # logcat is chronological → most recent first
+    return crashes
+
+
+@mcp.tool()
+def list_crashes(device: str, package: str = "", limit: int = 10) -> str:
+    """List recent app crashes and ANRs (from the logcat crash buffer, no root).
+
+    Android-only: iOS crash logs need syslog/CrashReporter access, not exposed yet.
+    Optionally filter by package (substring match on the crashing process).
+    Returns JSON: {count, crashes: [{type, timestamp, process, summary}]}.
+    Use get_crash() to pull a full stack for the most recent one."""
+    if is_ios_ref(device):
+        return json.dumps({"error": _ios_unsupported("list_crashes")})
+    try:
+        text = _run_logcat_crash(device)
+    except Exception as e:
+        return json.dumps({"error": f"could not read crash log: {e}"})
+    crashes = _parse_crashes(text)
+    if package:
+        crashes = [c for c in crashes if package in (c["process"] or "")]
+    out = [
+        {"type": c["type"], "timestamp": c["timestamp"], "process": c["process"], "summary": c["summary"][:300]}
+        for c in crashes[:limit]
+    ]
+    return json.dumps({"count": len(out), "crashes": out}, indent=2)
+
+
+@mcp.tool()
+def get_crash(device: str, package: str = "") -> str:
+    """Return the full stack trace of the MOST RECENT crash (from the crash buffer).
+
+    Android-only: iOS crash logs need syslog/CrashReporter access, not exposed yet.
+    Optionally filter by package. Pair with list_crashes() to see what's there."""
+    if is_ios_ref(device):
+        return f"Error: {_ios_unsupported('get_crash')}"
+    try:
+        text = _run_logcat_crash(device)
+    except Exception as e:
+        return f"Error: could not read crash log: {e}"
+    crashes = _parse_crashes(text)
+    if package:
+        crashes = [c for c in crashes if package in (c["process"] or "")]
+    if not crashes:
+        scope = f" for {package}" if package else ""
+        return f"No crashes found{scope} in the crash buffer."
+    c = crashes[0]
+    return f"[{c['type']}] {c['timestamp']} {c['process']}\n{c['raw'][:6000]}"
+
+
 # ── Tier 3: Meta / Discovery ────────────────────────────────────────────
 
 
 @mcp.tool()
+def wait(seconds: float = 2.0) -> str:
+    """Pause execution for a fixed number of seconds."""
+    from gitd.services.agent_tools import execute_tool
+
+    return execute_tool("wait", {"seconds": seconds})
+
+
+@mcp.tool()
 def explore_app(device: str, package: str, max_depth: int = 2, max_states: int = 10) -> str:
-    """Explore an Android app's UI autonomously using BFS.
+    """Explore an app's UI autonomously using BFS.
     Launches the app, taps every interactive element, builds a state graph.
     Returns JSON with discovered screens, elements, and transitions.
     Use this to understand an unfamiliar app before writing automation for it."""
     script = Path(__file__).parent / "skills" / "auto_creator.py"
     result = subprocess.run(
         [
-            "python3",
+            sys.executable,
             "-u",
             str(script),
             "--package",
@@ -514,11 +1128,22 @@ def explore_app(device: str, package: str, max_depth: int = 2, max_states: int =
     graph_path = Path(f"data/app_explorer/{package}/state_graph.json")
     if graph_path.exists():
         return graph_path.read_text()[:10000]
-    return f"Exploration finished. Output:\n{result.stdout[-1000:]}"
+    output = result.stdout[-1000:]
+    if result.returncode != 0 and result.stderr:
+        output += f"\nSTDERR:\n{result.stderr[-1000:]}"
+    return f"Exploration finished. Output:\n{output}"
 
 
 @mcp.tool()
-def create_skill(name: str, app_package: str, steps: str) -> str:
+def create_skill(
+    name: str,
+    app_package: str,
+    steps: str,
+    platforms: str = "",
+    ios_bundle_id: str = "",
+    elements_ios: str = "",
+    elements_android: str = "",
+) -> str:
     """Create a new reusable skill from a JSON list of recorded steps.
 
     steps is a JSON array like:
@@ -530,26 +1155,85 @@ def create_skill(name: str, app_package: str, steps: str) -> str:
     ]
 
     Supported actions: launch, tap (x,y or element_idx), type, swipe, back, home, wait.
+    For iOS skills, pass platforms="ios" and either app_package or ios_bundle_id as the bundle id.
+    Optional elements_ios/elements_android are JSON selector maps written to elements_ios.yaml/elements.yaml.
     After creating, use run_workflow(dev, name, "recorded", params) to replay it."""
-    import yaml
+    from gitd.services.skill_creation import create_recorded_skill
 
-    parsed_steps = json.loads(steps)
-    skill_dir = Path(__file__).parent / "skills" / name
-    skill_dir.mkdir(parents=True, exist_ok=True)
-    (skill_dir / "actions").mkdir(exist_ok=True)
-    (skill_dir / "workflows").mkdir(exist_ok=True)
+    result = create_recorded_skill(
+        name=name,
+        app_package=app_package,
+        steps=steps,
+        platforms=platforms,
+        ios_bundle_id=ios_bundle_id,
+        elements_ios=elements_ios,
+        elements_android=elements_android,
+        skills_dir=Path(__file__).parent / "skills",
+    )
+    return result["message"]
 
-    meta = {
-        "name": name,
-        "version": "1.0.0",
-        "app_package": app_package,
-        "description": f"Auto-generated skill with {len(parsed_steps)} steps",
-    }
-    (skill_dir / "skill.yaml").write_text(yaml.dump(meta, default_flow_style=False))
-    (skill_dir / "workflows" / "recorded.json").write_text(json.dumps(parsed_steps, indent=2))
-    (skill_dir / "__init__.py").write_text(f'"""Skill: {name}"""\n')
 
-    return f"Skill '{name}' created at skills/{name}/ with {len(parsed_steps)} steps"
+# ── Lead / influencer lookups (for marketing agents) ────────────────────────
+
+
+@mcp.tool()
+def lookup_lead(handle: str) -> str:
+    """Get the full fact sheet for one influencer lead by handle.
+
+    Use this when you need to know everything about an influencer to draft
+    a personalised reply or decide next-step outreach: their follower count,
+    engagement, bio, niche, what hashtag we found them on, when we DMed them,
+    which account sent the DM, their latest reply, and unread state.
+
+    Args:
+        handle: TikTok username, with or without @ (e.g. 'creatorhandle' or '@creatorhandle')
+    """
+    from gitd.services.marketing_lookup import lookup_lead as _lookup_lead
+
+    return _lookup_lead(handle)
+
+
+@mcp.tool()
+def list_unread_leads() -> str:
+    """List every influencer with an unread reply in the inbox, sorted by recency.
+
+    Returns one row per unread conversation with the handle, unread count,
+    last message preview, and timestamp. Useful for daily prioritisation:
+    'which leads should I respond to right now?'
+    """
+    from gitd.services.marketing_lookup import list_unread_leads as _list_unread_leads
+
+    return _list_unread_leads()
+
+
+# ── Local CRM lookups ────────────────────────────────────────────────────────
+
+
+@mcp.tool()
+def crm_lookup_contact(handle: str) -> str:
+    """Get the stored fact sheet for one local CRM contact by handle. Read-only.
+
+    Returns the contact's profile fields, contact status/history, and the
+    latest conversation state (last message, unread count, timestamps).
+
+    Args:
+        handle: Contact handle, with or without @.
+    """
+    from gitd.services.crm_lookup import crm_lookup_contact as _lookup
+
+    return _lookup(handle)
+
+
+@mcp.tool()
+def crm_list_unread_messages() -> str:
+    """List local CRM contacts with unread messages, sorted by recency. Read-only.
+
+    Returns one row per unread conversation with the handle, unread count,
+    last message preview, and timestamp.
+    """
+    from gitd.services.crm_lookup import crm_list_unread_messages as _list_unread
+
+    return _list_unread()
 
 
 def main():

--- a/gitd/models/__init__.py
+++ b/gitd/models/__init__.py
@@ -10,6 +10,7 @@ from .chat import ChatConversation, ChatMessageRow
 from .phone import Phone, TikTokAccount
 from .schedule import JobQueue, JobRun, ScheduledJob
 from .skill_compat import SkillCompat, SkillRun
+from .trace import Trace, TraceSpan
 
 __all__ = [
     # Base
@@ -30,6 +31,9 @@ __all__ = [
     # Chat
     "ChatConversation",
     "ChatMessageRow",
+    # Tracing
+    "Trace",
+    "TraceSpan",
     # Skill compat
     "SkillRun",
     "SkillCompat",

--- a/gitd/models/trace.py
+++ b/gitd/models/trace.py
@@ -1,0 +1,64 @@
+"""Local tracing — Trace and TraceSpan models.
+
+Mirrors Langfuse's data shape so the same write helpers can fan out to both:
+- Always: local SQLite (this module)
+- Optionally: Langfuse remote, when LANGFUSE_PUBLIC_KEY is set
+
+A *trace* is one user-message → final-answer round-trip ("turn"). A *span* is
+one tool call or LLM generation inside that trace.
+"""
+
+from typing import Optional
+
+from sqlalchemy import Float, ForeignKey, Index, Integer, Text, text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import Base
+
+
+class Trace(Base):
+    __tablename__ = "traces"
+
+    id: Mapped[str] = mapped_column(Text, primary_key=True)  # uuid4 hex (32-char)
+    # Soft reference (no FK): the trace is opened before the conversation row
+    # exists in chat_conversations (save_session_to_db runs in the SSE finally
+    # block, after the trace closes). Cascading deletes are handled in
+    # delete_conversation_endpoint.
+    conversation_id: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    provider: Mapped[str] = mapped_column(Text, nullable=False)  # claude-code, on-device, ollama, anthropic
+    model: Mapped[str] = mapped_column(Text, server_default=text("''"))
+    device: Mapped[str] = mapped_column(Text, server_default=text("''"))
+    source: Mapped[str] = mapped_column(Text, server_default=text("'mac'"))  # mac, android
+    user_input: Mapped[str] = mapped_column(Text, server_default=text("''"))
+    final_output: Mapped[str] = mapped_column(Text, server_default=text("''"))
+    status: Mapped[str] = mapped_column(Text, server_default=text("'running'"))  # running, success, error, stopped
+    error_text: Mapped[Optional[str]] = mapped_column(Text, server_default=text("''"))
+    input_tokens: Mapped[int] = mapped_column(Integer, server_default=text("0"))
+    output_tokens: Mapped[int] = mapped_column(Integer, server_default=text("0"))
+    cost_usd: Mapped[float] = mapped_column(Float, server_default=text("0"))
+    duration_ms: Mapped[int] = mapped_column(Integer, server_default=text("0"))
+    started_at: Mapped[str] = mapped_column(Text, nullable=False)  # ISO-8601 UTC
+    ended_at: Mapped[Optional[str]] = mapped_column(Text, server_default=text("''"))
+
+
+# Index for "list traces newest-first" — the dominant query.
+Index("ix_traces_started_at", Trace.started_at.desc())
+Index("ix_traces_conversation", Trace.conversation_id)
+
+
+class TraceSpan(Base):
+    __tablename__ = "trace_spans"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    trace_id: Mapped[str] = mapped_column(Text, ForeignKey("traces.id", ondelete="CASCADE"), nullable=False)
+    kind: Mapped[str] = mapped_column(Text, nullable=False)  # tool, generation, event
+    name: Mapped[str] = mapped_column(Text, nullable=False)  # e.g. "tool:web_search", "llm-call"
+    input_json: Mapped[Optional[str]] = mapped_column(Text, server_default=text("''"))
+    output_json: Mapped[Optional[str]] = mapped_column(Text, server_default=text("''"))
+    level: Mapped[str] = mapped_column(Text, server_default=text("'DEFAULT'"))  # DEFAULT, ERROR
+    started_at: Mapped[str] = mapped_column(Text, nullable=False)
+    ended_at: Mapped[Optional[str]] = mapped_column(Text, server_default=text("''"))
+    duration_ms: Mapped[int] = mapped_column(Integer, server_default=text("0"))
+
+
+Index("ix_trace_spans_trace_id", TraceSpan.trace_id)

--- a/gitd/routers/agent_chat.py
+++ b/gitd/routers/agent_chat.py
@@ -107,6 +107,11 @@ def send_message(data: dict = Body({})):
         raise HTTPException(status_code=400, detail="content required")
 
     session = get_session(sid) if sid else None
+    # Session not in memory — try to reload from DB (happens after backend restart)
+    if not session and sid:
+        from gitd.services.agent_chat import load_conversation
+
+        session = load_conversation(sid)
     # Auto-create session if device provided but no session
     if not session:
         device = data.get("device", "")
@@ -209,6 +214,74 @@ def list_providers():
     from gitd.services.agent_chat import get_providers
 
     return get_providers()
+
+
+@router.post("/warmup", summary="Pre-fill on-device KV cache")
+def warmup_on_device(data: dict = Body({})):
+    """
+    Pre-bake the system + tool list prefix into the on-device LLM's KV cache
+    so the user's first chat turn lands as a "turn 2" with full prefix
+    reuse. Saves ~120 s of cold prefill on Snapdragon-class CPUs with the
+    default 1.3K-token system prompt.
+
+    The Android app should POST this once at launch (idempotent; subsequent
+    calls are near-free if the prefix is already cached). No-op for
+    non-llama.cpp runtimes.
+
+    Body: {"device": "<adb_serial>", "model": "gemma-4-e2b-q4km-gguf"}
+    """
+    from gitd.services.agent_chat import DEFAULT_SYSTEM, system_prompt_for_device
+    from gitd.services.agent_chat_ondevice import _kotlin_llm
+    from gitd.services.agent_tools import tool_prompt_list, tools_for_device
+
+    device = (data.get("device") or "").strip()
+    model_id = (data.get("model") or "").strip()
+    if not model_id:
+        raise HTTPException(status_code=400, detail="model required")
+
+    llm = _kotlin_llm()
+    if llm is None:
+        return {"ok": False, "warmed": 0, "reason": "Chaquopy bridge missing"}
+
+    try:
+        if not bool(llm.ensureLoaded(model_id)):
+            return {"ok": False, "warmed": 0, "reason": f"model {model_id} not loaded"}
+    except Exception as e:
+        return {"ok": False, "warmed": 0, "reason": f"ensureLoaded failed: {e}"}
+
+    # Stable prefix + disk cache path are computed in agent_chat_ondevice so
+    # chat and warmup share the same key. Without this, the chat path's
+    # generateStart sees an empty KV and pays a full cold prefill (~4 min on
+    # Q5_K_M / Q6_K) every time even though the prefix is already on disk.
+    from gitd.services.agent_chat_ondevice import (
+        _ensure_kv_warmed,
+        _kv_cache_path,
+        ondevice_stable_prefix,
+    )
+
+    system = DEFAULT_SYSTEM.replace("{tool_list}", tool_prompt_list(tools_for_device(device)))
+    system = system_prompt_for_device(device, system)
+    stable_prefix = ondevice_stable_prefix(system, device)
+    cache_path = _kv_cache_path(model_id, stable_prefix)
+
+    # Try restore first.
+    from_cache, loaded = _ensure_kv_warmed(llm, model_id, stable_prefix)
+    if from_cache:
+        return {"ok": True, "warmed": loaded, "model": model_id, "from_cache": True}
+
+    # Cold path: do the full prefill.
+    try:
+        warmed = int(llm.warmup(model_id, stable_prefix))
+    except Exception as e:
+        return {"ok": False, "warmed": 0, "reason": f"warmup failed: {e}"}
+
+    # Save for next launch (best-effort; failure doesn't break the warmup).
+    try:
+        getattr(llm, "saveState")(model_id, cache_path)
+    except Exception:
+        pass
+
+    return {"ok": True, "warmed": warmed, "model": model_id, "from_cache": False}
 
 
 # ── Ollama model management ──────────────────────────────────────────────

--- a/gitd/routers/benchmarks.py
+++ b/gitd/routers/benchmarks.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 from starlette.responses import StreamingResponse
 
 from gitd.benchmarks.runner import get_run, list_runs, run_benchmark, stop_run, subscribe, unsubscribe
+from gitd.bots.common.device import platform_for_device
 
 log = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/benchmarks", tags=["benchmarks"])
@@ -75,6 +76,9 @@ def api_list_tasks(suite: str = "ghost_bench", category: Optional[str] = None):
             "category": t.category,
             "complexity": t.complexity,
             "max_steps": t.max_steps,
+            "platforms": t.supported_platforms(),
+            "supports_android": t.supports_platform("android"),
+            "supports_ios": t.supports_platform("ios"),
         }
         for t in tasks
     ]
@@ -94,6 +98,24 @@ def api_start_run(req: RunRequest):
             raise HTTPException(status_code=400, detail="No valid task IDs provided")
     else:
         tasks = load_tasks()
+
+    platform = platform_for_device(req.device)
+    unsupported = [t.id for t in tasks if not t.supports_platform(platform)]
+    if unsupported:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "unsupported_platform",
+                "suite": req.suite,
+                "device": req.device,
+                "platform": platform,
+                "unsupported_tasks": unsupported,
+                "message": (
+                    f"Benchmark suite '{req.suite}' has {len(unsupported)} task(s) "
+                    f"that do not support {platform}: {', '.join(unsupported)}"
+                ),
+            },
+        )
 
     run_id = str(uuid.uuid4())[:8]
 

--- a/gitd/routers/bot.py
+++ b/gitd/routers/bot.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, Body, Depends
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
+from gitd.bots.common.device import is_ios_ref
 from gitd.config import settings
 from gitd.models.base import get_db
 
@@ -33,6 +34,21 @@ _SCRIPTS_DIR = Path(__file__).resolve().parent.parent
 
 
 _PREMIUM_JOB_TYPES = {"outreach", "crawl", "inbox_scan", "perf_scan", "engage", "content_gen", "content_plan"}
+_ANDROID_BOT_JOB_TYPES = {"post", "publish_draft"}
+
+
+def _bot_platform_error(job_type: str, device: str | None) -> dict | None:
+    if is_ios_ref(device) and job_type in _ANDROID_BOT_JOB_TYPES:
+        return {
+            "ok": False,
+            "error": "unsupported_platform",
+            "job_type": job_type,
+            "device": device,
+            "platform": "ios",
+            "supported_platforms": ["android"],
+            "message": f"{job_type} jobs are Android-only until the iOS TikTok workflow is ported",
+        }
+    return None
 
 
 def _build_cmd(job: dict, device: str | None = None) -> list:
@@ -41,6 +57,9 @@ def _build_cmd(job: dict, device: str | None = None) -> list:
 
     if job_type in _PREMIUM_JOB_TYPES:
         raise ValueError(f"Job type '{job_type}' requires the ghost_premium plugin.")
+    platform_error = _bot_platform_error(job_type, dev)
+    if platform_error:
+        raise ValueError(platform_error["message"])
 
     if job_type == "post":
         script = _SCRIPTS_DIR / "bots" / "tiktok" / "upload.py"
@@ -177,6 +196,9 @@ def bot_queue_add(data: dict = Body({})):
         }
         if job_type in _PREMIUM_JOB_TYPES:
             return {"ok": False, "error": f"Job type '{job_type}' requires the ghost_premium plugin."}
+        platform_error = _bot_platform_error(job_type, job["device"])
+        if platform_error:
+            return platform_error
         if job_type == "post":
             job.update(
                 {

--- a/gitd/routers/creator.py
+++ b/gitd/routers/creator.py
@@ -15,6 +15,7 @@ def _build_creator_system_prompt(data: dict) -> str:
 
     Uses shared device_context functions for all screen understanding.
     """
+    from gitd.bots.common.device import is_ios_ref
     from gitd.services.device_context import (
         get_phone_state,
         get_screen_tree,
@@ -23,7 +24,40 @@ def _build_creator_system_prompt(data: dict) -> str:
 
     backend = data.get("backend", "openrouter")
     context = data.get("context", {})
-    system = """You are a mobile automation agent that controls Android devices via ADB.
+    device_serial = context.get("device", "")
+    is_ios_device = is_ios_ref(device_serial)
+    if is_ios_device:
+        system = """You are a mobile automation agent that controls iOS devices through Appium XCUITest and WebDriverAgent.
+You help users create automation skills by proposing step-by-step plans and executing them.
+
+## Your capabilities (via Appium/WDA):
+- **tap(x, y)** -- tap at screen coordinates
+- **long_press(x, y, duration_ms)** -- long press
+- **swipe(x1, y1, x2, y2)** -- swipe gesture
+- **type(text)** -- type text into the focused input
+- **back** -- best-effort browser/app back
+- **home** -- press the iOS Home button through WDA
+- **launch(bundle_id)** -- open an app by iOS bundle id
+- **wait(seconds)** -- pause between actions
+- **screenshot** -- capture current screen
+- **get_screen_tree** -- LLM-readable iOS accessibility hierarchy with element indices
+- **get_elements** -- interactive elements as JSON with bounds + centers
+- **ocr_screen** -- OCR all visible text (for canvas/image content)
+- **ocr_region(x1,y1,x2,y2)** -- OCR a specific screen region
+- **classify_screen** -- detect screen type (home, search, dialog, error, etc.)
+
+## iOS skill metadata:
+- Saved iOS skills should use `platforms: ["ios"]` and `ios_bundle_id`.
+- Put iOS selectors in `elements_ios.yaml`; do not write Android-only `resource-id` selectors unless they are normalized from WDA.
+- Do NOT use ADB shell, Android intents, Portal overlay, Play Store flows, or Android package-manager commands on iOS.
+
+## Rules:
+- Do NOT create/write files. Only describe plans as JSON.
+- Each step MUST have an "action" and "description" field.
+- Use element_idx to reference screen elements when overlay is active.
+"""
+    else:
+        system = """You are a mobile automation agent that controls Android devices via ADB.
 You help users create automation skills by proposing step-by-step plans and executing them.
 
 ## Your capabilities (via ADB):
@@ -48,13 +82,14 @@ You help users create automation skills by proposing step-by-step plans and exec
 - Use element_idx to reference screen elements when overlay is active.
 """
 
-    device_serial = context.get("device", "")
     if device_serial:
         # Phone state
         try:
             state = get_phone_state(device_serial)
             if state:
-                system += f"\n\n## Current app: {state.get('currentApp', '')} ({state.get('packageName', '')})"
+                app_name = state.get("currentApp", "") or state.get("name", "")
+                target_id = state.get("packageName", "") or state.get("bundleId", "") or state.get("bundle_id", "")
+                system += f"\n\n## Current app: {app_name} ({target_id})"
                 if state.get("keyboardVisible"):
                     system += " [KEYBOARD OPEN]"
         except Exception:

--- a/gitd/routers/explorer.py
+++ b/gitd/routers/explorer.py
@@ -3,12 +3,14 @@
 import json
 import shutil
 import subprocess as _subprocess
+import sys
 from datetime import datetime
 from pathlib import Path
 
 from fastapi import APIRouter, Body, HTTPException
 from fastapi.responses import FileResponse
 
+from gitd.bots.common.device import is_ios_ref
 from gitd.config import settings
 
 router = APIRouter(prefix="/api/explorer", tags=["explorer"])
@@ -31,6 +33,7 @@ def explorer_start(data: dict = Body({})):
     if not package:
         raise HTTPException(status_code=400, detail="package is required")
     device = data.get("device", _BOT_DEVICE)
+    platform = "ios" if is_ios_ref(device) else "android"
     max_depth = int(data.get("max_depth", 3))
     max_states = int(data.get("max_states", 20))
     settle = float(data.get("settle", 1.5))
@@ -47,7 +50,7 @@ def explorer_start(data: dict = Body({})):
     # Start directly as subprocess
     log_file = f"/tmp/explorer_{package.replace('.', '_')}.log"
     cmd = [
-        "python3",
+        sys.executable,
         "-u",
         str(_SCRIPT),
         "--package",
@@ -70,11 +73,12 @@ def explorer_start(data: dict = Body({})):
         "pid": proc.pid,
         "package": package,
         "device": device,
+        "platform": platform,
         "log_file": log_file,
         "output_dir": output_dir,
         "max_states": max_states,
     }
-    return {"ok": True, "pid": proc.pid, "output_dir": output_dir}
+    return {"ok": True, "pid": proc.pid, "output_dir": output_dir, "platform": platform}
 
 
 @router.post("/stop", summary="Stop App Exploration")
@@ -108,7 +112,11 @@ def explorer_status():
     result = {
         "running": is_running,
         "pid": _active_proc.get("pid"),
+        "device": _active_proc.get("device", ""),
         "package": package,
+        "platform": _active_proc.get("platform", "android"),
+        "output_dir": output_dir,
+        "current_activity": "",
         "max_states": _active_proc.get("max_states", 20),
         "states_found": 0,
         "transitions": 0,
@@ -121,6 +129,11 @@ def explorer_status():
     if progress_path.exists():
         try:
             prog = json.loads(progress_path.read_text())
+            result["device"] = prog.get("device") or result["device"]
+            result["package"] = prog.get("package") or result["package"]
+            result["platform"] = prog.get("platform") or result["platform"]
+            result["output_dir"] = prog.get("output_dir") or result["output_dir"]
+            result["current_activity"] = prog.get("current_activity") or result["current_activity"]
             result["states_found"] = prog.get("states_found", 0)
             result["transitions"] = prog.get("transitions", 0)
             result["current_depth"] = prog.get("current_depth", 0)
@@ -167,6 +180,7 @@ def explorer_runs():
                         "states": g.get("total_states", 0),
                         "transitions": g.get("total_transitions", 0),
                         "max_depth": g.get("max_depth", 0),
+                        "platform": g.get("platform", "android"),
                         "device": g.get("device", ""),
                         "date": mtime.strftime("%Y-%m-%d %H:%M"),
                     }

--- a/gitd/routers/h264_stream.py
+++ b/gitd/routers/h264_stream.py
@@ -1,0 +1,223 @@
+"""GhostAgent H.264 screen-stream proxy.
+
+The patched WebDriverAgent runs an H.264-over-WebSocket server on the device
+(mjpegServerPort + 100, e.g. :9200). Appium only forwards the single MJPEG port,
+so the device stream port is not reachable at localhost. This router is a
+hardened relay: the browser (or a fleet master) connects to a same-origin
+WebSocket here, and the backend connects to the device stream over whichever
+strategy works, with reconnect/backoff. One device connection can fan out to
+many viewers.
+
+Reachability strategies, in order (first that connects wins, remembered):
+  1. localhost:<port>            — if a forward happens to exist
+  2. [tunnel-ipv6-address]:<port> — the RemoteXPC tunnel route from the registry
+  3. 127.0.0.1:<port>            — explicit loopback
+
+Frontend decodes the Annex-B H.264 with WebCodecs. See docs/ios/FLEET.md.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+from gitd.bots.common.device import get_device, is_ios_ref
+from gitd.bots.common.ios import (
+    _host_device_config_for_udid,
+    remote_xpc_tunnel_status,
+    strip_ios_prefix,
+)
+
+try:  # core-dev owns is_remote_ref (Ghost-side @host parsing); use it once it lands.
+    from gitd.bots.common.device import is_remote_ref as _is_remote_ref
+except ImportError:  # safe interim signal: only remote refs carry "@" (Android serials never do)
+
+    def _is_remote_ref(ref: str) -> bool:
+        return "@" in (ref or "")
+
+
+def _env_force_localhost() -> bool:
+    """Optional global override on top of the per-device signal (mixed hosts should
+    prefer the per-device param; this is an escape hatch for all-remote deployments)."""
+    return os.getenv("IOS_STREAM_FORCE_LOCALHOST", "").strip().lower() in ("1", "true", "yes")
+
+
+router = APIRouter(tags=["streaming"])
+
+MJPEG_DEFAULT_PORT = 9100
+H264_PORT_OFFSET = 100
+CONNECT_TIMEOUT = 5.0
+RECONNECT_BACKOFF_MIN = 0.5
+RECONNECT_BACKOFF_MAX = 5.0
+
+
+def _h264_port(udid: str) -> int:
+    host = _host_device_config_for_udid(udid)
+    try:
+        base = int(host.get("mjpeg_server_port") or MJPEG_DEFAULT_PORT)
+    except (TypeError, ValueError):
+        base = MJPEG_DEFAULT_PORT
+    return base + H264_PORT_OFFSET
+
+
+def _candidate_urls(udid: str, port: int, force_localhost: bool = False) -> list[str]:
+    urls = [f"ws://localhost:{port}/", f"ws://127.0.0.1:{port}/"]
+    # Remote-drive (Linux Ghost -> SSH -> Mac -> iPhone, docs/ios/REMOTE_DRIVE.md):
+    # the RemoteXPC tunnel IPv6 (fdxx::) is only routable ON the Mac, so a remote
+    # caller must use the SSH-forwarded localhost port and MUST NOT probe the tunnel
+    # address. force_localhost is passed PER-DEVICE (is_remote_ref(ref)) — not a
+    # process-global — so a mixed host (a local iPhone physically on the Mac + a
+    # remote one, both streaming) still lets the LOCAL device use its tunnel-IPv6
+    # candidate while the remote one stays on localhost.
+    if not force_localhost:
+        try:
+            tunnel = remote_xpc_tunnel_status(udid)
+            addr = str((tunnel.get("registry") or {}).get("address") or "")
+            if addr:
+                host = f"[{addr}]" if ":" in addr and not addr.startswith("[") else addr
+                urls.insert(0, f"ws://{host}:{port}/")  # tunnel route first — most reliable on iOS 17+
+        except Exception:
+            pass
+    # de-dup, keep order
+    seen: set[str] = set()
+    out: list[str] = []
+    for u in urls:
+        if u not in seen:
+            seen.add(u)
+            out.append(u)
+    return out
+
+
+# Guard WDA launches: at most one in flight per device, and not more often than
+# the cooldown — otherwise a reconnect storm spawns a pile of xcodebuild launches
+# that jam the device and fight the dashboard's own session.
+_session_locks: dict[str, asyncio.Lock] = {}
+_last_ensure: dict[str, float] = {}
+ENSURE_COOLDOWN = 30.0
+
+
+async def _ensure_session(device: str) -> None:
+    def _ens() -> None:
+        try:
+            get_device(device)._ensure_session()
+        except Exception:
+            pass
+
+    await asyncio.to_thread(_ens)
+
+
+async def _ensure_session_guarded(device: str, udid: str) -> None:
+    """Launch WDA only if nothing else is launching it and it wasn't launched in
+    the last ENSURE_COOLDOWN seconds. Concurrent callers wait for the in-flight
+    launch instead of starting their own."""
+    loop = asyncio.get_event_loop()
+    lock = _session_locks.setdefault(udid, asyncio.Lock())
+    if lock.locked():
+        async with lock:  # someone is launching — just wait for it
+            return
+    async with lock:
+        if loop.time() - _last_ensure.get(udid, 0.0) < ENSURE_COOLDOWN:
+            return  # launched recently; don't relaunch
+        _last_ensure[udid] = loop.time()
+        await _ensure_session(device)
+
+
+async def _connect_device(udid: str, port: int, force_localhost: bool = False):
+    """Try each reachability strategy; return (ws, url) or (None, error)."""
+    import websockets
+
+    last_err = ""
+    # _candidate_urls does a blocking tunnel-registry HTTP lookup; run it off the
+    # event loop so it can't stall the WS handshake / other streams.
+    candidates = await asyncio.to_thread(_candidate_urls, udid, port, force_localhost)
+    for url in candidates:
+        try:
+            ws = await asyncio.wait_for(
+                websockets.connect(url, max_size=None, open_timeout=CONNECT_TIMEOUT),
+                timeout=CONNECT_TIMEOUT,
+            )
+            return ws, url
+        except Exception as e:  # noqa: BLE001 — try the next strategy
+            last_err = f"{url}: {e}"
+    return None, last_err
+
+
+@router.websocket("/api/phone/h264/{device}")
+async def h264_stream(client: WebSocket, device: str):
+    await client.accept()
+    if not is_ios_ref(device):
+        await client.send_json({"error": "h264 stream is iOS-only"})
+        await client.close()
+        return
+
+    udid = strip_ios_prefix(device)
+    port = _h264_port(udid)
+    # Remote refs (<name>@<host>) reach us over the SSH forward, where the tunnel
+    # IPv6 isn't routable — force the localhost candidate for THIS device only.
+    force_localhost = _is_remote_ref(device) or _env_force_localhost()
+    backoff = RECONNECT_BACKOFF_MIN
+    stop = False
+
+    async def pump_client_control():
+        # Detect the browser going away; also drains any client messages.
+        nonlocal stop
+        try:
+            while True:
+                await client.receive_text()
+        except Exception:
+            stop = True
+
+    control_task = asyncio.create_task(pump_client_control())
+
+    try:
+        while not stop:
+            # Try the device stream FIRST — if a session already exists (e.g. the
+            # dashboard's), :9200 is up and we connect immediately with no launch.
+            dev_ws, info = await _connect_device(udid, port, force_localhost)
+            if dev_ws is None:
+                # Not reachable — WDA probably isn't running. Launch it (guarded so
+                # reconnect storms can't pile up xcodebuild), then retry once.
+                with contextlib.suppress(Exception):
+                    await client.send_json({"status": "starting WDA session"})
+                await _ensure_session_guarded(device, udid)
+                dev_ws, info = await _connect_device(udid, port, force_localhost)
+
+            if dev_ws is None:
+                # Still down — back off and retry (guard's cooldown prevents relaunch).
+                with contextlib.suppress(Exception):
+                    await client.send_json({"status": "connecting", "detail": info})
+                await asyncio.sleep(backoff)
+                backoff = min(RECONNECT_BACKOFF_MAX, backoff * 2)
+                continue
+
+            backoff = RECONNECT_BACKOFF_MIN
+            with contextlib.suppress(Exception):
+                await client.send_json({"status": "connected", "via": info})
+            try:
+                async for frame in dev_ws:
+                    if stop:
+                        break
+                    if isinstance(frame, (bytes, bytearray)):
+                        await client.send_bytes(frame)
+            except Exception:
+                # device stream dropped — loop reconnects
+                pass
+            finally:
+                with contextlib.suppress(Exception):
+                    await dev_ws.close()
+            if not stop:
+                with contextlib.suppress(Exception):
+                    await client.send_json({"status": "reconnecting"})
+                await asyncio.sleep(backoff)
+    except WebSocketDisconnect:
+        pass
+    finally:
+        stop = True
+        control_task.cancel()
+        with contextlib.suppress(Exception):
+            await control_task
+        with contextlib.suppress(Exception):
+            await client.close()

--- a/gitd/routers/marketing_jobs.py
+++ b/gitd/routers/marketing_jobs.py
@@ -1,0 +1,258 @@
+"""Marketing-jobs router — single seam for external marketing agents to
+queue safe mobile jobs via Ghost's scheduler/job_queue.
+
+Lives in the public gitd/ namespace so external marketing agents — the
+social-media-agent (at ~/Agent/social-media-agent/) and content-planning
+agents — can call into Ghost without depending on the premium plugin.
+
+Safety: `action` is force-overridden to 'draft' regardless of input.
+The agent has no permission to live-publish from this seam — that's a
+separate design review. If callers pass action='publish' we log a
+warning and still save as draft.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from gitd.bots.common.device import is_ios_ref
+from gitd.models.base import get_db
+from gitd.services._job_helpers import _enqueue_job
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/marketing-jobs", tags=["marketing-jobs"])
+
+
+class EnqueueRequest(BaseModel):
+    video_path: Optional[str] = Field(None, description="Absolute path to the video file on this machine")
+    caption: str = ""
+    hashtags: str = ""
+    query: Optional[str] = Field(None, description="Search query for iOS TikTok search smoke jobs")
+    url: Optional[str] = Field(None, description="URL for iOS browser/news smoke jobs")
+    bundle_id: Optional[str] = Field(None, description="iOS browser bundle id override, e.g. com.google.chrome.ios")
+    phone_serial: str = Field(..., description="Android ADB serial or ios:<udid> phone ref")
+    tts_text: Optional[str] = None
+    scheduled_at: Optional[str] = Field(None, description="ISO timestamp; informational only — runs ASAP")
+    account: Optional[str] = Field(None, description="Expected active TikTok account on the phone")
+    action: str = Field("draft", description="Forced to 'draft' regardless of input")
+    max_lines: int = Field(80, ge=1, le=500, description="Visible text line cap for iOS profile smoke jobs")
+    max_headlines: int = Field(5, ge=1, le=20, description="Headline cap for iOS read_news jobs")
+    max_articles: int = Field(3, ge=0, le=10, description="Article cap for iOS read_news jobs")
+    wait_s: float = Field(2.0, ge=0, le=30, description="Readiness wait for iOS browser/news jobs")
+    save_screenshots: bool = Field(False, description="Save screenshots for iOS browser/news jobs")
+
+
+_IOS_TIKTOK_SMOKE_ACTIONS = {
+    "ios_profile_smoke": "profile_smoke",
+    "profile_smoke": "profile_smoke",
+    "verify_profile": "profile_smoke",
+    "smoke": "profile_smoke",
+    "ios_open_app_smoke": "open_app_smoke",
+    "open_app_smoke": "open_app_smoke",
+    "open_app": "open_app_smoke",
+    "launch_smoke": "open_app_smoke",
+    "ios_search_smoke": "search_smoke",
+    "search_smoke": "search_smoke",
+    "search": "search_smoke",
+}
+
+
+def _ios_tiktok_smoke_workflow(action: str | None) -> str:
+    return _IOS_TIKTOK_SMOKE_ACTIONS.get((action or "").strip().lower(), "")
+
+
+_IOS_BROWSER_WORKFLOWS = {
+    "ios_read_news": "read_news",
+    "read_news": "read_news",
+    "news": "read_news",
+    "news_smoke": "read_news",
+    "chrome_news": "read_news",
+    "browser_news": "read_news",
+}
+
+
+def _ios_browser_workflow(action: str | None) -> str:
+    return _IOS_BROWSER_WORKFLOWS.get((action or "").strip().lower(), "")
+
+
+def _unsupported_ios_post_detail() -> dict:
+    return {
+        "ok": False,
+        "error": "unsupported_platform",
+        "platform": "ios",
+        "message": "TikTok marketing post jobs are Android-only until the iOS TikTok workflow is ported",
+    }
+
+
+def _ios_tiktok_smoke_params(req: EnqueueRequest, workflow: str) -> dict:
+    if workflow == "profile_smoke":
+        return {"max_lines": req.max_lines}
+    if workflow == "search_smoke":
+        query = (req.query or req.hashtags or "").strip() or "#fyp"
+        return {"query": query}
+    return {}
+
+
+def _enqueue_ios_tiktok_smoke(req: EnqueueRequest, db: Session) -> dict:
+    workflow = _ios_tiktok_smoke_workflow(req.action)
+    params = _ios_tiktok_smoke_params(req, workflow)
+    config = {
+        "skill": "tiktok_ios",
+        "workflow": workflow,
+        "params": params,
+        "source": "marketing_jobs",
+        "action": workflow,
+    }
+    if req.account:
+        config["account"] = req.account
+
+    job_id = _enqueue_job(
+        db,
+        scheduled_job_id=None,
+        phone_serial=req.phone_serial,
+        job_type="skill_workflow",
+        priority=2,
+        config_json=config,
+        max_duration_s=300,
+        trigger="marketing_agent",
+        status="pending",
+    )
+
+    return {
+        "job_id": f"ghost-job-{job_id}",
+        "estimated_post_at": req.scheduled_at,
+        "action": workflow,
+        "phone_serial": req.phone_serial,
+        "job_type": "skill_workflow",
+        "skill": "tiktok_ios",
+        "workflow": workflow,
+        "params": params,
+    }
+
+
+def _ios_read_news_params(req: EnqueueRequest) -> dict:
+    params = {
+        "url": (req.url or req.query or "").strip() or "https://text.npr.org/",
+        "max_headlines": req.max_headlines,
+        "max_articles": req.max_articles,
+        "wait_s": req.wait_s,
+        "save_screenshots": req.save_screenshots,
+    }
+    if req.bundle_id:
+        params["bundle_id"] = req.bundle_id
+    return params
+
+
+def _enqueue_ios_browser_workflow(req: EnqueueRequest, db: Session) -> dict:
+    workflow = _ios_browser_workflow(req.action)
+    params = _ios_read_news_params(req)
+    config = {
+        "skill": "safari",
+        "workflow": workflow,
+        "params": params,
+        "source": "marketing_jobs",
+        "action": workflow,
+    }
+
+    job_id = _enqueue_job(
+        db,
+        scheduled_job_id=None,
+        phone_serial=req.phone_serial,
+        job_type="skill_workflow",
+        priority=2,
+        config_json=config,
+        max_duration_s=600,
+        trigger="marketing_agent",
+        status="pending",
+    )
+
+    return {
+        "job_id": f"ghost-job-{job_id}",
+        "estimated_post_at": req.scheduled_at,
+        "action": workflow,
+        "phone_serial": req.phone_serial,
+        "job_type": "skill_workflow",
+        "skill": "safari",
+        "workflow": workflow,
+        "params": params,
+    }
+
+
+@router.post("/enqueue", summary="Enqueue a marketing mobile job")
+def enqueue_marketing_job(req: EnqueueRequest, db: Session = Depends(get_db)):
+    """Queue a marketing job for the scheduler to pick up.
+
+    Android refs use the legacy TikTok draft post path. iOS refs can enqueue
+    safe smoke/browser workflows while TikTok upload remains unported.
+    """
+    if not req.phone_serial:
+        raise HTTPException(status_code=400, detail="phone_serial required")
+    if is_ios_ref(req.phone_serial):
+        if _ios_browser_workflow(req.action):
+            return _enqueue_ios_browser_workflow(req, db)
+        if _ios_tiktok_smoke_workflow(req.action):
+            return _enqueue_ios_tiktok_smoke(req, db)
+        raise HTTPException(status_code=400, detail=_unsupported_ios_post_detail())
+
+    if _ios_browser_workflow(req.action):
+        raise HTTPException(
+            status_code=400,
+            detail="iOS browser/news marketing actions require phone_serial like ios:<udid>",
+        )
+    if _ios_tiktok_smoke_workflow(req.action):
+        raise HTTPException(
+            status_code=400,
+            detail="iOS TikTok smoke marketing actions require phone_serial like ios:<udid>",
+        )
+    if not req.video_path:
+        raise HTTPException(status_code=400, detail="video_path required")
+    if not os.path.isabs(req.video_path):
+        raise HTTPException(status_code=400, detail="video_path must be absolute")
+    if not os.path.exists(req.video_path):
+        raise HTTPException(status_code=400, detail=f"video_path does not exist: {req.video_path}")
+
+    # Hard-force draft. If the caller asked for publish, log a warning so we
+    # can see attempts in the log, but never honor it.
+    if req.action and req.action.lower() != "draft":
+        logger.warning(
+            "marketing_jobs.enqueue: rejecting action=%r from external caller; saving as draft instead",
+            req.action,
+        )
+
+    config = {
+        "video": req.video_path,
+        "caption": req.caption,
+        "hashtags": req.hashtags,
+        "action": "draft",
+    }
+    if req.tts_text:
+        config["inject_tts"] = True
+        config["tts_text"] = req.tts_text
+    if req.account:
+        config["account"] = req.account
+
+    job_id = _enqueue_job(
+        db,
+        scheduled_job_id=None,
+        phone_serial=req.phone_serial,
+        job_type="post",
+        priority=2,
+        config_json=config,
+        max_duration_s=1800,
+        trigger="marketing_agent",
+        status="pending",
+    )
+
+    return {
+        "job_id": f"ghost-job-{job_id}",
+        "estimated_post_at": req.scheduled_at,  # informational, not enforced
+        "action": "draft",
+        "phone_serial": req.phone_serial,
+    }

--- a/gitd/routers/phone.py
+++ b/gitd/routers/phone.py
@@ -5,14 +5,48 @@ import subprocess
 import time as _time
 
 from fastapi import APIRouter, Body, Depends, HTTPException
+from fastapi.responses import FileResponse
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
+from gitd.bots.common.device import get_device, is_ios_ref, list_configured_ios_devices
 from gitd.models.base import get_db
 
 router = APIRouter(prefix="/api/phone", tags=["phone"])
 
 _last_wifi_reconnect: float = 0
+
+
+def _ios_unsupported(feature: str) -> dict:
+    return {"ok": False, "platform": "ios", "error": f"{feature} is Android-only and is not supported for iOS devices"}
+
+
+def _platform(device: str) -> str:
+    return "ios" if is_ios_ref(device) else "android"
+
+
+def _phone_error(device: str, error: str) -> dict:
+    return {"ok": False, "device": device, "platform": _platform(device), "error": error}
+
+
+def _error_text(exc: Exception) -> str:
+    return str(exc) or exc.__class__.__name__
+
+
+def _ios_unsupported(feature: str) -> dict:
+    return {"ok": False, "platform": "ios", "error": f"{feature} is Android-only and is not supported for iOS devices"}
+
+
+def _platform(device: str) -> str:
+    return "ios" if is_ios_ref(device) else "android"
+
+
+def _phone_error(device: str, error: str) -> dict:
+    return {"ok": False, "device": device, "platform": _platform(device), "error": error}
+
+
+def _error_text(exc: Exception) -> str:
+    return str(exc) or exc.__class__.__name__
 
 
 def _try_wifi_reconnect(db: Session):
@@ -42,65 +76,93 @@ def _try_wifi_reconnect(db: Session):
 
 
 @router.get("/devices", summary="List Connected Phone Devices")
-def phone_devices(db: Session = Depends(get_db)):
+def phone_devices(probe: str = "", db: Session = Depends(get_db)):
     """List ADB-connected devices with model info and nicknames."""
     try:
+        devices = []
+        adb_error = ""
+        deep_ios_probe = probe.lower() in {"1", "true", "deep", "full", "wda"}
         # Try reconnecting known WiFi devices that aren't currently connected
         _try_wifi_reconnect(db)
 
-        out = subprocess.check_output(["adb", "devices", "-l"], timeout=5).decode()
-        devices = []
-        for line in out.strip().split("\n")[1:]:
-            line = line.strip()
-            if not line:
-                continue
-            parts = line.split()
-            if len(parts) < 2 or parts[1] not in ("device", "recovery", "sideload"):
-                continue
-            serial = parts[0]
-            model = ""
-            if "model:" in line:
-                model = line.split("model:")[1].split()[0].replace("_", " ")
-            now_str = __import__("datetime").datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-            is_wifi = ":" in serial
+        try:
+            out = subprocess.check_output(["adb", "devices", "-l"], timeout=5).decode()
+        except Exception as e:
+            out = ""
+            adb_error = str(e)
+        if out:
+            for line in out.strip().split("\n")[1:]:
+                line = line.strip()
+                if not line:
+                    continue
+                parts = line.split()
+                if len(parts) < 2 or parts[1] not in ("device", "recovery", "sideload"):
+                    continue
+                serial = parts[0]
+                model = ""
+                if "model:" in line:
+                    model = line.split("model:")[1].split()[0].replace("_", " ")
+                now_str = __import__("datetime").datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                is_wifi = ":" in serial
 
-            # Save WiFi IP to DB for auto-reconnect
-            wifi_ip = serial.split(":")[0] if is_wifi else None
-            wifi_port = int(serial.split(":")[1]) if is_wifi and ":" in serial else None
-            conn_type = "wifi" if is_wifi else "usb"
+                # Save WiFi IP to DB for auto-reconnect
+                wifi_ip = serial.split(":")[0] if is_wifi else None
+                wifi_port = int(serial.split(":")[1]) if is_wifi and ":" in serial else None
+                conn_type = "wifi" if is_wifi else "usb"
 
-            if is_wifi:
-                # For WiFi devices, also update the USB entry if we know the model
+                if is_wifi:
+                    # For WiFi devices, also update the USB entry if we know the model
+                    db.execute(
+                        text("""
+                        UPDATE phones SET wifi_ip=:ip, wifi_port=:port, connection_type=:conn
+                        WHERE model=:model AND wifi_ip IS NULL
+                    """),
+                        {"ip": wifi_ip, "port": wifi_port, "conn": conn_type, "model": model},
+                    )
+
                 db.execute(
                     text("""
-                    UPDATE phones SET wifi_ip=:ip, wifi_port=:port, connection_type=:conn
-                    WHERE model=:model AND wifi_ip IS NULL
+                    INSERT INTO phones (serial, model, first_seen, last_seen, wifi_ip, wifi_port, connection_type)
+                    VALUES (:serial, :model, :now, :now, :ip, :port, :conn)
+                    ON CONFLICT(serial) DO UPDATE SET model=:model, last_seen=:now,
+                        wifi_ip=COALESCE(:ip, wifi_ip), wifi_port=COALESCE(:port, wifi_port),
+                        connection_type=:conn
                 """),
-                    {"ip": wifi_ip, "port": wifi_port, "conn": conn_type, "model": model},
+                    {
+                        "serial": serial,
+                        "model": model,
+                        "now": now_str,
+                        "ip": wifi_ip,
+                        "port": wifi_port,
+                        "conn": conn_type,
+                    },
                 )
-
-            db.execute(
-                text("""
-                INSERT INTO phones (serial, model, first_seen, last_seen, wifi_ip, wifi_port, connection_type)
-                VALUES (:serial, :model, :now, :now, :ip, :port, :conn)
-                ON CONFLICT(serial) DO UPDATE SET model=:model, last_seen=:now,
-                    wifi_ip=COALESCE(:ip, wifi_ip), wifi_port=COALESCE(:port, wifi_port),
-                    connection_type=:conn
-            """),
-                {"serial": serial, "model": model, "now": now_str, "ip": wifi_ip, "port": wifi_port, "conn": conn_type},
-            )
-            db.commit()
-            devices.append({"serial": serial, "model": model or serial, "connection": conn_type})
+                db.commit()
+                devices.append(
+                    {
+                        "serial": serial,
+                        "model": model or serial,
+                        "connection": conn_type,
+                        "platform": "android",
+                    }
+                )
 
         # Deduplicate: if same model has both USB and WiFi, keep USB only
         usb_models = {d["model"] for d in devices if d["connection"] == "usb"}
         devices = [d for d in devices if d["connection"] == "usb" or d["model"] not in usb_models]
 
+        for ios_device in list_configured_ios_devices(deep_probe=deep_ios_probe):
+            if not any(d["serial"] == ios_device["serial"] for d in devices):
+                devices.append(ios_device)
+
         registry_rows = db.execute(text("SELECT * FROM phones")).mappings().all()
         registry = {r["serial"]: dict(r) for r in registry_rows}
         for d in devices:
             d["nickname"] = registry.get(d["serial"], {}).get("nickname", "")
-        return {"devices": devices}
+        response = {"devices": devices}
+        if adb_error:
+            response["adb_error"] = adb_error
+        return response
     except Exception as e:
         return {"devices": [], "error": str(e)}
 
@@ -122,8 +184,28 @@ def phone_nickname(data: dict = Body({}), db: Session = Depends(get_db)):
 @router.post("/input", summary="Send Input To Phone")
 def phone_input(data: dict = Body({})):
     """Send a tap, swipe, keyevent, or text input to a device."""
-    device = data.get("device")
+    device = data.get("device", "")
     action = data.get("action")
+    if is_ios_ref(device):
+        dev = get_device(device)
+        try:
+            if action == "tap":
+                dev.tap(int(data["x"]), int(data["y"]))
+            elif action == "swipe":
+                dur = int(data.get("duration", 300))
+                dev.swipe(int(data["x1"]), int(data["y1"]), int(data["x2"]), int(data["y2"]), ms=dur)
+            elif action == "keyevent":
+                key = data.get("keycode") or data.get("key")
+                if not key:
+                    return _phone_error(device, "key or keycode required")
+                dev.press_key(str(key))
+            elif action == "text":
+                dev.type_text(data["text"])
+            else:
+                return _phone_error(device, "unknown action")
+            return {"ok": True, "device": device, "platform": "ios"}
+        except Exception as e:
+            return _phone_error(device, str(e))
     cmd = ["adb"]
     if device:
         cmd += ["-s", device]
@@ -143,24 +225,40 @@ def phone_input(data: dict = Body({})):
                 str(dur),
             ]
         elif action == "keyevent":
-            cmd += ["shell", "input", "keyevent", str(data["keycode"])]
+            key = data.get("keycode") or data.get("key")
+            if not key:
+                return _phone_error(device, "key or keycode required")
+            cmd += ["shell", "input", "keyevent", str(key)]
         elif action == "text":
             cmd += ["shell", "input", "text", data["text"]]
         else:
-            return {"ok": False, "error": "unknown action"}
+            return _phone_error(device, "unknown action")
         subprocess.check_output(cmd, timeout=6)
-        return {"ok": True}
+        return {"ok": True, "device": device, "platform": "android"}
     except Exception as e:
-        return {"ok": False, "error": str(e)}
+        return _phone_error(device, str(e))
 
 
 @router.get("/elements/{device}", summary="Get Phone UI Elements")
 def api_phone_elements(device: str):
     """Get interactive UI elements from device screen."""
+    from gitd.bots.common.adb import Device
     from gitd.services.device_context import get_interactive_elements
 
     elements = get_interactive_elements(device)
-    return {"elements": elements, "count": len(elements)}
+    screen_size = {}
+    try:
+        if is_ios_ref(device):
+            width, height = get_device(device).get_screen_size()
+        else:
+            out = Device(device).adb("shell", "wm", "size", timeout=3)
+            m = re.search(r"(\d+)x(\d+)", out)
+            width, height = (int(m.group(1)), int(m.group(2))) if m else (0, 0)
+        if width and height:
+            screen_size = {"width": width, "height": height}
+    except Exception:
+        screen_size = {}
+    return {"elements": elements, "count": len(elements), "platform": _platform(device), "screen_size": screen_size}
 
 
 @router.post("/tap", summary="Tap On Phone Screen")
@@ -168,77 +266,272 @@ def api_phone_tap(data: dict = Body({})):
     """Tap at coordinates or send a keyevent to a device."""
     from gitd.bots.common.adb import Device
 
-    dev = Device(data.get("device", ""))
-    if data.get("keyevent"):
-        dev.adb("shell", "input", "keyevent", data["keyevent"])
-    else:
-        x, y = int(data.get("x", 0)), int(data.get("y", 0))
-        stream_w = int(data.get("stream_w", 0))
-        stream_h = int(data.get("stream_h", 0))
-        if stream_w and stream_h:
-            try:
-                out = dev.adb("shell", "wm", "size", timeout=3)
-                m = re.search(r"(\d+)x(\d+)", out)
-                if m:
-                    real_w, real_h = int(m.group(1)), int(m.group(2))
-                    x = int(x * real_w / stream_w)
-                    y = int(y * real_h / stream_h)
-            except Exception:
-                pass
-        dev.tap(x, y)
-    return {"ok": True}
+    device = data.get("device", "")
+    try:
+        dev = get_device(device)
+        if data.get("keyevent"):
+            if is_ios_ref(device):
+                dev.press_key(str(data["keyevent"]))
+            else:
+                from gitd.bots.common.adb import normalize_keycode
+
+                dev.adb("shell", "input", "keyevent", normalize_keycode(str(data["keyevent"])))
+        else:
+            x, y = int(data.get("x", 0)), int(data.get("y", 0))
+            stream_w = int(data.get("stream_w", 0))
+            stream_h = int(data.get("stream_h", 0))
+            if stream_w and stream_h:
+                try:
+                    if is_ios_ref(device):
+                        real_w, real_h = dev.get_screen_size()
+                    else:
+                        out = Device(device).adb("shell", "wm", "size", timeout=3)
+                        m = re.search(r"(\d+)x(\d+)", out)
+                        real_w, real_h = (int(m.group(1)), int(m.group(2))) if m else (0, 0)
+                    if real_w and real_h:
+                        x = int(x * real_w / stream_w)
+                        y = int(y * real_h / stream_h)
+                except Exception:
+                    pass
+            dev.tap(x, y)
+        return {"ok": True, "device": device, "platform": _platform(device)}
+    except Exception as e:
+        return _phone_error(device, _error_text(e))
 
 
 @router.post("/type", summary="Type Text On Phone")
 def api_phone_type(data: dict = Body({})):
     """Type text into the focused input field on a device."""
-    from gitd.bots.common.adb import Device
+    device = data.get("device", "")
+    text_val = data.get("text", "")
+    try:
+        dev = get_device(device)
+        if is_ios_ref(device):
+            dev.type_text(text_val)
+        else:
+            from gitd.bots.common.adb import ascii_typeable, input_text_arg
 
-    dev = Device(data.get("device", ""))
-    text_val = data.get("text", "").replace(" ", "%s")
-    dev.adb("shell", "input", "text", text_val)
-    return {"ok": True}
+            dev.adb("shell", "input", "text", input_text_arg(ascii_typeable(str(text_val))))
+        return {"ok": True, "device": device, "platform": _platform(device)}
+    except Exception as e:
+        return _phone_error(device, _error_text(e))
+
+
+@router.get("/clipboard/{device}", summary="Get Device Clipboard")
+def api_phone_clipboard_get(device: str):
+    """Read plain-text clipboard contents from Android or iOS."""
+    from gitd.services.device_context import clipboard_get
+
+    try:
+        text_value = clipboard_get(device)
+        return {
+            "ok": True,
+            "device": device,
+            "platform": "ios" if is_ios_ref(device) else "android",
+            "text": text_value,
+        }
+    except Exception as e:
+        return _phone_error(device, _error_text(e))
+
+
+@router.post("/clipboard", summary="Set Device Clipboard")
+def api_phone_clipboard_set(data: dict = Body({})):
+    """Set plain-text clipboard contents on Android or iOS."""
+    from gitd.services.device_context import clipboard_set
+
+    device = data.get("device", "")
+    text_value = data.get("text", "")
+    if not device:
+        raise HTTPException(status_code=400, detail="device required")
+    try:
+        ok = clipboard_set(device, str(text_value))
+        return {"ok": bool(ok), "device": device, "platform": "ios" if is_ios_ref(device) else "android"}
+    except Exception as e:
+        return _phone_error(device, _error_text(e))
+
+
+@router.post("/paste-text", summary="Paste Text On Phone")
+def api_phone_paste_text(data: dict = Body({})):
+    """Set clipboard text and paste it into the focused field."""
+    from gitd.services.device_context import clipboard_set
+
+    device = data.get("device", "")
+    text_value = data.get("text", "")
+    if not device:
+        raise HTTPException(status_code=400, detail="device required")
+    try:
+        if is_ios_ref(device):
+            ok = bool(get_device(device).paste_text(str(text_value)))
+        else:
+            ok = clipboard_set(device, str(text_value))
+            if ok:
+                from gitd.bots.common.adb import Device
+
+                Device(device).adb("shell", "input", "keyevent", "KEYCODE_PASTE")
+        return {"ok": bool(ok), "device": device, "platform": "ios" if is_ios_ref(device) else "android"}
+    except Exception as e:
+        return _phone_error(device, _error_text(e))
 
 
 @router.post("/back", summary="Press Back Button")
 def api_phone_back(data: dict = Body({})):
-    """Press the Android back button on a device."""
-    from gitd.bots.common.adb import Device
-
-    dev = Device(data.get("device", ""))
-    dev.back(delay=0.3)
-    return {"ok": True}
+    """Press the platform back/navigation control on a device."""
+    device = data.get("device", "")
+    try:
+        dev = get_device(device)
+        dev.back(delay=0.3)
+        return {"ok": True, "device": device, "platform": _platform(device)}
+    except Exception as e:
+        return _phone_error(device, _error_text(e))
 
 
 @router.post("/key", summary="Send Keyevent To Phone")
 def api_phone_key(data: dict = Body({})):
     """Send a keyevent to device."""
-    from gitd.bots.common.adb import Device
-
-    dev = Device(data.get("device", ""))
+    device = data.get("device", "")
     key = data.get("key", "")
     if not key:
         raise HTTPException(status_code=400, detail="key required")
-    if not key.startswith("KEYCODE_"):
-        key = "KEYCODE_" + key
-    dev.adb("shell", "input", "keyevent", key)
-    return {"ok": True}
+    try:
+        dev = get_device(device)
+        if is_ios_ref(device):
+            dev.press_key(key)
+        else:
+            from gitd.bots.common.adb import normalize_keycode
+
+            key = normalize_keycode(key)
+            dev.adb("shell", "input", "keyevent", key)
+        return {"ok": True, "device": device, "platform": _platform(device)}
+    except Exception as e:
+        return _phone_error(device, _error_text(e))
 
 
 @router.post("/launch", summary="Launch App On Phone")
 def api_phone_launch(data: dict = Body({})):
-    """Launch an app by package name on a device."""
-    from gitd.bots.common.adb import Device
-
-    dev = Device(data.get("device", ""))
+    """Launch an Android package or iOS bundle id on a device."""
+    device = data.get("device", "")
     pkg = data.get("package", "")
-    dev.adb("shell", "monkey", "-p", pkg, "-c", "android.intent.category.LAUNCHER", "1")
-    return {"ok": True}
+    if not pkg:
+        raise HTTPException(status_code=400, detail="package required")
+    try:
+        dev = get_device(device)
+        if is_ios_ref(device):
+            dev.launch_app(pkg)
+            return {"ok": True, "device": device, "platform": "ios", "package": pkg, "bundle_id": pkg}
+        else:
+            dev.adb("shell", "monkey", "-p", pkg, "-c", "android.intent.category.LAUNCHER", "1")
+        return {"ok": True, "device": device, "platform": "android", "package": pkg, "bundle_id": ""}
+    except Exception as e:
+        return _phone_error(device, _error_text(e))
+
+
+@router.post("/browser/open-url", summary="Open URL In Browser")
+def api_phone_browser_open_url(data: dict = Body({})):
+    """Open a URL in the platform browser."""
+    from gitd.services.browser import open_url
+
+    device = data.get("device", "")
+    url = data.get("url", "")
+    if not device or not url:
+        raise HTTPException(status_code=400, detail="device and url required")
+    return open_url(device, url, bundle_id=data.get("bundle_id") or None)
+
+
+@router.post("/browser/search", summary="Search Web In Browser")
+def api_phone_browser_search(data: dict = Body({})):
+    """Open a web search in the platform browser."""
+    from gitd.services.browser import web_search
+
+    device = data.get("device", "")
+    query = data.get("query", "")
+    if not device or not query:
+        raise HTTPException(status_code=400, detail="device and query required")
+    return web_search(device, query, engine=data.get("engine", "google"), bundle_id=data.get("bundle_id") or None)
+
+
+@router.post("/browser/back", summary="Navigate Browser Back")
+def api_phone_browser_back(data: dict = Body({})):
+    """Navigate back in the browser/app context."""
+    from gitd.services.browser import browser_back
+
+    device = data.get("device", "")
+    if not device:
+        raise HTTPException(status_code=400, detail="device required")
+    return browser_back(device)
+
+
+@router.get("/browser/current-url/{device}", summary="Get Current Browser URL")
+def api_phone_browser_current_url(device: str):
+    """Return the current browser URL when available."""
+    from gitd.services.tool_platforms import platform_error, supports_platform
+
+    platform = _platform(device)
+    if not supports_platform("get_current_url", platform):
+        return platform_error("get_current_url", platform)
+    from gitd.services.browser import get_current_url
+
+    return get_current_url(device)
+
+
+@router.post("/browser/wait-for-text", summary="Wait For Browser Text")
+def api_phone_browser_wait_for_text(data: dict = Body({})):
+    """Wait for text to appear on screen."""
+    from gitd.services.browser import wait_for_text
+
+    device = data.get("device", "")
+    text_value = data.get("text", "")
+    if not device or not text_value:
+        raise HTTPException(status_code=400, detail="device and text required")
+    return wait_for_text(device, text_value, timeout=float(data.get("timeout", 12.0)))
+
+
+@router.get("/browser/visible-text/{device}", summary="Extract Browser Visible Text")
+def api_phone_browser_visible_text(device: str, max_lines: int = 200, include_controls: bool = False):
+    """Extract visible text from the current screen."""
+    from gitd.services.browser import extract_visible_text
+
+    return extract_visible_text(device, max_lines=max_lines, include_controls=include_controls)
+
+
+@router.get("/browser/articles/{device}", summary="Extract Browser Articles")
+def api_phone_browser_articles(device: str, max_items: int = 5):
+    """Extract likely visible article/headline candidates from the current page."""
+    from gitd.services.browser import extract_articles
+
+    return extract_articles(device, max_items=max_items)
+
+
+@router.post("/browser/read-news", summary="Read News In Browser")
+def api_phone_browser_read_news(data: dict = Body({})):
+    """Open a news page and return headlines plus article snippets."""
+    device = data.get("device", "")
+    if not device:
+        raise HTTPException(status_code=400, detail="device required")
+    from gitd.services.tool_platforms import platform_error, supports_platform
+
+    platform = _platform(device)
+    if not supports_platform("read_news", platform):
+        return platform_error("read_news", platform)
+
+    from gitd.services.browser import read_news
+
+    return read_news(
+        device,
+        data.get("url", "https://text.npr.org/"),
+        max_headlines=int(data.get("max_headlines", 5)),
+        max_articles=int(data.get("max_articles", 3)),
+        bundle_id=data.get("bundle_id") or None,
+        wait_s=float(data.get("wait_s", 2.0)),
+        save_screenshots=bool(data.get("save_screenshots", False)),
+        out_dir=data.get("out_dir") or None,
+    )
 
 
 @router.post("/reconnect/{device}", summary="Reconnect Phone Portal")
 def api_phone_reconnect(device: str):
     """Clear Portal cache for a device and re-establish connection."""
+    if is_ios_ref(device):
+        return _ios_unsupported("Portal reconnect")
     from gitd.bots.common.adb import Device
 
     dev = Device(device)
@@ -251,14 +544,50 @@ def api_phone_reconnect(device: str):
 @router.post("/force-stop", summary="Force Stop App On Phone")
 def api_phone_force_stop(data: dict = Body({})):
     """Force-stop an app by package name on a device."""
+    device = data.get("device", "")
+    pkg = data.get("package", "")
+    try:
+        if is_ios_ref(device):
+            if not pkg:
+                raise HTTPException(status_code=400, detail="package required")
+            get_device(device).terminate_app(pkg)
+            return {"ok": True, "device": device, "platform": "ios", "bundle_id": pkg}
+    except HTTPException:
+        raise
+    except Exception as e:
+        return _phone_error(device, _error_text(e))
     from gitd.bots.common.adb import Device
 
-    dev = Device(data.get("device", ""))
-    pkg = data.get("package", "")
+    dev = Device(device)
     if not pkg:
         raise HTTPException(status_code=400, detail="package required")
-    dev.adb("shell", "am", "force-stop", pkg)
-    return {"ok": True}
+    try:
+        dev.adb("shell", "am", "force-stop", pkg)
+        return {"ok": True, "device": device, "platform": "android", "package": pkg}
+    except Exception as e:
+        return _phone_error(device, _error_text(e))
+
+
+@router.get("/app-state/{device}", summary="Get App State")
+def api_phone_app_state_get(device: str, package: str = ""):
+    """Check whether an Android package or iOS bundle id is installed/running/foreground."""
+    from gitd.services.device_context import app_state
+
+    if not package:
+        raise HTTPException(status_code=400, detail="package required")
+    return app_state(device, package)
+
+
+@router.post("/app-state", summary="Get App State")
+def api_phone_app_state_post(data: dict = Body({})):
+    """Check whether an Android package or iOS bundle id is installed/running/foreground."""
+    from gitd.services.device_context import app_state
+
+    device = data.get("device", "")
+    package = data.get("package", "")
+    if not device or not package:
+        raise HTTPException(status_code=400, detail="device and package required")
+    return app_state(device, package)
 
 
 @router.post("/swipe", summary="Swipe On Phone Screen")
@@ -266,25 +595,32 @@ def api_phone_swipe(data: dict = Body({})):
     """Perform a swipe gesture on a device with coordinate scaling."""
     from gitd.bots.common.adb import Device
 
-    dev = Device(data.get("device", ""))
-    x1, y1 = int(data.get("x1", 540)), int(data.get("y1", 1600))
-    x2, y2 = int(data.get("x2", 540)), int(data.get("y2", 400))
-    stream_w = int(data.get("stream_w", 0))
-    stream_h = int(data.get("stream_h", 0))
-    if stream_w and stream_h:
-        try:
-            out = dev.adb("shell", "wm", "size", timeout=3)
-            m = re.search(r"(\d+)x(\d+)", out)
-            if m:
-                real_w, real_h = int(m.group(1)), int(m.group(2))
-                x1 = int(x1 * real_w / stream_w)
-                y1 = int(y1 * real_h / stream_h)
-                x2 = int(x2 * real_w / stream_w)
-                y2 = int(y2 * real_h / stream_h)
-        except Exception:
-            pass
-    dev.swipe(x1, y1, x2, y2)
-    return {"ok": True}
+    device = data.get("device", "")
+    try:
+        dev = get_device(device)
+        x1, y1 = int(data.get("x1", 540)), int(data.get("y1", 1600))
+        x2, y2 = int(data.get("x2", 540)), int(data.get("y2", 400))
+        stream_w = int(data.get("stream_w", 0))
+        stream_h = int(data.get("stream_h", 0))
+        if stream_w and stream_h:
+            try:
+                if is_ios_ref(device):
+                    real_w, real_h = dev.get_screen_size()
+                else:
+                    out = Device(device).adb("shell", "wm", "size", timeout=3)
+                    m = re.search(r"(\d+)x(\d+)", out)
+                    real_w, real_h = (int(m.group(1)), int(m.group(2))) if m else (0, 0)
+                if real_w and real_h:
+                    x1 = int(x1 * real_w / stream_w)
+                    y1 = int(y1 * real_h / stream_h)
+                    x2 = int(x2 * real_w / stream_w)
+                    y2 = int(y2 * real_h / stream_h)
+            except Exception:
+                pass
+        dev.swipe(x1, y1, x2, y2)
+        return {"ok": True, "device": device, "platform": _platform(device)}
+    except Exception as e:
+        return _phone_error(device, _error_text(e))
 
 
 @router.get("/screenshot/{device}", summary="Take Phone Screenshot")
@@ -298,7 +634,7 @@ def api_phone_screenshot(device: str):
 
 @router.get("/screenshot-annotated/{device}", summary="Take Annotated Screenshot")
 def api_phone_screenshot_annotated(device: str):
-    """Take screenshot with Portal's numbered element overlay."""
+    """Take a screenshot with server-side numbered element labels."""
     from gitd.services.device_context import screenshot_annotated
 
     result = screenshot_annotated(device)
@@ -320,7 +656,7 @@ def api_phone_xml(device: str):
     from gitd.services.device_context import get_screen_xml
 
     xml = get_screen_xml(device)
-    return {"ok": True, "xml": xml[:10000], "length": len(xml)}
+    return {"ok": True, "device": device, "platform": _platform(device), "xml": xml[:10000], "length": len(xml)}
 
 
 @router.get("/screen-tree/{device}", summary="Get LLM-Readable Screen Tree")
@@ -328,7 +664,7 @@ def api_phone_screen_tree(device: str):
     """Get indented UI hierarchy optimized for LLM consumption."""
     from gitd.services.device_context import get_screen_tree
 
-    return {"ok": True, "tree": get_screen_tree(device)}
+    return {"ok": True, "device": device, "platform": _platform(device), "tree": get_screen_tree(device)}
 
 
 @router.get("/ocr/{device}", summary="OCR Phone Screen")
@@ -340,7 +676,55 @@ def api_phone_ocr(device: str, x1: int = 0, y1: int = 0, x2: int = 0, y2: int = 
         texts = ocr_region(device, x1, y1, x2, y2)
     else:
         texts = ocr_screen(device)
-    return {"ok": True, "texts": texts, "count": len(texts)}
+    return {"ok": True, "device": device, "platform": _platform(device), "texts": texts, "count": len(texts)}
+
+
+@router.get("/notifications/{device}", summary="Get Device Notifications")
+def api_phone_notifications(device: str):
+    """Read visible active notifications from Android or iOS."""
+    from gitd.services.device_context import get_notifications
+
+    try:
+        items = get_notifications(device)
+        return {
+            "ok": True,
+            "device": device,
+            "platform": "ios" if is_ios_ref(device) else "android",
+            "notifications": items,
+            "count": len(items),
+        }
+    except Exception as e:
+        return _phone_error(device, _error_text(e))
+
+
+@router.post("/notifications/open", summary="Open Notifications")
+def api_phone_notifications_open(data: dict = Body({})):
+    """Open Android notification shade or iOS Notification Center."""
+    from gitd.services.device_context import open_notifications
+
+    device = data.get("device", "")
+    if not device:
+        raise HTTPException(status_code=400, detail="device required")
+    try:
+        ok = open_notifications(device)
+        return {"ok": bool(ok), "device": device, "platform": "ios" if is_ios_ref(device) else "android"}
+    except Exception as e:
+        return _phone_error(device, _error_text(e))
+
+
+@router.post("/notifications/clear", summary="Clear Notifications")
+def api_phone_notifications_clear(data: dict = Body({})):
+    """Dismiss visible notifications when the platform exposes a clear control."""
+    from gitd.services.device_context import clear_notifications
+
+    device = data.get("device", "")
+    if not device:
+        raise HTTPException(status_code=400, detail="device required")
+    try:
+        ok = clear_notifications(device)
+        return {"ok": bool(ok), "device": device, "platform": "ios" if is_ios_ref(device) else "android"}
+    except Exception as e:
+        return _phone_error(device, _error_text(e))
 
 
 @router.get("/classify/{device}", summary="Classify Phone Screen")
@@ -351,9 +735,77 @@ def api_phone_classify(device: str):
     return classify_screen(device)
 
 
+@router.post("/recording/start", summary="Start Screen Recording")
+def api_phone_recording_start(data: dict = Body({})):
+    """Start cross-platform screen recording for Android or iOS."""
+    from gitd.services.phone_recording import start_recording
+
+    device = data.get("device", "")
+    if not device:
+        raise HTTPException(status_code=400, detail="device required")
+    result = start_recording(device, filename=data.get("filename", ""))
+    if not result.get("ok"):
+        raise HTTPException(status_code=400, detail=result)
+    return result
+
+
+@router.post("/recording/stop", summary="Stop Screen Recording")
+def api_phone_recording_stop(data: dict = Body({})):
+    """Stop a running screen recording and save the MP4."""
+    from gitd.services.phone_recording import stop_recording
+
+    device = data.get("device", "")
+    if not device:
+        raise HTTPException(status_code=400, detail="device required")
+    result = stop_recording(device)
+    if not result.get("ok"):
+        raise HTTPException(status_code=400, detail=result)
+    return result
+
+
+@router.get("/recording/status/{device}", summary="Screen Recording Status")
+def api_phone_recording_status(device: str):
+    """Return active screen recording status for a device."""
+    from gitd.services.phone_recording import recording_status
+
+    return recording_status(device)
+
+
+@router.get("/recordings", summary="List Screen Recordings")
+def api_phone_recordings():
+    """List saved phone screen recordings."""
+    from gitd.services.phone_recording import list_recordings
+
+    return {"recordings": list_recordings()}
+
+
+@router.get("/recording/{filename:path}", summary="Serve Screen Recording")
+def api_phone_recording_file(filename: str):
+    """Serve a saved phone screen recording MP4."""
+    from gitd.services.phone_recording import recording_file
+
+    try:
+        return FileResponse(str(recording_file(filename)), media_type="video/mp4")
+    except (FileNotFoundError, ValueError):
+        raise HTTPException(status_code=404, detail="recording not found")
+
+
+@router.delete("/recording/{filename:path}", summary="Delete Screen Recording")
+def api_phone_recording_delete(filename: str):
+    """Delete a saved phone screen recording."""
+    from gitd.services.phone_recording import delete_recording
+
+    try:
+        return delete_recording(filename)
+    except (FileNotFoundError, ValueError):
+        raise HTTPException(status_code=404, detail="recording not found")
+
+
 @router.post("/overlay/{device}", summary="Toggle Phone Overlay")
 def api_phone_overlay(device: str, data: dict = Body({})):
     """Toggle Droidrun Portal overlay on/off."""
+    if is_ios_ref(device):
+        return _ios_unsupported("Portal overlay")
     import json as _json
     import urllib.request
 
@@ -380,7 +832,20 @@ def api_phone_overlay(device: str, data: dict = Body({})):
 
 @router.get("/packages/{device}", summary="List Installed Packages")
 def api_phone_packages(device: str, all: str = ""):
-    """List installed packages on device."""
+    """List Android packages or known iOS bundle ids on a device."""
+    if is_ios_ref(device):
+        from gitd.services.device_context import list_apps
+
+        apps = list_apps(device, verify=True)
+        packages = [app.get("bundle_id") or app.get("package", "") for app in apps]
+        return {
+            "device": device,
+            "packages": [pkg for pkg in packages if pkg],
+            "apps": apps,
+            "count": len(packages),
+            "platform": "ios",
+            "note": "iOS app inventory is limited to configured/common bundle ids verified through Appium when available.",
+        }
     from gitd.bots.common.adb import Device
 
     dev = Device(device)
@@ -390,7 +855,24 @@ def api_phone_packages(device: str, all: str = ""):
     else:
         raw = dev.adb("shell", "pm", "list", "packages", timeout=15)
     packages = sorted([pkg.replace("package:", "").strip() for pkg in raw.splitlines() if pkg.startswith("package:")])
-    return {"packages": packages, "count": len(packages)}
+    return {"device": device, "platform": "android", "packages": packages, "count": len(packages)}
+
+
+@router.get("/apps/{device}", summary="List Installed Apps")
+def api_phone_apps(device: str, query: str = "", all: str = "", verify: bool = True):
+    """List app inventory with display names and Android package or iOS bundle IDs."""
+    from gitd.services.device_context import list_apps
+
+    include_system = str(all).lower() in {"1", "true", "yes", "all"}
+    apps = list_apps(device, query=query, verify=verify, include_system=include_system)
+    packages = [app.get("bundle_id") or app.get("package", "") for app in apps]
+    return {
+        "apps": apps,
+        "packages": [pkg for pkg in packages if pkg],
+        "count": len(apps),
+        "platform": "ios" if is_ios_ref(device) else "android",
+        "query": query,
+    }
 
 
 # ── Device health ────────────────────────────────────────────────────────────
@@ -407,17 +889,9 @@ def api_phone_health(device: str):
 @router.post("/health/{device}/fix", summary="Auto-Fix Device Issue")
 def api_phone_health_fix(device: str, data: dict = Body({})):
     """Fix a specific device issue (portal_service, portal_install, screen_capture)."""
-    from gitd.routers.streaming import portal_fix
+    from gitd.services.device_context import fix_device_health
 
-    issue = data.get("issue", "")
-    if issue in ("portal_service", "portal_install", "portal"):
-        return portal_fix(device)
-    if issue == "screen_wake":
-        subprocess.run(
-            ["adb", "-s", device, "shell", "input", "keyevent", "KEYCODE_WAKEUP"], capture_output=True, timeout=3
-        )
-        return {"ok": True, "message": "Screen woken"}
-    return {"ok": False, "error": f"Unknown issue: {issue}"}
+    return fix_device_health(device, data.get("issue", ""))
 
 
 # ── Wireless ADB ─────────────────────────────────────────────────────────────
@@ -431,6 +905,8 @@ def api_wireless_enable(data: dict = Body({}), db: Session = Depends(get_db)):
     device = data.get("device", "")
     if not device:
         raise HTTPException(status_code=400, detail="device serial required")
+    if is_ios_ref(device):
+        return _ios_unsupported("Wireless ADB")
     result = wireless_enable(device)
     if result.get("ok"):
         # Persist in DB
@@ -478,6 +954,8 @@ def api_wireless_disconnect(data: dict = Body({})):
     device = data.get("device", "")
     if not device:
         raise HTTPException(status_code=400, detail="device required")
+    if is_ios_ref(device):
+        return _ios_unsupported("Wireless ADB disconnect")
     return wireless_disconnect(device)
 
 

--- a/gitd/routers/scheduler.py
+++ b/gitd/routers/scheduler.py
@@ -16,6 +16,19 @@ from gitd.models.base import get_db
 router = APIRouter(tags=["scheduler"])
 
 
+def _phone_platform(phone_serial: str | None) -> str | None:
+    if not phone_serial:
+        return None
+    from gitd.skills.platforms import platform_for_device_ref
+
+    return platform_for_device_ref(phone_serial)
+
+
+def _annotate_phone_platform(record: dict) -> dict:
+    record["platform"] = _phone_platform(record.get("phone_serial"))
+    return record
+
+
 def _sched_next_run(sched: dict, db: Session) -> str | None:
     """Compute the next scheduled run time as HH:MM string."""
     if sched["schedule_type"] == "daily":
@@ -83,6 +96,85 @@ def _parse_live_stats(job: dict) -> str:
     return ""
 
 
+def _coerce_config(value) -> dict:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+            return parsed if isinstance(parsed, dict) else {}
+        except Exception:
+            return {}
+    return {}
+
+
+def _scheduler_platform_error(record: dict) -> dict | None:
+    phone = record.get("phone_serial")
+    job_type = record.get("job_type", "")
+    if not phone or not job_type:
+        return None
+
+    config = _coerce_config(record.get("config_json"))
+    from gitd.services.job_engine import (
+        _job_platform_preflight,
+        _skill_config_preflight,
+        _skill_platform_preflight,
+    )
+    from gitd.skills.platforms import platform_for_device_ref
+
+    message = _skill_config_preflight(job_type, config)
+    if message:
+        detail = {
+            "error": "invalid_config",
+            "platform": platform_for_device_ref(phone),
+            "job_type": job_type,
+            "message": message,
+        }
+        skill = config.get("skill")
+        if skill:
+            detail["skill"] = skill
+        return detail
+
+    message = _job_platform_preflight(phone, job_type)
+    if not message:
+        message = _skill_platform_preflight(phone, job_type, config)
+    if not message:
+        return None
+
+    detail = {
+        "error": "unsupported_platform",
+        "platform": platform_for_device_ref(phone),
+        "job_type": job_type,
+        "message": message,
+    }
+    skill = config.get("skill")
+    if skill:
+        detail["skill"] = skill
+    return detail
+
+
+def _raise_scheduler_platform_error(record: dict):
+    detail = _scheduler_platform_error(record)
+    if detail:
+        raise HTTPException(status_code=400, detail=detail)
+
+
+def _restart_max_duration(row: dict, db: Session) -> int | None:
+    max_duration = row.get("max_duration_s")
+    if max_duration:
+        return int(max_duration)
+    scheduled_job_id = row.get("scheduled_job_id")
+    if not scheduled_job_id:
+        return None
+    existing = db.execute(
+        text("SELECT max_duration_s FROM scheduled_jobs WHERE id = :sid"),
+        {"sid": scheduled_job_id},
+    ).first()
+    if existing and existing[0]:
+        return int(existing[0])
+    return None
+
+
 # ── Schedules CRUD ──────────────────────────────────────────────────────────
 
 
@@ -93,6 +185,7 @@ def schedules_list(db: Session = Depends(get_db)):
     result = []
     for s in scheds:
         s = dict(s)
+        _annotate_phone_platform(s)
         last_run = (
             db.execute(
                 text("SELECT * FROM job_runs WHERE scheduled_job_id = :sid ORDER BY created_at DESC LIMIT 1"),
@@ -101,7 +194,7 @@ def schedules_list(db: Session = Depends(get_db)):
             .mappings()
             .first()
         )
-        s["last_run"] = dict(last_run) if last_run else None
+        s["last_run"] = _annotate_phone_platform(dict(last_run)) if last_run else None
         s["next_run"] = _sched_next_run(s, db) if s.get("is_enabled") else None
         result.append(s)
     return result
@@ -114,6 +207,7 @@ def schedules_create(data: dict = Body({}), db: Session = Depends(get_db)):
     for r in required:
         if not data.get(r):
             raise HTTPException(status_code=400, detail=f"{r} required")
+    _raise_scheduler_platform_error(data)
     from gitd.services.db_helpers import create_scheduled_job
 
     sid = create_scheduled_job(db, **data)
@@ -124,6 +218,13 @@ def schedules_create(data: dict = Body({}), db: Session = Depends(get_db)):
 def schedules_update(sid: int, data: dict = Body({}), db: Session = Depends(get_db)):
     """Update an existing scheduled job's configuration."""
     from gitd.services.db_helpers import update_scheduled_job
+
+    existing = db.execute(text("SELECT * FROM scheduled_jobs WHERE id = :sid"), {"sid": sid}).mappings().first()
+    if not existing:
+        raise HTTPException(status_code=404, detail="not found")
+    merged = dict(existing)
+    merged.update(data)
+    _raise_scheduler_platform_error(merged)
 
     update_scheduled_job(db, sid, **data)
     return {"ok": True}
@@ -170,6 +271,7 @@ def schedules_run_now(sid: int, db: Session = Depends(get_db)):
     if not sched:
         raise HTTPException(status_code=404, detail="not found")
     sched = dict(sched)
+    _raise_scheduler_platform_error(sched)
     from gitd.services.db_helpers import enqueue_job
 
     qid = enqueue_job(
@@ -196,14 +298,15 @@ def scheduler_status(db: Session = Depends(get_db)):
     for row in db_running:
         row = dict(row)
         key = row.get("phone_serial") or "__none__"
-        phones[key] = {"running": True, "job": row, "pid": row.get("pid")}
+        _annotate_phone_platform(row)
+        phones[key] = {"running": True, "job": row, "pid": row.get("pid"), "platform": row["platform"]}
     pending = db.execute(
         text("SELECT phone_serial, COUNT(*) as cnt FROM job_queue WHERE status='pending' GROUP BY phone_serial")
     ).fetchall()
     for row in pending:
         key = row[0] or "__none__"
         if key not in phones:
-            phones[key] = {"running": False, "job": None, "pid": None}
+            phones[key] = {"running": False, "job": None, "pid": None, "platform": _phone_platform(row[0])}
         phones[key]["pending"] = row[1]
     return phones
 
@@ -215,6 +318,7 @@ def scheduler_queue(db: Session = Depends(get_db)):
     result = []
     for r in rows:
         r = dict(r)
+        _annotate_phone_platform(r)
         if r.get("scheduled_job_id"):
             s = db.execute(
                 text("SELECT name FROM scheduled_jobs WHERE id = :sid"),
@@ -308,6 +412,7 @@ def scheduler_run_restart(run_id: int, db: Session = Depends(get_db)):
     if not row:
         raise HTTPException(status_code=404, detail="Run not found")
     row = dict(row)
+    _raise_scheduler_platform_error(row)
     from gitd.services.db_helpers import enqueue_job
 
     new_id = enqueue_job(
@@ -317,9 +422,10 @@ def scheduler_run_restart(run_id: int, db: Session = Depends(get_db)):
         config_json=row.get("config_json"),
         priority=row.get("priority", 2),
         scheduled_job_id=row.get("scheduled_job_id"),
+        max_duration_s=_restart_max_duration(row, db),
         trigger="manual",
     )
-    return {"ok": True, "new_job_id": new_id}
+    return {"ok": True, "new_job_id": new_id, "platform": _phone_platform(row.get("phone_serial"))}
 
 
 # ── History & timeline ──────────────────────────────────────────────────────
@@ -332,6 +438,7 @@ def scheduler_history(db: Session = Depends(get_db)):
     result = []
     for r in rows:
         r = dict(r)
+        _annotate_phone_platform(r)
         if r.get("scheduled_job_id"):
             s = db.execute(
                 text("SELECT name FROM scheduled_jobs WHERE id = :sid"),
@@ -360,6 +467,33 @@ def scheduler_history_logs(run_id: int, since: int = 0, db: Session = Depends(ge
     }
 
 
+@router.get("/api/scheduler/history/{run_id}/result", summary="Get Run Structured Result")
+def scheduler_history_result(run_id: int, db: Session = Depends(get_db)):
+    """Return the newest structured Data JSON emitted by a completed scheduler run."""
+    from gitd.services._job_helpers import _parse_job_result_data, _summarize_job_result_data
+
+    row = (
+        db.execute(
+            text("SELECT id, log_file FROM job_runs WHERE id = :rid"),
+            {"rid": run_id},
+        )
+        .mappings()
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Run not found")
+    log_path = row.get("log_file")
+    if not log_path or not Path(log_path).exists():
+        return {"ok": False, "result": None, "summary": "", "error": "log file not found"}
+    result = _parse_job_result_data(run_id, log_path=log_path)
+    return {
+        "ok": result is not None,
+        "result": result,
+        "summary": _summarize_job_result_data(result),
+        "error": "" if result is not None else "structured result not found",
+    }
+
+
 @router.get("/api/scheduler/timeline", summary="Get Scheduler Timeline")
 def scheduler_timeline(db: Session = Depends(get_db)):
     """Return 24h timeline data — past runs + future scheduled times per phone."""
@@ -384,6 +518,7 @@ def scheduler_timeline(db: Session = Depends(get_db)):
             ).first()
             if s:
                 r["schedule_name"] = s[0]
+        _annotate_phone_platform(r)
         past.append(r)
 
     future = []
@@ -402,6 +537,7 @@ def scheduler_timeline(db: Session = Depends(get_db)):
                         "scheduled_job_id": s["id"],
                         "schedule_name": s["name"],
                         "phone_serial": s.get("phone_serial"),
+                        "platform": _phone_platform(s.get("phone_serial")),
                         "job_type": s["job_type"],
                         "time": t,
                         "is_past": t <= now_time,
@@ -430,6 +566,7 @@ def scheduler_timeline(db: Session = Depends(get_db)):
                     "plan_id": cp["id"],
                     "schedule_name": f"CP: {cp.get('style_id', '?')}",
                     "phone_serial": cp.get("phone_serial"),
+                    "platform": _phone_platform(cp.get("phone_serial")),
                     "job_type": "content_plan",
                     "time": cp.get("scheduled_time"),
                     "date": cp.get("scheduled_date"),
@@ -442,3 +579,41 @@ def scheduler_timeline(db: Session = Depends(get_db)):
         pass
 
     return {"past": past, "future": future, "content_plan": content_plan_items}
+
+
+# ── Account health endpoints ────────────────────────────────────────────────
+
+
+@router.get("/api/scheduler/account-health", summary="Account Health for All Devices")
+def account_health_all():
+    """Probe every connected device for its TikTok account state."""
+    from gitd.services.account_health import all_devices_health
+
+    return all_devices_health()
+
+
+@router.get("/api/scheduler/account-health/{device}", summary="Account Health for One Device")
+def account_health_one(device: str, fresh: bool = False):
+    """Probe a single device. Pass ?fresh=true to bypass the 60s cache."""
+    from gitd.services.account_health import device_account_health
+
+    return device_account_health(device, fresh=fresh)
+
+
+@router.post("/api/scheduler/account-switch/{device}", summary="Switch Active TikTok Account")
+def account_switch(device: str, data: dict = Body(...)):
+    """Switch the active TikTok account on `device` to body.handle."""
+    handle = (data.get("handle") or "").strip()
+    if not handle:
+        raise HTTPException(status_code=400, detail="handle required")
+    from gitd.services.account_health import switch_active_account
+
+    return switch_active_account(device, handle)
+
+
+@router.post("/api/scheduler/account-sync/{device}", summary="Sync DB tiktok_accounts with Device State")
+def account_sync(device: str):
+    """Update tiktok_accounts DB rows to match what's actually logged in on `device`."""
+    from gitd.services.account_health import sync_tiktok_accounts_table
+
+    return sync_tiktok_accounts_table(device)

--- a/gitd/routers/skills.py
+++ b/gitd/routers/skills.py
@@ -3,6 +3,7 @@
 import io
 import json
 import shutil
+import sys
 import time
 import zipfile
 from pathlib import Path
@@ -13,6 +14,12 @@ from fastapi.responses import Response
 from sqlalchemy.orm import Session
 
 from gitd.models.base import get_db
+from gitd.skills.platforms import (
+    normalize_platforms,
+    skill_platform_error,
+    skill_platform_summary,
+    skill_supports_device,
+)
 
 router = APIRouter(prefix="/api/skills", tags=["skills"])
 
@@ -46,6 +53,16 @@ def _fetch_cached(url: str, cache_key: str) -> list:
 _SKILLS_DIR = Path(__file__).resolve().parent.parent / "skills"
 
 
+def _require_skill_supports_device(name: str, device: str) -> dict:
+    skills = _load_all_skills()
+    if name not in skills:
+        raise HTTPException(status_code=404, detail=f'Skill "{name}" not found')
+    meta = skills[name].get("metadata") or {}
+    if not skill_supports_device(meta, device):
+        raise HTTPException(status_code=400, detail=skill_platform_error(name, meta, device))
+    return meta
+
+
 def _load_all_skills() -> dict:
     """Load all installed skills from gitd/skills/."""
     results = {}
@@ -58,14 +75,26 @@ def _load_all_skills() -> dict:
                 elements = {}
                 if (d / "elements.yaml").exists():
                     elements = yaml.safe_load((d / "elements.yaml").read_text()) or {}
+                elements_ios = {}
+                if (d / "elements_ios.yaml").exists():
+                    elements_ios = yaml.safe_load((d / "elements_ios.yaml").read_text()) or {}
                 popups = meta.get("popup_detectors", [])
+                platform_summary = skill_platform_summary(meta)
                 results[d.name] = {
                     "name": meta.get("name", d.name),
                     "description": meta.get("description", ""),
                     "version": meta.get("version", "0.0.0"),
-                    "app_package": meta.get("app_package", ""),
+                    "app_package": platform_summary["app_package"],
+                    "android_package": platform_summary["android_package"],
+                    "ios_bundle_id": platform_summary["ios_bundle_id"],
+                    "platforms": platform_summary["platforms"],
+                    "supports_android": platform_summary["supports_android"],
+                    "supports_ios": platform_summary["supports_ios"],
+                    "platform_limitations": platform_summary["platform_limitations"],
                     "dir": d.name,
                     "elements_count": len(elements),
+                    "elements_android_count": len(elements),
+                    "elements_ios_count": len(elements_ios),
                     "popup_count": len(popups),
                     "popup_detectors": popups,
                     "metadata": meta,
@@ -94,10 +123,12 @@ def _load_skill(name: str):
 
 
 @router.get("", summary="List All Installed Skills")
-def api_skills_list():
+def api_skills_list(device: str = ""):
     """List all installed skills."""
     skills = _load_all_skills()
     for name, info in skills.items():
+        if device:
+            info["supported_on_device"] = skill_supports_device(info.get("metadata") or {}, device)
         try:
             s = _load_skill(name)
             if s is None:
@@ -237,12 +268,14 @@ def api_skill_runs(device: str = "", skill: str = "", limit: int = 50, db: Sessi
 
 
 @router.get("/{name}", summary="Get Skill Detail")
-def api_skill_detail(name: str):
+def api_skill_detail(name: str, device: str = ""):
     """Skill detail."""
     skills = _load_all_skills()
     if name not in skills:
         raise HTTPException(status_code=404, detail=f'Skill "{name}" not found')
     info = skills[name]
+    if device:
+        info["supported_on_device"] = skill_supports_device(info.get("metadata") or {}, device)
     try:
         s = _load_skill(name)
         if s is None:
@@ -312,6 +345,7 @@ def api_skill_run(name: str, data: dict = Body({})):
         raise HTTPException(status_code=400, detail="workflow name required")
     if not device_serial:
         raise HTTPException(status_code=400, detail="device serial required")
+    _require_skill_supports_device(name, device_serial)
 
     from gitd.models import SessionLocal
     from gitd.services.db_helpers import enqueue_job
@@ -341,6 +375,7 @@ def api_skill_run_action(name: str, data: dict = Body({})):
         raise HTTPException(status_code=400, detail="action name required")
     if not device_serial:
         raise HTTPException(status_code=400, detail="device serial required")
+    _require_skill_supports_device(name, device_serial)
 
     from gitd.models import SessionLocal
     from gitd.services.db_helpers import enqueue_job
@@ -372,12 +407,13 @@ def api_skill_verify(name: str, data: dict = Body({})):
         raise HTTPException(status_code=400, detail="device serial required")
     if not workflow_name and not action_name:
         raise HTTPException(status_code=400, detail="workflow or action name required")
+    _require_skill_supports_device(name, device_serial)
 
     import subprocess
 
     runner = Path(__file__).resolve().parent.parent / "skills" / "_run_skill.py"
     cmd = [
-        "python3",
+        sys.executable,
         "-u",
         str(runner),
         "--skill",
@@ -419,28 +455,26 @@ def api_skills_create_from_recording(data: dict = Body({})):
     name = data.get("name", "new_skill").strip().lower().replace(" ", "_")
     steps = data.get("steps", [])
     app_package = data.get("app_package", "")
+    ios_bundle_id = data.get("ios_bundle_id", "")
 
     if not name or not steps:
         raise HTTPException(status_code=400, detail="name and steps required")
 
-    skill_dir = _SKILLS_DIR / name
-    skill_dir.mkdir(parents=True, exist_ok=True)
-    (skill_dir / "actions").mkdir(exist_ok=True)
-    (skill_dir / "workflows").mkdir(exist_ok=True)
+    from gitd.services.skill_creation import create_recorded_skill
 
-    import yaml
-
-    meta = {
-        "name": name,
-        "version": "1.0.0",
-        "app_package": app_package,
-        "description": f"Auto-generated skill from {len(steps)} recorded steps",
-    }
-    (skill_dir / "skill.yaml").write_text(yaml.dump(meta, default_flow_style=False))
-    (skill_dir / "workflows" / "recorded.json").write_text(json.dumps(steps, indent=2))
-    (skill_dir / "__init__.py").write_text(f'"""Skill: {name} -- auto-generated from recording."""\n')
-
-    return {"ok": True, "skill": name, "steps": len(steps), "dir": str(skill_dir)}
+    result = create_recorded_skill(
+        name=name,
+        app_package=app_package,
+        android_package=data.get("android_package", app_package),
+        steps=steps,
+        platforms=data.get("platforms"),
+        ios_bundle_id=ios_bundle_id,
+        elements_android=data.get("elements_android") if "elements_android" in data else data.get("elements"),
+        elements_ios=data.get("elements_ios") if "elements_ios" in data else None,
+        skills_dir=_SKILLS_DIR,
+        description_prefix="Auto-generated skill from",
+    )
+    return {"ok": True, "skill": result["skill"], "steps": result["steps"], "dir": result["dir"]}
 
 
 @router.delete("/{name}", summary="Delete Custom Skill")
@@ -470,14 +504,27 @@ def api_skill_update(name: str, data: dict = Body({})):
         meta["name"] = data["name"]
     if data.get("description"):
         meta["description"] = data["description"]
-    if data.get("app_package"):
+    if "platforms" in data:
+        meta["platforms"] = normalize_platforms(data.get("platforms"))
+    if "app_package" in data:
         meta["app_package"] = data["app_package"]
+    if "android_package" in data:
+        meta["android_package"] = data["android_package"]
+    if "ios_bundle_id" in data:
+        meta["ios_bundle_id"] = data["ios_bundle_id"]
     meta_path.write_text(yaml.dump(meta, default_flow_style=False))
 
     if data.get("steps"):
         rec_dir = skill_dir / "workflows"
         rec_dir.mkdir(exist_ok=True)
         (rec_dir / "recorded.json").write_text(json.dumps(data["steps"], indent=2))
+    if "elements" in data or "elements_android" in data:
+        elements_android = data.get("elements_android") if "elements_android" in data else data.get("elements")
+        (skill_dir / "elements.yaml").write_text(yaml.dump(elements_android or {}, default_flow_style=False))
+    if "elements_ios" in data:
+        (skill_dir / "elements_ios.yaml").write_text(
+            yaml.dump(data.get("elements_ios") or {}, default_flow_style=False)
+        )
 
     return {"ok": True, "steps": len(data.get("steps", []))}
 

--- a/gitd/routers/streaming.py
+++ b/gitd/routers/streaming.py
@@ -1,14 +1,18 @@
 """Streaming routes: MJPEG phone stream, WebRTC signaling."""
 
 import asyncio
+import base64
 import hashlib
 import json
 import subprocess
 import time
+import urllib.parse
 import urllib.request
 
 from fastapi import APIRouter, Body, HTTPException, Request
 from starlette.responses import StreamingResponse
+
+from gitd.bots.common.device import get_device, is_ios_ref
 
 router = APIRouter(tags=["streaming"])
 
@@ -31,7 +35,105 @@ def _stable_ws_port(serial: str) -> int:
     return 19000 + int(hashlib.md5(serial.encode()).hexdigest()[:3], 16) % 1000
 
 
+def _ios_unsupported(feature: str) -> dict:
+    return {"ok": False, "platform": "ios", "error": f"{feature} is Android-only and is not supported for iOS devices"}
+
+
+def _ios_stream_fallback(device: str, feature: str) -> dict:
+    health_endpoint = f"/api/phone/health/{device}"
+    fix_endpoint = f"{health_endpoint}/fix"
+    stream_url = f"/api/phone/stream?{urllib.parse.urlencode({'device': device, 'fps': 10, 'mode': 'wda-mjpeg'})}"
+    return {
+        "ok": False,
+        "platform": "ios",
+        "error": f"{feature} uses Android Portal/WebRTC and is not supported for iOS devices",
+        "stream_fallback": {
+            "endpoint": "/api/phone/stream",
+            "device": device,
+            "recommended_mode": "wda-mjpeg",
+            "fallback_mode": "screenshot-polling",
+            "stream_url": stream_url,
+            "url": stream_url,
+        },
+        "recovery": {
+            "health_endpoint": health_endpoint,
+            "fix_endpoint": fix_endpoint,
+            "fix_tool": "fix_device_health",
+            "common_fixes": ["reset_session", "restart_remote_xpc_tunnel"],
+            "message": "Use WDA MJPEG for iOS live view, or screenshot polling if Appium/WDA MJPEG is unavailable.",
+        },
+    }
+
+
 # ── MJPEG Stream ────────────────────────────────────────────────────────────
+
+
+def _phone_stream_url(device: str, *, fps: int, mode: str) -> str:
+    query = urllib.parse.urlencode({"device": device, "fps": fps, "mode": mode})
+    return f"/api/phone/stream?{query}"
+
+
+def _stream_health_links(device: str) -> dict:
+    health_endpoint = f"/api/phone/health/{device}"
+    return {
+        "health_endpoint": health_endpoint,
+        "fix_endpoint": f"{health_endpoint}/fix",
+        "fix_tool": "fix_device_health",
+    }
+
+
+@router.get("/api/phone/stream-info", summary="Describe Effective Phone Stream Mode")
+def phone_stream_info(device: str = "", fps: int = 30, quality: int = 8, mode: str = "screencap"):
+    """Return stream metadata without opening the streaming response."""
+    fps = max(1, min(fps, 60))
+    quality = max(1, min(quality, 31))
+    if is_ios_ref(device):
+        ios_dev = get_device(device)
+        requested_mode = mode or "mjpeg"
+        effective_mode = "wda-mjpeg" if requested_mode in {"mjpeg", "wda", "wda-mjpeg"} else "screenshot-polling"
+        stream_mode = "wda-mjpeg" if effective_mode == "wda-mjpeg" else "screencap"
+        return {
+            "ok": True,
+            "device": device,
+            "platform": "ios",
+            "requested_mode": requested_mode,
+            "effective_mode": effective_mode,
+            "recommended_mode": "wda-mjpeg",
+            "fallback_mode": "screenshot-polling",
+            "stream_url": _phone_stream_url(device, fps=min(fps, 10), mode=stream_mode),
+            "mjpeg_url": ios_dev.mjpeg_url,
+            "mjpeg_settings": getattr(ios_dev, "mjpeg_settings", {}) or {},
+            "fps": min(fps, 10),
+            "quality": quality,
+            "portal_supported": False,
+            "webrtc_supported": False,
+            "control_supported": True,
+            "unsupported_actions": ["portal", "webrtc", "wireless_adb", "overlay"],
+            "recovery": {
+                **_stream_health_links(device),
+                "common_fixes": ["start_appium", "reset_session", "restart_remote_xpc_tunnel"],
+            },
+        }
+
+    requested_mode = mode or "screencap"
+    effective_mode = "portal" if requested_mode == "portal" else ("h264" if requested_mode == "h264" else "screencap")
+    return {
+        "ok": True,
+        "device": device,
+        "platform": "android",
+        "requested_mode": requested_mode,
+        "effective_mode": effective_mode,
+        "recommended_mode": "portal",
+        "fallback_mode": "screencap",
+        "stream_url": _phone_stream_url(device, fps=fps, mode=effective_mode),
+        "fps": fps,
+        "quality": quality,
+        "portal_supported": True,
+        "webrtc_supported": True,
+        "control_supported": True,
+        "unsupported_actions": [],
+        "recovery": _stream_health_links(device),
+    }
 
 
 @router.get("/api/phone/stream", summary="Stream Phone Screen MJPEG")
@@ -39,6 +141,57 @@ def phone_stream(device: str = "", fps: int = 30, quality: int = 8, mode: str = 
     """Stream phone screen via MJPEG."""
     fps = max(1, min(fps, 60))
     quality = max(1, min(quality, 31))
+    if is_ios_ref(device):
+        ios_dev = get_device(device)
+        frame_delay = max(0.05, 1.0 / min(fps, 10))
+        stream_url = ios_dev.mjpeg_url
+        stream_settings = getattr(ios_dev, "mjpeg_settings", {}) or {}
+
+        ios_stream_mode = "wda-mjpeg" if mode in {"mjpeg", "wda", "wda-mjpeg"} else "screenshot-polling"
+        boundary = "BoundaryString" if ios_stream_mode == "wda-mjpeg" else "frame"
+        boundary_bytes = boundary.encode("ascii")
+
+        def gen_ios_mjpeg():
+            try:
+                with urllib.request.urlopen(stream_url, timeout=10) as resp:
+                    while True:
+                        chunk = resp.read(16384)
+                        if not chunk:
+                            break
+                        yield chunk
+            except Exception:
+                yield from gen_ios_screencap()
+
+        def gen_ios_screencap():
+            from gitd.services.device_context import screenshot
+
+            while True:
+                try:
+                    result = screenshot(device, half_res=True, quality=45)
+                    frame = base64.b64decode(result["image"])
+                    yield (b"--" + boundary_bytes + b"\r\nContent-Type: image/jpeg\r\n\r\n" + frame + b"\r\n")
+                except Exception:
+                    time.sleep(0.5)
+                    continue
+                time.sleep(frame_delay)
+
+        gen = gen_ios_mjpeg if ios_stream_mode == "wda-mjpeg" else gen_ios_screencap
+        return StreamingResponse(
+            gen(),
+            media_type=f"multipart/x-mixed-replace; boundary={boundary}",
+            headers={
+                "Cache-Control": "no-cache",
+                "X-Accel-Buffering": "no",
+                "X-Phone-Platform": "ios",
+                "X-Phone-Stream-Mode": ios_stream_mode,
+                "X-Phone-Stream-Fallback-Mode": "screenshot-polling",
+                "X-Phone-Health-URL": f"/api/phone/health/{device}",
+                "X-Phone-Health-Fix-URL": f"/api/phone/health/{device}/fix",
+                "X-Phone-MJPEG-URL": stream_url,
+                "X-Phone-MJPEG-Settings": json.dumps(stream_settings, sort_keys=True),
+            },
+        )
+
     dev_args = ["-s", device] if device else []
 
     def gen_h264():
@@ -181,11 +334,23 @@ def phone_stream(device: str = "", fps: int = 30, quality: int = 8, mode: str = 
                 continue
             time.sleep(delay)
 
-    gen = gen_portal if mode == "portal" else (gen_h264 if mode == "h264" else gen_screencap)
+    android_stream_mode = "portal" if mode == "portal" else ("h264" if mode == "h264" else "screencap")
+    gen = (
+        gen_portal
+        if android_stream_mode == "portal"
+        else (gen_h264 if android_stream_mode == "h264" else gen_screencap)
+    )
     return StreamingResponse(
         gen(),
         media_type="multipart/x-mixed-replace; boundary=frame",
-        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+            "X-Phone-Platform": "android",
+            "X-Phone-Stream-Mode": android_stream_mode,
+            "X-Phone-Health-URL": f"/api/phone/health/{device}",
+            "X-Phone-Health-Fix-URL": f"/api/phone/health/{device}/fix",
+        },
     )
 
 
@@ -195,6 +360,8 @@ def phone_stream(device: str = "", fps: int = 30, quality: int = 8, mode: str = 
 @router.get("/api/phone/portal-status/{device}", summary="Check Portal Health")
 def portal_status(device: str):
     """Check Portal health on a device: process, accessibility service, HTTP API."""
+    if is_ios_ref(device):
+        return _ios_unsupported("Portal status")
     import urllib.error
 
     from gitd.bots.common.adb import Device
@@ -252,6 +419,8 @@ def portal_status(device: str):
 @router.post("/api/phone/portal-fix/{device}", summary="Auto-Fix Phone Portal")
 def portal_fix(device: str):
     """Auto-fix Portal: wake screen, enable accessibility service, restart."""
+    if is_ios_ref(device):
+        return _ios_unsupported("Portal fix")
     import urllib.error
 
     from gitd.bots.common.adb import _stable_port
@@ -333,6 +502,8 @@ async def webrtc_callback_handler(device: str, request: Request):
 @router.get("/api/phone/webrtc-poll-signals/{device}", summary="Poll WebRTC Signals")
 def webrtc_poll_signals(device: str):
     """Poll pending signaling messages from Portal for this device (legacy)."""
+    if is_ios_ref(device):
+        return _ios_stream_fallback(device, "WebRTC signal polling")
     msgs = _signaling_queues.pop(device, [])
     return {"ok": True, "messages": msgs}
 
@@ -340,6 +511,8 @@ def webrtc_poll_signals(device: str):
 @router.get("/api/phone/webrtc-signals-stream/{device}", summary="SSE Signal Stream")
 async def webrtc_signals_stream(device: str):
     """Server-Sent Events stream — pushes signaling messages instantly (no polling)."""
+    if is_ios_ref(device):
+        return _ios_stream_fallback(device, "WebRTC signal stream")
 
     async def generate():
         # Create per-device event for notifications
@@ -386,6 +559,8 @@ def _webrtc_signal_sync(data: dict):
 
     if not device or not method:
         raise HTTPException(status_code=400, detail="device and method required")
+    if is_ios_ref(device):
+        return _ios_stream_fallback(device, "WebRTC signaling")
 
     from gitd.bots.common.adb import Device
 
@@ -479,6 +654,8 @@ def webrtc_ws_send(data: dict = Body({})):
 
     if not device:
         raise HTTPException(status_code=400, detail="device required")
+    if is_ios_ref(device):
+        return _ios_stream_fallback(device, "Portal WebSocket")
 
     import websocket as ws_client
 
@@ -520,6 +697,8 @@ def webrtc_ws_send(data: dict = Body({})):
 def webrtc_ws_poll(data: dict = Body({})):
     """Poll for pending WebSocket messages from Portal."""
     device = data.get("device", "")
+    if is_ios_ref(device):
+        return _ios_stream_fallback(device, "Portal WebSocket polling")
     relay = _ws_relays.get(device)
     if not relay or not relay["ws"].connected:
         return {"ok": False, "responses": []}

--- a/gitd/routers/streaming_viewers.py
+++ b/gitd/routers/streaming_viewers.py
@@ -1,14 +1,17 @@
 """Streaming viewer routes: WebRTC viewer HTML pages."""
 
 import hashlib
+import html as html_lib
 import json
 import subprocess
+import urllib.parse
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
+from gitd.bots.common.device import is_ios_ref
 from gitd.models.base import get_db
 
 router = APIRouter(tags=["streaming"])
@@ -16,6 +19,61 @@ router = APIRouter(tags=["streaming"])
 
 def _stable_ws_port(serial: str) -> int:
     return 19000 + int(hashlib.md5(serial.encode()).hexdigest()[:3], 16) % 1000
+
+
+def _stream_url(serial: str, *, fps: int = 10, mode: str = "mjpeg") -> str:
+    query = urllib.parse.urlencode({"device": serial, "fps": fps, "mode": mode})
+    return f"/api/phone/stream?{query}"
+
+
+def _device_label(db: Session, serial: str) -> str:
+    label = serial[:8]
+    try:
+        row = db.execute(
+            text("SELECT nickname FROM phones WHERE serial = :serial"),
+            {"serial": serial},
+        ).first()
+        if row and row[0]:
+            label = row[0]
+    except Exception:
+        pass
+    return label
+
+
+def _viewer_config(serial: str, db: Session, *, setup_android: bool = True) -> dict:
+    label = _device_label(db, serial)
+    if is_ios_ref(serial):
+        return {
+            "serial": serial,
+            "label": label,
+            "platform": "ios",
+            "mode": "wda-mjpeg",
+            "streamUrl": _stream_url(serial, mode="wda-mjpeg"),
+            "wsPort": None,
+            "portalSupported": False,
+        }
+
+    from gitd.bots.common.adb import Device as AdbDevice
+
+    local_ws = _stable_ws_port(serial)
+    if setup_android:
+        dev = AdbDevice(serial)
+        dev._ensure_portal_forward()
+        try:
+            subprocess.run(
+                ["adb", "-s", serial, "forward", f"tcp:{local_ws}", "tcp:8081"], capture_output=True, timeout=3
+            )
+        except Exception:
+            pass
+    return {
+        "serial": serial,
+        "label": label,
+        "platform": "android",
+        "mode": "portal-webrtc",
+        "streamUrl": "",
+        "wsPort": local_ws,
+        "portalSupported": True,
+    }
 
 
 # ── WebRTC viewer pages ────────────────────────────────────────────────────
@@ -28,30 +86,7 @@ def webrtc_multi_viewer(request: Request, db: Session = Depends(get_db)):
     if not devices:
         raise HTTPException(status_code=400, detail="No devices specified")
 
-    from gitd.bots.common.adb import Device as AdbDevice
-
-    device_configs = []
-    for serial in devices:
-        dev = AdbDevice(serial)
-        dev._ensure_portal_forward()
-        local_ws = _stable_ws_port(serial)
-        try:
-            subprocess.run(
-                ["adb", "-s", serial, "forward", f"tcp:{local_ws}", "tcp:8081"], capture_output=True, timeout=3
-            )
-        except Exception:
-            pass
-        label = serial[:8]
-        try:
-            row = db.execute(
-                text("SELECT nickname FROM phones WHERE serial = :serial"),
-                {"serial": serial},
-            ).first()
-            if row and row[0]:
-                label = row[0]
-        except Exception:
-            pass
-        device_configs.append({"serial": serial, "label": label, "wsPort": local_ws})
+    device_configs = [_viewer_config(serial, db) for serial in devices]
 
     configs_json = json.dumps(device_configs)
     cols = min(len(devices), 3)
@@ -64,14 +99,19 @@ def webrtc_multi_viewer(request: Request, db: Session = Depends(get_db)):
   .cell {{ background:#111827; border:1px solid #1e2438; border-radius:8px; overflow:hidden; }}
   .cell-header {{ padding:6px 10px; display:flex; align-items:center; gap:8px; background:#0d1018; }}
   .name {{ font-size:12px; font-weight:600; }}
-  video {{ width:100%; background:#000; }}
+  .platform {{ font-size:10px; color:#94a3b8; margin-left:auto; }}
+  video, img {{ width:100%; background:#000; display:block; }}
 </style></head><body>
 <div class="grid" id="grid"></div>
 <script>
 const DEVICES = {configs_json};
 document.getElementById('grid').innerHTML = DEVICES.map(d =>
-  '<div class="cell"><div class="cell-header"><span class="name">' + d.label + '</span></div>' +
-  '<video id="video-' + d.serial + '" autoplay playsinline muted></video></div>'
+  '<div class="cell"><div class="cell-header"><span class="name">' + d.label + '</span>' +
+  '<span class="platform">' + d.platform + ' · ' + d.mode + '</span></div>' +
+  (d.platform === 'ios'
+    ? '<img id="stream-' + d.serial + '" src="' + d.streamUrl + '" alt="' + d.label + ' stream" />'
+    : '<video id="video-' + d.serial + '" autoplay playsinline muted></video>') +
+  '</div>'
 ).join('');
 </script></body></html>"""
     return HTMLResponse(content=html)
@@ -80,34 +120,40 @@ document.getElementById('grid').innerHTML = DEVICES.map(d =>
 @router.get("/api/phone/webrtc-viewer", summary="Single-Device WebRTC Viewer Page")
 def webrtc_viewer(device: str = "", db: Session = Depends(get_db)):
     """Standalone WebRTC viewer page."""
-    label = device[:8]
-    try:
-        row = db.execute(
-            text("SELECT nickname FROM phones WHERE serial = :serial"),
-            {"serial": device},
-        ).first()
-        if row and row[0]:
-            label = row[0]
-    except Exception:
-        pass
+    cfg = _viewer_config(device, db, setup_android=False)
+    label = cfg["label"]
+    title_label = html_lib.escape(label)
+    escaped_device = html_lib.escape(device)
+    stream_url = html_lib.escape(str(cfg.get("streamUrl") or ""))
+    platform = html_lib.escape(str(cfg["platform"]))
+    mode = html_lib.escape(str(cfg["mode"]))
+    media = (
+        f'<img id="stream" src="{stream_url}" alt="{title_label} stream" />'
+        if cfg["platform"] == "ios"
+        else '<video id="video" autoplay playsinline muted></video>'
+    )
 
     html = f"""<!DOCTYPE html>
-<html><head><title>Phone Stream - {label}</title>
+<html><head><title>Phone Stream - {title_label}</title>
 <style>
   body {{ background:#0f172a; color:#e2e8f0; font-family:monospace; margin:0; padding:20px; }}
-  video {{ max-width:100%; max-height:85vh; border:1px solid #334155; border-radius:8px; background:#000; }}
+  video, img {{ max-width:100%; max-height:85vh; border:1px solid #334155; border-radius:8px; background:#000; display:block; }}
   .toolbar {{ display:flex; gap:12px; align-items:center; margin-bottom:12px; }}
   button {{ background:#334155; color:#e2e8f0; border:1px solid #475569; padding:6px 16px;
            border-radius:4px; cursor:pointer; font-size:13px; }}
   .status {{ font-size:12px; color:#64748b; }}
+  .pill {{ padding:2px 6px; border:1px solid #334155; border-radius:999px; color:#94a3b8; font-size:11px; }}
 </style></head><body>
 <div class="toolbar">
   <button onclick="location.reload()">Reload</button>
-  <span class="status">Device: {device} ({label})</span>
+  <span class="status">Device: {escaped_device} ({title_label})</span>
+  <span class="pill">{platform}</span>
+  <span class="pill">{mode}</span>
 </div>
-<video id="video" autoplay playsinline muted></video>
+{media}
 <script>
-const DEVICE = "{device}";
+const DEVICE = {json.dumps(device)};
+const VIEWER_CONFIG = {json.dumps(cfg)};
 // WebRTC viewer JS would go here - simplified for now
 </script></body></html>"""
     return HTMLResponse(content=html)

--- a/gitd/routers/tests.py
+++ b/gitd/routers/tests.py
@@ -5,8 +5,8 @@ import logging
 import os
 import re
 import shutil
-import signal
 import subprocess
+import sys
 import threading
 import time
 from datetime import datetime
@@ -15,11 +15,14 @@ from pathlib import Path
 from fastapi import APIRouter, Body, HTTPException
 from fastapi.responses import FileResponse
 
+from gitd.bots.common.device import is_ios_ref
+from gitd.services import phone_recording
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["tests"])
 
-_tr_runs: dict = {}  # serial -> {proc, log_f, log_path, sr_proc, ...}
+_tr_runs: dict = {}  # serial -> {proc, log_f, log_path, sr_active, ...}
 _tr_lock = threading.Lock()
 _TESTS_DIR = Path(__file__).parent.parent.parent / "tests"
 _TR_RECORDINGS_DIR = Path(__file__).parent.parent.parent / "test_recordings"
@@ -43,50 +46,83 @@ def _device_label(serial: str) -> str:
     return serial[:5] if serial else ""
 
 
-def _sr_start(serial: str) -> tuple:
+def _safe_recording_name(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "_", value).strip("_") or "device"
+
+
+def _recording_device_ref(device_safe: str) -> str:
+    if device_safe.startswith("ios_") and len(device_safe) > 4:
+        return "ios:" + device_safe[4:]
+    return device_safe
+
+
+def _parse_recording_name(filename: str) -> dict[str, str]:
+    stem = Path(filename).stem
+    match = re.match(r"^(?P<device>.+?)_(?P<date>\d{8})_(?P<time>\d{6})(?:_(?P<test>.*))?$", stem)
+    if not match:
+        return {"device_ref": "", "device_safe": "", "test_name": stem}
+    device_safe = match.group("device")
+    return {
+        "device_ref": _recording_device_ref(device_safe),
+        "device_safe": device_safe,
+        "test_name": match.group("test") or "",
+    }
+
+
+def _pytest_cmd(node: str, *, retry: bool = False) -> list[str]:
+    cmd = [sys.executable, "-u", "-m", "pytest", "-v", "--tb=short", "-s"]
+    if retry:
+        cmd += ["--reruns", "2", "--reruns-delay", "5"]
+    cmd.append(node)
+    return cmd
+
+
+def _pytest_env(device: str) -> dict[str, str]:
+    env = {**os.environ, "PYTHONUNBUFFERED": "1", "DEVICE": device}
+    if is_ios_ref(device):
+        env["IOS_DEVICE_UDID"] = device.removeprefix("ios:")
+    return env
+
+
+def _sr_start(serial: str, local_name: str | None = None) -> dict:
     """Start screen recording on device."""
-    subprocess.run(
-        ["adb", "-s", serial, "shell", "input", "keyevent", "KEYCODE_WAKEUP"], timeout=5, capture_output=True
-    )
-    subprocess.run(["adb", "-s", serial, "shell", "input", "keyevent", "KEYCODE_MENU"], timeout=5, capture_output=True)
-    time.sleep(0.3)
-    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
-    device_path = f"/sdcard/test_rec_{ts}.mp4"
-    proc = subprocess.Popen(
-        ["adb", "-s", serial, "shell", "screenrecord", device_path],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
-    return proc, device_path
-
-
-def _sr_stop_and_pull(serial, sr_proc, device_path, local_name):
-    """Stop screen recording and pull MP4 from device."""
-    sr_proc.send_signal(signal.SIGINT)
-    try:
-        sr_proc.wait(timeout=15)
-    except subprocess.TimeoutExpired:
-        sr_proc.kill()
-    time.sleep(2)
-    local_path = _TR_RECORDINGS_DIR / local_name
-    try:
+    if not local_name:
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        local_name = f"{_safe_recording_name(serial)}_{ts}.mp4"
+    if not is_ios_ref(serial):
         subprocess.run(
-            ["adb", "-s", serial, "pull", device_path, str(local_path)], timeout=30, check=True, capture_output=True
+            ["adb", "-s", serial, "shell", "input", "keyevent", "KEYCODE_WAKEUP"], timeout=5, capture_output=True
         )
-        subprocess.run(["adb", "-s", serial, "shell", "rm", device_path], timeout=5, capture_output=True)
-        return local_path
-    except (subprocess.SubprocessError, OSError):
+        subprocess.run(
+            ["adb", "-s", serial, "shell", "input", "keyevent", "KEYCODE_MENU"], timeout=5, capture_output=True
+        )
+        time.sleep(0.3)
+    return phone_recording.start_recording(serial, filename=local_name, recordings_dir=_TR_RECORDINGS_DIR)
+
+
+def _sr_stop_and_pull(serial, local_name=""):
+    """Stop screen recording and pull MP4 from device."""
+    result = phone_recording.stop_recording(serial)
+    if not result.get("ok") or not result.get("saved"):
         return None
+    path = Path(str(result.get("path") or ""))
+    if path.exists() and path.is_file():
+        return path
+    if local_name:
+        fallback = _TR_RECORDINGS_DIR / Path(local_name).name
+        if fallback.exists() and fallback.is_file():
+            return fallback
+    return None
 
 
 def _tr_finalize(device):
     """Stop recording + pull MP4. Must be called with _tr_lock held."""
     entry = _tr_runs.get(device)
-    if not entry or not entry.get("sr_proc"):
+    if not entry or not entry.get("sr_active"):
         return
-    lp = _sr_stop_and_pull(device, entry["sr_proc"], entry["sr_device_path"], entry["sr_local_name"])
+    lp = _sr_stop_and_pull(device, entry["sr_local_name"])
     entry["sr_local_path"] = str(lp) if lp else None
-    entry["sr_proc"] = None
+    entry["sr_active"] = False
     try:
         entry["log_f"].close()
     except Exception:
@@ -119,9 +155,14 @@ def _tr_watcher():
         wake_counter += 1
         with _tr_lock:
             for dev, entry in list(_tr_runs.items()):
-                if entry["proc"].poll() is not None and entry.get("sr_proc") and not entry.get("sr_local_path"):
+                if entry["proc"].poll() is not None and entry.get("sr_active") and not entry.get("sr_local_path"):
                     _tr_finalize(dev)
-                elif entry["proc"].poll() is None and entry.get("sr_proc") and wake_counter % 15 == 0:
+                elif (
+                    entry["proc"].poll() is None
+                    and entry.get("sr_active")
+                    and wake_counter % 15 == 0
+                    and not is_ios_ref(dev)
+                ):
                     try:
                         subprocess.run(
                             ["adb", "-s", dev, "shell", "input", "keyevent", "KEYCODE_WAKEUP"],
@@ -172,20 +213,17 @@ def tr_start(data: dict = Body({})):
         node = f"tests/{file_}" + (f"::{test_}" if test_ else "")
         test_label = test_ or file_.replace(".py", "")
 
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        sr_local_name = f"{_safe_recording_name(device)}_{ts}_{_safe_recording_name(test_label)}.mp4"
+
         try:
-            sr_proc, sr_device_path = _sr_start(device)
+            sr_result = _sr_start(device, sr_local_name)
             time.sleep(0.5)
         except Exception:
-            sr_proc, sr_device_path = None, None
+            sr_result = {"ok": False}
 
-        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
-        sr_local_name = f"{device}_{ts}_{test_label}.mp4"
-
-        cmd = ["python3", "-u", "-m", "pytest", "-v", "--tb=short", "-s"]
-        if retry:
-            cmd += ["--reruns", "2", "--reruns-delay", "5"]
-        cmd.append(node)
-        env = {**os.environ, "PYTHONUNBUFFERED": "1", "DEVICE": device}
+        cmd = _pytest_cmd(node, retry=retry)
+        env = _pytest_env(device)
         log_path = Path(f"/tmp/tiktok_tests_{device}.log")
         log_f = open(log_path, "w", buffering=1)
         proc = subprocess.Popen(
@@ -208,8 +246,8 @@ def tr_start(data: dict = Body({})):
             "proc": proc,
             "log_f": log_f,
             "log_path": log_path,
-            "sr_proc": sr_proc,
-            "sr_device_path": sr_device_path,
+            "sr_active": bool(sr_result.get("ok")),
+            "sr_start": sr_result,
             "sr_local_name": sr_local_name,
             "sr_local_path": None,
             "test_node": node,
@@ -320,7 +358,8 @@ def tr_recordings():
                 }
             except Exception:
                 pass
-        serial = f.stem.split("_")[0] if "_" in f.stem else ""
+        parsed = _parse_recording_name(f.name)
+        device_ref = parsed["device_ref"]
         recs.append(
             {
                 "name": f.name,
@@ -329,7 +368,11 @@ def tr_recordings():
                 "has_log": log_file.exists(),
                 "has_overlay": overlay_file.exists(),
                 "result": result,
-                "device": _device_label(serial),
+                "device": _device_label(device_ref),
+                "device_ref": device_ref,
+                "device_label": _device_label(device_ref),
+                "platform": "ios" if is_ios_ref(device_ref) else "android",
+                "test_name": parsed["test_name"],
             }
         )
     return recs

--- a/gitd/routers/tools_hub.py
+++ b/gitd/routers/tools_hub.py
@@ -10,32 +10,62 @@ router = APIRouter(prefix="/api/tools", tags=["tools-hub"])
 def _get_all_tools() -> list[dict]:
     """Return all tools grouped by category."""
     from gitd.services.agent_tools import TOOLS
+    from gitd.services.tool_platforms import tool_platform_info
 
     CATEGORIES = {
         "Screen Reading": [
             "screenshot",
             "screenshot_annotated",
             "screenshot_cropped",
+            "start_screen_recording",
+            "stop_screen_recording",
+            "screen_recording_status",
+            "get_stream_info",
             "get_screen_tree",
             "get_elements",
             "get_phone_state",
+            "device_health",
+            "fix_device_health",
             "classify_screen",
             "find_on_screen",
             "ocr_screen",
             "ocr_region",
             "get_screen_xml",
         ],
-        "Input": ["tap", "tap_element", "swipe", "type_text", "press_key", "long_press"],
-        "App Management": ["launch_app", "force_stop", "list_packages", "launch_intent"],
+        "Web": [
+            "web_search",
+            "open_url",
+            "browser_back",
+            "get_current_url",
+            "wait_for_text",
+            "extract_visible_text",
+            "extract_articles",
+            "read_news",
+        ],
+        "Input": [
+            "tap",
+            "tap_element",
+            "swipe",
+            "type_text",
+            "type_unicode",
+            "press_back",
+            "press_home",
+            "press_key",
+            "long_press",
+        ],
+        "App Management": ["launch_app", "force_stop", "app_state", "list_packages", "explore_app", "launch_intent"],
         "Shell": ["shell"],
         "Clipboard & Notifications": [
+            "paste_text",
             "clipboard_get",
             "clipboard_set",
             "get_notifications",
             "open_notifications",
             "clear_notifications",
         ],
-        "Skills": ["list_skills", "run_skill"],
+        "Skills": ["list_skills", "run_skill", "run_workflow", "run_action", "create_skill"],
+        "Marketing": ["lookup_lead", "list_unread_leads"],
+        "CRM": ["crm_lookup_contact", "crm_list_unread_messages"],
         "Device": ["list_devices", "toggle_overlay"],
         "System": ["wait"],
     }
@@ -47,13 +77,13 @@ def _get_all_tools() -> list[dict]:
     extra_tools = [
         {
             "name": "get_screen_xml",
-            "description": "Get raw UI XML dump from uiautomator.",
+            "description": "Get raw Android UIAutomator XML or normalized iOS WDA XML.",
             "input_schema": {"type": "object", "properties": {"device": {"type": "string"}}, "required": ["device"]},
             "category": "Screen Reading",
         },
         {
             "name": "launch_intent",
-            "description": "Launch full Android intent (action, data, package, extras).",
+            "description": "Launch a full Android intent (Android-only: action, data, package, extras).",
             "input_schema": {
                 "type": "object",
                 "properties": {
@@ -68,7 +98,7 @@ def _get_all_tools() -> list[dict]:
         },
         {
             "name": "open_notifications",
-            "description": "Pull down the notification shade.",
+            "description": "Open Android notification shade or iOS Notification Center.",
             "input_schema": {"type": "object", "properties": {"device": {"type": "string"}}, "required": ["device"]},
             "category": "Clipboard & Notifications",
         },
@@ -80,13 +110,13 @@ def _get_all_tools() -> list[dict]:
         },
         {
             "name": "list_devices",
-            "description": "List all connected Android devices with serial and model.",
+            "description": "List connected Android ADB devices and configured iOS Appium devices.",
             "input_schema": {"type": "object", "properties": {}},
             "category": "Device",
         },
         {
             "name": "toggle_overlay",
-            "description": "Toggle Portal numbered element overlay on/off.",
+            "description": "Toggle Portal numbered element overlay on/off (Android-only).",
             "input_schema": {
                 "type": "object",
                 "properties": {"device": {"type": "string"}, "visible": {"type": "boolean"}},
@@ -115,6 +145,8 @@ def _get_all_tools() -> list[dict]:
                             "type": pschema.get("type", "string"),
                             "required": pname in required,
                             "default": pschema.get("default"),
+                            "description": pschema.get("description", ""),
+                            "items": pschema.get("items"),
                         }
                     )
                 tools.append(
@@ -123,6 +155,7 @@ def _get_all_tools() -> list[dict]:
                         "description": t.get("description", ""),
                         "params": params,
                         "category": cat,
+                        "platform_support": tool_platform_info(name).to_dict(),
                     }
                 )
         result.append({"category": cat, "tools": tools})
@@ -135,10 +168,28 @@ def list_tools():
     return _get_all_tools()
 
 
+@router.get("/platforms", summary="List Tool Platform Support")
+def list_tool_platforms():
+    """List platform support classification for every known agent/MCP tool."""
+    from gitd.services.tool_platforms import TOOL_PLATFORM_SUPPORT
+
+    return {
+        "tools": [info.to_dict() for _, info in sorted(TOOL_PLATFORM_SUPPORT.items())],
+        "categories": {
+            "cross_platform": "Works on Android and iOS, or is device-neutral.",
+            "android_only": "Intentionally Android-only; no iOS equivalent is planned for this tool shape.",
+            "ios_supported": "Implemented for iOS, but Android parity is not exposed through this tool yet.",
+            "ios_planned": "Android implementation exists; iOS replacement is planned but not implemented.",
+        },
+    }
+
+
 @router.post("/test", summary="Test a Tool")
 def test_tool(data: dict = Body({})):
     """Execute a tool with given args and return the result."""
+    from gitd.bots.common.device import is_ios_ref
     from gitd.services.agent_tools import execute_tool
+    from gitd.services.tool_platforms import platform_error, supports_platform
 
     tool_name = data.get("name", "")
     tool_args = data.get("args", {})
@@ -147,8 +198,32 @@ def test_tool(data: dict = Body({})):
 
     t0 = time.time()
     try:
+        known_tools = {tool["name"] for category in _get_all_tools() for tool in category["tools"]}
+        if tool_name not in known_tools:
+            duration_ms = (time.time() - t0) * 1000
+            return {
+                "ok": False,
+                "error": "unknown_tool",
+                "tool": tool_name,
+                "message": f"Unknown tool: {tool_name}",
+                "duration_ms": round(duration_ms, 1),
+            }
+        device = str(tool_args.get("device") or "")
+        if device:
+            platform = "ios" if is_ios_ref(device) else "android"
+            if not supports_platform(tool_name, platform):
+                duration_ms = (time.time() - t0) * 1000
+                return {**platform_error(tool_name, platform), "duration_ms": round(duration_ms, 1)}
         result = execute_tool(tool_name, tool_args)
         duration_ms = (time.time() - t0) * 1000
+        if result.startswith("Unknown tool:"):
+            return {
+                "ok": False,
+                "error": "unknown_tool",
+                "tool": tool_name,
+                "message": result,
+                "duration_ms": round(duration_ms, 1),
+            }
         return {"ok": True, "result": result[:5000], "duration_ms": round(duration_ms, 1)}
     except Exception as e:
         duration_ms = (time.time() - t0) * 1000

--- a/gitd/routers/traces.py
+++ b/gitd/routers/traces.py
@@ -1,0 +1,193 @@
+"""Local trace inspector API.
+
+Powers the in-app Traces tab. Read-only endpoints over the `traces` and
+`trace_spans` tables that the observability layer writes to.
+
+Endpoint surface kept small and JSON-shaped for the Android adapter:
+    GET  /api/traces                        list (filterable, paginated)
+    GET  /api/traces/stats                  aggregate counters for the header bar
+    GET  /api/traces/{trace_id}             full detail with all spans
+    DELETE /api/traces                      truncate (debug — clears all)
+    DELETE /api/traces/{trace_id}           single trace
+"""
+
+import json
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Query
+from sqlalchemy import desc, func
+
+router = APIRouter(prefix="/api/traces", tags=["traces"])
+
+
+def _row_to_summary(t) -> dict:
+    """Serialize one trace row → list-view summary (small payload)."""
+    return {
+        "id": t.id,
+        "conversation_id": t.conversation_id or "",
+        "provider": t.provider or "",
+        "model": t.model or "",
+        "device": t.device or "",
+        "source": t.source or "",
+        "status": t.status or "",
+        "user_input": t.user_input or "",
+        "final_output_preview": (t.final_output or "")[:200],
+        "input_tokens": t.input_tokens or 0,
+        "output_tokens": t.output_tokens or 0,
+        "cost_usd": float(t.cost_usd or 0),
+        "duration_ms": t.duration_ms or 0,
+        "started_at": t.started_at,
+        "ended_at": t.ended_at or "",
+        "error_text": t.error_text or "",
+    }
+
+
+def _span_to_dict(s) -> dict:
+    return {
+        "id": s.id,
+        "kind": s.kind,
+        "name": s.name,
+        "level": s.level or "DEFAULT",
+        "input": _safe_json_load(s.input_json),
+        "output": _safe_json_load(s.output_json),
+        "started_at": s.started_at,
+        "ended_at": s.ended_at or "",
+        "duration_ms": s.duration_ms or 0,
+    }
+
+
+def _safe_json_load(s: Optional[str]):
+    if not s:
+        return None
+    try:
+        return json.loads(s)
+    except (json.JSONDecodeError, TypeError):
+        return s  # raw string fallback for truncated/garbled values
+
+
+@router.get("", summary="List Traces")
+def list_traces(
+    limit: int = Query(50, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    provider: Optional[str] = Query(None, description="Filter by provider (claude-code, on-device, ollama, anthropic)"),
+    source: Optional[str] = Query(None, description="Filter by source (mac, android)"),
+    status: Optional[str] = Query(None, description="Filter by status (success, error, running, stopped)"),
+    conversation_id: Optional[str] = Query(None, description="Filter to one conversation"),
+):
+    """Newest-first list. Each row carries enough for the list-view card."""
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import Trace
+
+    db = SessionLocal()
+    try:
+        q = db.query(Trace).order_by(desc(Trace.started_at))
+        if provider:
+            q = q.filter(Trace.provider == provider)
+        if source:
+            q = q.filter(Trace.source == source)
+        if status:
+            q = q.filter(Trace.status == status)
+        if conversation_id:
+            q = q.filter(Trace.conversation_id == conversation_id)
+
+        total = q.count()
+        rows = q.limit(limit).offset(offset).all()
+        return {"total": total, "limit": limit, "offset": offset, "data": [_row_to_summary(r) for r in rows]}
+    finally:
+        db.close()
+
+
+@router.get("/stats", summary="Trace Stats")
+def trace_stats(
+    since_hours: int = Query(24, ge=1, le=24 * 30),
+):
+    """Aggregate counters for the Traces tab header bar."""
+    from datetime import datetime, timedelta, timezone
+
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import Trace
+
+    cutoff = (datetime.now(timezone.utc) - timedelta(hours=since_hours)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    db = SessionLocal()
+    try:
+        base_q = db.query(Trace).filter(Trace.started_at >= cutoff)
+        total = base_q.count()
+        errors = base_q.filter(Trace.status == "error").count()
+        avg_duration = (
+            db.query(func.avg(Trace.duration_ms)).filter(Trace.started_at >= cutoff, Trace.status == "success").scalar()
+            or 0
+        )
+        total_cost = db.query(func.sum(Trace.cost_usd)).filter(Trace.started_at >= cutoff).scalar() or 0.0
+        total_in = db.query(func.sum(Trace.input_tokens)).filter(Trace.started_at >= cutoff).scalar() or 0
+        total_out = db.query(func.sum(Trace.output_tokens)).filter(Trace.started_at >= cutoff).scalar() or 0
+        # Per-provider breakdown
+        per_provider = base_q.with_entities(Trace.provider, func.count(Trace.id)).group_by(Trace.provider).all()
+        return {
+            "since_hours": since_hours,
+            "total": total,
+            "errors": errors,
+            "success_rate": round((total - errors) / total, 3) if total else 1.0,
+            "avg_duration_ms": int(avg_duration),
+            "total_cost_usd": round(float(total_cost), 4),
+            "total_input_tokens": int(total_in),
+            "total_output_tokens": int(total_out),
+            "by_provider": [{"provider": p or "?", "count": int(c)} for p, c in per_provider],
+        }
+    finally:
+        db.close()
+
+
+@router.get("/{trace_id}", summary="Get Trace With Spans")
+def get_trace(trace_id: str):
+    """Full detail view: trace metadata + ordered span timeline."""
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import Trace, TraceSpan
+
+    db = SessionLocal()
+    try:
+        t = db.get(Trace, trace_id)
+        if not t:
+            raise HTTPException(status_code=404, detail="trace not found")
+        spans = db.query(TraceSpan).filter_by(trace_id=trace_id).order_by(TraceSpan.started_at, TraceSpan.id).all()
+        return {
+            "trace": {
+                **_row_to_summary(t),
+                "final_output": t.final_output or "",
+            },
+            "spans": [_span_to_dict(s) for s in spans],
+        }
+    finally:
+        db.close()
+
+
+@router.delete("/{trace_id}", summary="Delete Trace")
+def delete_trace(trace_id: str):
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import Trace
+
+    db = SessionLocal()
+    try:
+        t = db.get(Trace, trace_id)
+        if not t:
+            raise HTTPException(status_code=404, detail="trace not found")
+        db.delete(t)  # ON DELETE CASCADE cleans up spans
+        db.commit()
+        return {"ok": True, "deleted": trace_id}
+    finally:
+        db.close()
+
+
+@router.delete("", summary="Clear All Traces (Debug)")
+def clear_all_traces():
+    """Wipe everything — useful when iterating on observability code."""
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import Trace, TraceSpan
+
+    db = SessionLocal()
+    try:
+        n_spans = db.query(TraceSpan).delete()
+        n_traces = db.query(Trace).delete()
+        db.commit()
+        return {"ok": True, "deleted_traces": n_traces, "deleted_spans": n_spans}
+    finally:
+        db.close()

--- a/gitd/services/_emulator_helpers.py
+++ b/gitd/services/_emulator_helpers.py
@@ -1,65 +1,83 @@
 """
-Shared helpers for emulator_service — SDK paths, utility functions,
-EmulatorConfig dataclass, and discovery/query functions.
+Shared helpers for emulator_service — Docker-based Android emulators,
+ADB utilities, EmulatorConfig dataclass, and discovery/query functions.
+
+Replaces the AVD/SDK-based backend with Docker+KVM via budtmo/docker-android.
 """
 
-import configparser
 import logging
-import os
 import platform
 import shutil
 import subprocess
 import threading
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
 
-import psutil
+try:
+    import docker as docker_sdk
+except ImportError:
+    docker_sdk = None  # type: ignore[assignment]
+
+try:
+    import psutil
+except ImportError:
+    psutil = None  # Not available on Android (C extension)
 
 logger = logging.getLogger(__name__)
 
-# ── SDK paths ────────────────────────────────────────────────────────────────
+# ── Constants ────────────────────────────────────────────────────────────────
+
+DOCKER_IMAGE = "budtmo/docker-android:emulator_11.0"
+CONTAINER_LABEL = "ghost.type"
+CONTAINER_LABEL_VALUE = "emulator"
+CONTAINER_PORT = 5555  # internal ADB port inside every budtmo container
+BASE_HOST_PORT = 5555  # first mapped host port; increments per instance
+
+# ADB binary — still used to connect/run commands against containers
+ADB_BIN: str = shutil.which("adb") or "adb"
+
+# ── Legacy stubs kept so routers/pool don't need import changes ───────────────
+# These names were imported by emulator_service.py; keep them resolvable.
+AVD_HOME = Path.home() / ".android" / "avd"  # no-op in Docker mode
+AVDMANAGER = Path("/dev/null")  # not used
+EMULATOR_BIN = Path("/dev/null")  # not used
+SDKMANAGER = Path("/dev/null")  # not used
 
 
-def _detect_sdk_root() -> Path:
-    """Auto-detect Android SDK root across platforms."""
-    for var in ("ANDROID_SDK_ROOT", "ANDROID_HOME"):
-        val = os.environ.get(var)
-        if val and Path(val).exists():
-            return Path(val)
-    # macOS: Homebrew commandline-tools
-    brew = Path("/opt/homebrew/share/android-commandlinetools")
-    if brew.exists():
-        return brew
-    # macOS: Android Studio default
-    mac_studio = Path.home() / "Library" / "Android" / "sdk"
-    if mac_studio.exists():
-        return mac_studio
-    # Linux default
-    linux = Path.home() / "Android" / "Sdk"
-    if linux.exists():
-        return linux
-    return brew if platform.system() == "Darwin" else linux
+# ── Docker client ─────────────────────────────────────────────────────────────
 
 
-SDK_ROOT = _detect_sdk_root()
-
-EMULATOR_BIN = SDK_ROOT / "emulator" / "emulator"
-ADB_BIN = shutil.which("adb") or str(SDK_ROOT / "platform-tools" / "adb")
-SDKMANAGER = SDK_ROOT / "cmdline-tools" / "latest" / "bin" / "sdkmanager"
-AVDMANAGER = SDK_ROOT / "cmdline-tools" / "latest" / "bin" / "avdmanager"
-AVD_HOME = Path(os.environ.get("ANDROID_AVD_HOME", Path.home() / ".android" / "avd"))
+def _docker() -> "docker_sdk.DockerClient":
+    """Return a connected Docker client (raises RuntimeError if unavailable)."""
+    if docker_sdk is None:
+        raise RuntimeError("docker Python SDK not installed. Run: pip install docker")
+    return docker_sdk.from_env()
 
 
-# ── Utility functions ────────────────────────────────────────────────────────
+# ── Utility functions ─────────────────────────────────────────────────────────
 
 
 def _has_cmdline_tools() -> bool:
-    return AVDMANAGER.exists() and SDKMANAGER.exists()
+    """Docker mode — no SDK cmdline-tools needed."""
+    return False
 
 
 def _has_emulator() -> bool:
-    return EMULATOR_BIN.exists()
+    """Docker mode — no native emulator binary needed."""
+    return False
+
+
+def _has_docker() -> bool:
+    """Check if Docker daemon is reachable."""
+    try:
+        _docker().ping()
+        return True
+    except Exception:
+        return False
+
+
+def _has_kvm() -> bool:
+    return Path("/dev/kvm").exists()
 
 
 def _run(cmd: list[str], timeout: int = 60, check: bool = True, **kw) -> subprocess.CompletedProcess:
@@ -72,7 +90,7 @@ def _adb(serial: str, *args, timeout: int = 30) -> str:
 
 
 def _safe_int(val: str, default: int = 0) -> int:
-    """Parse int from string, stripping size suffixes like 'M', 'G', '2G'."""
+    """Parse int from string, stripping size suffixes like 'M', 'G'."""
     val = val.strip()
     if not val:
         return default
@@ -87,33 +105,32 @@ def _safe_int(val: str, default: int = 0) -> int:
 
 
 def is_emulator(serial: str) -> bool:
-    return serial.startswith("emulator-")
+    return serial.startswith("emulator-") or "localhost:" in serial
 
 
 def default_arch() -> str:
-    """Return the correct emulator arch for this platform."""
     if platform.machine().lower() in ("arm64", "aarch64"):
         return "arm64-v8a"
     return "x86_64"
 
 
-# ── Config dataclass ─────────────────────────────────────────────────────────
+# ── Config dataclass ──────────────────────────────────────────────────────────
 
 
 @dataclass
 class EmulatorConfig:
     name: str
-    api_level: int = 35
-    target: str = "google_apis_playstore"  # google_apis | google_apis_playstore | default
+    api_level: int = 30  # Android 11 (emulator_11.0 image)
+    target: str = "google_apis_playstore"
     arch: str = ""  # auto-detected if empty
-    device_profile: str = "medium_phone"  # hardware profile name
+    device_profile: str = "Samsung Galaxy S10"  # passed as EMULATOR_DEVICE env var
     ram_mb: int = 2048
     disk_mb: int = 6144
     resolution: str = "1080x2400"
     dpi: int = 420
-    gpu: str = "auto"  # auto | host | swiftshader_indirect | off
+    gpu: str = "auto"  # kept for API compat; Docker uses swiftshader internally
     cores: int = 2
-    headless: bool = False
+    headless: bool = False  # Docker is always headless
     snapshot: bool = True
 
     def __post_init__(self):
@@ -121,199 +138,191 @@ class EmulatorConfig:
             self.arch = default_arch()
 
     def system_image_pkg(self) -> str:
+        """Legacy compat — not used in Docker mode."""
         api = f"android-{self.api_level}"
         return f"system-images;{api};{self.target};{self.arch}"
 
     def system_image_dir(self) -> Path:
+        """Legacy compat — not used in Docker mode."""
         api = f"android-{self.api_level}"
-        return SDK_ROOT / "system-images" / api / self.target / self.arch
+        return Path("/dev/null") / "system-images" / api / self.target / self.arch
 
 
-# ── Discovery / query functions ──────────────────────────────────────────────
-# These were originally EmulatorManager methods but have no dependency on
-# instance state beyond _procs/_lock (which are passed in where needed).
+# ── Port allocation ───────────────────────────────────────────────────────────
+
+
+def _used_host_ports() -> set[int]:
+    """Collect host ports already in use by our emulator containers."""
+    used: set[int] = set()
+    try:
+        client = _docker()
+        for c in client.containers.list(filters={"label": f"{CONTAINER_LABEL}={CONTAINER_LABEL_VALUE}"}):
+            ports = c.ports or {}
+            # ports dict: {"5555/tcp": [{"HostIp": "0.0.0.0", "HostPort": "5556"}]}
+            for bindings in ports.values():
+                if bindings:
+                    for b in bindings:
+                        try:
+                            used.add(int(b["HostPort"]))
+                        except (KeyError, ValueError, TypeError):
+                            pass
+    except Exception:
+        pass
+    return used
+
+
+def next_available_port(used_ports: set[int] | None = None) -> int:
+    """Find the next free host port starting from BASE_HOST_PORT."""
+    if used_ports is None:
+        used_ports = _used_host_ports()
+    port = BASE_HOST_PORT
+    while port in used_ports:
+        port += 1
+    return port
+
+
+# ── Container helpers ─────────────────────────────────────────────────────────
+
+
+def _container_to_info(c) -> dict:
+    """Convert a Docker container object to the canonical emulator info dict."""
+    labels = c.labels or {}
+    ports = c.ports or {}
+
+    host_port = None
+    for bindings in ports.values():
+        if bindings:
+            for b in bindings:
+                try:
+                    host_port = int(b["HostPort"])
+                    break
+                except (KeyError, ValueError, TypeError):
+                    pass
+        if host_port:
+            break
+
+    serial = f"localhost:{host_port}" if host_port else None
+    status = c.status  # running / exited / created / ...
+
+    return {
+        "name": labels.get("ghost.name", c.name),
+        "container_id": c.short_id,
+        "container_name": c.name,
+        "host_port": host_port,
+        "serial": serial,
+        "status": "running" if status == "running" else status,
+        "device_profile": labels.get("ghost.device_profile", ""),
+        "api_level": int(labels.get("ghost.api_level", 30)),
+    }
+
+
+# ── Discovery / query functions ───────────────────────────────────────────────
 
 
 def check_prerequisites() -> dict:
-    """Check what SDK tools are available."""
-    is_mac = platform.system() == "Darwin"
-    hw_accel = True if is_mac else Path("/dev/kvm").exists()
+    """Check Docker + KVM availability (replaces SDK prerequisites check)."""
+    docker_ok = _has_docker()
+    kvm_ok = _has_kvm()
+    adb_ok = bool(shutil.which("adb"))
     return {
-        "sdk_root": str(SDK_ROOT),
-        "sdk_exists": SDK_ROOT.exists(),
-        "emulator_binary": EMULATOR_BIN.exists(),
-        "adb_binary": shutil.which("adb") is not None or (SDK_ROOT / "platform-tools" / "adb").exists(),
-        "cmdline_tools": _has_cmdline_tools(),
-        "hw_accel": hw_accel,
-        "hw_accel_type": "HVF" if is_mac else "KVM",
+        "backend": "docker",
+        "docker_available": docker_ok,
+        "kvm_available": kvm_ok,
+        "adb_binary": adb_ok,
+        "hw_accel": kvm_ok,
+        "hw_accel_type": "KVM",
         "platform": platform.system(),
         "arch": default_arch(),
-        "avd_home": str(AVD_HOME),
+        "image": DOCKER_IMAGE,
+        # Legacy fields (kept so existing frontend/clients don't break)
+        "sdk_root": "N/A (docker mode)",
+        "sdk_exists": False,
+        "emulator_binary": False,
+        "cmdline_tools": False,
+        "avd_home": "N/A (docker mode)",
     }
 
 
 def list_system_images() -> list[dict]:
-    """List installed system images by scanning the SDK directory."""
-    images = []
-    si_dir = SDK_ROOT / "system-images"
-    if not si_dir.exists():
-        return images
-    for api_dir in sorted(si_dir.iterdir()):
-        if not api_dir.is_dir():
-            continue
-        for target_dir in sorted(api_dir.iterdir()):
-            if not target_dir.is_dir():
-                continue
-            for arch_dir in sorted(target_dir.iterdir()):
-                if not arch_dir.is_dir():
-                    continue
-                api_str = api_dir.name  # e.g. android-35
-                api_level = api_str.replace("android-", "")
-                images.append(
-                    {
-                        "api_level": api_level,
-                        "target": target_dir.name,
-                        "arch": arch_dir.name,
-                        "package": f"system-images;{api_str};{target_dir.name};{arch_dir.name}",
-                        "path": str(arch_dir),
-                    }
-                )
-    return images
+    """In Docker mode, return the single bundled image as a pseudo-entry."""
+    return [
+        {
+            "api_level": "30",
+            "target": "google_apis_playstore",
+            "arch": default_arch(),
+            "package": DOCKER_IMAGE,
+            "path": f"docker://{DOCKER_IMAGE}",
+            "note": "Docker image — no SDK system images needed",
+        }
+    ]
 
 
 def install_system_image(api_level: int, target: str = "google_apis_playstore", arch: str = "") -> dict:
-    """Download a system image via sdkmanager. Requires cmdline-tools."""
-    if not arch:
-        arch = default_arch()
-    if not _has_cmdline_tools():
-        return {
-            "ok": False,
-            "error": 'cmdline-tools not installed. Run: sdkmanager --install "cmdline-tools;latest"',
-        }
-    pkg = f"system-images;android-{api_level};{target};{arch}"
+    """In Docker mode, 'install' means pull the image."""
     try:
-        r = _run([str(SDKMANAGER), "--install", pkg], timeout=600)
-        return {"ok": True, "package": pkg, "output": r.stdout[-500:]}
-    except subprocess.CalledProcessError as e:
-        return {"ok": False, "error": e.stderr[-500:]}
+        client = _docker()
+        client.images.pull(DOCKER_IMAGE)
+        return {"ok": True, "package": DOCKER_IMAGE, "output": f"Pulled {DOCKER_IMAGE}"}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
 
 
 def list_avds(running_list: list[dict]) -> list[dict]:
-    """List all created AVDs by reading .ini files from AVD_HOME.
+    """List all ghost-labelled emulator containers (running + stopped)."""
+    try:
+        client = _docker()
+        containers = client.containers.list(
+            all=True,
+            filters={"label": f"{CONTAINER_LABEL}={CONTAINER_LABEL_VALUE}"},
+        )
+    except Exception as e:
+        logger.warning("list_avds: Docker error: %s", e)
+        return []
 
-    Args:
-        running_list: output from list_running(), used to annotate status.
-    """
+    running_by_name = {r["name"]: r for r in running_list}
     avds = []
-    if not AVD_HOME.exists():
-        return avds
-
-    running = {info["name"]: info for info in running_list}
-
-    for ini_file in sorted(AVD_HOME.glob("*.ini")):
-        if ini_file.suffix != ".ini":
-            continue
-        name_from_file = ini_file.stem
-
-        cfg = configparser.ConfigParser()
-        cfg.read_string("[root]\n" + ini_file.read_text())
-        avd_path_str = cfg.get("root", "path", fallback="")
-        avd_path = Path(avd_path_str) if avd_path_str else None
-
-        avd_info = {
-            "name": name_from_file,
-            "path": avd_path_str,
-            "target": cfg.get("root", "target", fallback=""),
-        }
-
-        config_ini = avd_path / "config.ini" if avd_path else None
-        if config_ini and config_ini.exists():
-            lines = config_ini.read_text().splitlines()
-            kv = {}
-            for line in lines:
-                if "=" in line:
-                    k, v = line.split("=", 1)
-                    kv[k.strip()] = v.strip()
-            avd_info.update(
-                {
-                    "display_name": kv.get("avd.ini.displayname", name_from_file),
-                    "api_level": kv.get("image.sysdir.1", "").split("/")[1].replace("android-", "")
-                    if "image.sysdir.1" in kv
-                    else "",
-                    "target_flavor": kv.get("tag.display", ""),
-                    "abi": kv.get("abi.type", ""),
-                    "resolution": f"{kv.get('hw.lcd.width', '?')}x{kv.get('hw.lcd.height', '?')}",
-                    "dpi": _safe_int(kv.get("hw.lcd.density", "0")),
-                    "ram_mb": _safe_int(kv.get("hw.ramSize", "0")),
-                    "disk": kv.get("disk.dataPartition.size", ""),
-                    "gpu_mode": kv.get("hw.gpu.mode", ""),
-                    "cores": _safe_int(kv.get("hw.cpu.ncore", "0")),
-                    "playstore": kv.get("PlayStore.enabled", "false").lower() == "true",
-                }
-            )
-
-        run_info = running.get(name_from_file)
+    for c in containers:
+        info = _container_to_info(c)
+        run_info = running_by_name.get(info["name"])
         if run_info:
-            adb_state = run_info.get("adb_state", "device")
-            avd_info["status"] = "running" if adb_state == "device" else "booting"
-            avd_info["serial"] = run_info["serial"]
-            avd_info["pid"] = run_info.get("pid")
-        else:
-            avd_info["status"] = "stopped"
-            avd_info["serial"] = None
-            avd_info["pid"] = None
-
-        avds.append(avd_info)
+            info["status"] = "running" if run_info.get("adb_state") == "device" else "booting"
+            info["serial"] = run_info["serial"]
+        avds.append(info)
     return avds
 
 
 def list_running(procs: dict, lock: threading.Lock) -> list[dict]:
-    """List running emulators with serials and AVD names."""
+    """List running emulator containers that ADB can reach."""
     try:
-        r = _run([ADB_BIN, "devices"], timeout=10, check=False)
-    except (subprocess.SubprocessError, OSError):
+        client = _docker()
+        containers = client.containers.list(
+            filters={"label": f"{CONTAINER_LABEL}={CONTAINER_LABEL_VALUE}", "status": "running"}
+        )
+    except Exception as e:
+        logger.warning("list_running: Docker error: %s", e)
         return []
+
     running = []
-    for line in r.stdout.splitlines()[1:]:
-        parts = line.split()
-        if len(parts) >= 2 and parts[0].startswith("emulator-") and parts[1] in ("device", "offline"):
-            serial = parts[0]
-            adb_state = parts[1]
-            avd_name = "unknown"
-            if adb_state == "device":
-                name_out = _adb(serial, "emu", "avd", "name", timeout=5)
-                avd_name = name_out.splitlines()[0].strip() if name_out else "unknown"
-            pid = None
-            with lock:
-                proc = procs.get(serial)
-                if proc and proc.poll() is None:
-                    pid = proc.pid
-            if pid is None:
-                pid = find_emulator_pid(serial)
-            running.append(
-                {
-                    "serial": serial,
-                    "name": avd_name,
-                    "pid": pid,
-                    "adb_state": adb_state,
-                }
-            )
+    for c in containers:
+        info = _container_to_info(c)
+        serial = info.get("serial")
+        if not serial:
+            continue
+        # Check ADB state
+        try:
+            r = _run([ADB_BIN, "-s", serial, "get-state"], timeout=5, check=False)
+            adb_state = "device" if r.stdout.strip() == "device" else "offline"
+        except Exception:
+            adb_state = "offline"
+
+        running.append(
+            {
+                "serial": serial,
+                "name": info["name"],
+                "host_port": info.get("host_port"),
+                "pid": None,  # no native PID — it's a container
+                "adb_state": adb_state,
+                "container_id": info.get("container_id"),
+            }
+        )
     return running
-
-
-def find_emulator_pid(serial: str) -> Optional[int]:
-    """Find PID of emulator process by matching port."""
-    port = serial.replace("emulator-", "")
-    try:
-        for proc in psutil.process_iter(["pid", "name", "cmdline"]):
-            cmdline = proc.info.get("cmdline") or []
-            if any("emulator" in str(c) for c in cmdline) and "-port" in cmdline:
-                try:
-                    port_idx = cmdline.index("-port")
-                    if cmdline[port_idx + 1] == port:
-                        return proc.info["pid"]
-                except (ValueError, IndexError):
-                    continue
-    except Exception:
-        pass
-    return None

--- a/gitd/services/_emulator_pool.py
+++ b/gitd/services/_emulator_pool.py
@@ -11,7 +11,10 @@ import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
-import psutil
+try:
+    import psutil
+except ImportError:
+    psutil = None
 
 from gitd.services._emulator_helpers import EmulatorConfig
 

--- a/gitd/services/_job_helpers.py
+++ b/gitd/services/_job_helpers.py
@@ -5,6 +5,7 @@ Contains: timestamp helper, log-parsing utilities, DB helpers for
 finishing / archiving / enqueuing jobs, and shared path constants.
 """
 
+import json
 import logging
 import re
 from datetime import datetime
@@ -21,6 +22,29 @@ logger = logging.getLogger(__name__)
 _SCRIPT_DIR = Path(__file__).resolve().parent.parent  # gitd/
 _VERTICAL_DIR = _SCRIPT_DIR.parent / "data" / "vertical_videos"
 _BOT_DEVICE = settings.default_device
+
+# Premium plugin scripts live in internal/ghost_premium/ when installed.
+# Resolve script paths through this helper so scheduler works in both
+# public-only and premium-installed setups.
+_PREMIUM_DIR = _SCRIPT_DIR.parent.parent / "internal" / "ghost_premium"
+
+
+def resolve_script(relpath: str) -> Path:
+    """Resolve a script path — try public gitd/ first, then premium fallback.
+
+    Example: resolve_script("bots/tiktok/crawl_runner.py")
+    Returns the first existing path, or the public path (for clearer errors).
+    """
+    public = _SCRIPT_DIR / relpath
+    if public.exists():
+        return public
+    # Premium fallback: marketing_agent/agent_core.py lives under
+    # services/marketing_agent/ in premium, not agent/
+    premium_rel = relpath.replace("agent/", "services/marketing_agent/")
+    premium = _PREMIUM_DIR / premium_rel
+    if premium.exists():
+        return premium
+    return public  # fall through — caller will see the missing-file error
 
 
 def _now() -> str:
@@ -104,14 +128,86 @@ def _parse_partial_crawl(lines: list[str]) -> str:
     return ""
 
 
-def _parse_job_summary(jid: int, entry: dict | None = None, log_path: str | None = None) -> str:
-    """Parse [done] summary from a job's log file."""
+def _read_job_log_lines(jid: int, entry: dict | None = None, log_path: str | None = None) -> list[str]:
     log_path = log_path or (entry or {}).get("log_path") or f"/tmp/sched_job_{jid}.log"
     try:
         with open(log_path, "r", errors="replace") as lf:
-            all_lines = lf.readlines()
+            return lf.readlines()
     except (FileNotFoundError, OSError):
-        return ""
+        return []
+
+
+def _parse_job_result_data(jid: int, entry: dict | None = None, log_path: str | None = None) -> dict | None:
+    """Parse the newest structured ``Data: {...}`` payload from a scheduler log."""
+    for line in reversed(_read_job_log_lines(jid, entry, log_path)):
+        if "Data:" not in line:
+            continue
+        _, raw = line.split("Data:", 1)
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        return data if isinstance(data, dict) else {"value": data}
+    return None
+
+
+def _find_nested_result(data: dict | None, predicate) -> dict | None:
+    if not isinstance(data, dict):
+        return None
+    if predicate(data):
+        return data
+    nested = data.get("data")
+    if isinstance(nested, dict):
+        found = _find_nested_result(nested, predicate)
+        if found:
+            return found
+    for step in data.get("step_results") or []:
+        if isinstance(step, dict):
+            found = _find_nested_result(step.get("data"), predicate)
+            if found:
+                return found
+    return None
+
+
+def _summarize_job_result_data(data: dict | None) -> str:
+    """Build a compact history-table summary for structured skill output."""
+    read_news = _find_nested_result(
+        data,
+        lambda item: isinstance(item.get("headlines"), list) and isinstance(item.get("articles"), list),
+    )
+    if read_news:
+        headlines = read_news.get("headlines") or []
+        articles = read_news.get("articles") or []
+        first = ""
+        if headlines and isinstance(headlines[0], dict):
+            first = str(headlines[0].get("title") or headlines[0].get("source_headline") or "")
+        headline_word = "headline" if len(headlines) == 1 else "headlines"
+        article_word = "article" if len(articles) == 1 else "articles"
+        parts = [f"read_news: {len(headlines)} {headline_word}", f"{len(articles)} {article_word}"]
+        if first:
+            parts.append(f"first: {first[:90]}")
+        return " | ".join(parts)
+
+    if isinstance(data, dict) and isinstance(data.get("completed_steps"), int):
+        total = data.get("completed_steps", 0)
+        failed = ""
+        for step in data.get("step_results") or []:
+            if isinstance(step, dict) and not step.get("success", True):
+                failed = str(step.get("name") or "")
+                break
+        if failed:
+            return f"skill failed at {failed}"
+        return f"skill completed {total} step{'s' if total != 1 else ''}"
+
+    return ""
+
+
+def _parse_job_summary(jid: int, entry: dict | None = None, log_path: str | None = None) -> str:
+    """Parse [done] summary from a job's log file."""
+    all_lines = _read_job_log_lines(jid, entry, log_path)
     summary = ""
     sent_count = 0
     for line in all_lines:
@@ -132,6 +228,8 @@ def _parse_job_summary(jid: int, entry: dict | None = None, log_path: str | None
                 break
     if not summary:
         summary = _parse_partial_crawl(all_lines)
+    if not summary:
+        summary = _summarize_job_result_data(_parse_job_result_data(jid, entry, log_path))
     return summary
 
 

--- a/gitd/services/a11y_diff.py
+++ b/gitd/services/a11y_diff.py
@@ -1,0 +1,70 @@
+"""Differential accessibility state — a before/after UI-tree diff.
+
+A perception aid distilled from the AndroidWorld agent harness (``_a11y_diff``):
+after a UI action we show the model *what changed* (which elements appeared /
+disappeared) instead of making it re-read the whole tree and infer the delta.
+DroidRun-style; purely additive — the diff is appended to a tool result, it
+never alters the action that ran.
+
+Operates on the normalized element dicts returned by
+:func:`gitd.services.device_context.get_interactive_elements` — each element is
+``{idx, text, content_desc, resource_id, class, bounds, center, clickable,
+scrollable}`` — so it is cross-platform (Android + iOS share that shape).
+"""
+
+from __future__ import annotations
+
+# How many added/removed entries to spell out before collapsing to a count.
+_MAX_LISTED = 6
+# Position-bucket size (px). Two elements whose centers land in the same
+# ~40px bucket are treated as the same slot, so sub-pixel jitter between two
+# dumps of an unchanged screen does not read as a change.
+_POS_BUCKET = 40
+
+
+def element_label(el: dict) -> str:
+    """Human label for an element: visible text, else its a11y content-desc."""
+    return (el.get("text") or el.get("content_desc") or "").strip()
+
+
+def element_key(el: dict) -> tuple:
+    """Identity of an element for diffing: label + type + coarse position.
+
+    Deliberately coarse (label truncated, center bucketed) so an unchanged
+    screen dumped twice produces identical keys despite coordinate jitter —
+    matching the AW harness's ``(label[:30], ui_type, cx//40, cy//40)`` key.
+    """
+    center = el.get("center") or {}
+    cx = int(center.get("x", 0)) // _POS_BUCKET
+    cy = int(center.get("y", 0)) // _POS_BUCKET
+    return (element_label(el)[:30], el.get("class", ""), cx, cy)
+
+
+def diff_elements(prev: list[dict] | None, curr: list[dict] | None) -> str:
+    """Return a compact text diff of which elements appeared / disappeared.
+
+    Returns ``""`` when there is no previous state to compare against (the first
+    action of a session has nothing to diff), and ``"A11y diff: no change."``
+    when the two states are equivalent — both are cheap, unambiguous signals for
+    the caller to decide whether to surface anything.
+    """
+    if not prev:
+        return ""
+    curr = curr or []
+    prev_keys = {element_key(e) for e in prev}
+    curr_keys = {element_key(e) for e in curr}
+    added = [e for e in curr if element_key(e) not in prev_keys]
+    removed = [e for e in prev if element_key(e) not in curr_keys]
+    if not added and not removed:
+        return "A11y diff: no change."
+
+    parts = ["A11y diff (since last action):"]
+    for e in added[:_MAX_LISTED]:
+        parts.append(f"  + '{element_label(e)}' ({e.get('class', '')})")
+    if len(added) > _MAX_LISTED:
+        parts.append(f"  + …{len(added) - _MAX_LISTED} more new")
+    for e in removed[:_MAX_LISTED]:
+        parts.append(f"  - '{element_label(e)}' ({e.get('class', '')})")
+    if len(removed) > _MAX_LISTED:
+        parts.append(f"  - …{len(removed) - _MAX_LISTED} more gone")
+    return "\n".join(parts)

--- a/gitd/services/account_health.py
+++ b/gitd/services/account_health.py
@@ -1,0 +1,441 @@
+"""Account health — verify which TikTok account is logged in / active on a device.
+
+Lives in the public gitd/ namespace so the scheduler can call it without
+depending on the premium plugin. The actual UI automation (account switcher
+navigation, etc.) lives in internal/ghost_premium/bots/tiktok/upload.py —
+we delegate to it if installed, otherwise return a clean "not available"
+result so public users see no crashes.
+
+Public API:
+    device_account_health(device)        → dict
+    switch_active_account(device, handle) → dict
+    sync_tiktok_accounts_table(device)    → dict
+    all_devices_health()                  → list[dict]
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from typing import Optional
+
+from gitd.bots.common.device import get_device, is_ios_ref
+
+logger = logging.getLogger(__name__)
+
+# Cache results briefly to avoid hammering the phone with full account-switcher
+# navigations on every job preflight (each call takes 8-15s).
+_CACHE_TTL_S = 60
+_cache: dict[str, tuple[float, dict]] = {}
+_TIKTOK_IOS_BUNDLE_ID = "com.zhiliaoapp.musically"
+_HANDLE_RE = re.compile(r"(?<![\w.])@([A-Za-z0-9._]{2,30})")
+
+
+def _ios_unsupported_result(device: str, *, action: str = "account_health") -> dict:
+    if action == "account_switch":
+        message = (
+            "TikTok account switching is not implemented on iOS yet; "
+            "iOS account health and sync use best-effort visible text detection."
+        )
+    else:
+        message = "This TikTok account operation is not implemented on iOS yet"
+    result = {
+        "ok": False,
+        "device": device,
+        "platform": "ios",
+        "error": "unsupported_platform",
+        "message": message,
+        "action": action,
+        "checked_at": _now_iso(),
+    }
+    if action == "account_health":
+        result.update({"active": None, "logged_in": [], "cached": False})
+    return result
+
+
+def _normalize_handle(value: str) -> str:
+    return value.lstrip("@").strip().strip(".").lower()
+
+
+def _ios_visible_text(dev, *, max_lines: int = 120) -> tuple[str, list[str]]:
+    if hasattr(dev, "extract_visible_text"):
+        text = dev.extract_visible_text(max_lines=max_lines)
+    else:
+        xml = dev.dump_xml()
+        lines = []
+        seen = set()
+        if hasattr(dev, "nodes"):
+            for node in dev.nodes(xml):
+                parts = []
+                for method_name in ("node_text", "node_content_desc", "node_rid"):
+                    method = getattr(dev, method_name, None)
+                    if method:
+                        parts.append(method(node))
+                label = " ".join(part for part in parts if part).strip()
+                if label and label not in seen:
+                    seen.add(label)
+                    lines.append(label)
+                if len(lines) >= max_lines:
+                    break
+        text = "\n".join(lines)
+    lines = [line.strip() for line in str(text or "").splitlines() if line.strip()][:max_lines]
+    return "\n".join(lines), lines
+
+
+def _handles_from_text(text: str) -> list[str]:
+    handles: list[str] = []
+    seen: set[str] = set()
+    for match in _HANDLE_RE.finditer(text or ""):
+        handle = _normalize_handle(match.group(1))
+        if not handle or handle in seen:
+            continue
+        seen.add(handle)
+        handles.append(handle)
+    return handles
+
+
+def _ios_tiktok_account_health(device: str) -> dict:
+    result = {
+        "device": device,
+        "platform": "ios",
+        "ok": False,
+        "active": None,
+        "logged_in": [],
+        "error": None,
+        "cached": False,
+        "checked_at": _now_iso(),
+        "detection": {
+            "method": "wda_visible_text",
+            "bundle_id": _TIKTOK_IOS_BUNDLE_ID,
+            "limitations": [
+                "Best-effort iOS detection reads visible TikTok text; full account switcher enumeration is not implemented yet."
+            ],
+        },
+    }
+    try:
+        dev = get_device(device)
+        if hasattr(dev, "launch_app"):
+            dev.launch_app(_TIKTOK_IOS_BUNDLE_ID)
+            time.sleep(1)
+        text, lines = _ios_visible_text(dev)
+        handles = _handles_from_text(text)
+        result["detection"].update(
+            {
+                "line_count": len(lines),
+                "text_excerpt": "\n".join(lines[:20]),
+            }
+        )
+        if not handles:
+            result["error"] = "no visible TikTok account handle detected"
+            return result
+        result["ok"] = True
+        result["active"] = handles[0]
+        result["logged_in"] = handles
+        return result
+    except Exception as e:
+        result["error"] = str(e)[:200]
+        return result
+
+
+def _premium_available() -> bool:
+    """Whether the premium TikTok upload module is installed."""
+    try:
+        import ghost_premium.bots.tiktok.upload  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def device_account_health(device: str, fresh: bool = False) -> dict:
+    """Probe a device for its TikTok account state.
+
+    Args:
+        device: ADB serial or ios:<udid> device ref.
+        fresh: If True, bypass the 60s cache.
+
+    Returns:
+        {
+            "device": serial,
+            "ok": bool,                  # True if detection succeeded
+            "active": "handle" | None,   # currently active account
+            "logged_in": ["h1", "h2"],   # all logged-in accounts
+            "error": "..." | None,       # error message if detection failed
+            "cached": bool,              # True if returned from cache
+            "checked_at": iso_ts,
+        }
+    """
+    if is_ios_ref(device):
+        if not fresh:
+            cached = _cache.get(device)
+            if cached and time.time() - cached[0] < _CACHE_TTL_S:
+                return {**cached[1], "cached": True}
+        result = _ios_tiktok_account_health(device)
+        _cache[device] = (time.time(), result)
+        return result
+
+    if not fresh:
+        cached = _cache.get(device)
+        if cached and time.time() - cached[0] < _CACHE_TTL_S:
+            return {**cached[1], "cached": True}
+
+    result = {
+        "device": device,
+        "platform": "android",
+        "ok": False,
+        "active": None,
+        "logged_in": [],
+        "error": None,
+        "cached": False,
+        "checked_at": _now_iso(),
+    }
+
+    if not _premium_available():
+        result["error"] = "premium not installed"
+        return result
+
+    try:
+        from ghost_premium.bots.tiktok.upload import get_logged_in_accounts
+
+        accounts = get_logged_in_accounts(device=device)
+    except Exception as e:
+        result["error"] = str(e)[:200]
+        _cache[device] = (time.time(), result)
+        return result
+
+    result["ok"] = True
+    result["logged_in"] = [a["handle"] for a in accounts]
+    active = next((a["handle"] for a in accounts if a.get("active")), None)
+    result["active"] = active
+    _cache[device] = (time.time(), result)
+    return result
+
+
+def switch_active_account(device: str, handle: str) -> dict:
+    """Switch the TikTok active account on the device to `handle`.
+
+    Args:
+        device: ADB serial or ios:<udid> device ref.
+        handle: Target username (with or without @).
+
+    Returns:
+        {"ok": bool, "device": serial, "active": handle | None, "error": str | None}
+    """
+    handle = handle.lstrip("@").strip()
+    if is_ios_ref(device):
+        target = _normalize_handle(handle)
+        health = device_account_health(device, fresh=True)
+        active = _normalize_handle(health.get("active") or "")
+        if health.get("ok") and active == target:
+            return {
+                "ok": True,
+                "device": device,
+                "platform": "ios",
+                "active": active,
+                "target": target,
+                "logged_in": health.get("logged_in", []),
+                "error": None,
+                "switched": False,
+                "message": "target TikTok account is already active on iOS",
+                "detection": health.get("detection"),
+            }
+        result = _ios_unsupported_result(device, action="account_switch")
+        result.update(
+            {
+                "active": active or health.get("active"),
+                "target": target,
+                "logged_in": health.get("logged_in", []),
+                "health_ok": bool(health.get("ok")),
+                "health_error": health.get("error"),
+                "detection": health.get("detection"),
+            }
+        )
+        return result
+    if not _premium_available():
+        return {"ok": False, "device": device, "platform": "android", "active": None, "error": "premium not installed"}
+
+    # First check if already active — save 10+ seconds
+    health = device_account_health(device, fresh=True)
+    if health["active"] == handle:
+        return {"ok": True, "device": device, "active": handle, "error": None}
+    if not health["ok"]:
+        return {"ok": False, "device": device, "active": None, "error": f"can't detect state: {health['error']}"}
+    if handle not in health["logged_in"]:
+        return {
+            "ok": False,
+            "device": device,
+            "active": health["active"],
+            "error": f"@{handle} not logged in on this device (have: {health['logged_in']})",
+        }
+
+    try:
+        from ghost_premium.bots.tiktok.upload import switch_account
+
+        switch_account(handle, device=device)
+    except Exception as e:
+        return {"ok": False, "device": device, "active": health["active"], "error": str(e)[:200]}
+
+    # Invalidate cache and re-probe
+    _cache.pop(device, None)
+    after = device_account_health(device, fresh=True)
+    return {
+        "ok": after["active"] == handle,
+        "device": device,
+        "active": after["active"],
+        "error": None if after["active"] == handle else f"switch attempted but active is still @{after['active']}",
+    }
+
+
+def _sync_detected_accounts(device: str, health: dict) -> dict:
+    if not health["ok"]:
+        return {
+            "ok": False,
+            "device": device,
+            "platform": health.get("platform") or ("ios" if is_ios_ref(device) else "android"),
+            "added": [],
+            "updated": [],
+            "active": None,
+            "error": health["error"],
+        }
+
+    from gitd.db import DEFAULT_DB, create_tables, get_connection
+
+    conn = get_connection(DEFAULT_DB)
+    create_tables(conn)
+
+    added, updated = [], []
+    active_handle = health["active"]
+    for handle in health["logged_in"]:
+        existing = conn.execute("SELECT handle, phone_serial FROM tiktok_accounts WHERE handle=?", (handle,)).fetchone()
+        if existing is None:
+            conn.execute(
+                "INSERT INTO tiktok_accounts (handle, phone_serial, is_active) VALUES (?, ?, 1)",
+                (handle, device),
+            )
+            added.append(handle)
+        elif existing["phone_serial"] != device:
+            conn.execute(
+                "UPDATE tiktok_accounts SET phone_serial=?, is_active=1 WHERE handle=?",
+                (device, handle),
+            )
+            updated.append(handle)
+    conn.commit()
+    conn.close()
+    return {
+        "ok": True,
+        "device": device,
+        "platform": health.get("platform") or ("ios" if is_ios_ref(device) else "android"),
+        "added": added,
+        "updated": updated,
+        "active": active_handle,
+        "error": None,
+    }
+
+
+def sync_tiktok_accounts_table(device: str) -> dict:
+    """Refresh the tiktok_accounts DB table to match what's actually on the device.
+
+    On iOS this uses best-effort visible text account detection; it can only
+    sync accounts that are visible to WDA/Appium at probe time.
+
+    For each logged-in handle on `device`:
+      - Upsert (handle, phone_serial, is_active=1)
+      - If the row already exists with a different phone_serial, update it
+        (an account is "where it was last seen logged in").
+
+    Returns:
+        {"ok": bool, "device": serial, "added": [...], "updated": [...], "active": "...", "error": str | None}
+    """
+    if is_ios_ref(device):
+        health = device_account_health(device, fresh=True)
+        return _sync_detected_accounts(device, health)
+
+    health = device_account_health(device, fresh=True)
+    return _sync_detected_accounts(device, health)
+
+
+def all_devices_health() -> list[dict]:
+    """Probe every connected Android device and configured iOS device ref."""
+    from gitd.bots.common.adb import list_connected
+    from gitd.bots.common.device import ios_refs_from_host
+
+    devices: list[str] = []
+    seen: set[str] = set()
+    for serial in [*list_connected(), *ios_refs_from_host()]:
+        if serial and serial not in seen:
+            seen.add(serial)
+            devices.append(serial)
+    return [device_account_health(serial) for serial in devices]
+
+
+def expected_account_matches(device: str, expected: Optional[str]) -> dict:
+    """Lightweight pre-flight check for the scheduler.
+
+    Args:
+        device: ADB serial.
+        expected: Handle the job expects to run as (without @). None = no check.
+
+    Returns:
+        {"ok": bool, "reason": str | None, "active": handle, "expected": expected}
+
+        ok=True when:
+          - expected is None / empty (job doesn't care)
+          - or detection succeeded and active matches expected
+        ok=False when:
+          - active is detected but different
+        ok=True with reason set ("undetectable") when:
+          - premium not installed
+          - or detection failed (we don't block jobs on detection failures —
+            log warning and let job try, since false-blocks are worse than
+            false-allows here)
+    """
+    if not expected:
+        return {"ok": True, "reason": None, "active": None, "expected": expected}
+
+    expected_clean = expected.lstrip("@").strip()
+    if is_ios_ref(device):
+        health = device_account_health(device)
+        if not health["ok"]:
+            return {
+                "ok": True,
+                "reason": f"undetectable: {health['error']}",
+                "active": None,
+                "expected": expected_clean,
+            }
+        active = _normalize_handle(health["active"] or "")
+        if active == _normalize_handle(expected_clean):
+            return {"ok": True, "reason": None, "active": active, "expected": expected_clean}
+        return {
+            "ok": False,
+            "reason": f"wrong active account: have @{active or '?'}, expected @{expected_clean}",
+            "active": active,
+            "expected": expected_clean,
+        }
+
+    health = device_account_health(device)
+
+    if not health["ok"]:
+        return {
+            "ok": True,
+            "reason": f"undetectable: {health['error']}",
+            "active": None,
+            "expected": expected_clean,
+        }
+
+    active = (health["active"] or "").lstrip("@").strip()
+    if active == expected_clean:
+        return {"ok": True, "reason": None, "active": active, "expected": expected_clean}
+
+    return {
+        "ok": False,
+        "reason": f"wrong active account: have @{active or '?'}, expected @{expected_clean}",
+        "active": active,
+        "expected": expected_clean,
+    }
+
+
+def _now_iso() -> str:
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/gitd/services/agent_chat.py
+++ b/gitd/services/agent_chat.py
@@ -16,15 +16,17 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
-from gitd.services.agent_tools import TOOLS, execute_tool, get_screenshot_b64
+from gitd.bots.common.device import is_ios_ref
+from gitd.services.agent_tools import execute_tool, get_screenshot_b64, tool_prompt_list, tools_for_device
 from gitd.services.device_context import get_phone_state, get_screen_tree
+from gitd.services.llm_backoff import backoff_stream, effort_timeout
 
 log = logging.getLogger(__name__)
 
-DEFAULT_SYSTEM = """You are an Android automation agent with full control over a physical Android device.
+DEFAULT_SYSTEM = """You are a mobile automation agent with full control over one connected mobile device.
 
 You can see the screen (via screenshots and UI tree), interact with it (tap, swipe, type),
-manage apps (install, uninstall, launch), run shell commands, and execute automation skills.
+launch and control apps, navigate browser pages, and execute automation skills.
 
 ## Available tools:
 {tool_list}
@@ -41,20 +43,22 @@ You can call multiple tools in sequence. After each tool call, I'll show you the
 - Always use get_screen_tree first to understand what's on screen
 - Use element indices from the tree for precise tapping (tap_element)
 - After actions, verify results with get_screen_tree
+- Use only the tools listed above; unavailable platform-specific tools have been filtered out
 - Keep responses concise"""
 
-ANTHROPIC_SYSTEM = """You are an Android automation agent with full control over a physical Android device.
+ANTHROPIC_SYSTEM = """You are a mobile automation agent with full control over one connected mobile device.
 
 You can see the screen (via screenshots and UI tree), interact with it (tap, swipe, type),
-manage apps (install, uninstall, launch), run shell commands, and execute automation skills.
+launch and control apps, navigate browser pages, and execute automation skills.
 
 Guidelines:
 - Always use get_screen_tree first to understand what's on screen before tapping
 - Use element indices from the tree for precise tapping (tap_element)
 - After performing actions, use get_screen_tree to verify the result
+- Use only the tools exposed for the current device platform
 - Keep responses concise — show what you did and the result"""
 
-MAX_TURNS = 15
+MAX_TURNS = 24
 
 PROVIDERS = {
     "claude-code": {"label": "Claude Code (free)", "models": ["sonnet", "opus", "haiku"]},
@@ -69,6 +73,26 @@ PROVIDERS = {
             "qwen3:4b",
             "phi4-mini:3.8b",
             "mistral:7b",
+        ],
+    },
+    # On-device — runs the model in-process via MediaPipe (.task) or
+    # llama.cpp JNI (.gguf). The Kotlin OnDeviceModelRegistry is the source of
+    # truth for ids; we ship a default subset here and overlay live ids below.
+    "on-device": {
+        "label": "On-device (Gemma)",
+        "models": ["gemma-3-1b-it", "gemma-2-2b-it", "gemma-4-e2b-q4km-gguf"],
+    },
+    # vLLM — full-precision Gemma 4 served from the GPU box,
+    # routed via Mac SSH tunnel + adb reverse so the phone hits it as if it
+    # were on localhost. Same OpenAI-compatible shape as openrouter; we just
+    # point the client at config.vllm_base_url instead.
+    "vllm": {
+        "label": "vLLM (remote GPU)",
+        "models": [
+            "unsloth/gemma-4-E2B-it",
+            "unsloth/gemma-4-E2B-it-bnb-4bit",
+            "unsloth/gemma-4-E4B-it",
+            "unsloth/gemma-4-E4B-it-bnb-4bit",
         ],
     },
 }
@@ -100,29 +124,92 @@ _sessions: dict[str, ChatSession] = {}
 _active_procs: dict[str, subprocess.Popen] = {}  # session_id -> running subprocess
 
 
-def stop_agent(session_id: str):
-    """Kill the running agent subprocess AND all its children."""
-    proc = _active_procs.pop(session_id, None)
-    if proc:
-        try:
-            proc.kill()
-        except Exception:
-            pass
-    # Nuclear option: kill ALL claude --print processes (only agent chat uses this)
-    # This catches cases where the PID changed (node re-exec) or psutil can't find it
-    try:
-        subprocess.run(
-            ["pkill", "-9", "-f", "claude.*--print.*--output-format.*stream-json"],
-            capture_output=True,
-            timeout=3,
+def platform_context(device: str) -> str:
+    if is_ios_ref(device):
+        return (
+            "Target platform: iOS via Appium/WebDriverAgent. Device refs look like ios:<udid>. "
+            "Use iOS bundle ids with launch_app; call search_apps/list_apps if you need to discover a bundle id. "
+            "Use browser tools such as open_url/extract_visible_text/extract_articles/read_news for web tasks, "
+            "and avoid Android-only concepts such as ADB shell, Android intents, Portal overlay, Play Store, "
+            "and Android package-manager commands."
         )
-    except Exception:
+    return (
+        "Target platform: Android via ADB/Portal. Device refs are Android serials. "
+        "Android intents, ADB shell, app packages, Portal overlay, notifications, and package search "
+        "may be available when their tools are listed."
+    )
+
+
+def system_prompt_for_device(device: str, base: str = ANTHROPIC_SYSTEM) -> str:
+    return f"{base}\n\n{platform_context(device)}"
+
+
+def openai_tools_for_device(device: str) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {"name": t["name"], "description": t["description"], "parameters": t["input_schema"]},
+        }
+        for t in tools_for_device(device)
+    ]
+
+
+def stop_agent(session_id: str):
+    """Kill the running agent subprocess AND all its children — THIS session only.
+
+    chat_claude_code launches claude with start_new_session=True, so claude and
+    its node + MCP-tool children share one process group (pgid == the claude
+    pid). Killing that group through the proc handle registered in
+    _active_procs[session_id] is a complete, session-scoped stop: SIGTERM the
+    group, then SIGKILL if it doesn't exit within 2s. A re-exec (execve) keeps
+    the same pgid, so a changed PID doesn't escape this.
+
+    We deliberately do NOT fall back to `pkill -f claude...stream-json`: that
+    pattern matches EVERY claude stream-json process on the box, so stopping
+    session A would reap session B mid-tap. Worse, the router calls stop_agent
+    in the finally of every stream (including non-claude providers that never
+    register a proc), so a normal completion on one session would nuke every
+    other live agent. Multi-session is a headline capability — keep stops
+    isolated to their own process group.
+    """
+    import os as _os
+    import signal as _sig
+
+    proc = _active_procs.pop(session_id, None)
+    if proc is None:
+        # No process for this session (e.g. anthropic/ollama providers, or
+        # already stopped). Nothing to kill — and crucially, no global sweep.
+        return
+    try:
+        pgid = _os.getpgid(proc.pid)
+        _os.killpg(pgid, _sig.SIGTERM)
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            _os.killpg(pgid, _sig.SIGKILL)
+    except (ProcessLookupError, PermissionError):
         pass
+    except Exception:
+        # pgid lookup failed (proc already reaped) — best-effort plain kill.
+        try:
+            pgid = _os.getpgid(proc.pid)
+            _os.killpg(pgid, _sig.SIGTERM)
+            try:
+                proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                _os.killpg(pgid, _sig.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            pass
     log.info("Stopped agent for session %s", session_id)
 
 
-def create_session(device: str, provider: str = "claude-code", model: str = "", system_prompt: str = "") -> ChatSession:
+def create_session(device: str, provider: str = "", model: str = "", system_prompt: str = "") -> ChatSession:
     sid = str(uuid.uuid4())[:8]
+    if not provider:
+        # Honor the configured default (set by `android-agent login`).
+        from gitd.config import settings
+
+        provider = settings.default_provider or "claude-code"
     default_model = PROVIDERS.get(provider, {}).get("models", ["sonnet"])[0] if not model else model
     session = ChatSession(id=sid, device=device, provider=provider, model=default_model or "sonnet")
     _sessions[sid] = session
@@ -340,194 +427,16 @@ def chat_turn(session: ChatSession, user_message: str):
         yield from chat_claude_code(session, user_message)
     elif provider == "openrouter":
         yield from _chat_openrouter(session, user_message)
+    elif provider == "vllm":
+        yield from _chat_vllm(session, user_message)
     elif provider == "ollama":
         yield from _chat_ollama(session, user_message)
+    elif provider == "on-device":
+        from gitd.services.agent_chat_ondevice import chat_ondevice
+
+        yield from chat_ondevice(session, user_message)
     else:
         yield {"type": "error", "content": f"Unknown provider: {provider}"}
-
-
-# ── Claude Code (free, local CLI) ────────────────────────────────────────────
-
-
-def _chat_claude_code(session: ChatSession, user_message: str):
-    """Use claude CLI with MCP android-agent tools — streams output line-by-line."""
-    session.messages.append(ChatMessage(role="user", content=user_message))
-
-    # Build context
-    yield {"type": "activity", "content": "📱 Reading screen..."}
-    context_parts = []
-    try:
-        tree = get_screen_tree(session.device)
-        if tree and tree != "(empty screen)":
-            context_parts.append(f"[Current screen]\n{tree[:1500]}")
-        state = get_phone_state(session.device)
-        if state:
-            context_parts.append(f"[App: {state.get('currentApp', '?')} ({state.get('packageName', '?')})]")
-    except Exception:
-        pass
-    context = "\n".join(context_parts)
-
-    prompt = f"""You are controlling an Android phone (serial: {session.device}).
-{context}
-
-The user wants: {user_message}
-
-IMPORTANT: Use the MCP android-agent tools for ALL phone interactions. Never use Bash/shell for ADB — the MCP tools handle everything. Bash is only for non-phone tasks.
-Key tools:
-- get_screen_tree: read what's on screen (ALWAYS call this before tapping)
-- tap_element(idx): tap by element index from the tree
-- tap(x,y): tap by coordinates
-- swipe(x1,y1,x2,y2): scroll/swipe
-- type_text(text): type into focused field
-- screenshot: see the screen visually
-- search_apps(query): find apps by name
-- launch_app(package): open an app
-- press_back / press_home: navigation
-
-After each action the screen tree is auto-included in the result.
-Keep going until the task is done."""
-
-    yield {"type": "activity", "content": "🧠 Starting agent..."}
-
-    # Use claude CLI with full tool access via MCP
-    # The .mcp.json in the project root gives it android-agent tools
-    try:
-        proc = subprocess.Popen(
-            [
-                "claude",
-                "--print",
-                "--model",
-                session.model or "sonnet",
-                "--output-format",
-                "stream-json",
-                "--dangerously-skip-permissions",
-            ],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            bufsize=1,
-            cwd=str(__import__("pathlib").Path(__file__).parent.parent.parent),
-            env={**os.environ, "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1"},
-        )
-    except FileNotFoundError:
-        yield {"type": "error", "content": "claude CLI not found. Install: npm i -g @anthropic-ai/claude-code"}
-        return
-
-    _active_procs[session.id] = proc
-
-    proc.stdin.write(prompt)
-    proc.stdin.close()
-
-    full_text = ""
-    current_tool = ""
-
-    try:
-        for raw_line in proc.stdout:
-            line = raw_line.strip()
-            if not line:
-                continue
-
-            # Try to parse as JSON (stream-json format)
-            try:
-                event = json.loads(line)
-                etype = event.get("type", "")
-
-                if etype == "assistant":
-                    # Full assistant message with content blocks
-                    for block in event.get("message", {}).get("content", []):
-                        if block.get("type") == "text" and block.get("text"):
-                            text = block["text"]
-                            full_text += text
-                            session.messages.append(ChatMessage(role="assistant", content=text))
-                            yield {"type": "text", "content": text}
-                        elif block.get("type") == "tool_use":
-                            current_tool = block.get("name", "")
-                            args = block.get("input", {})
-                            session.messages.append(
-                                ChatMessage(role="tool_call", tool_name=current_tool, tool_args=args, content="")
-                            )
-                            yield {"type": "tool_call", "name": current_tool, "args": args}
-                            yield {"type": "activity", "content": f"⚡ {current_tool}..."}
-
-                elif etype == "content_block_start":
-                    cb = event.get("content_block", {})
-                    if cb.get("type") == "tool_use":
-                        current_tool = cb.get("name", "")
-                        yield {"type": "tool_call", "name": current_tool, "args": cb.get("input", {})}
-                        yield {"type": "activity", "content": f"⚡ {current_tool}..."}
-                    elif cb.get("type") == "text":
-                        yield {"type": "activity", "content": "💬 Writing..."}
-
-                elif etype == "content_block_delta":
-                    delta = event.get("delta", {})
-                    if delta.get("type") == "text_delta" and delta.get("text"):
-                        text = delta["text"]
-                        full_text += text
-                        yield {"type": "text", "content": text}
-
-                elif etype == "result":
-                    # Final result
-                    for block in event.get("result", {}).get("content", []):
-                        if block.get("type") == "text" and block.get("text"):
-                            text = block["text"]
-                            if text not in full_text:
-                                full_text += text
-                                session.messages.append(ChatMessage(role="assistant", content=text))
-                                yield {"type": "text", "content": text}
-
-                elif etype == "tool_result":
-                    result_text = ""
-                    for block in event.get("content", []):
-                        if block.get("type") == "text":
-                            result_text += block.get("text", "")
-                    if result_text:
-                        session.messages.append(
-                            ChatMessage(role="tool_result", content=result_text[:500], tool_name=current_tool)
-                        )
-                        yield {"type": "tool_result", "name": current_tool, "result": result_text[:500]}
-                    yield {"type": "activity", "content": "🤔 Thinking..."}
-
-                continue
-            except json.JSONDecodeError:
-                pass
-
-            # Not JSON — plain text line (fallback for --print without stream-json)
-            if line and line not in full_text:
-                full_text += line + "\n"
-
-    except Exception as e:
-        yield {"type": "error", "content": f"Stream error: {e}"}
-
-    # Wait for process to finish
-    _active_procs.pop(session.id, None)
-    try:
-        proc.wait(timeout=10)
-    except subprocess.TimeoutExpired:
-        proc.kill()
-
-    # If streaming didn't produce output, fall back to --print
-    if not full_text:
-        yield {"type": "activity", "content": "⏳ Fallback mode..."}
-        try:
-            proc2 = subprocess.run(
-                ["claude", "--print", "--model", session.model or "sonnet", "--dangerously-skip-permissions"],
-                input=prompt,
-                capture_output=True,
-                text=True,
-                timeout=300,
-                cwd=str(__import__("pathlib").Path(__file__).parent.parent.parent),
-                env={**os.environ, "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1"},
-            )
-            if proc2.stdout.strip():
-                session.messages.append(ChatMessage(role="assistant", content=proc2.stdout.strip()))
-                yield {"type": "text", "content": proc2.stdout.strip()}
-            elif proc2.stderr:
-                yield {"type": "error", "content": proc2.stderr[:500]}
-        except subprocess.TimeoutExpired:
-            yield {"type": "error", "content": "Claude Code timed out (5min)"}
-
-    yield {"type": "done"}
 
 
 # ── Anthropic API (native tool_use) ──────────────────────────────────────────
@@ -541,16 +450,25 @@ def _chat_anthropic(session: ChatSession, user_message: str):
     session.api_messages.append({"role": "user", "content": _build_vision_content(session, user_message)})
 
     client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY", ""))
+    available_tools = tools_for_device(session.device)
 
     for turn in range(MAX_TURNS):
         try:
-            resp = client.messages.create(
-                model=session.model,
-                max_tokens=4096,
-                system=ANTHROPIC_SYSTEM,
-                messages=session.api_messages,
-                tools=TOOLS,
-            )
+            resp = None
+            for ev in backoff_stream(
+                lambda: client.messages.create(
+                    model=session.model,
+                    max_tokens=4096,
+                    system=system_prompt_for_device(session.device),
+                    messages=session.api_messages,
+                    tools=available_tools,
+                    timeout=effort_timeout(session.model),
+                )
+            ):
+                if "__result__" in ev:
+                    resp = ev["__result__"]
+                else:
+                    yield ev
         except Exception as e:
             yield {"type": "error", "content": str(e)}
             return
@@ -575,7 +493,16 @@ def _chat_anthropic(session: ChatSession, user_message: str):
                 )
                 yield {"type": "tool_call", "name": tool_name, "args": tool_args}
 
-                result = execute_tool(tool_name, tool_args)
+                # Catch tool failures (e.g. ADBError on an offline/unauthorized
+                # device) so they become a tool_result the model can react to,
+                # not an uncaught raise that breaks the SSE stream. Every
+                # tool_use MUST get a matching tool_result or the next turn's
+                # Anthropic request is malformed — so the error text flows into
+                # the same result path below. Mirrors the vllm/ollama loops.
+                try:
+                    result = execute_tool(tool_name, tool_args)
+                except Exception as e:
+                    result = f"Tool error: {e}"
                 image_b64 = ""
                 if tool_name in ("screenshot", "screenshot_annotated", "screenshot_cropped"):
                     image_b64 = get_screenshot_b64(tool_args.get("device", session.device)) or ""
@@ -604,26 +531,24 @@ def _chat_anthropic(session: ChatSession, user_message: str):
 
 
 def _chat_openrouter(session: ChatSession, user_message: str):
-    """Use OpenRouter with OpenAI-compatible tool calling."""
+    """Use OpenRouter with OpenAI-compatible tool calling.
+
+    Multi-turn agent loop (same shape as _chat_vllm): feed each tool result
+    back to the model until it answers without tool calls or MAX_TURNS.
+    """
     from openai import OpenAI
+
+    from gitd.config import settings
 
     session.messages.append(ChatMessage(role="user", content=user_message))
 
     client = OpenAI(
-        api_key=os.environ.get("OPENROUTER_API_KEY", ""),
+        api_key=os.environ.get("OPENROUTER_API_KEY", settings.openrouter_api_key or ""),
         base_url="https://openrouter.ai/api/v1",
     )
 
-    # Convert tools to OpenAI format
-    oai_tools = [
-        {
-            "type": "function",
-            "function": {"name": t["name"], "description": t["description"], "parameters": t["input_schema"]},
-        }
-        for t in TOOLS
-    ]
+    oai_tools = openai_tools_for_device(session.device)
 
-    # Build messages
     context = ""
     try:
         tree = get_screen_tree(session.device)
@@ -632,76 +557,403 @@ def _chat_openrouter(session: ChatSession, user_message: str):
     except Exception:
         pass
 
-    messages = [
-        {"role": "system", "content": ANTHROPIC_SYSTEM},
+    messages: list[dict] = [
+        {"role": "system", "content": system_prompt_for_device(session.device)},
         {"role": "user", "content": f"{context}Device: {session.device}\n\n{user_message}"},
     ]
 
-    try:
-        resp = client.chat.completions.create(
-            model=session.model or "anthropic/claude-sonnet-4",
-            messages=messages,
-            tools=oai_tools,
-            max_tokens=4096,
-        )
+    model = session.model or "anthropic/claude-sonnet-4"
+
+    for _turn in range(MAX_TURNS):
+        try:
+            resp = None
+            for ev in backoff_stream(
+                lambda: client.chat.completions.create(
+                    model=model,
+                    messages=messages,
+                    tools=oai_tools,
+                    max_tokens=4096,
+                    timeout=effort_timeout(model),
+                )
+            ):
+                if "__result__" in ev:
+                    resp = ev["__result__"]
+                else:
+                    yield ev
+        except Exception as e:
+            yield {"type": "error", "content": str(e)}
+            yield {"type": "done"}
+            return
+
         msg = resp.choices[0].message
 
         if msg.content:
             session.messages.append(ChatMessage(role="assistant", content=msg.content))
             yield {"type": "text", "content": msg.content}
 
-        if msg.tool_calls:
-            for tc in msg.tool_calls:
-                tool_name = tc.function.name
-                tool_args = json.loads(tc.function.arguments)
-                tool_args.setdefault("device", session.device)
+        tool_calls = getattr(msg, "tool_calls", None) or []
+        if not tool_calls:
+            break
 
-                session.messages.append(
-                    ChatMessage(role="tool_call", tool_name=tool_name, tool_args=tool_args, content="")
-                )
-                yield {"type": "tool_call", "name": tool_name, "args": tool_args}
+        messages.append(
+            {
+                "role": "assistant",
+                "content": msg.content or "",
+                "tool_calls": [
+                    {
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {"name": tc.function.name, "arguments": tc.function.arguments},
+                    }
+                    for tc in tool_calls
+                ],
+            }
+        )
 
+        for tc in tool_calls:
+            tool_name = tc.function.name
+            try:
+                tool_args = json.loads(tc.function.arguments) if tc.function.arguments else {}
+            except json.JSONDecodeError:
+                tool_args = {}
+            tool_args.setdefault("device", session.device)
+
+            session.messages.append(ChatMessage(role="tool_call", tool_name=tool_name, tool_args=tool_args, content=""))
+            yield {"type": "tool_call", "name": tool_name, "args": tool_args}
+
+            try:
                 result = execute_tool(tool_name, tool_args)
-                session.messages.append(ChatMessage(role="tool_result", content=result, tool_name=tool_name))
-                yield {"type": "tool_result", "name": tool_name, "result": result[:500]}
+            except Exception as e:
+                result = f"Tool error: {e}"
+            session.messages.append(ChatMessage(role="tool_result", content=result[:500], tool_name=tool_name))
+            yield {"type": "tool_result", "name": tool_name, "result": result[:500]}
 
-    except Exception as e:
-        yield {"type": "error", "content": str(e)}
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": tc.id,
+                    "name": tool_name,
+                    "content": result[:1500],
+                }
+            )
 
     yield {"type": "done"}
 
 
-# ── Ollama ───────────────────────────────────────────────────────────────────
+# ── vLLM (OpenAI-compatible, remote GPU via SSH) ──────────────────────────────
+
+
+def _chat_vllm(session: ChatSession, user_message: str):
+    """Use a vLLM server (default: remote GPU via SSH tunnel + adb reverse) with
+    OpenAI-compatible tool calling and multi-turn agent loop.
+
+    Same OpenAI surface as _chat_openrouter, but unlike that one we DO loop on
+    tool results — the whole point of routing to a real GPU is to put a smarter
+    model into the actual agent loop (open Settings → tap Wi-Fi → ...), not
+    just emit a single round of tool calls.
+    """
+    from openai import OpenAI
+
+    from gitd.config import settings
+
+    session.messages.append(ChatMessage(role="user", content=user_message))
+
+    client = OpenAI(
+        api_key=os.environ.get("GITD_VLLM_API_KEY", settings.vllm_api_key) or "EMPTY",
+        base_url=os.environ.get("GITD_VLLM_BASE_URL", settings.vllm_base_url),
+    )
+
+    oai_tools = openai_tools_for_device(session.device)
+
+    # Initial screen context.
+    context = ""
+    try:
+        tree = get_screen_tree(session.device)
+        state = get_phone_state(session.device)
+        context = f"[Screen]\n{tree[:1500]}\n[App: {state.get('currentApp', '?')}]\n\n"
+    except Exception:
+        pass
+
+    messages: list[dict] = [
+        {"role": "system", "content": system_prompt_for_device(session.device)},
+        {"role": "user", "content": f"{context}Device: {session.device}\n\n{user_message}"},
+    ]
+
+    model = session.model or "unsloth/gemma-4-E4B-it"
+
+    for turn in range(MAX_TURNS):
+        yield {"type": "activity", "content": f"🧠 Inferring (turn {turn + 1})..."}
+
+        try:
+            resp = None
+            for ev in backoff_stream(
+                lambda: client.chat.completions.create(
+                    model=model,
+                    messages=messages,
+                    tools=oai_tools,
+                    max_tokens=2048,
+                    timeout=effort_timeout(model),
+                )
+            ):
+                if "__result__" in ev:
+                    resp = ev["__result__"]
+                else:
+                    yield ev
+        except Exception as e:
+            yield {
+                "type": "error",
+                "content": (
+                    f"vLLM unreachable at {client.base_url}. "
+                    f"Start the server on your GPU host and ensure the SSH tunnel + "
+                    f"`adb reverse tcp:8000 tcp:8000` are up. ({e})"
+                ),
+            }
+            yield {"type": "done"}
+            return
+
+        msg = resp.choices[0].message
+
+        if msg.content:
+            session.messages.append(ChatMessage(role="assistant", content=msg.content))
+            yield {"type": "text", "content": msg.content}
+
+        # OpenAI-shape tool_calls. If absent, the model is done.
+        tool_calls = getattr(msg, "tool_calls", None) or []
+        if not tool_calls:
+            break
+
+        # Append the assistant turn to the rolling conversation BEFORE running
+        # tools so the next request sees the assistant's tool_calls in
+        # context (OpenAI shape requires this).
+        messages.append(
+            {
+                "role": "assistant",
+                "content": msg.content or "",
+                "tool_calls": [
+                    {
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {"name": tc.function.name, "arguments": tc.function.arguments},
+                    }
+                    for tc in tool_calls
+                ],
+            }
+        )
+
+        for tc in tool_calls:
+            tool_name = tc.function.name
+            try:
+                tool_args = json.loads(tc.function.arguments) if tc.function.arguments else {}
+            except json.JSONDecodeError:
+                tool_args = {}
+            tool_args.setdefault("device", session.device)
+
+            session.messages.append(ChatMessage(role="tool_call", tool_name=tool_name, tool_args=tool_args, content=""))
+            yield {"type": "tool_call", "name": tool_name, "args": tool_args}
+
+            try:
+                result = execute_tool(tool_name, tool_args)
+            except Exception as e:
+                result = f"Tool error: {e}"
+            session.messages.append(ChatMessage(role="tool_result", content=result[:500], tool_name=tool_name))
+            yield {"type": "tool_result", "name": tool_name, "result": result[:500]}
+
+            # Feed result back to the model for the next turn.
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": tc.id,
+                    "name": tool_name,
+                    "content": result[:1500],
+                }
+            )
+
+    yield {"type": "done"}
+
+
+# ── Tool-call parsing + Ollama ────────────────────────────────────────────────
 
 
 def _parse_tool_calls(text: str) -> list[dict]:
-    """Extract tool calls from LLM output. Handles ```tool blocks and common LLM quirks."""
+    """Extract tool calls from LLM output.
+
+    Handles a fair amount of slop because small models — especially raw Gemma 4 —
+    emit f-string-style doubled braces, half-quoted keys, trailing ``, " "``
+    junk, missing/extra closing braces, and similar near-misses.
+
+    Accepted shapes:
+      - {"tool": "X", "args": {...}}           (canonical)
+      - {"tool": "X", "kwarg1": ..., ...}      (flat — e.g. ghost-gemma trained)
+      - {"action_type": "X", ...}              (action-schema — translated to tool)
+    """
     import re
 
-    calls = []
-    for match in re.finditer(r"```tool\s*\n?(.*?)\n?```", text, re.DOTALL):
-        raw = match.group(1).strip()
-        # Try parsing as-is first (valid JSON)
+    if not text:
+        return []
+
+    calls: list[dict] = []
+
+    # Map from action-schema "action_type" → ("tool", arg-key-rewrites). For raw
+    # Gemma 4 emitting the action schema we trained on, this lets the dispatcher
+    # see canonical tool calls without retraining the parser side.
+    action_to_tool = {
+        "open_app": ("launch_app", {"app_name": "package"}),
+        "click": ("tap", {"x": "x", "y": "y"}),
+        "tap": ("tap", {}),
+        "long_press": ("long_press", {}),
+        "type_text": ("input_text", {"text": "text"}),
+        "input_text": ("input_text", {}),
+        "swipe": ("swipe", {}),
+        "key_event": ("key_event", {"key": "key"}),
+        "screenshot": ("screenshot", {}),
+        "wait": ("wait", {"duration_ms": "ms"}),
+        "force_stop": ("force_stop", {}),
+    }
+
+    def _coerce_action(d: dict) -> dict | None:
+        action = d.get("action_type")
+        if not isinstance(action, str):
+            return None
+        mapping = action_to_tool.get(action)
+        if not mapping:
+            return None
+        tool_name, key_map = mapping
+        args = {}
+        for k, v in d.items():
+            if k == "action_type":
+                continue
+            args[key_map.get(k, k)] = v
+        return {"tool": tool_name, "args": args}
+
+    def _try_dict(d: object) -> bool:
+        if not isinstance(d, dict):
+            return False
+        if "tool" in d:
+            calls.append(d)
+            return True
+        coerced = _coerce_action(d)
+        if coerced:
+            calls.append(coerced)
+            return True
+        return False
+
+    def _try_loads(raw: str) -> bool:
         try:
-            call = json.loads(raw)
-            if isinstance(call, dict) and "tool" in call:
-                calls.append(call)
+            return _try_dict(json.loads(raw))
+        except (ValueError, TypeError):
+            return False
+
+    def _attempt_repairs(raw: str) -> bool:
+        """Run a chain of cleanups, retrying json.loads at every checkpoint."""
+        candidate = raw
+
+        # Doubled braces (Gemma f-string artefact) → singles. Only run when at
+        # least one ``{{`` is present — otherwise we'd corrupt valid JSON like
+        # ``{"a":{"b":1}}`` which has trailing ``}}`` for nested closes.
+        # Do it ONCE only; iterating collapses legitimate triples like ``}}}``
+        # (which is ``}}`` + ``}`` in the doubled convention) past the right
+        # shape.
+        if "{{" in candidate:
+            new = candidate.replace("{{", "{").replace("}}", "}")
+            if new != candidate:
+                candidate = new
+                if _try_loads(candidate):
+                    return True
+
+        # Strip dangling-comma "junk pairs" like ``, " "`` or ``, ""`` that some
+        # models tack on before a closing brace.
+        cleaned = re.sub(r',\s*"[^"]*"\s*(?=[,}])', "", candidate)
+        if cleaned != candidate:
+            candidate = cleaned
+            if _try_loads(candidate):
+                return True
+
+        # Drop trailing ``,`` before ``}`` / ``]``.
+        cleaned = re.sub(r",\s*([}\]])", r"\1", candidate)
+        if cleaned != candidate:
+            candidate = cleaned
+            if _try_loads(candidate):
+                return True
+
+        # Truncate to the first balanced brace span — handles trailing prose
+        # or extra closing braces.
+        depth = 0
+        start = candidate.find("{")
+        if start >= 0:
+            for i in range(start, len(candidate)):
+                ch = candidate[i]
+                if ch == "{":
+                    depth += 1
+                elif ch == "}":
+                    depth -= 1
+                    if depth == 0:
+                        if _try_loads(candidate[start : i + 1]):
+                            return True
+                        break
+
+        return False
+
+    # 1) ```tool / ```json fenced blocks (prompt asks for these)
+    for match in re.finditer(r"```(?:tool|json)?\s*\n?(.*?)\n?```", text, re.DOTALL):
+        raw = match.group(1).strip()
+        if not raw:
+            continue
+        if _try_loads(raw):
+            continue
+        _attempt_repairs(raw)
+
+    if calls:
+        return calls
+
+    # 2) No fences — scan for inline JSON objects mentioning "tool" or
+    #    "action_type". Greedy: match every {...} and try each.
+    for match in re.finditer(r"\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}", text, re.DOTALL):
+        raw = match.group(0)
+        if '"tool"' not in raw and '"action_type"' not in raw:
+            continue
+        if _try_loads(raw):
+            continue
+        _attempt_repairs(raw)
+
+    if calls:
+        return calls
+
+    # 3) Last-ditch fallback — Gemma at temp 0 routinely emits inline doubled
+    #    braces with a mismatched count of closing `}` (e.g. five `}` for two
+    #    `{{`). The step-2 regex above can't match a `{{` start because it
+    #    expects a non-brace character after the first `{`. Collapse doubled
+    #    braces over the whole text and try the same scan again.
+    if "{{" in text or "}}" in text:
+        flattened = text.replace("{{", "{").replace("}}", "}")
+        for match in re.finditer(r"\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}", flattened, re.DOTALL):
+            raw = match.group(0)
+            if '"tool"' not in raw and '"action_type"' not in raw:
                 continue
-        except json.JSONDecodeError:
-            pass
-        # Fallback: some models wrap JSON in doubled braces {{ ... }}
-        fixed = raw
-        for _ in range(3):
-            fixed = re.sub(r"\{\{", "{", fixed)
-            fixed = re.sub(r"\}\}", "}", fixed)
-            try:
-                call = json.loads(fixed)
-                if isinstance(call, dict) and "tool" in call:
-                    calls.append(call)
-                    break
-            except json.JSONDecodeError:
+            if _try_loads(raw):
                 continue
+            _attempt_repairs(raw)
+
     return calls
+
+
+def normalize_tool_call(call: dict) -> tuple[str, dict]:
+    """Split a parsed tool call into ``(tool_name, args)``.
+
+    Two shapes are seen in the wild and every provider must accept both:
+      - ``{"tool": "X", "args": {...}}``          (gemma-4-e2b, llama, canonical)
+      - ``{"tool": "X", "package": "...", ...}``   (ghost-gemma trained, qwen — flat)
+
+    Prefer the nested ``args`` dict; otherwise treat the rest of the dict
+    (every key except ``tool``) as kwargs. Returns a fresh dict the caller
+    can mutate (e.g. ``setdefault("device", ...)``) without touching ``call``.
+    """
+    tool_name = call.get("tool", "")
+    raw_args = call.get("args")
+    if isinstance(raw_args, dict):
+        args = dict(raw_args)
+    else:
+        args = {k: v for k, v in call.items() if k != "tool"}
+    return tool_name, args
 
 
 def _chat_ollama(session: ChatSession, user_message: str):
@@ -720,11 +972,8 @@ def _chat_ollama(session: ChatSession, user_message: str):
         pass
 
     # Build tool list with param names so the LLM knows what args to send
-    tool_list = "\n".join(
-        f"- {t['name']}: {t['description']}  params: {list(t.get('input_schema', {}).get('properties', {}).keys())}"
-        for t in TOOLS
-    )
-    system = DEFAULT_SYSTEM.replace("{tool_list}", tool_list)
+    system = DEFAULT_SYSTEM.replace("{tool_list}", tool_prompt_list(tools_for_device(session.device)))
+    system = system_prompt_for_device(session.device, system)
 
     messages = [
         {"role": "system", "content": system},
@@ -733,16 +982,25 @@ def _chat_ollama(session: ChatSession, user_message: str):
 
     model = session.model or "llama3.2:3b"
 
+    # Gemma 4 (and other reasoning models) emit chain-of-thought into a
+    # separate `thinking` field. The agent loop wants direct JSON tool calls,
+    # so disable thinking for the action loop. Surface any thinking that does
+    # arrive as a `thinking` event so the UI can show it.
+    is_thinking_model = any(t in model.lower() for t in ("gemma-4", "gemma4", "ghost-gemma", "qwen3", "deepseek-r1"))
+
     for turn in range(MAX_TURNS):
         try:
+            payload = {
+                "model": model,
+                "messages": messages,
+                "stream": False,
+                "options": {"num_ctx": 4096, "num_predict": 512},
+            }
+            if is_thinking_model:
+                payload["think"] = False
             r = requests.post(
                 "http://localhost:11434/api/chat",
-                json={
-                    "model": model,
-                    "messages": messages,
-                    "stream": False,
-                    "options": {"num_ctx": 4096},
-                },
+                json=payload,
                 timeout=120,
             )
             data = r.json()
@@ -756,7 +1014,14 @@ def _chat_ollama(session: ChatSession, user_message: str):
                 else:
                     yield {"type": "error", "content": f"Ollama error: {error}"}
                 return
-            reply = data.get("message", {}).get("content", "")
+            msg = data.get("message", {}) or {}
+            reply = msg.get("content", "") or ""
+            thinking = msg.get("thinking", "") or ""
+            if thinking:
+                yield {"type": "thinking", "content": thinking}
+            # Fallback: if think:false was ignored and content is empty but thinking has the answer
+            if not reply and thinking:
+                reply = thinking
         except requests.ConnectionError:
             yield {
                 "type": "error",
@@ -781,8 +1046,7 @@ def _chat_ollama(session: ChatSession, user_message: str):
 
         tool_results = []
         for call in tool_calls:
-            tool_name = call.get("tool", "")
-            tool_args = call.get("args", {})
+            tool_name, tool_args = normalize_tool_call(call)
             tool_args.setdefault("device", session.device)
 
             session.messages.append(ChatMessage(role="tool_call", tool_name=tool_name, tool_args=tool_args, content=""))

--- a/gitd/services/agent_chat_claude_code.py
+++ b/gitd/services/agent_chat_claude_code.py
@@ -4,41 +4,162 @@ import json
 import os
 import subprocess
 import threading
+import time
 
-from gitd.services.agent_chat import ChatMessage, ChatSession
+from gitd.bots.common.device import is_ios_ref
+from gitd.services.agent_chat import ChatMessage, ChatSession, platform_context
 from gitd.services.device_context import get_phone_state, get_screen_tree
+from gitd.services.llm_backoff import effort_timeout
+from gitd.services.observability import (
+    record_generation,
+    record_tool_result,
+    set_trace_output,
+    trace_chat_turn,
+)
+
+
+def _tts_speak_bg(device: str, text: str, max_chars: int = 250) -> None:
+    """Speak agent response on the phone — fire and forget, non-blocking."""
+    if is_ios_ref(device):
+        return
+    speak_text = text.strip()[:max_chars]
+    if not speak_text:
+        return
+
+    def _run():
+        try:
+            from gitd.services.device_context import speak_text as _speak
+
+            _speak(device, speak_text)
+        except Exception:
+            pass
+
+    threading.Thread(target=_run, daemon=True).start()
+
+
+def _build_history_prefix(session: ChatSession, current_user_message: str) -> str:
+    """Build a condensed history block from prior session messages.
+
+    Includes user/assistant text + brief tool summaries (no screenshots).
+    Skips the message we're about to append (current_user_message).
+    """
+    prior = [m for m in session.messages if not (m.role == "user" and m.content == current_user_message)]
+    if not prior:
+        return ""
+
+    lines = ["[Conversation history — read carefully before acting]"]
+    for m in prior:
+        if m.role == "user":
+            lines.append(f"User: {m.content}")
+        elif m.role == "assistant" and m.content.strip():
+            lines.append(f"Assistant: {m.content.strip()}")
+        elif m.role == "tool_call":
+            condensed = {
+                k: (v[:80] + "…" if isinstance(v, str) and len(v) > 80 else v)
+                for k, v in m.tool_args.items()
+                if k != "device"
+            }
+            args_str = ", ".join(f"{k}={json.dumps(v)}" for k, v in condensed.items())
+            lines.append(f"  • {m.tool_name}({args_str})")
+        elif m.role == "tool_result" and m.content:
+            content = m.content.strip()
+            if content.startswith(("/9j/", "iVBOR", "data:image")):
+                lines.append("    → [screenshot]")
+                continue
+            if len(content) > 150:
+                content = content[:150] + "…"
+            lines.append(f"    → {content}")
+        # skip: thinking, activity
+
+    return "\n".join(lines) if len(lines) > 1 else ""
 
 
 def chat_claude_code(session: ChatSession, user_message: str):
     """Use claude CLI with --print --output-format stream-json --verbose.
     Streams tool calls, text, and usage in real-time."""
+    history_prefix = _build_history_prefix(session, user_message)
     session.messages.append(ChatMessage(role="user", content=user_message))
 
     yield {"type": "activity", "content": "📱 Reading screen..."}
     context_parts = []
+    foreground_pkg = ""
     try:
-        tree = get_screen_tree(session.device)
-        if tree and tree != "(empty screen)":
-            context_parts.append(f"[Current screen]\n{tree[:1500]}")
         state = get_phone_state(session.device)
         if state:
-            context_parts.append(f"[App: {state.get('currentApp', '?')} ({state.get('packageName', '?')})]")
+            foreground_pkg = state.get("packageName", "") or ""
+            context_parts.append(f"[Foreground app: {state.get('currentApp', '?')} ({foreground_pkg})]")
+        # Skip injecting the chat-app's own screen tree — it'd be the user's chat
+        # bubble (incl. prior answers) and tempts the model to "answer from screen"
+        # instead of actually performing the task.
+        if foreground_pkg != "com.ghostinthedroid.app":
+            tree = get_screen_tree(session.device)
+            if tree and tree != "(empty screen)":
+                context_parts.append(f"[Current screen]\n{tree[:1500]}")
     except Exception:
         pass
     context = "\n".join(context_parts)
 
-    prompt = f"""You are controlling Android phone serial={session.device}.
+    history_block = f"\n{history_prefix}\n" if history_prefix else ""
+    if is_ios_ref(session.device):
+        action_rules = (
+            "- For browser/news/web tasks, prefer read_news for article summaries, or open_url, web_search, wait_for_text, "
+            "extract_visible_text, extract_articles, and browser_back before manual coordinate tapping.\n"
+            "- launch_app expects an iOS bundle id, for example com.google.chrome.ios. If the bundle id is unknown, "
+            "use search_apps or list_apps instead of Android package-manager commands.\n"
+            "- For camera/photo/video tasks, use open_camera with mode photo, video, selfie, or selfie_video.\n"
+            "- Do not use Android-only tools such as speak_text, shell, launch_intent, "
+            "Portal overlay, Play Store, or Android package-manager commands."
+        )
+        system_prompt = (
+            "You are an iOS automation agent using Appium/WebDriverAgent through the android-agent MCP server. "
+            "Use only iOS-supported MCP tools. Prefer browser primitives for Chrome/Safari web tasks."
+        )
+    else:
+        action_rules = (
+            "- CAMERA: for any photo/selfie/video/camera task do EXACTLY these two steps: "
+            '(1) ToolSearch({"query":"select:mcp__android-agent__open_camera"}) '
+            "(2) mcp__android-agent__open_camera(device=..., mode=photo|video|selfie|selfie_video, timer_s=0|2|3|5|10). "
+            "Do NOT use launch_app. Do NOT tap camera UI manually.\n"
+            '- To make the phone speak text aloud, call `mcp__android-agent__speak_text(device=..., text="...")`.'
+        )
+        system_prompt = (
+            "You are an Android automation agent. Rules that override all defaults:\n"
+            "1. For any camera/photo/selfie/video task: your FIRST tool call must be "
+            'ToolSearch({"query":"select:mcp__android-agent__open_camera"}) then call '
+            "mcp__android-agent__open_camera(device, mode, timer_s). Do NOT use launch_app, "
+            "do NOT call list_skills, do NOT tap any camera UI. open_camera handles everything.\n"
+            "2. For any speak/TTS task: ToolSearch select mcp__android-agent__speak_text then call it.\n"
+            "3. For all other app tasks: use launch_app first.\n"
+            "4. POST/COMMENT APPROVAL GATE: For any task involving posting a comment, reply, "
+            "or public post, first type the composed text into the input field, then STOP "
+            "WITHOUT tapping the submit/post/reply button. Tell the user the exact text you "
+            "drafted and ask them to reply 'APPROVED' to post it. Only after the user replies "
+            "with a message containing APPROVED may you tap the submit button to publish it."
+        )
+
+    prompt = f"""You are controlling mobile device serial={session.device}.
+{platform_context(session.device)}
 {context}
+{history_block}
+CURRENT TASK: {user_message}
 
-Task: {user_message}
-
-You have MCP android-agent tools. Use them to accomplish the task.
-After each action, verify with get_screen_tree or screenshot.
-Keep going until done. Be concise."""
+Rules:
+- Read the conversation history above carefully before acting — it shows what was done, what was in progress when stopped, and what the user's actual intent is. Do NOT contradict or forget it.
+- Use the MCP android-agent tools to control the phone.
+- For app tasks, start with `launch_app` to open the target app. Do not assume any app is already open.
+{action_rules}
+- After each action, verify the new state with `get_screen_tree` or `screenshot`.
+- Only after you've actually observed the result on the phone, answer the user. Be concise."""
 
     yield {"type": "activity", "content": "🧠 Starting Claude Code..."}
 
     project_dir = str(__import__("pathlib").Path(__file__).parent.parent.parent)
+
+    # On-device: proxy to remote host that has claude CLI + MCP tools
+    remote_host = os.environ.get("GHOST_REMOTE_HOST", "")
+    if remote_host or not __import__("shutil").which("claude"):
+        yield from _chat_claude_code_remote(session, prompt, remote_host or "http://localhost:5055")
+        return
 
     try:
         proc = subprocess.Popen(
@@ -51,6 +172,8 @@ Keep going until done. Be concise."""
                 "stream-json",
                 "--verbose",
                 "--dangerously-skip-permissions",
+                "--append-system-prompt",
+                system_prompt,
             ],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
@@ -59,13 +182,35 @@ Keep going until done. Be concise."""
             bufsize=1,
             cwd=project_dir,
             env={**os.environ, "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1"},
+            # New session so we can SIGTERM the whole process group (claude
+            # spawns node + MCP-tool child processes; killing just the parent
+            # leaves those orphaned and still tapping the phone).
+            start_new_session=True,
         )
     except FileNotFoundError:
-        yield {"type": "error", "content": "claude CLI not found"}
+        yield {"type": "error", "content": "claude CLI not found. Set GHOST_REMOTE_HOST to proxy."}
         return
+
+    # Register so the /stop/{sid} endpoint can find this proc by session id
+    # without relying on the nuclear `pkill -f claude.*--print...` fallback.
+    from gitd.services.agent_chat import _active_procs
+
+    _active_procs[session.id] = proc
 
     proc.stdin.write(prompt)
     proc.stdin.close()
+
+    # Open Langfuse trace for this turn (no-op if observability disabled)
+    _trace_cm = trace_chat_turn(
+        session_id=getattr(session, "id", "") or "",
+        user_message=user_message,
+        provider="claude-code",
+        model=session.model or "sonnet",
+        device=session.device,
+        source="mac",
+    )
+    trace = _trace_cm.__enter__()
+    tool_spans: dict[str, object] = {}  # tool_use_id → span
 
     # Read stdout lines in a thread so we can yield events as they arrive
     lines_queue: list[str] = []
@@ -87,8 +232,31 @@ Keep going until done. Be concise."""
     total_output_tokens = 0
     total_cost = 0.0
 
+    # Idle/stall guard: the subprocess runs the whole agentic loop itself, so a
+    # total-time cap would cut off legitimate long tasks. Instead we guard on
+    # SILENCE — if no new output arrives for the effort-scaled window (a bigger
+    # model reasons longer between lines), the claude process is wedged, so kill
+    # it and surface an error rather than streaming nothing forever. Any new
+    # line resets the clock.
+    idle_ceiling = effort_timeout(session.model or "sonnet")
+    last_output_at = time.monotonic()
+
     while not finished.is_set():
         finished.wait(timeout=0.5)
+
+        if processed_idx < len(lines_queue):
+            last_output_at = time.monotonic()
+        elif time.monotonic() - last_output_at > idle_ceiling:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+            finished.set()
+            yield {
+                "type": "error",
+                "content": f"Agent stalled: no output for {idle_ceiling}s (claude subprocess wedged). Stopped.",
+            }
+            break
 
         while processed_idx < len(lines_queue):
             line = lines_queue[processed_idx]
@@ -130,10 +298,14 @@ Keep going until done. Be concise."""
                             full_text += text
                             session.messages.append(ChatMessage(role="assistant", content=text))
                             yield {"type": "text", "content": text}
+                            # Auto-speak agent response on the phone (fire-and-forget)
+                            if session.device:
+                                _tts_speak_bg(session.device, text)
 
                     elif btype == "tool_use":
                         tool_name = block.get("name", "")
                         tool_args = block.get("input", {})
+                        tool_id = block.get("id", "")
                         # Strip mcp prefix for display
                         display_name = (
                             tool_name.replace("mcp__android-agent__", "")
@@ -145,6 +317,11 @@ Keep going until done. Be concise."""
                         )
                         yield {"type": "tool_call", "name": display_name, "args": tool_args}
                         yield {"type": "activity", "content": f"⚡ {display_name}..."}
+                        if trace is not None and tool_id:
+                            try:
+                                tool_spans[tool_id] = trace.span(name=f"tool:{display_name}", input={"args": tool_args})
+                            except Exception:
+                                pass
 
                     elif btype == "tool_result":
                         content_parts = block.get("content", [])
@@ -157,11 +334,26 @@ Keep going until done. Be concise."""
                         if result_text:
                             session.messages.append(ChatMessage(role="tool_result", content=result_text[:500]))
                             yield {"type": "tool_result", "name": "", "result": result_text[:300]}
+                        is_err = bool(block.get("is_error"))
+                        record_tool_result(
+                            tool_spans.pop(block.get("tool_use_id", ""), None),
+                            result_text,
+                            error=is_err,
+                        )
                         yield {"type": "activity", "content": "🤔 Thinking..."}
 
                     elif btype == "thinking":
-                        # Extended thinking — show brief activity
-                        yield {"type": "activity", "content": "🧠 Reasoning..."}
+                        # Extended thinking — surface the actual reasoning text
+                        # so the UI can render it (in addition to the activity ping).
+                        thinking_text = block.get("thinking", "")
+                        if thinking_text:
+                            # Persist alongside text/tool_use blocks so it survives
+                            # save_session_to_db and reappears on resumeConversation —
+                            # otherwise thinking bubbles are live-only and vanish.
+                            session.messages.append(ChatMessage(role="thinking", content=thinking_text))
+                            yield {"type": "thinking", "content": thinking_text}
+                        else:
+                            yield {"type": "activity", "content": "🧠 Reasoning..."}
 
             elif etype == "result":
                 # Final result with cost info
@@ -201,7 +393,198 @@ Keep going until done. Be concise."""
     except subprocess.TimeoutExpired:
         proc.kill()
 
+    # Unregister now that the process is done — leaving a stale entry would
+    # make a later stop_agent try to killpg() a dead pid (harmless, but
+    # noisy in logs).
+    _active_procs.pop(session.id, None)
+
+    # Record final generation + close trace
+    try:
+        set_trace_output(trace, full_text)
+        record_generation(
+            trace,
+            model=session.model or "sonnet",
+            prompt=prompt,
+            output=full_text,
+            input_tokens=total_input_tokens,
+            output_tokens=total_output_tokens,
+            cost_usd=total_cost,
+        )
+    finally:
+        try:
+            _trace_cm.__exit__(None, None, None)
+        except Exception:
+            pass
+
     if not full_text:
         yield {"type": "error", "content": "No response from Claude Code"}
+
+    yield {"type": "done"}
+
+
+def _chat_claude_code_remote(session, prompt: str, remote_host: str):
+    """Proxy Claude Code request to a remote host running the ghost backend.
+
+    The remote host has `claude` CLI + MCP android-agent tools configured.
+    Tool calls from Claude Code execute on the remote host's MCP server,
+    which routes to Android through ADB or iOS through Appium/WebDriverAgent
+    based on the target device ref.
+
+    We open a *shadow* trace on the phone side too, mirroring the events as
+    they stream past — so the in-app Traces tab shows claude-code runs even
+    though the real LLM trace lives on the Mac. Without this, the tab would
+    appear empty for everything except on-device runs.
+    """
+    import requests
+
+    # Open phone-local trace so the in-app Traces tab sees this run.
+    _trace_cm = trace_chat_turn(
+        session_id=getattr(session, "id", "") or "",
+        user_message=prompt[-2000:],  # the prompt has full screen context — keep tail
+        provider="claude-code",
+        model=session.model or "sonnet",
+        device=session.device,
+        source="ios" if is_ios_ref(session.device) else "android",
+    )
+    trace = _trace_cm.__enter__()
+    open_spans: dict[str, object] = {}  # last-tool-name → span (best-effort match since remote events lack ids)
+    full_text = ""
+    total_input_tokens = 0
+    total_output_tokens = 0
+    total_cost = 0.0
+
+    yield {"type": "activity", "content": f"🔗 Connecting to {remote_host}..."}
+
+    # When the phone user hits Stop, this generator gets GeneratorExit. We
+    # need to propagate that to the Mac so its claude subprocess actually
+    # dies — closing our `requests` connection alone isn't enough because
+    # Mac's chat_claude_code generator only notices the broken pipe AFTER
+    # claude has streamed its current chunk (which may include several more
+    # tool calls). The fix: capture Mac's session_id from the first SSE
+    # `session` event, and on GeneratorExit POST to Mac's /stop/{sid}.
+    remote_sid: str = ""
+    resp = None
+    try:
+        resp = requests.post(
+            f"{remote_host}/api/agent-chat/message",
+            json={
+                "content": prompt,
+                "device": session.device,
+                "provider": "claude-code",
+                "model": session.model or "sonnet",
+            },
+            timeout=300,
+            stream=True,
+        )
+
+        for line in resp.iter_lines():
+            if not line:
+                continue
+            text_line = line.decode()
+            if text_line.startswith("data: "):
+                try:
+                    event = json.loads(text_line[6:])
+                    etype = event.get("type", "")
+
+                    if etype == "session":
+                        # First event from Mac carries the remote session_id.
+                        # Capture it so a phone-side Stop can hit Mac's
+                        # /stop/{sid} endpoint and actually kill the claude
+                        # subprocess.
+                        remote_sid = event.get("session_id", "") or ""
+                        yield event
+                    elif etype == "text":
+                        chunk = event.get("content", "")
+                        full_text += chunk
+                        session.messages.append(ChatMessage(role="assistant", content=chunk))
+                        yield event
+                        if session.device:
+                            _tts_speak_bg(session.device, chunk)
+                    elif etype == "tool_call":
+                        tool_name = event.get("name", "")
+                        tool_args = event.get("args", {})
+                        session.messages.append(
+                            ChatMessage(
+                                role="tool_call",
+                                tool_name=tool_name,
+                                tool_args=tool_args,
+                                content="",
+                            )
+                        )
+                        if trace is not None:
+                            try:
+                                open_spans[tool_name] = trace.span(name=f"tool:{tool_name}", input={"args": tool_args})
+                            except Exception:
+                                pass
+                        yield event
+                    elif etype == "tool_result":
+                        result_text = event.get("result", "")
+                        tool_name = event.get("name", "")
+                        session.messages.append(
+                            ChatMessage(role="tool_result", content=result_text, tool_name=tool_name)
+                        )
+                        # The remote stream sends tool_result without a tool_id;
+                        # close the most recent span for that tool name.
+                        span = open_spans.pop(tool_name, None) or (open_spans.popitem()[1] if open_spans else None)
+                        record_tool_result(span, result_text)
+                        yield event
+                    elif etype == "tokens":
+                        total_input_tokens = int(event.get("input", 0) or 0)
+                        total_output_tokens = int(event.get("output", 0) or 0)
+                        total_cost = float(event.get("cost", 0) or 0)
+                        yield event
+                    elif etype == "thinking":
+                        thinking_text = event.get("content", "")
+                        if thinking_text:
+                            session.messages.append(ChatMessage(role="thinking", content=thinking_text))
+                        yield event
+                    elif etype in ("activity", "screenshot", "error"):
+                        yield event
+                    elif etype == "done":
+                        break
+                except json.JSONDecodeError:
+                    pass
+
+    except GeneratorExit:
+        # Phone user hit Stop. Propagate to Mac so its claude subprocess
+        # actually dies — without this, Mac keeps streaming tool calls and
+        # the phone keeps getting tapped even though the UI says "stopped".
+        if remote_sid:
+            try:
+                requests.post(
+                    f"{remote_host}/api/agent-chat/stop/{remote_sid}",
+                    timeout=4,
+                )
+            except Exception:
+                pass
+        raise
+    except requests.ConnectionError:
+        yield {"type": "error", "content": f"Cannot reach {remote_host}. Start the backend on your Mac: python3 run.py"}
+    except Exception as e:
+        yield {"type": "error", "content": str(e)}
+    finally:
+        # Always close the upstream HTTP stream so Mac's send_message
+        # finally-block fires (which calls stop_agent on its session).
+        try:
+            if resp is not None:
+                resp.close()
+        except Exception:
+            pass
+        try:
+            set_trace_output(trace, full_text)
+            record_generation(
+                trace,
+                model=session.model or "sonnet",
+                prompt=prompt[-4000:],
+                output=full_text,
+                input_tokens=total_input_tokens,
+                output_tokens=total_output_tokens,
+                cost_usd=total_cost,
+            )
+        finally:
+            try:
+                _trace_cm.__exit__(None, None, None)  # noqa: E701
+            except Exception:
+                pass  # noqa: E701
 
     yield {"type": "done"}

--- a/gitd/services/agent_chat_ondevice.py
+++ b/gitd/services/agent_chat_ondevice.py
@@ -1,0 +1,292 @@
+"""On-device LLM provider — runs Gemma (or any registered model) via MediaPipe.
+
+Bridges to Kotlin singleton `OnDeviceLLM` through Chaquopy. Falls back gracefully
+when running outside Chaquopy (e.g., dev tests on a Mac).
+
+Model selection:
+    session.model is the registry id, e.g. "gemma-4-e2b-it" / "gemma-2-2b-it".
+"""
+
+from __future__ import annotations
+
+from typing import Iterator
+
+from gitd.services.agent_chat import (
+    DEFAULT_SYSTEM,
+    MAX_TURNS,
+    ChatMessage,
+    ChatSession,
+    _parse_tool_calls,
+    normalize_tool_call,
+    system_prompt_for_device,
+)
+from gitd.services.agent_tools import execute_tool, tool_prompt_list, tools_for_device
+from gitd.services.device_context import get_phone_state, get_screen_tree
+from gitd.services.observability import (
+    record_generation,
+    record_tool_result,
+    set_trace_output,
+    trace_chat_turn,
+)
+
+
+def _kotlin_llm():
+    """Return the Kotlin OnDeviceLLM singleton, or None if Chaquopy is missing."""
+    try:
+        from java import jclass  # type: ignore[import-not-found]
+
+        return jclass("com.ghostinthedroid.app.ondevice.OnDeviceLLM").INSTANCE
+    except Exception:
+        return None
+
+
+# ── Gemma chat template ──────────────────────────────────────────────────────
+# Gemma 4 uses <start_of_turn>user / <end_of_turn> / <start_of_turn>model
+# markers. There's no separate system role — system content is prepended
+# into the first user turn. Earlier we used a custom [SYSTEM]/[USER]/[ASSISTANT]
+# scaffold, which the model cheerfully echoed back into its own output (it had
+# never seen those tokens in fine-tuning), causing repetition loops where the
+# model kept "writing" extra fake [USER] turns from inside its own reply.
+# Switching to the canonical Gemma markers fixes coherence on multi-turn
+# tool chains.
+
+
+def ondevice_stable_prefix(system: str, device: str) -> str:
+    """Stable prefix shared by warmup pre-fill and chat path. Anything beyond
+    this point varies per turn and must NOT be in the warmup KV."""
+    return f"<start_of_turn>user\n{system}\n\nDevice: {device}\n\n"
+
+
+def _ondevice_first_turn(system: str, device: str, user_message: str, screen_block: str) -> str:
+    return (
+        ondevice_stable_prefix(system, device)
+        + f"{user_message}{screen_block}<end_of_turn>\n"
+        + "<start_of_turn>model\n"
+    )
+
+
+def _ondevice_tool_results_turn(tool_results: list[str]) -> str:
+    return (
+        "<end_of_turn>\n"
+        "<start_of_turn>user\n"
+        + "Tool results:\n"
+        + "\n".join(tool_results)
+        + "<end_of_turn>\n"
+        + "<start_of_turn>model\n"
+    )
+
+
+def _kv_cache_path(model_id: str, stable_prefix: str) -> str:
+    """Deterministic on-device path for the saved KV state of (model, prefix).
+    Mirrors the warmup endpoint's logic so chat and warmup share the same file."""
+    import hashlib
+    import os
+
+    cache_dir = "/data/data/com.ghostinthedroid.app/files/ondevice/kv-cache"
+    os.makedirs(cache_dir, exist_ok=True)
+    h = hashlib.sha256()
+    h.update(model_id.encode())
+    h.update(b"\n")
+    h.update(stable_prefix.encode())
+    return os.path.join(cache_dir, f"warmup-{h.hexdigest()[:16]}.bin")
+
+
+def _ensure_kv_warmed(llm, model_id: str, stable_prefix: str) -> tuple[bool, int]:
+    """Load the disk-persisted KV state for (model, prefix) into the JNI handle
+    if a cache file exists. Returns (from_cache, n_tokens). Caller can fall
+    back to a cold prefill via llm.warmup() if from_cache is False; we DON'T
+    do that here because it'd add ~4 min latency to a chat turn — leave that
+    to the explicit /warmup endpoint that fires from MainActivity at app start."""
+    path = _kv_cache_path(model_id, stable_prefix)
+    try:
+        loaded = int(llm.loadState(model_id, path))
+    except Exception:
+        loaded = -1
+    if loaded > 0:
+        return True, loaded
+    return False, 0
+
+
+def chat_ondevice(session: ChatSession, user_message: str) -> Iterator[dict]:
+    """Run a tool-using turn against an on-device Gemma model."""
+    session.messages.append(ChatMessage(role="user", content=user_message))
+
+    llm = _kotlin_llm()
+    if llm is None:
+        yield {
+            "type": "error",
+            "content": "On-device LLM only available inside the ghost-app (Chaquopy bridge missing)",
+        }
+        return
+
+    model_id = session.model or "gemma-3-1b-it"
+
+    yield {"type": "activity", "content": f"🧠 Loading {model_id}..."}
+    try:
+        loaded = bool(llm.ensureLoaded(model_id))
+    except Exception as e:
+        yield {"type": "error", "content": f"On-device load crashed: {e}"}
+        return
+    if not loaded:
+        yield {
+            "type": "error",
+            "content": (
+                f"Model '{model_id}' not downloaded yet. Open Settings → On-Device → Download to fetch it (~1-3 GB)."
+            ),
+        }
+        return
+
+    yield {"type": "activity", "content": "📱 Reading screen..."}
+    screen_block = ""
+    try:
+        tree = get_screen_tree(session.device)
+        state = get_phone_state(session.device)
+        screen_block = f"\n\n[Screen]\n{tree[:1500]}\n[App: {state.get('currentApp', '?')}]"
+    except Exception:
+        pass
+
+    system = DEFAULT_SYSTEM.replace("{tool_list}", tool_prompt_list(tools_for_device(session.device)))
+    system = system_prompt_for_device(session.device, system)
+
+    # Prompt structure tuned for KV prefix reuse:
+    #   [SYSTEM]              ← invariant across turns + sessions
+    #   {tools list}          ← invariant
+    #   [USER]                ← invariant
+    #   Device: ...           ← invariant per session
+    #   {user_message}        ← changes per turn (small)
+    #   [Screen]              ← changes per turn (large)
+    #   {screen tree}
+    # Putting the dynamic screen tree LAST means the long stable prefix
+    # (system + tools + device + user message) is fully cached on every
+    # subsequent turn, even when the screen state changes between turns.
+    # NOTE: warmup() exists on OnDeviceLLM and bakes the stable system+tools
+    # prefix into the KV cache before any user input — but it has to run
+    # BEFORE this chat call, in the background at app start. Calling it
+    # inline here just serialises the cold prefill in front of the user's
+    # first response, doubling the perceived latency. The right wiring is
+    # a Kotlin coroutine in MainActivity that fires `OnDeviceLLM.warmup(
+    # selected_model_id, stable_prefix)` right after the on-device model is
+    # selected. With that in place, the first chat turn lands at ~13 s
+    # instead of ~140 s, same as turn 2+. For now the unwired path gives
+    # turn-2+ the 10× win and the user pays the cold cost on turn 1.
+
+    # If the warmup endpoint previously saved a KV state for this exact
+    # (model, system+device) prefix, restore it now so the first generateStart
+    # only has to decode the user_message + screen_block diff. Without this,
+    # every model switch costs a ~4-minute cold prefill on the first chat
+    # because ensureLoaded() doesn't know about the cache file. Idempotent —
+    # if no file matches we just continue with an empty KV.
+    stable_prefix = ondevice_stable_prefix(system, session.device)
+    from_cache, kv_tokens = _ensure_kv_warmed(llm, model_id, stable_prefix)
+    if from_cache:
+        yield {"type": "activity", "content": f"⚡ KV cache hit ({kv_tokens} tokens)"}
+
+    # Gemma chat template — see ondevice_stable_prefix() and friends above.
+    # `prompt` accumulates over turns: the assistant reply + each tool-results
+    # turn get appended in-place so the next iteration runs against the full
+    # rolling conversation (KV prefix reuse means we only re-decode the diff).
+    prompt = _ondevice_first_turn(system, session.device, user_message, screen_block)
+
+    with trace_chat_turn(
+        session_id=getattr(session, "id", "") or "",
+        user_message=user_message,
+        provider="on-device",
+        model=model_id,
+        device=session.device,
+        source="android",  # this code path runs inside Chaquopy on the phone
+    ) as trace:
+        last_reply = ""
+        for turn in range(MAX_TURNS):
+            yield {"type": "activity", "content": f"🧠 Inferring (turn {turn + 1})..."}
+
+            # Try streaming first — yields token-by-token so the UI can show
+            # the response building char-by-char ("ghost is typing"). Falls
+            # back to one-shot generate if the JNI doesn't expose the
+            # streaming API yet (MediaPipe runtime, older builds).
+            reply = ""
+            streamed = False
+            try:
+                if int(llm.generateStart(model_id, prompt)) > 0:
+                    streamed = True
+                    while True:
+                        piece = str(llm.generateStep())
+                        # JNI protocol:
+                        #   "\x00"  → end of stream (EOS or stop-tag hit)
+                        #   ""      → no new text this step (the streamer is
+                        #             holding back bytes that might form a
+                        #             stop tag; keep polling)
+                        #   anything else → stream as text_delta.
+                        if piece == "\x00":
+                            break
+                        if piece == "":
+                            continue
+                        reply += piece
+                        yield {"type": "text_delta", "content": piece}
+            except Exception as e:
+                yield {"type": "error", "content": f"On-device streaming error: {e}"}
+                return
+
+            if not streamed:
+                # Fallback: one-shot generate (no live streaming).
+                try:
+                    reply = str(llm.generate(model_id, prompt))
+                except Exception as e:
+                    yield {"type": "error", "content": f"On-device inference error: {e}"}
+                    return
+
+            # Native error sentinel — surface and stop.
+            if reply.startswith("[on-device error") or reply.startswith("[llama_jni:"):
+                yield {"type": "error", "content": reply}
+                return
+            # Empty reply = model emitted EOG/<end_of_turn> as the first token.
+            # That means "no further actions" — finish the turn cleanly rather
+            # than treating it as a failure.
+            if not reply.strip():
+                break
+
+            session.messages.append(ChatMessage(role="assistant", content=reply))
+            # Final full-text event for clients that didn't subscribe to
+            # text_delta deltas (or to keep the protocol backward-compatible).
+            yield {"type": "text", "content": reply}
+            # Append the assistant turn to the rolling conversation so the
+            # next iteration sees the full chat history. `reply` already had
+            # any trailing <end_of_turn> stripped by the JNI streaming loop;
+            # we add it back so the model sees a clean turn boundary.
+            prompt += reply
+            record_generation(trace, model=model_id, prompt=prompt, output=reply)
+            last_reply = reply
+
+            tool_calls = _parse_tool_calls(reply)
+            if not tool_calls:
+                break
+
+            tool_results = []
+            for call in tool_calls:
+                tool_name, tool_args = normalize_tool_call(call)
+                tool_args.setdefault("device", session.device)
+
+                session.messages.append(
+                    ChatMessage(role="tool_call", tool_name=tool_name, tool_args=tool_args, content="")
+                )
+                yield {"type": "tool_call", "name": tool_name, "args": tool_args}
+                yield {"type": "activity", "content": f"⚡ {tool_name}..."}
+
+                span = trace.span(name=f"tool:{tool_name}", input={"args": tool_args}) if trace else None
+                try:
+                    result = execute_tool(tool_name, tool_args)
+                    session.messages.append(ChatMessage(role="tool_result", content=result[:500], tool_name=tool_name))
+                    yield {"type": "tool_result", "name": tool_name, "result": result[:500]}
+                    tool_results.append(f"[{tool_name}] {result[:800]}")
+                    record_tool_result(span, result)
+                except Exception as e:
+                    err = f"Tool error: {e}"
+                    session.messages.append(ChatMessage(role="tool_result", content=err, tool_name=tool_name))
+                    yield {"type": "tool_result", "name": tool_name, "result": err}
+                    tool_results.append(f"[{tool_name}] ERROR: {err}")
+                    record_tool_result(span, err, error=True)
+
+            prompt += _ondevice_tool_results_turn(tool_results)
+
+        set_trace_output(trace, last_reply)
+
+    yield {"type": "done"}

--- a/gitd/services/agent_tools.py
+++ b/gitd/services/agent_tools.py
@@ -5,12 +5,21 @@ Tool schemas are in Anthropic's tool format and auto-converted for other provide
 """
 
 import json
+import sys
 
+from gitd.bots.common.device import get_device, is_ios_ref
 from gitd.services import device_context as ctx
+from gitd.services.tool_platforms import platform_error_text, supports_platform
+from gitd.skills.platforms import skill_platform_error_text, skill_supports_device
 
 # ── Tool registry ────────────────────────────────────────────────────────────
 
 TOOLS = [
+    {
+        "name": "list_devices",
+        "description": "List connected Android ADB device refs and configured iOS Appium device refs.",
+        "input_schema": {"type": "object", "properties": {}},
+    },
     # Screen reading
     {
         "name": "screenshot",
@@ -38,8 +47,56 @@ TOOLS = [
         },
     },
     {
+        "name": "start_screen_recording",
+        "description": "Start recording the device screen. iOS uses WDA MJPEG through ffmpeg; Android uses adb screenrecord.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "device": {"type": "string"},
+                "filename": {"type": "string", "description": "Optional MP4 filename."},
+            },
+            "required": ["device"],
+        },
+    },
+    {
+        "name": "stop_screen_recording",
+        "description": "Stop a running device screen recording and return the saved MP4 path/URL.",
+        "input_schema": {"type": "object", "properties": {"device": {"type": "string"}}, "required": ["device"]},
+    },
+    {
+        "name": "screen_recording_status",
+        "description": "Return active screen recording status for a device.",
+        "input_schema": {"type": "object", "properties": {"device": {"type": "string"}}, "required": ["device"]},
+    },
+    {
+        "name": "get_stream_info",
+        "description": (
+            "Return platform-aware stream metadata without opening the stream. "
+            "iOS reports WDA MJPEG URL/settings and unsupported Portal/WebRTC actions; "
+            "Android reports Portal/H264/screencap mode metadata."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "device": {"type": "string"},
+                "mode": {
+                    "type": "string",
+                    "description": "Requested mode, e.g. mjpeg, wda-mjpeg, portal, h264, screencap.",
+                },
+                "fps": {"type": "integer", "default": 5},
+                "quality": {"type": "integer", "default": 8},
+            },
+            "required": ["device"],
+        },
+    },
+    {
         "name": "get_screen_tree",
         "description": 'Get LLM-readable indented UI hierarchy. Each node: [idx] Class "label" [clickable] [bounds]. Use this to understand screen layout before acting.',
+        "input_schema": {"type": "object", "properties": {"device": {"type": "string"}}, "required": ["device"]},
+    },
+    {
+        "name": "get_screen_xml",
+        "description": "Get the raw normalized UI XML dump. Prefer get_screen_tree unless exact attributes are needed.",
         "input_schema": {"type": "object", "properties": {"device": {"type": "string"}}, "required": ["device"]},
     },
     {
@@ -51,6 +108,26 @@ TOOLS = [
         "name": "get_phone_state",
         "description": "Get current app, activity, keyboard state. Quick check what's on screen.",
         "input_schema": {"type": "object", "properties": {"device": {"type": "string"}}, "required": ["device"]},
+    },
+    {
+        "name": "device_health",
+        "description": "Run a comprehensive device health check. On iOS, includes Appium/WDA status and recovery steps.",
+        "input_schema": {"type": "object", "properties": {"device": {"type": "string"}}, "required": ["device"]},
+    },
+    {
+        "name": "fix_device_health",
+        "description": (
+            "Apply a recovery action returned by device_health.recommended_fix. "
+            "On iOS this can reset stale Appium/WDA sessions or restart a user-owned RemoteXPC tunnel."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "device": {"type": "string"},
+                "issue": {"type": "string", "description": "Recovery code from device_health.recommended_fix."},
+            },
+            "required": ["device", "issue"],
+        },
     },
     {
         "name": "classify_screen",
@@ -131,6 +208,25 @@ TOOLS = [
         },
     },
     {
+        "name": "type_unicode",
+        "description": "Type unicode text into the focused field. Use for emoji, CJK, accented characters, and other non-ASCII input.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"device": {"type": "string"}, "text": {"type": "string"}},
+            "required": ["device", "text"],
+        },
+    },
+    {
+        "name": "press_back",
+        "description": "Press the platform Back/navigation-back control.",
+        "input_schema": {"type": "object", "properties": {"device": {"type": "string"}}, "required": ["device"]},
+    },
+    {
+        "name": "press_home",
+        "description": "Press the platform Home button.",
+        "input_schema": {"type": "object", "properties": {"device": {"type": "string"}}, "required": ["device"]},
+    },
+    {
         "name": "press_key",
         "description": "Press a key: BACK, HOME, ENTER, TAB, POWER, VOLUME_UP, VOLUME_DOWN, APP_SWITCH.",
         "input_schema": {
@@ -156,11 +252,91 @@ TOOLS = [
     # App management
     {
         "name": "launch_app",
-        "description": "Launch an app by package name. E.g. com.zhiliaoapp.musically (TikTok). Use search_apps to find the package name.",
+        "description": (
+            "Launch an app by Android package name or iOS bundle id. "
+            "Use search_apps to find the package or bundle id. "
+            "Set fresh=true to force-stop first (cold start, clears state — use for benchmarks "
+            "or when prior app state would interfere). Default is warm start (resumes prior state)."
+        ),
         "input_schema": {
             "type": "object",
-            "properties": {"device": {"type": "string"}, "package": {"type": "string"}},
+            "properties": {
+                "device": {"type": "string"},
+                "package": {"type": "string"},
+                "fresh": {"type": "boolean", "description": "Force-stop first for a clean state. Default false."},
+            },
             "required": ["device", "package"],
+        },
+    },
+    {
+        "name": "launch_intent",
+        "description": "Launch a full Android intent with optional action, data URI, package/component, and extras. Android-only.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "device": {"type": "string"},
+                "action": {"type": "string"},
+                "data": {"type": "string"},
+                "package": {"type": "string"},
+                "component": {"type": "string"},
+                "extras": {"type": "object"},
+            },
+            "required": ["device"],
+        },
+    },
+    {
+        "name": "open_camera",
+        "description": (
+            "Open the platform camera app in a specific mode. "
+            "On Android this uses launcher/UI automation; on iOS this uses the Camera bundle and WDA UI controls. "
+            "Modes: 'photo' (default rear photo), 'video' (rear video), "
+            "'selfie' (front photo), 'selfie_video' (front video). "
+            "Set timer_s=3 or timer_s=10 to activate the self-timer."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "device": {"type": "string"},
+                "mode": {"type": "string", "enum": ["photo", "video", "selfie", "selfie_video"], "default": "photo"},
+                "timer_s": {
+                    "type": "integer",
+                    "enum": [0, 3, 10],
+                    "description": "Self-timer delay. 0 = off.",
+                    "default": 0,
+                },
+            },
+            "required": ["device"],
+        },
+    },
+    {
+        "name": "speak_text",
+        "description": (
+            "Make the phone speak text aloud using its built-in TTS engine. "
+            "Works from PC and on-device — always emits audio on the phone. "
+            "Requires Ghost portal app to be running. "
+            "Use for audio feedback, accessibility, or voice responses."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "device": {"type": "string"},
+                "text": {"type": "string", "description": "Text to speak aloud."},
+                "rate": {
+                    "type": "number",
+                    "description": "Speed: 0.5=slow, 1.0=normal, 1.5=fast. Default 1.0.",
+                    "default": 1.0,
+                },
+            },
+            "required": ["device", "text"],
+        },
+    },
+    {
+        "name": "toggle_overlay",
+        "description": "Toggle Portal numbered element overlay on/off. Android-only.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"device": {"type": "string"}, "visible": {"type": "boolean", "default": True}},
+            "required": ["device"],
         },
     },
     {
@@ -173,13 +349,22 @@ TOOLS = [
         },
     },
     {
+        "name": "app_state",
+        "description": "Check whether an Android package or iOS bundle id is installed, running, or foreground.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"device": {"type": "string"}, "package": {"type": "string"}},
+            "required": ["device", "package"],
+        },
+    },
+    {
         "name": "list_apps",
-        "description": "List installed apps with human-readable names and package names. Returns [{name, package}]. Use search_apps for faster lookup.",
+        "description": "List installed apps with human-readable names and Android package names or iOS bundle ids. Returns [{name, package, bundle_id}]. Use search_apps for faster lookup.",
         "input_schema": {"type": "object", "properties": {"device": {"type": "string"}}, "required": ["device"]},
     },
     {
         "name": "search_apps",
-        "description": "Search installed apps by name. E.g. search_apps('tiktok') returns matching apps with package names. Case-insensitive.",
+        "description": "Search installed apps by name. Returns Android package names or iOS bundle ids. Case-insensitive.",
         "input_schema": {
             "type": "object",
             "properties": {"device": {"type": "string"}, "query": {"type": "string"}},
@@ -188,8 +373,126 @@ TOOLS = [
     },
     {
         "name": "list_packages",
-        "description": "List raw package names (no app names). Use list_apps or search_apps instead.",
+        "description": "List raw Android package names or iOS bundle ids. Use list_apps or search_apps instead.",
         "input_schema": {"type": "object", "properties": {"device": {"type": "string"}}, "required": ["device"]},
+    },
+    {
+        "name": "explore_app",
+        "description": (
+            "Explore an app UI with the cross-platform BFS app explorer and return the discovered state graph. "
+            "Use an Android package name or iOS bundle id."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "device": {"type": "string"},
+                "package": {"type": "string", "description": "Android package name or iOS bundle id."},
+                "max_depth": {"type": "integer", "default": 2},
+                "max_states": {"type": "integer", "default": 10},
+            },
+            "required": ["device", "package"],
+        },
+    },
+    {
+        "name": "web_search",
+        "description": (
+            "Open a web search in the best available browser. "
+            "Use when the user asks to search/look up something — faster than launching Chrome "
+            "and typing into the address bar. Falls back through Chrome → Firefox → Samsung "
+            "Internet → Edge → Brave → … → system default if a specific browser isn't installed. "
+            "Engines: 'google' (default), 'ddg', 'bing', 'brave'."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "device": {"type": "string"},
+                "query": {"type": "string"},
+                "engine": {"type": "string", "description": "Search engine: google, ddg, bing, brave. Default google."},
+                "bundle_id": {"type": "string", "description": "Optional iOS browser bundle id override."},
+            },
+            "required": ["device", "query"],
+        },
+    },
+    {
+        "name": "open_url",
+        "description": "Open a URL in the platform browser. On iOS, uses Appium/WDA and the configured browser bundle id.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "device": {"type": "string"},
+                "url": {"type": "string"},
+                "bundle_id": {"type": "string", "description": "Optional iOS browser bundle id override."},
+            },
+            "required": ["device", "url"],
+        },
+    },
+    {
+        "name": "browser_back",
+        "description": "Navigate back in the current browser/app context.",
+        "input_schema": {"type": "object", "properties": {"device": {"type": "string"}}, "required": ["device"]},
+    },
+    {
+        "name": "get_current_url",
+        "description": "Get the current browser URL when the platform exposes it.",
+        "input_schema": {"type": "object", "properties": {"device": {"type": "string"}}, "required": ["device"]},
+    },
+    {
+        "name": "wait_for_text",
+        "description": "Wait until text appears on screen and return visible text context.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "device": {"type": "string"},
+                "text": {"type": "string"},
+                "timeout": {"type": "number", "default": 12.0},
+            },
+            "required": ["device", "text"],
+        },
+    },
+    {
+        "name": "extract_visible_text",
+        "description": "Extract visible text from the current screen. Browser controls are filtered by default.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "device": {"type": "string"},
+                "max_lines": {"type": "integer", "default": 200},
+                "include_controls": {"type": "boolean", "default": False},
+            },
+            "required": ["device"],
+        },
+    },
+    {
+        "name": "extract_articles",
+        "description": "Extract likely visible article/headline candidates from the current browser page.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "device": {"type": "string"},
+                "max_items": {"type": "integer", "default": 5},
+            },
+            "required": ["device"],
+        },
+    },
+    {
+        "name": "read_news",
+        "description": (
+            "Open a news page in iOS Chrome/browser, extract headlines, open the first articles, "
+            "and return structured title/body snippets. Use this for news-reading tasks."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "device": {"type": "string"},
+                "url": {"type": "string", "default": "https://text.npr.org/"},
+                "max_headlines": {"type": "integer", "default": 5},
+                "max_articles": {"type": "integer", "default": 3},
+                "bundle_id": {"type": "string", "description": "Optional iOS browser bundle id override."},
+                "wait_s": {"type": "number", "default": 2.0},
+                "save_screenshots": {"type": "boolean", "default": False},
+            },
+            "required": ["device"],
+        },
     },
     # Shell
     {
@@ -202,6 +505,22 @@ TOOLS = [
         },
     },
     # Clipboard & notifications
+    {
+        "name": "paste_text",
+        "description": (
+            "Set clipboard and paste into the currently focused input field in one call. "
+            "Tap the target field first, then call this. "
+            "Prefer this over type_text for long text, passwords, or special characters."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "device": {"type": "string"},
+                "text": {"type": "string"},
+            },
+            "required": ["device", "text"],
+        },
+    },
     {
         "name": "clipboard_get",
         "description": "Get current clipboard text.",
@@ -221,11 +540,30 @@ TOOLS = [
         "description": "List active notifications.",
         "input_schema": {"type": "object", "properties": {"device": {"type": "string"}}, "required": ["device"]},
     },
+    {
+        "name": "open_notifications",
+        "description": "Open the platform notification shade or Notification Center.",
+        "input_schema": {"type": "object", "properties": {"device": {"type": "string"}}, "required": ["device"]},
+    },
+    {
+        "name": "clear_notifications",
+        "description": "Dismiss visible notifications when the platform exposes a clear control.",
+        "input_schema": {"type": "object", "properties": {"device": {"type": "string"}}, "required": ["device"]},
+    },
     # Skills
     {
         "name": "list_skills",
         "description": "List installed automation skills with actions and workflows.",
-        "input_schema": {"type": "object", "properties": {}},
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "device": {
+                    "type": "string",
+                    "description": "Optional device ref used to include platform support flags.",
+                },
+                "supported_only": {"type": "boolean", "default": False},
+            },
+        },
     },
     {
         "name": "run_skill",
@@ -241,6 +579,135 @@ TOOLS = [
             "required": ["device", "skill", "workflow"],
         },
     },
+    {
+        "name": "run_workflow",
+        "description": "Run a skill workflow. Alias of run_skill for MCP/agent parity.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "device": {"type": "string"},
+                "skill": {"type": "string"},
+                "workflow": {"type": "string"},
+                "params": {"type": "object", "default": {}},
+            },
+            "required": ["device", "skill", "workflow"],
+        },
+    },
+    {
+        "name": "run_action",
+        "description": "Run a single skill action when the skill supports the target device platform.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "device": {"type": "string"},
+                "skill": {"type": "string"},
+                "action": {"type": "string"},
+                "params": {"type": "object", "default": {}},
+            },
+            "required": ["device", "skill", "action"],
+        },
+    },
+    {
+        "name": "create_skill",
+        "description": "Create a recorded automation skill with Android/iOS platform metadata and optional element selectors.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "app_package": {
+                    "type": "string",
+                    "description": "Android package, or iOS bundle id when platforms is ios.",
+                },
+                "steps": {"type": "array", "description": "Recorded step list."},
+                "platforms": {"type": "array", "items": {"type": "string"}, "default": []},
+                "ios_bundle_id": {"type": "string", "default": ""},
+                "elements_ios": {
+                    "type": ["object", "array"],
+                    "items": {"type": "object"},
+                    "default": [],
+                    "description": "Captured iOS element list or selector map for elements_ios.yaml.",
+                },
+                "elements_android": {
+                    "type": ["object", "array"],
+                    "items": {"type": "object"},
+                    "default": [],
+                    "description": "Captured Android element list or selector map for elements.yaml.",
+                },
+            },
+            "required": ["name", "app_package", "steps"],
+        },
+    },
+    {
+        "name": "lookup_lead",
+        "description": "Get the marketing fact sheet for one influencer lead by handle.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"handle": {"type": "string", "description": "TikTok handle with or without @."}},
+            "required": ["handle"],
+        },
+    },
+    {
+        "name": "crm_lookup_contact",
+        "description": "Get the stored fact sheet for one local CRM contact by handle. Read-only.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"handle": {"type": "string", "description": "Contact handle with or without @."}},
+            "required": ["handle"],
+        },
+    },
+    {
+        "name": "list_unread_leads",
+        "description": "List influencer leads with unread replies, sorted by recency.",
+        "input_schema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "crm_list_unread_messages",
+        "description": "List local CRM contacts with unread messages, sorted by recency. Read-only.",
+        "input_schema": {"type": "object", "properties": {}},
+    },
+    # Frame capture + vision sub-agent (for image-heavy subtasks like reading a
+    # playing video). screenshot_sequence captures a burst; sub_agent reads it.
+    {
+        "name": "screenshot_sequence",
+        "description": (
+            "Capture a burst of screenshots over a window while something plays on "
+            "screen (e.g. a video), caching them for sub_agent — do NOT dump them into "
+            "your own context. Media usually autoplays when opened and a short clip can "
+            "finish during one turn, so open AND capture in ONE step: "
+            "chain[{open the item}, {screenshot_sequence}]. Then call sub_agent to read them."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "duration_seconds": {"type": "integer", "default": 4, "description": "Capture window (2-180)."},
+                "fps": {"type": "number", "default": 1.0, "description": "Frames per second (0.1-4.0)."},
+            },
+        },
+    },
+    {
+        "name": "sub_agent",
+        "description": (
+            "Hand the cached screenshot_sequence frames to a SEPARATE vision sub-agent "
+            "that returns ONLY its text answer, keeping your context lean on image-heavy "
+            "subtasks (e.g. transcribing frames of a video). Give a precise task. Requires "
+            "an Anthropic API key; unavailable under the claude-code subscription provider."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "task": {
+                    "type": "string",
+                    "description": "Precise instruction for the sub-agent (e.g. what to transcribe).",
+                },
+                "max_frames": {
+                    "type": "integer",
+                    "default": 60,
+                    "description": "Cap on frames sent (subsampled, hard max 60).",
+                },
+            },
+            "required": ["task"],
+        },
+    },
     # System
     {
         "name": "wait",
@@ -251,12 +718,196 @@ TOOLS = [
             "required": ["seconds"],
         },
     },
+    {
+        "name": "chain",
+        "description": (
+            "Run several device actions in ONE step, settling between each — e.g. fill a form's "
+            "fields, or tap→type→tap a submit. Saves turns on known sequences. Each sub-action is "
+            '{"tool": "<name>", "args": {...}} using the same tool names; only read/UI tools are '
+            "allowed inside a chain (no shell/run_skill/nested chain). Returns each sub-action's result."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "actions": {
+                    "type": "array",
+                    "description": 'Ordered sub-actions, e.g. [{"tool":"tap_element","args":{"idx":3}},{"tool":"type_text","args":{"text":"hi"}}].',
+                    "items": {"type": "object"},
+                },
+                "settle": {
+                    "type": "string",
+                    "enum": ["stabilize", "delay"],
+                    "default": "stabilize",
+                    "description": "How to wait between sub-actions: 'stabilize' (short fixed settle) or 'delay' (delay_ms).",
+                },
+                "delay_ms": {
+                    "type": "integer",
+                    "default": 600,
+                    "description": "Settle time when settle='delay' (capped 3000).",
+                },
+            },
+            "required": ["actions"],
+        },
+    },
 ]
+
+
+# Vetted allow-list of tools that are safe to expose in untrusted / third-party
+# contexts — the run_flow batch primitive and the LangChain/LlamaIndex adapters
+# both gate on this. It is an EXPLICIT allow-list (not "all TOOLS minus a
+# dangerous set") so it fails CLOSED: a tool added to the dispatch later is NOT
+# auto-exposed until it's deliberately vetted and added here. Every iOS-era
+# tool below was classified individually; the exec-capable ones live in
+# EXEC_CAPABLE_TOOLS instead and must never move here.
+SAFE_DEVICE_TOOLS = frozenset(
+    {
+        # Screen reading
+        "screenshot",
+        "screenshot_annotated",
+        "screenshot_cropped",
+        "get_screen_tree",
+        "get_screen_xml",
+        "get_elements",
+        "get_phone_state",
+        "classify_screen",
+        "find_on_screen",
+        "ocr_screen",
+        "ocr_region",
+        "get_notifications",
+        # Device inventory / status (read-only)
+        "list_devices",
+        "device_health",
+        "app_state",
+        "get_stream_info",
+        "screen_recording_status",
+        # Screen recording (writes only to the vetted recordings dir)
+        "start_screen_recording",
+        "stop_screen_recording",
+        # Frame-burst capture (read-only screenshots; chainable so open+capture is one step)
+        "screenshot_sequence",
+        # UI actions
+        "tap",
+        "tap_element",
+        "swipe",
+        "type_text",
+        "type_unicode",
+        "press_key",
+        "press_back",
+        "press_home",
+        "long_press",
+        "paste_text",
+        "clipboard_get",
+        "clipboard_set",
+        "launch_app",
+        "force_stop",
+        "open_camera",
+        "speak_text",
+        "toggle_overlay",
+        "open_notifications",
+        "clear_notifications",
+        "wait",
+        # App inventory
+        "list_apps",
+        "search_apps",
+        "list_packages",
+        "list_skills",
+        # Browser (read/navigate)
+        "web_search",
+        "open_url",
+        "browser_back",
+        "get_current_url",
+        "wait_for_text",
+        "extract_visible_text",
+        "extract_articles",
+        "read_news",
+        # Local CRM (read-only DB queries, no exec)
+        "crm_lookup_contact",
+        "crm_list_unread_messages",
+        # Marketing lead lookups (read-only DB queries, no exec)
+        "lookup_lead",
+        "list_unread_leads",
+    }
+)
+
+# Exec-capable tools, deliberately EXCLUDED from SAFE_DEVICE_TOOLS — same class
+# as `shell`: they run subprocesses, launch arbitrary intents, or write code
+# that is later imported. Kept as an explicit set so tests can prove the two
+# sets stay disjoint and that new dispatch branches land in one or the other.
+#   shell            — arbitrary adb shell
+#   run_skill / run_workflow / run_action — execute skill code in a subprocess
+#   create_skill     — writes skill code to gitd/skills/ (later imported)
+#   launch_intent    — arbitrary Android intent incl. component + extras
+#   explore_app      — spawns the BFS explorer subprocess, drives UI for minutes
+#   fix_device_health — device-admin recovery actions (can install the Portal APK)
+#   chain            — meta-executor: runs N sub-actions. Like run_flow it must
+#                      not be reachable from run_flow / framework adapters (an
+#                      untrusted batch shouldn't nest another batch), so it's
+#                      denied here. It still gates its OWN sub-actions to
+#                      SAFE_DEVICE_TOOLS, so even first-party callers can't
+#                      smuggle shell/run_skill through it.
+#   sub_agent        — spawns a fresh (paid) Anthropic vision call over cached
+#                      frames. Kept out of SAFE so it can't be smuggled into a
+#                      run_flow/chain batch (which would let an untrusted flow fan
+#                      out arbitrary billed LLM calls).
+EXEC_CAPABLE_TOOLS = frozenset(
+    {
+        "shell",
+        "run_skill",
+        "run_workflow",
+        "run_action",
+        "create_skill",
+        "launch_intent",
+        "explore_app",
+        "fix_device_health",
+        "chain",
+        "sub_agent",
+    }
+)
 
 
 # ── Tool execution ───────────────────────────────────────────────────────────
 
-_UI_ACTION_TOOLS = {"tap", "tap_element", "swipe", "type_text", "press_key", "long_press", "launch_app"}
+_KNOWN_TOOL_NAMES = {tool["name"] for tool in TOOLS}
+_UI_ACTION_TOOLS = {
+    "tap",
+    "tap_element",
+    "swipe",
+    "type_text",
+    "type_unicode",
+    "press_back",
+    "press_home",
+    "press_key",
+    "long_press",
+    "launch_app",
+    "open_url",
+    "web_search",
+    "browser_back",
+    "wait_for_text",
+}
+
+
+def _device_platform(device: str) -> str:
+    return "ios" if is_ios_ref(device) else "android"
+
+
+def _platform_unsupported(tool_name: str, device: str) -> str:
+    return platform_error_text(tool_name, _device_platform(device))
+
+
+def tools_for_device(device: str | None) -> list[dict]:
+    """Return the tools that should be offered to an agent for this device."""
+    if not device:
+        return list(TOOLS)
+    platform = _device_platform(device)
+    return [tool for tool in TOOLS if supports_platform(tool["name"], platform)]
+
+
+def tool_prompt_list(tools: list[dict]) -> str:
+    """Compact tool list for text-only providers."""
+    return "\n".join(
+        f"- {t['name']}: {t['description']}  params: {list(t.get('input_schema', {}).get('properties', {}).keys())}"
+        for t in tools
+    )
 
 
 def execute_tool(name: str, args: dict) -> str:
@@ -274,7 +925,41 @@ def execute_tool(name: str, args: dict) -> str:
                 result += f"\n\n[Screen after action]\n{tree}"
         except Exception:
             pass
+        result += _a11y_diff_suffix(args["device"])
     return result
+
+
+# Per-device cache of the element list seen after the previous UI action, so the
+# next UI action can show a before/after diff. Read-only tools do not update it,
+# keeping the diff strictly action-to-action.
+_LAST_ELEMENTS: dict[str, list[dict]] = {}
+
+
+def _a11y_diff_suffix(device: str) -> str:
+    """Diff the current interactive elements against the ones cached after the
+    previous UI action on this device; return a text block to append (or "").
+
+    Fail-open: any error (or the kill-switch off) yields an empty string, so the
+    existing post-action screen-tree behaviour is never disturbed. Costs one
+    extra UI-tree dump per UI action — disable with A11Y_DIFF_ENABLED=false.
+    """
+    try:
+        from gitd.config import settings
+        from gitd.services.a11y_diff import diff_elements
+
+        if not settings.a11y_diff_enabled:
+            return ""
+        curr = ctx.get_interactive_elements(device)
+        prev = _LAST_ELEMENTS.get(device)
+        _LAST_ELEMENTS[device] = curr
+        diff = diff_elements(prev, curr)
+        # Suppress the "no change" line — only surface an actual delta (or the
+        # first-action empty string), to avoid nudging the model on a no-op.
+        if diff and diff != "A11y diff: no change.":
+            return f"\n\n[{diff}]"
+    except Exception:
+        pass
+    return ""
 
 
 def _execute_tool_inner(name: str, args: dict) -> str:
@@ -286,27 +971,111 @@ def _execute_tool_inner(name: str, args: dict) -> str:
     device = args.get("device", "")
 
     try:
-        if name == "screenshot":
+        if name not in _KNOWN_TOOL_NAMES:
+            return f"Unknown tool: {name}"
+        if device and not supports_platform(name, _device_platform(device)):
+            return _platform_unsupported(name, device)
+
+        if name == "list_devices":
+            from gitd.bots.common.device import list_configured_ios_devices, list_connected_device_refs
+
+            ios_details = {}
+            try:
+                ios_details = {
+                    item.get("serial"): item
+                    for item in list_configured_ios_devices(deep_probe=False)
+                    if item.get("serial")
+                }
+            except Exception:
+                ios_details = {}
+            entries = []
+            for serial in list_connected_device_refs():
+                platform = "ios" if is_ios_ref(serial) else "android"
+                entry = {"serial": serial, "platform": platform}
+                if platform == "ios":
+                    details = ios_details.get(serial) or {}
+                    for key in (
+                        "status",
+                        "status_message",
+                        "device_name",
+                        "model",
+                        "appium_url",
+                        "source",
+                        "host_state",
+                    ):
+                        if details.get(key):
+                            entry[key] = details[key]
+                entries.append(entry)
+            return json.dumps(entries, indent=2)
+        elif name == "screenshot":
             r = ctx.screenshot(device)
             return json.dumps(
-                {"image": r["image"][:100] + "...(truncated)", "width": r["width"], "height": r["height"]}
+                {
+                    "device": r.get("device", device),
+                    "platform": r.get("platform", "ios" if is_ios_ref(device) else "android"),
+                    "image": r["image"][:100] + "...(truncated)",
+                    "width": r["width"],
+                    "height": r["height"],
+                }
             )
         elif name == "screenshot_annotated":
             r = ctx.screenshot_annotated(device)
             return json.dumps(
-                {"image": r["image"][:100] + "...(truncated)", "width": r["width"], "height": r["height"]}
+                {
+                    "device": r.get("device", device),
+                    "platform": r.get("platform", "ios" if is_ios_ref(device) else "android"),
+                    "image": r["image"][:100] + "...(truncated)",
+                    "width": r["width"],
+                    "height": r["height"],
+                }
             )
         elif name == "screenshot_cropped":
             r = ctx.screenshot_cropped(device, args["x1"], args["y1"], args["x2"], args["y2"])
             return json.dumps(
-                {"image": r["image"][:100] + "...(truncated)", "width": r["width"], "height": r["height"]}
+                {
+                    "device": r.get("device", device),
+                    "platform": r.get("platform", "ios" if is_ios_ref(device) else "android"),
+                    "image": r["image"][:100] + "...(truncated)",
+                    "width": r["width"],
+                    "height": r["height"],
+                }
+            )
+        elif name == "start_screen_recording":
+            from gitd.services.phone_recording import start_recording
+
+            return json.dumps(start_recording(device, filename=args.get("filename", "")), indent=2)
+        elif name == "stop_screen_recording":
+            from gitd.services.phone_recording import stop_recording
+
+            return json.dumps(stop_recording(device), indent=2)
+        elif name == "screen_recording_status":
+            from gitd.services.phone_recording import recording_status
+
+            return json.dumps(recording_status(device), indent=2)
+        elif name == "get_stream_info":
+            from gitd.routers.streaming import phone_stream_info
+
+            return json.dumps(
+                phone_stream_info(
+                    device=device,
+                    fps=int(args.get("fps", 5)),
+                    quality=int(args.get("quality", 8)),
+                    mode=args.get("mode", "mjpeg"),
+                ),
+                indent=2,
             )
         elif name == "get_screen_tree":
             return ctx.get_screen_tree(device)
+        elif name == "get_screen_xml":
+            return ctx.get_screen_xml(device)
         elif name == "get_elements":
             return json.dumps(ctx.get_interactive_elements(device), indent=2)
         elif name == "get_phone_state":
             return json.dumps(ctx.get_phone_state(device), indent=2)
+        elif name == "device_health":
+            return json.dumps(ctx.device_health(device), indent=2)
+        elif name == "fix_device_health":
+            return json.dumps(ctx.fix_device_health(device, args["issue"]), indent=2)
         elif name == "classify_screen":
             return json.dumps(ctx.classify_screen(device), indent=2)
         elif name == "find_on_screen":
@@ -317,7 +1086,7 @@ def _execute_tool_inner(name: str, args: dict) -> str:
         elif name == "ocr_region":
             return json.dumps(ctx.ocr_region(device, args["x1"], args["y1"], args["x2"], args["y2"]), indent=2)
         elif name == "tap":
-            Device(device).tap(args["x"], args["y"])
+            get_device(device).tap(args["x"], args["y"])
             return f"Tapped ({args['x']}, {args['y']})"
         elif name == "tap_element":
             elements = ctx.get_interactive_elements(device)
@@ -325,93 +1094,492 @@ def _execute_tool_inner(name: str, args: dict) -> str:
             if 0 <= idx < len(elements):
                 el = elements[idx]
                 cx, cy = el["center"]["x"], el["center"]["y"]
-                Device(device).tap(cx, cy)
+                get_device(device).tap(cx, cy)
                 return f"Tapped element #{idx} '{el.get('text') or el.get('content_desc') or el.get('resource_id', '')}' at ({cx}, {cy})"
             return f"Element index {idx} out of range (0-{len(elements) - 1})"
         elif name == "swipe":
-            Device(device).swipe(args["x1"], args["y1"], args["x2"], args["y2"], ms=args.get("duration_ms", 500))
+            get_device(device).swipe(args["x1"], args["y1"], args["x2"], args["y2"], ms=args.get("duration_ms", 500))
             return f"Swiped ({args['x1']},{args['y1']}) -> ({args['x2']},{args['y2']})"
         elif name == "type_text":
-            Device(device).adb("shell", "input", "text", args["text"].replace(" ", "%s"))
-            return f"Typed: {args['text']}"
+            if is_ios_ref(device):
+                get_device(device).type_text(args["text"])
+                return f"Typed: {args['text']}"
+            # `adb input text` is ASCII-only — one non-ASCII char blanks the whole
+            # field. Transliterate to the closest ASCII so accented input still
+            # lands (use type_unicode for full-fidelity emoji/CJK).
+            from gitd.bots.common.adb import ascii_typeable, input_text_arg
+
+            typed = ascii_typeable(args["text"])
+            Device(device).adb("shell", "input", "text", input_text_arg(typed))
+            if typed != args["text"]:
+                return f"Typed (transliterated non-ASCII): {args['text']!r} -> {typed!r}"
+            return f"Typed: {typed}"
+        elif name == "type_unicode":
+            if is_ios_ref(device):
+                get_device(device).type_text(args["text"])
+            else:
+                Device(device).type_unicode(args["text"])
+            return f"Typed (unicode): {args['text']}"
+        elif name == "press_back":
+            get_device(device).back()
+            return "Pressed Back"
+        elif name == "press_home":
+            if is_ios_ref(device):
+                get_device(device).press_key("HOME")
+            else:
+                Device(device).adb("shell", "input", "keyevent", "KEYCODE_HOME")
+            return "Pressed Home"
         elif name == "press_key":
             key = args["key"]
-            if not key.startswith("KEYCODE_"):
-                key = "KEYCODE_" + key
-            Device(device).adb("shell", "input", "keyevent", key)
+            if is_ios_ref(device):
+                get_device(device).press_key(key)
+            else:
+                from gitd.bots.common.adb import normalize_keycode
+
+                key = normalize_keycode(key)
+                Device(device).adb("shell", "input", "keyevent", key)
             return f"Pressed {key}"
         elif name == "long_press":
-            Device(device).long_press(args["x"], args["y"], duration_ms=args.get("duration_ms", 1000))
+            get_device(device).long_press(args["x"], args["y"], duration_ms=args.get("duration_ms", 1000))
             return f"Long pressed ({args['x']}, {args['y']})"
         elif name == "launch_app":
-            Device(device).adb("shell", "monkey", "-p", args["package"], "-c", "android.intent.category.LAUNCHER", "1")
-            return f"Launched {args['package']}"
+            if is_ios_ref(device):
+                bundle_id = args["package"]
+                if bool(args.get("fresh", False)):
+                    try:
+                        get_device(device).terminate_app(bundle_id)
+                    except Exception:
+                        pass
+                get_device(device).launch_app(bundle_id)
+                return f"Launched iOS app {bundle_id}" + (" [fresh]" if args.get("fresh", False) else "")
+            dev = Device(device)
+            pkg = args["package"]
+            fresh = bool(args.get("fresh", False))
+            # Verify the package exists first — `monkey`/`am start` both fall
+            # through silently for missing packages, so without this the agent
+            # gets a phantom success and burns turns wondering why the app
+            # didn't open.
+            installed = dev.adb("shell", "pm", "list", "packages", pkg, timeout=10)
+            if f"package:{pkg}" not in installed:
+                pkgs_out = dev.adb("shell", "pm", "list", "packages", timeout=10)
+                all_pkgs = [
+                    p.replace("package:", "").strip() for p in pkgs_out.splitlines() if p.startswith("package:")
+                ]
+                # Suggest installed packages whose name contains a token from the
+                # requested one — usually catches `com.reddit.android` →
+                # `com.reddit.frontpage`.
+                tokens = [t for t in pkg.split(".") if len(t) > 2 and t not in {"com", "org", "net", "android", "app"}]
+                hits = [p for p in all_pkgs if any(t in p for t in tokens)][:6]
+                hint = f" Did you mean: {', '.join(hits)}?" if hits else ""
+                return f"ERROR: package {pkg} is not installed.{hint}"
+            # Check if the package is disabled — `pm list packages -d` lists disabled
+            # packages. All launch methods silently fail (or "No activities found") when
+            # the package is disabled, giving the agent a phantom success.
+            disabled = dev.adb("shell", "pm", "list", "packages", "-d", pkg, timeout=10)
+            if f"package:{pkg}" in disabled:
+                return f"ERROR: {pkg} is installed but disabled. Enable it first: adb shell pm enable {pkg}"
+            # When the daemon runs ON the phone (Chaquopy), `am start` and
+            # `monkey` both fail under the app's own uid: am resolves to
+            # USER_CURRENT_OR_SELF and gets blocked on INTERACT_ACROSS_USERS_FULL,
+            # monkey aborts setting a system property. Going through the app
+            # process's own Context.startActivity() works because it's a
+            # public Android surface — same path any third-party launcher
+            # uses. The Kotlin helper `DeviceActions.launchApp` lives at
+            # app/src/main/java/com/ghostinthedroid/app/ondevice/DeviceActions.kt.
+            # Outside Chaquopy (host-side dev runs), fall back to the adb
+            # `am start` path, which works because host adb runs as `shell`
+            # (uid 2000) and has the cross-user permission.
+            try:
+                from java import jclass  # type: ignore[import-not-found]
+
+                actions = jclass("com.ghostinthedroid.app.ondevice.DeviceActions").INSTANCE
+                return str(actions.launchApp(pkg, fresh))
+            except Exception:
+                # Host-side fallback (no Chaquopy): use am start through ADB.
+                resolve = dev.adb(
+                    "shell",
+                    "cmd",
+                    "package",
+                    "resolve-activity",
+                    "--brief",
+                    "-c",
+                    "android.intent.category.LAUNCHER",
+                    pkg,
+                    timeout=10,
+                )
+                launcher = ""
+                for line in resolve.splitlines():
+                    line = line.strip()
+                    if "/" in line and line.startswith(pkg):
+                        launcher = line
+                        break
+                if not launcher:
+                    # resolve-activity can fail on some ROMs (ASUS, Samsung) even for
+                    # valid launcher packages. Fall back to monkey which works as long
+                    # as the package is enabled and has a LAUNCHER activity.
+                    if fresh:
+                        dev.adb("shell", "am", "force-stop", pkg)
+                    monkey_out = dev.adb(
+                        "shell",
+                        "monkey",
+                        "-p",
+                        pkg,
+                        "-c",
+                        "android.intent.category.LAUNCHER",
+                        "1",
+                        timeout=10,
+                    )
+                    if "Events injected: 1" in monkey_out:
+                        return f"Launched {pkg} (monkey)" + (" [fresh]" if fresh else "")
+                    return f"ERROR: {pkg} has no LAUNCHER activity (monkey: {monkey_out.strip()[:100]})"
+                am_args = ["shell", "am", "start", "--user", "0"]
+                if fresh:
+                    am_args += ["--activity-clear-task"]
+                am_args += ["-n", launcher]
+                out = dev.adb(*am_args, timeout=15)
+                if "Error:" in out or "Activity not started" in out:
+                    return f"ERROR launching {pkg}: {out.strip()[:200]}"
+                return f"Launched {pkg} ({launcher})" + (" [fresh]" if fresh else "")
+        elif name == "open_camera":
+            if is_ios_ref(device):
+                result = get_device(device).open_camera(
+                    mode=args.get("mode", "photo"),
+                    timer_s=int(args.get("timer_s", 0)),
+                )
+                warnings = []
+                if not result.get("selected_mode"):
+                    warnings.append("mode control not found")
+                if result.get("switched_camera") is False:
+                    warnings.append("front camera switch not found")
+                if result.get("timer_set") is False:
+                    warnings.append("timer control not found")
+                suffix = f" ({'; '.join(warnings)})" if warnings else ""
+                return f"Opened iOS Camera - {result['mode']}{suffix}"
+            dev = Device(device)
+            mode = args.get("mode", "photo").lower()
+            timer_s = int(args.get("timer_s", 0))
+            import time as _time
+
+            _VIDEO_MODES = {"video", "selfie_video"}
+            _FRONT_MODES = {"selfie", "selfie_video"}
+
+            # Find installed camera package
+            _CAMERA_PKGS = [
+                "com.asus.camera",
+                "com.sec.android.app.camera",
+                "com.google.android.GoogleCamera",
+                "com.android.camera2",
+                "com.android.camera",
+            ]
+            camera_pkg = None
+            for cpkg in _CAMERA_PKGS:
+                if f"package:{cpkg}" in dev.adb("shell", "pm", "list", "packages", cpkg, timeout=5):
+                    camera_pkg = cpkg
+                    break
+            if not camera_pkg:
+                return "ERROR: no camera app found on device"
+
+            # Wake screen if it's off — camera won't open on a sleeping display
+            awake = dev.adb("shell", "dumpsys", "window", "displays", timeout=5)
+            if "mAwake=false" in awake:
+                dev.adb("shell", "input", "keyevent", "KEYCODE_WAKEUP")
+                _time.sleep(0.5)
+                # Dismiss any lock screen via swipe up
+                dev.adb("shell", "input", "swipe", "540", "1600", "540", "800", "300")
+                _time.sleep(0.5)
+
+            # Always force-stop for clean state — avoids stale mode/timer from last session
+            dev.adb("shell", "am", "force-stop", camera_pkg)
+            _time.sleep(0.4)
+
+            # Launch via LAUNCHER intent — same as tapping the icon.
+            # DO NOT use IMAGE_CAPTURE/VIDEO_CAPTURE intents — those open a
+            # "capture for app" flow that shows a Retake/Use dialog and saves
+            # nothing to the gallery.
+            launch_result = execute_tool("launch_app", {"device": device, "package": camera_pkg, "fresh": False})
+            if "ERROR" in launch_result:
+                return f"ERROR opening camera: {launch_result}"
+
+            # Wait for camera UI to be ready
+            _READY = {"button_capture", "take picture", "shutter", "capture"}
+            _ERRORS = {"being used by another", "camera not ready"}
+            for _ in range(10):  # up to 5s
+                _time.sleep(0.5)
+                xml = dev.dump_xml() or ""
+                xml_lower = xml.lower()
+                if any(ind in xml_lower for ind in _READY):
+                    break
+                if any(ind in xml_lower for ind in _ERRORS):
+                    return "ERROR: camera busy — try again in a moment"
+            else:
+                return "ERROR: camera did not become ready in time"
+
+            # Switch to front camera if needed
+            if mode in _FRONT_MODES:
+                xml = dev.dump_xml() or ""
+                switched = False
+                _FRONT_KEYWORDS = ("switch", "front", "toggle", "flip", "selfie", "btn_toggle")
+                for node in dev.nodes(xml):
+                    desc = (dev.node_content_desc(node) or "").lower()
+                    text = (dev.node_text(node) or "").lower()
+                    rid = (dev.node_rid(node) or "").lower()
+                    if any(k in desc or k in text or k in rid for k in _FRONT_KEYWORDS):
+                        b = dev.node_bounds(node)
+                        if b and 'clickable="true"' in node:
+                            dev.tap((b[0] + b[2]) // 2, (b[1] + b[3]) // 2)
+                            _time.sleep(0.8)
+                            switched = True
+                            break
+                if not switched:
+                    return "ERROR: could not find front-camera switch button"
+
+            # Switch to video mode if needed
+            if mode in _VIDEO_MODES:
+                xml = dev.dump_xml() or ""
+                for node in dev.nodes(xml):
+                    text = (dev.node_text(node) or "").lower()
+                    desc = (dev.node_content_desc(node) or "").lower()
+                    if text == "video" or desc == "video":
+                        b = dev.node_bounds(node)
+                        if b:
+                            dev.tap((b[0] + b[2]) // 2, (b[1] + b[3]) // 2)
+                            _time.sleep(0.6)
+                            break
+
+            mode_label = {
+                "photo": "📷 photo",
+                "video": "🎬 video",
+                "selfie": "🤳 selfie",
+                "selfie_video": "🤳🎬 selfie video",
+            }.get(mode, mode)
+            result = f"Opened camera — {mode_label}"
+
+            # Timer: UI automation — not a native intent parameter.
+            # Supported values differ by OEM: ASUS=3s/10s, Samsung=2s/5s/10s.
+            # Pick the closest supported value and tap through the UI.
+            if timer_s > 0:
+                _time.sleep(1.0)
+                # Snap to closest OEM-supported value
+                _SUPPORTED = [2, 3, 5, 10]
+                timer_s = min(_SUPPORTED, key=lambda v: abs(v - timer_s))
+
+                def _find_timer_node(xml_str, secs):
+                    """Search for a timer button matching `secs` seconds."""
+                    targets = [
+                        f"{secs}s",
+                        f"{secs} s",
+                        f"timer_{secs}s",  # Samsung: FRONT_TIMER_5S / REAR_TIMER_5S
+                        f"_{secs}s",  # suffix match for TIMER_5S
+                    ]
+                    for node in dev.nodes(xml_str):
+                        text = (dev.node_text(node) or "").lower()
+                        desc = (dev.node_content_desc(node) or "").lower()
+                        combined = text + " " + desc
+                        if any(t in combined for t in targets):
+                            return dev.node_bounds(node)
+                    return None
+
+                xml = dev.dump_xml() or ""
+                bounds = _find_timer_node(xml, timer_s)
+
+                if not bounds:
+                    # Samsung pattern: timer is inside "Quick controls" panel.
+                    # Step 1: tap "Quick controls" to expand.
+                    for node in dev.nodes(xml):
+                        desc = (dev.node_content_desc(node) or "").lower()
+                        text = (dev.node_text(node) or "").lower()
+                        if "quick control" in desc or "quick control" in text:
+                            b = dev.node_bounds(node)
+                            if b:
+                                dev.tap((b[0] + b[2]) // 2, (b[1] + b[3]) // 2)
+                                _time.sleep(0.6)
+                                break
+                    # Step 2: tap "Timer" entry to expand timer options.
+                    xml = dev.dump_xml() or ""
+                    for node in dev.nodes(xml):
+                        desc = (dev.node_content_desc(node) or "").lower()
+                        text = (dev.node_text(node) or "").lower()
+                        if (desc == "timer" or text == "timer") and "off" not in desc:
+                            b = dev.node_bounds(node)
+                            if b:
+                                dev.tap((b[0] + b[2]) // 2, (b[1] + b[3]) // 2)
+                                _time.sleep(0.6)
+                                break
+                    # Step 3: now find the specific value.
+                    xml = dev.dump_xml() or ""
+                    bounds = _find_timer_node(xml, timer_s)
+
+                if bounds:
+                    dev.tap((bounds[0] + bounds[2]) // 2, (bounds[1] + bounds[3]) // 2)
+                    _time.sleep(0.4)
+                    # Close the Quick controls panel if it's still open (Samsung leaves it open).
+                    # Press Back once to dismiss it without closing the camera.
+                    xml_after = dev.dump_xml() or ""
+                    for node in dev.nodes(xml_after):
+                        desc = (dev.node_content_desc(node) or "").lower()
+                        text_n = (dev.node_text(node) or "").lower()
+                        if "close" in desc or "close" in text_n or "dismiss" in desc:
+                            b = dev.node_bounds(node)
+                            if b:
+                                dev.tap((b[0] + b[2]) // 2, (b[1] + b[3]) // 2)
+                                break
+                    else:
+                        # No close button found — tap outside the panel (top of screen)
+                        dev.adb("shell", "input", "keyevent", "KEYCODE_BACK")
+                    _time.sleep(0.3)
+                    result += f" | ⏱ {timer_s}s timer set"
+                else:
+                    result += " | ⚠️ timer button not found (tap it manually)"
+
+            return result
+        elif name == "speak_text":
+            from gitd.services.device_context import speak_text as _speak
+
+            return _speak(device, args["text"], float(args.get("rate", 1.0)))
+        elif name == "toggle_overlay":
+            ok = ctx.toggle_overlay(device, bool(args.get("visible", True)))
+            return (
+                f"Overlay {'enabled' if args.get('visible', True) else 'disabled'}"
+                if ok
+                else "Failed — Portal not available"
+            )
         elif name == "force_stop":
+            if is_ios_ref(device):
+                get_device(device).terminate_app(args["package"])
+                return f"Stopped iOS app {args['package']}"
             Device(device).adb("shell", "am", "force-stop", args["package"])
             return f"Stopped {args['package']}"
+        elif name == "app_state":
+            return json.dumps(ctx.app_state(device, args["package"]), indent=2)
+        elif name == "launch_intent":
+            return ctx.launch_intent(
+                device,
+                action=args.get("action", ""),
+                data=args.get("data", ""),
+                package=args.get("package", ""),
+                component=args.get("component", ""),
+                extras=args.get("extras") or None,
+            )
+        elif name == "web_search":
+            if is_ios_ref(device):
+                from gitd.services.browser import dumps
+                from gitd.services.browser import web_search as _web_search
+
+                return dumps(
+                    _web_search(
+                        device,
+                        args["query"],
+                        engine=args.get("engine", "google"),
+                        bundle_id=args.get("bundle_id") or None,
+                    )
+                )
+            from gitd.services.web_search import open_search
+
+            return open_search(device, args["query"], engine=args.get("engine", "google"))
+        elif name == "open_url":
+            from gitd.services.browser import dumps
+            from gitd.services.browser import open_url as _open_url
+
+            return dumps(_open_url(device, args["url"], bundle_id=args.get("bundle_id") or None))
+        elif name == "browser_back":
+            from gitd.services.browser import browser_back as _browser_back
+            from gitd.services.browser import dumps
+
+            return dumps(_browser_back(device))
+        elif name == "get_current_url":
+            from gitd.services.browser import dumps
+            from gitd.services.browser import get_current_url as _get_current_url
+
+            return dumps(_get_current_url(device))
+        elif name == "wait_for_text":
+            from gitd.services.browser import dumps
+            from gitd.services.browser import wait_for_text as _wait_for_text
+
+            return dumps(_wait_for_text(device, args["text"], timeout=float(args.get("timeout", 12.0))))
+        elif name == "extract_visible_text":
+            from gitd.services.browser import dumps
+            from gitd.services.browser import extract_visible_text as _extract_visible_text
+
+            return dumps(
+                _extract_visible_text(
+                    device,
+                    max_lines=int(args.get("max_lines", 200)),
+                    include_controls=bool(args.get("include_controls", False)),
+                )
+            )
+        elif name == "extract_articles":
+            from gitd.services.browser import dumps
+            from gitd.services.browser import extract_articles as _extract_articles
+
+            return dumps(_extract_articles(device, max_items=int(args.get("max_items", 5))))
+        elif name == "read_news":
+            from gitd.services.browser import dumps
+            from gitd.services.browser import read_news as _read_news
+
+            return dumps(
+                _read_news(
+                    device,
+                    args.get("url", "https://text.npr.org/"),
+                    max_headlines=int(args.get("max_headlines", 5)),
+                    max_articles=int(args.get("max_articles", 3)),
+                    bundle_id=args.get("bundle_id") or None,
+                    wait_s=float(args.get("wait_s", 2.0)),
+                    save_screenshots=bool(args.get("save_screenshots", False)),
+                )
+            )
         elif name == "list_apps" or name == "search_apps":
-            out = Device(device).adb("shell", "pm", "list", "packages", timeout=10)
-            pkgs = [p.replace("package:", "").strip() for p in out.splitlines() if p.startswith("package:")]
-            # Known app names for common packages
-            KNOWN = {
-                "com.zhiliaoapp.musically": "TikTok",
-                "com.instagram.android": "Instagram",
-                "com.facebook.katana": "Facebook",
-                "com.facebook.orca": "Messenger",
-                "com.whatsapp": "WhatsApp",
-                "com.twitter.android": "X (Twitter)",
-                "com.snapchat.android": "Snapchat",
-                "com.google.android.youtube": "YouTube",
-                "com.google.android.apps.youtube.music": "YouTube Music",
-                "com.google.android.apps.maps": "Google Maps",
-                "com.google.android.gm": "Gmail",
-                "com.google.android.apps.photos": "Google Photos",
-                "com.google.android.apps.docs": "Google Drive",
-                "com.android.chrome": "Chrome",
-                "com.android.vending": "Play Store",
-                "org.telegram.messenger": "Telegram",
-                "com.discord": "Discord",
-                "com.reddit.frontpage": "Reddit",
-                "com.spotify.music": "Spotify",
-                "com.amazon.mShop.android.shopping": "Amazon",
-                "com.tinder": "Tinder",
-                "com.bumble.app": "Bumble",
-                "co.hinge.app": "Hinge",
-                "com.nordvpn.android": "NordVPN",
-                "com.anydesk.adcontrol.ad1": "AnyDesk",
-                "com.google.android.calendar": "Calendar",
-                "com.google.android.contacts": "Contacts",
-                "com.google.android.dialer": "Phone",
-                "com.android.camera": "Camera",
-                "com.sec.android.app.camera": "Camera",
-                "com.android.settings": "Settings",
-                "com.android.calculator2": "Calculator",
-                "com.android.deskclock": "Clock",
-                "com.sec.android.gallery3d": "Gallery",
-                "com.samsung.android.messaging": "Messages",
-                "com.samsung.android.dialer": "Phone",
-                "com.samsung.android.app.notes": "Samsung Notes",
-            }
-            apps = []
-            for pkg in pkgs:
-                name_guess = KNOWN.get(pkg, "")
-                if not name_guess:
-                    # Derive from package: com.example.myapp → myapp, capitalize
-                    last = pkg.split(".")[-1]
-                    name_guess = last.replace("_", " ").replace("-", " ").title()
-                apps.append({"name": name_guess, "package": pkg})
-            apps.sort(key=lambda a: a["name"].lower())
-            if name == "search_apps":
-                query = args.get("query", "").lower()
-                apps = [a for a in apps if query in a["name"].lower() or query in a["package"].lower()]
-            return json.dumps(apps, indent=2)
+            query = args.get("query", "") if name == "search_apps" else ""
+            return json.dumps(ctx.list_apps(device, query=query), indent=2)
         elif name == "list_packages":
-            out = Device(device).adb("shell", "pm", "list", "packages", "-3", timeout=15)
-            pkgs = [p.replace("package:", "").strip() for p in out.splitlines() if p.startswith("package:")]
-            return json.dumps(pkgs[:50])
+            return json.dumps(ctx.list_packages(device)[:50], indent=2)
+        elif name == "explore_app":
+            from pathlib import Path
+
+            package = args["package"]
+            script = Path(__file__).resolve().parents[1] / "skills" / "auto_creator.py"
+            project_dir = Path(__file__).resolve().parents[2]
+            max_depth = int(args.get("max_depth", 2))
+            max_states = int(args.get("max_states", 10))
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-u",
+                    str(script),
+                    "--package",
+                    package,
+                    "--device",
+                    device,
+                    "--max-depth",
+                    str(max_depth),
+                    "--max-states",
+                    str(max_states),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=300,
+                cwd=str(project_dir),
+            )
+            graph_path = project_dir / "data" / "app_explorer" / package / "state_graph.json"
+            if graph_path.exists():
+                return graph_path.read_text()[:10000]
+            output = result.stdout[-1000:]
+            if result.returncode != 0 and result.stderr:
+                output += f"\nSTDERR:\n{result.stderr[-1000:]}"
+            return f"Exploration finished. Output:\n{output}"
         elif name == "shell":
             out = Device(device).adb("shell", *args["command"].split(), timeout=15)
             return out[:3000]
+        elif name == "paste_text":
+            if is_ios_ref(device):
+                get_device(device).paste_text(args["text"])
+                t = args["text"]
+                return f"Inserted text on iOS: {t[:60]}{'...' if len(t) > 60 else ''}"
+            from gitd.bots.common.adb import Device as _Dev
+
+            ctx.clipboard_set(device, args["text"])
+            _Dev(device).adb("shell", "input", "keyevent", "KEYCODE_PASTE")
+            t = args["text"]
+            return f"Pasted: {t[:60]}{'…' if len(t) > 60 else ''}"
         elif name == "clipboard_get":
             return ctx.clipboard_get(device) or "(empty)"
         elif name == "clipboard_set":
@@ -419,31 +1587,63 @@ def _execute_tool_inner(name: str, args: dict) -> str:
             return "Clipboard set"
         elif name == "get_notifications":
             return json.dumps(ctx.get_notifications(device), indent=2)
+        elif name == "open_notifications":
+            if not ctx.open_notifications(device):
+                return "Failed"
+            return "Notification Center opened" if is_ios_ref(device) else "Notification shade opened"
+        elif name == "clear_notifications":
+            return "Notifications cleared" if ctx.clear_notifications(device) else "Failed"
         elif name == "list_skills":
             from gitd.routers.skills import _load_all_skills, _load_skill
 
             skills = _load_all_skills()
             result = []
+            target_device = args.get("device") or device
+            supported_only = bool(args.get("supported_only"))
             for sname, info in skills.items():
+                supported = skill_supports_device(info.get("metadata") or {}, target_device) if target_device else None
+                if supported_only and supported is False:
+                    continue
                 s = _load_skill(sname)
-                entry = {"name": info["name"], "app_package": info.get("app_package", "")}
+                entry = {
+                    "name": info["name"],
+                    "description": info.get("description", ""),
+                    "app_package": info.get("app_package", ""),
+                    "android_package": info.get("android_package", ""),
+                    "ios_bundle_id": info.get("ios_bundle_id", ""),
+                    "platforms": info.get("platforms", []),
+                    "supports_android": info.get("supports_android", False),
+                    "supports_ios": info.get("supports_ios", False),
+                    "platform_limitations": info.get("platform_limitations", {}),
+                    "default_params": info.get("default_params", {}),
+                }
+                if supported is not None:
+                    entry["supported_on_device"] = supported
                 if s and not isinstance(s, dict):
                     entry["workflows"] = s.list_workflows()
                     entry["actions"] = s.list_actions()
                 result.append(entry)
             return json.dumps(result, indent=2)
-        elif name == "run_skill":
+        elif name in {"run_skill", "run_workflow", "run_action"}:
+            from gitd.routers.skills import _load_all_skills
+
+            skills = _load_all_skills()
+            skill_info = skills.get(args["skill"])
+            if skill_info and not skill_supports_device(skill_info.get("metadata") or {}, device):
+                return skill_platform_error_text(args["skill"], skill_info.get("metadata") or {}, device)
             runner = __import__("pathlib").Path(__file__).parent.parent / "skills" / "_run_skill.py"
             params = json.dumps(args.get("params", {}))
+            mode_arg = "--action" if name == "run_action" else "--workflow"
+            target = args["action"] if name == "run_action" else args["workflow"]
             r = subprocess.run(
                 [
-                    "python3",
+                    sys.executable,
                     "-u",
                     str(runner),
                     "--skill",
                     args["skill"],
-                    "--workflow",
-                    args["workflow"],
+                    mode_arg,
+                    target,
                     "--device",
                     device,
                     "--params",
@@ -455,25 +1655,158 @@ def _execute_tool_inner(name: str, args: dict) -> str:
                 cwd=str(__import__("pathlib").Path(__file__).parent.parent.parent),
             )
             return r.stdout[-2000:] if r.returncode == 0 else f"FAILED: {r.stdout[-1000:]}\n{r.stderr[-500:]}"
+        elif name == "create_skill":
+            from gitd.services.skill_creation import create_recorded_skill
+
+            result = create_recorded_skill(
+                name=args["name"],
+                app_package=args.get("app_package", ""),
+                steps=args.get("steps", []),
+                platforms=args.get("platforms", []),
+                ios_bundle_id=args.get("ios_bundle_id", ""),
+                elements_ios=args.get("elements_ios") if "elements_ios" in args else None,
+                elements_android=args.get("elements_android") if "elements_android" in args else None,
+            )
+            return json.dumps(
+                {
+                    "ok": True,
+                    "skill": result["skill"],
+                    "steps": result["steps"],
+                    "dir": result["dir"],
+                    "platforms": result["platforms"],
+                    "metadata": result["metadata"],
+                },
+                indent=2,
+            )
+        elif name == "lookup_lead":
+            from gitd.services.marketing_lookup import lookup_lead
+
+            return lookup_lead(args["handle"])
+        elif name == "list_unread_leads":
+            from gitd.services.marketing_lookup import list_unread_leads
+
+            return list_unread_leads()
+        elif name == "crm_lookup_contact":
+            from gitd.services.crm_lookup import crm_lookup_contact
+
+            return crm_lookup_contact(args["handle"])
+        elif name == "crm_list_unread_messages":
+            from gitd.services.crm_lookup import crm_list_unread_messages
+
+            return crm_list_unread_messages()
+        elif name == "screenshot_sequence":
+            return _capture_sequence(device, args)
+        elif name == "sub_agent":
+            return _run_sub_agent_tool(device, args)
         elif name == "wait":
             time.sleep(args.get("seconds", 2))
             return f"Waited {args.get('seconds', 2)}s"
+        elif name == "chain":
+            return _execute_chain(device, args)
         else:
             return f"Unknown tool: {name}"
     except Exception as e:
         return f"Error: {e}"
 
-    # Auto-append screen tree after UI actions so agent sees result immediately
-    if name in _UI_ACTION_TOOLS and device and isinstance(result, str):
-        try:
-            import time as _t
 
-            _t.sleep(0.5)  # Brief settle time for UI to update
-            tree = ctx.get_screen_tree(device)
-            if tree and tree != "(empty screen)":
-                result += f"\n\n[Screen after action]\n{tree}"
-        except Exception:
-            pass
+# Cap on sub-actions per chain — a batch that big is almost certainly a
+# runaway; bound it so one chain call can't monopolise the device.
+_CHAIN_MAX_ACTIONS = 15
+_CHAIN_MAX_DELAY_S = 3.0
+_CHAIN_STABILIZE_S = 0.6
+
+
+def _execute_chain(device: str, args: dict) -> str:
+    """Run a sequence of sub-actions in one step, settling between each.
+
+    Fail-closed like run_flow: every sub-action's tool must be on
+    SAFE_DEVICE_TOOLS, and a chain may not nest another chain — a batch is
+    exactly where an injected instruction would try to smuggle an exec tool, so
+    the whole chain is refused before any sub-action runs if any step names a
+    non-allowed tool. Sub-actions dispatch via _execute_tool_inner (no
+    per-action screen-tree append); we settle between them instead.
+    """
+    import time
+
+    subs = args.get("actions")
+    if not isinstance(subs, list) or not subs:
+        return "chain: 'actions' must be a non-empty list of {tool, args}"
+    if len(subs) > _CHAIN_MAX_ACTIONS:
+        return f"chain: too many actions ({len(subs)} > {_CHAIN_MAX_ACTIONS})"
+
+    # Validate the WHOLE batch before running ANY of it, so a chain that hides a
+    # disallowed action after some benign steps executes nothing.
+    for i, sub in enumerate(subs):
+        if not isinstance(sub, dict) or "tool" not in sub:
+            return f"chain: step {i} must be an object with a 'tool' field"
+        tool = sub["tool"]
+        if tool == "chain":
+            return f"chain: step {i} may not nest another chain"
+        if tool not in SAFE_DEVICE_TOOLS:
+            return f"chain: step {i} tool '{tool}' is not allowed inside a chain (only read/UI tools)"
+
+    settle = args.get("settle", "stabilize")
+    delay_s = min(max(int(args.get("delay_ms", 600)), 0) / 1000, _CHAIN_MAX_DELAY_S)
+
+    infos: list[str] = []
+    for i, sub in enumerate(subs):
+        tool = sub["tool"]
+        sub_args = dict(sub.get("args") or {})
+        sub_args.setdefault("device", device)
+        try:
+            out = _execute_tool_inner(tool, sub_args)
+            infos.append(f"{tool}: {str(out)[:80]}")
+        except Exception as e:
+            infos.append(f"{tool}: err:{e}")
+            break  # abort the rest of the chain on the first hard failure
+        if i < len(subs) - 1:
+            time.sleep(delay_s if settle == "delay" else _CHAIN_STABILIZE_S)
+
+    return f"chain[{len(infos)}/{len(subs)}]: " + " > ".join(infos)
+
+
+# Per-device burst of frames captured by screenshot_sequence, read by sub_agent.
+# Module-level so it survives across tool calls (and works inside a chain step).
+_SEQ_FRAMES: dict[str, list[str]] = {}
+
+_SEQ_MAX_DURATION_S = 180
+_SEQ_MAX_FPS = 4.0
+
+
+def _capture_sequence(device: str, args: dict) -> str:
+    """Poll per-frame screenshots over a window, caching them for sub_agent.
+
+    Uses the normal screenshot path (screencap on Android / WDA on iOS) rather than
+    a video recorder: a recorder can freeze on a playing SurfaceView, but per-frame
+    screenshots capture playing content fine. Frames are cached (NOT returned) so
+    they never bloat the master agent's context — sub_agent reads them.
+    """
+    import time as _t
+
+    dur = max(2, min(int(args.get("duration_seconds", args.get("seconds", 4))), _SEQ_MAX_DURATION_S))
+    fps = max(0.1, min(float(args.get("fps", 1.0)), _SEQ_MAX_FPS))
+    interval = 1.0 / fps
+    n = max(1, int(dur * fps))
+    frames: list[str] = []
+    for i in range(n):
+        shot = get_screenshot_b64(device)
+        if shot:
+            frames.append(shot)
+        if i < n - 1:
+            _t.sleep(interval)
+    _SEQ_FRAMES[device] = frames
+    return f"screenshot_sequence: captured {len(frames)} frames over {dur}s @ {fps}fps (cached for sub_agent)"
+
+
+def _run_sub_agent_tool(device: str, args: dict) -> str:
+    """Hand the cached frames for this device to the vision sub-agent; return its text."""
+    from gitd.services.sub_agent import run_sub_agent
+
+    task = args.get("task", "") or args.get("prompt", "")
+    frames = _SEQ_FRAMES.get(device) or []
+    result = run_sub_agent(task, frames, max_frames=int(args.get("max_frames", 60)))
+    if frames and not result.startswith(("sub_agent", "SUB_AGENT")):
+        return f"SUB_AGENT RESULT ({len(frames)} frames): {result}"
     return result
 
 

--- a/gitd/services/browser.py
+++ b/gitd/services/browser.py
@@ -1,0 +1,994 @@
+"""Platform-aware browser helpers."""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+import urllib.parse
+from pathlib import Path
+from typing import Any, Callable
+
+from gitd.bots.common.device import get_device, is_ios_ref
+
+_ENGINE_URLS = {
+    "google": "https://www.google.com/search?q={query}",
+    "ddg": "https://duckduckgo.com/?q={query}",
+    "duckduckgo": "https://duckduckgo.com/?q={query}",
+    "bing": "https://www.bing.com/search?q={query}",
+    "brave": "https://search.brave.com/search?q={query}",
+}
+
+
+def _normalize_url(url: str) -> str:
+    cleaned = url.strip()
+    if cleaned and "://" not in cleaned:
+        cleaned = "https://" + cleaned
+    return cleaned
+
+
+def _urls_equivalent(left: str | None, right: str | None) -> bool:
+    if not left or not right:
+        return False
+    try:
+        left_parts = urllib.parse.urlparse(_normalize_url(left))
+        right_parts = urllib.parse.urlparse(_normalize_url(right))
+    except Exception:
+        return str(left).strip().rstrip("/") == str(right).strip().rstrip("/")
+    left_path = (left_parts.path or "/").rstrip("/") or "/"
+    right_path = (right_parts.path or "/").rstrip("/") or "/"
+    return (
+        left_parts.netloc.lower() == right_parts.netloc.lower()
+        and left_path == right_path
+        and left_parts.query == right_parts.query
+    )
+
+
+def _search_url(query: str, engine: str = "google") -> str:
+    template = _ENGINE_URLS.get(engine.lower(), _ENGINE_URLS["google"])
+    return template.format(query=urllib.parse.quote_plus(query))
+
+
+def _set_ios_bundle_override(dev, bundle_id: str | None) -> None:
+    if not bundle_id:
+        return
+    if hasattr(dev, "set_target_app"):
+        dev.set_target_app(bundle_id=bundle_id)
+    else:
+        dev.bundle_id = bundle_id
+
+
+def _platform(device: str) -> str:
+    return "ios" if is_ios_ref(device) else "android"
+
+
+def _error_text(exc: Exception) -> str:
+    return str(exc) or exc.__class__.__name__
+
+
+def _browser_error(device: str, operation: str, exc: Exception, **extra: Any) -> dict[str, Any]:
+    return {
+        "ok": False,
+        "platform": _platform(device),
+        "device": device,
+        "operation": operation,
+        "error": _error_text(exc),
+        **extra,
+    }
+
+
+def open_url(device: str, url: str, bundle_id: str | None = None) -> dict[str, Any]:
+    normalized_url = _normalize_url(url)
+    try:
+        if is_ios_ref(device):
+            dev = get_device(device)
+            _set_ios_bundle_override(dev, bundle_id)
+            navigation = dev.open_url(normalized_url)
+            current_url = ""
+            current_url_error = ""
+            try:
+                current_url = dev.get_current_url() or ""
+            except Exception as exc:
+                current_url_error = str(exc)
+            if not current_url and isinstance(navigation, dict):
+                current_url = str(navigation.get("url") or "")
+            result = {
+                "ok": navigation.get("ok", True) if isinstance(navigation, dict) else True,
+                "platform": "ios",
+                "url": current_url or normalized_url,
+                "navigation": navigation if isinstance(navigation, dict) else {},
+            }
+            if current_url_error:
+                result["current_url_error"] = current_url_error
+            return result
+
+        from gitd.services.device_context import launch_intent
+
+        out = launch_intent(device, action="android.intent.action.VIEW", data=normalized_url)
+        return {"ok": not out.lower().startswith("error"), "platform": "android", "result": out, "url": normalized_url}
+    except Exception as exc:
+        return _browser_error(device, "open_url", exc, url=normalized_url)
+
+
+def web_search(device: str, query: str, engine: str = "google", bundle_id: str | None = None) -> dict[str, Any]:
+    url = _search_url(query, engine)
+    result = open_url(device, url, bundle_id=bundle_id)
+    result["query"] = query
+    result["engine"] = engine
+    return result
+
+
+def browser_back(device: str) -> dict[str, Any]:
+    try:
+        dev = get_device(device)
+        if is_ios_ref(device) and hasattr(dev, "browser_back"):
+            dev.browser_back()
+        else:
+            dev.back()
+        return {"ok": True, "platform": _platform(device)}
+    except Exception as exc:
+        return _browser_error(device, "browser_back", exc)
+
+
+def get_current_url(device: str) -> dict[str, Any]:
+    try:
+        dev = get_device(device)
+    except Exception as exc:
+        return _browser_error(device, "get_current_url", exc, url="")
+    if is_ios_ref(device) and hasattr(dev, "get_current_url"):
+        try:
+            current_url = dev.get_current_url() or ""
+        except Exception as exc:
+            return {"ok": False, "platform": "ios", "url": "", "error": str(exc)}
+        if current_url:
+            return {"ok": True, "platform": "ios", "url": current_url}
+        return {
+            "ok": False,
+            "platform": "ios",
+            "url": "",
+            "error": "Current URL is not exposed by the active iOS browser context",
+        }
+    return {"ok": False, "platform": "android", "error": "Current URL is not implemented for Android yet"}
+
+
+def wait_for_text(device: str, text: str, timeout: float = 12.0) -> dict[str, Any]:
+    try:
+        dev = get_device(device)
+    except Exception as exc:
+        return _browser_error(device, "wait_for_text", exc, text=text, found=False, visible_text="")
+    if is_ios_ref(device) and hasattr(dev, "wait_for_text"):
+        try:
+            visible = dev.wait_for_text(text, timeout=timeout)
+            return {"ok": True, "platform": "ios", "text": text, "found": True, "visible_text": visible}
+        except Exception as exc:
+            visible = ""
+            try:
+                visible = dev.extract_visible_text(max_lines=120)
+            except Exception:
+                pass
+            return {
+                "ok": False,
+                "platform": "ios",
+                "text": text,
+                "found": False,
+                "timeout": timeout,
+                "visible_text": visible,
+                "error": str(exc),
+            }
+
+    from gitd.services.device_context import find_on_screen
+
+    timeout = max(0.0, float(timeout))
+    interval = 0.5
+    deadline = _retry_deadline(timeout)
+    attempts = 0
+    while True:
+        attempts += 1
+        try:
+            found = find_on_screen(device, text)
+        except Exception as exc:
+            return _browser_error(
+                device,
+                "wait_for_text",
+                exc,
+                text=text,
+                found=False,
+                match=None,
+                attempts=attempts,
+                timeout=timeout,
+            )
+        if found:
+            return {
+                "ok": True,
+                "platform": "android",
+                "text": text,
+                "found": True,
+                "match": found,
+                "attempts": attempts,
+                "timeout": timeout,
+            }
+        remaining = deadline - time.time()
+        if remaining <= 0:
+            return {
+                "ok": False,
+                "platform": "android",
+                "text": text,
+                "found": False,
+                "match": None,
+                "attempts": attempts,
+                "timeout": timeout,
+            }
+        time.sleep(min(interval, remaining))
+
+
+def extract_visible_text(device: str, max_lines: int = 200, include_controls: bool = False) -> dict[str, Any]:
+    try:
+        dev = get_device(device)
+    except Exception as exc:
+        return _browser_error(device, "extract_visible_text", exc, text="", lines=[], source="")
+    if is_ios_ref(device) and hasattr(dev, "extract_visible_text"):
+        extraction_error = ""
+        source = "native_or_web"
+        try:
+            text, source = _device_visible_text(dev, max_lines=max_lines, include_controls=include_controls)
+        except Exception as exc:
+            extraction_error = _error_text(exc)
+            text = ""
+        if not text.strip() and not include_controls:
+            text = _ocr_visible_text(device, max_lines=max_lines)
+            source = "ocr" if text.strip() else source
+        if text.strip():
+            result = {"ok": True, "platform": "ios", "text": text, "lines": text.splitlines(), "source": source}
+            if extraction_error:
+                result["extraction_error"] = extraction_error
+            return result
+        if extraction_error:
+            return _browser_error(
+                device,
+                "extract_visible_text",
+                RuntimeError(extraction_error),
+                text="",
+                lines=[],
+                source=source,
+            )
+        return {"ok": True, "platform": "ios", "text": text, "lines": [], "source": source}
+
+    from gitd.services.device_context import get_interactive_elements
+
+    try:
+        lines = []
+        for element in get_interactive_elements(device, interactive_only=False):
+            label = element.get("text") or element.get("content_desc") or ""
+            if label and label not in lines:
+                lines.append(label)
+            if len(lines) >= max_lines:
+                break
+        return {"ok": True, "platform": "android", "text": "\n".join(lines), "lines": lines}
+    except Exception as exc:
+        return _browser_error(device, "extract_visible_text", exc, text="", lines=[], source="")
+
+
+def extract_articles(device: str, max_items: int = 5) -> dict[str, Any]:
+    try:
+        dev = get_device(device)
+    except Exception as exc:
+        return _browser_error(device, "extract_articles", exc, articles=[], source="")
+    if is_ios_ref(device) and hasattr(dev, "extract_articles"):
+        extraction_error = ""
+        source = "native_or_web"
+        try:
+            articles = _dedupe_article_candidates(dev.extract_articles(max_items=max_items * 2), max_items=max_items)
+            source = _article_source(articles) or source
+        except Exception as exc:
+            extraction_error = _error_text(exc)
+            articles = []
+        if not articles:
+            articles = _ocr_articles(device, max_items=max_items)
+            source = "ocr" if articles else source
+        if articles:
+            result = {"ok": True, "platform": "ios", "articles": articles, "source": source}
+            if extraction_error:
+                result["extraction_error"] = extraction_error
+            return result
+        if extraction_error:
+            return _browser_error(
+                device,
+                "extract_articles",
+                RuntimeError(extraction_error),
+                articles=[],
+                source=source,
+            )
+        return {"ok": True, "platform": "ios", "articles": articles, "source": source}
+
+    visible = extract_visible_text(device, max_lines=200)
+    if not visible.get("ok", True):
+        return {
+            "ok": False,
+            "platform": "android",
+            "articles": [],
+            "error": visible.get("error", "visible text extraction failed"),
+        }
+    articles = [{"title": line} for line in visible.get("lines", []) if len(line) > 18][:max_items]
+    return {"ok": True, "platform": "android", "articles": articles}
+
+
+def _snippet(text: str, max_chars: int = 1800) -> str:
+    lines = []
+    seen = set()
+    for raw in text.splitlines():
+        line = re.sub(r"\s+", " ", raw).strip()
+        if not line or line in seen:
+            continue
+        seen.add(line)
+        lines.append(line)
+        if sum(len(item) for item in lines) > max_chars:
+            break
+    return "\n".join(lines)[:max_chars]
+
+
+def _content_line_count(text: str) -> int:
+    return len([line for line in text.splitlines() if line.strip()])
+
+
+def _article_has_body(article: dict[str, Any]) -> bool:
+    if not article.get("opened"):
+        return False
+    text = str(article.get("body_snippet") or "")
+    return _article_text_has_body(text, source_headline=str(article.get("source_headline") or ""))
+
+
+_NON_ARTICLE_BODY_LINES = {
+    "advertisement",
+    "back",
+    "close",
+    "home",
+    "listen",
+    "menu",
+    "more",
+    "next",
+    "previous",
+    "read more",
+    "refresh",
+    "search",
+    "sections",
+    "share",
+    "sponsor message",
+    "subscribe",
+}
+
+
+def _article_text_has_body(text: str, *, source_headline: str = "") -> bool:
+    lines = [re.sub(r"\s+", " ", line).strip() for line in text.splitlines() if line.strip()]
+    if not lines:
+        return False
+
+    # Some iOS WebView/WDA contexts expose article pages as one paragraph rather
+    # than separate title/body nodes. Count a substantial single paragraph as
+    # body text, but keep title-only and toolbar-only extraction as partial.
+    title_like: set[str] = set()
+    if source_headline:
+        title_like.add(re.sub(r"\s+", " ", source_headline).strip().lower())
+    body_lines = [
+        line for line in lines if line.lower() not in title_like and line.lower() not in _NON_ARTICLE_BODY_LINES
+    ]
+    if not body_lines:
+        return False
+    for line in body_lines:
+        words = re.findall(r"[A-Za-z0-9]+", line)
+        if len(line) >= 80 or len(words) >= 14:
+            return True
+        if len(line) >= 20 and len(words) >= 4:
+            return True
+    combined = " ".join(body_lines)
+    return len(combined) >= 35 and len(re.findall(r"[A-Za-z0-9]+", combined)) >= 6
+
+
+def _article_text_confirms_open_page(text: str, *, source_headline: str = "") -> bool:
+    if not _article_text_has_body(text, source_headline=source_headline):
+        return False
+    lines = [re.sub(r"\s+", " ", line).strip() for line in text.splitlines() if line.strip()]
+    lower_lines = [line.lower() for line in lines]
+    normalized_headline = re.sub(r"\s+", " ", source_headline or "").strip().lower()
+    if normalized_headline and normalized_headline not in lower_lines:
+        return False
+    if any(line.startswith("by ") for line in lower_lines):
+        return True
+    date_pattern = (
+        r"\b(?:jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec|"
+        r"monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b"
+    )
+    if any(re.search(date_pattern, line) and re.search(r"\b20\d{2}\b", line) for line in lower_lines):
+        return True
+    return len(lines) >= 6 and any(len(re.findall(r"[A-Za-z0-9]+", line)) >= 12 for line in lines)
+
+
+def _article_source(articles: list[dict[str, Any]]) -> str:
+    sources = sorted(
+        {str(article.get("provenance") or "").strip() for article in articles if article.get("provenance")}
+    )
+    if not sources:
+        return ""
+    return sources[0] if len(sources) == 1 else "mixed:" + ",".join(sources)
+
+
+def _entry_source(entries: list[dict[str, Any]]) -> str:
+    sources = sorted({str(entry.get("provenance") or "").strip() for entry in entries if entry.get("provenance")})
+    if not sources:
+        return "native_or_web"
+    return sources[0] if len(sources) == 1 else "mixed:" + ",".join(sources)
+
+
+def _device_visible_text(dev, *, max_lines: int, include_controls: bool = False) -> tuple[str, str]:
+    if hasattr(dev, "visible_text_entries"):
+        try:
+            entries = dev.visible_text_entries(include_controls=include_controls, max_entries=max_lines)
+            if entries:
+                return "\n".join(str(entry.get("text") or "") for entry in entries[:max_lines]), _entry_source(entries)
+        except Exception:
+            pass
+    text = dev.extract_visible_text(max_lines=max_lines)
+    return text, "native_or_web"
+
+
+def _looks_like_article_title(text: str) -> bool:
+    cleaned = re.sub(r"\s+", " ", text or "").strip()
+    if len(cleaned) < 18:
+        return False
+    lower = cleaned.lower()
+    if lower.startswith(("http://", "https://", "www.")):
+        return False
+    if lower in {"home", "menu", "sections", "search", "sponsor message", "advertisement"}:
+        return False
+    words = re.findall(r"[A-Za-z0-9]+", cleaned)
+    return len(words) >= 4
+
+
+def _article_title_key(article: dict[str, Any]) -> str:
+    title = re.sub(
+        r"\W+",
+        "",
+        str(article.get("title") or article.get("source_headline") or article.get("text") or "").lower(),
+    )
+    return f"text:{title}" if title else ""
+
+
+def _article_candidate_keys(article: dict[str, Any]) -> list[str]:
+    keys: list[str] = []
+    url = str(article.get("url") or "").strip()
+    if url:
+        try:
+            parsed = urllib.parse.urlparse(url)
+            keys.append(f"url:{parsed.netloc.lower()}{parsed.path.rstrip('/').lower()}")
+        except Exception:
+            keys.append(f"url:{url.lower()}")
+    title_key = _article_title_key(article)
+    if title_key:
+        keys.append(title_key)
+    return keys
+
+
+def _article_candidate_quality(article: dict[str, Any]) -> int:
+    score = 0
+    if article.get("url"):
+        score += 30
+    if article.get("provenance") == "web_context":
+        score += 20
+    if article.get("center"):
+        score += 8
+    if article.get("bounds"):
+        score += 5
+    if str(article.get("class") or "").lower() in {"a", "h1", "h2", "h3"}:
+        score += 5
+    score += min(len(str(article.get("title") or "").split()), 10)
+    return score
+
+
+def _dedupe_article_candidates(articles: list[dict[str, Any]], *, max_items: int | None = None) -> list[dict[str, Any]]:
+    ordered_keys: list[str] = []
+    by_key: dict[str, dict[str, Any]] = {}
+    quality: dict[str, int] = {}
+    aliases: dict[str, str] = {}
+    for index, article in enumerate(articles or []):
+        keys = _article_candidate_keys(article) or [f"index:{index}"]
+        key = next((aliases[item] for item in keys if item in aliases), keys[0])
+        score = _article_candidate_quality(article)
+        if key not in by_key:
+            ordered_keys.append(key)
+            by_key[key] = article
+            quality[key] = score
+        elif score > quality[key]:
+            by_key[key] = article
+            quality[key] = score
+        for alias in keys:
+            aliases[alias] = key
+    deduped = [by_key[key] for key in ordered_keys]
+    return deduped[:max_items] if max_items is not None else deduped
+
+
+def _ocr_entries(device: str, *, max_items: int = 200) -> list[dict[str, Any]]:
+    try:
+        from gitd.services.device_context import ocr_screen
+
+        raw_entries = ocr_screen(device)
+    except Exception:
+        return []
+
+    entries: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for raw in raw_entries:
+        text = re.sub(r"\s+", " ", str(raw.get("text") or "")).strip()
+        if not text:
+            continue
+        key = text.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        x = int(raw.get("x") or 0)
+        y = int(raw.get("y") or 0)
+        w = int(raw.get("w") or 0)
+        h = int(raw.get("h") or 0)
+        entries.append(
+            {
+                "text": text,
+                "bounds": {"x1": x, "y1": y, "x2": x + w, "y2": y + h},
+                "center": {"x": x + w // 2, "y": y + h // 2},
+                "class": "ocr",
+                "resource_id": "",
+                "content_desc": "",
+                "url": "",
+                "provenance": "ocr",
+                "confidence": raw.get("conf"),
+            }
+        )
+        if len(entries) >= max_items:
+            break
+    return entries
+
+
+def _ocr_visible_text(device: str, *, max_lines: int = 200) -> str:
+    return "\n".join(entry["text"] for entry in _ocr_entries(device, max_items=max_lines))
+
+
+def _ocr_articles(device: str, *, max_items: int = 5) -> list[dict[str, Any]]:
+    articles: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for entry in _ocr_entries(device, max_items=200):
+        title = entry["text"].strip()
+        if not _looks_like_article_title(title):
+            continue
+        key = re.sub(r"\W+", "", title.lower())
+        if key in seen:
+            continue
+        seen.add(key)
+        articles.append(
+            {
+                "title": title,
+                "url": "",
+                "bounds": entry["bounds"],
+                "center": entry["center"],
+                "class": "ocr",
+                "provenance": "ocr",
+                "confidence": entry.get("confidence"),
+            }
+        )
+        if len(articles) >= max_items:
+            break
+    return articles
+
+
+def _save_device_screenshot(dev, path: Path) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(dev.take_screenshot())
+    return str(path)
+
+
+def _retry_deadline(timeout: float) -> float:
+    return time.time() + max(0.0, float(timeout))
+
+
+def _extract_articles_with_retry(
+    device: str,
+    dev,
+    *,
+    max_items: int,
+    min_items: int | None = None,
+    timeout: float,
+    interval: float = 0.5,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    requested = int(min_items if min_items is not None else max_items)
+    target_items = min(max(0, int(max_items)), max(0, requested))
+    if target_items <= 0:
+        return [], {
+            "requested": max_items,
+            "target": target_items,
+            "returned": 0,
+            "ready": True,
+            "attempts": 0,
+            "source": "",
+        }
+    deadline = _retry_deadline(timeout)
+    best: list[dict[str, Any]] = []
+    best_source = ""
+    attempts = 0
+    while True:
+        attempts += 1
+        try:
+            articles = _dedupe_article_candidates(dev.extract_articles(max_items=max_items * 2), max_items=max_items)
+            if len(articles or []) > len(best):
+                best = articles or []
+                best_source = _article_source(best) or "native_or_web"
+            if len(articles or []) >= target_items:
+                return articles, {
+                    "requested": max_items,
+                    "target": target_items,
+                    "returned": len(articles or []),
+                    "ready": True,
+                    "attempts": attempts,
+                    "source": _article_source(articles or []) or "native_or_web",
+                }
+        except Exception:
+            pass
+        if is_ios_ref(device):
+            ocr_articles = _ocr_articles(device, max_items=max_items)
+            if len(ocr_articles or []) > len(best):
+                best = ocr_articles or []
+                best_source = "ocr"
+            if len(ocr_articles or []) >= target_items:
+                return ocr_articles, {
+                    "requested": max_items,
+                    "target": target_items,
+                    "returned": len(ocr_articles or []),
+                    "ready": True,
+                    "attempts": attempts,
+                    "source": "ocr",
+                }
+        if time.time() >= deadline:
+            return best, {
+                "requested": max_items,
+                "target": target_items,
+                "returned": len(best),
+                "ready": len(best) >= target_items,
+                "attempts": attempts,
+                "source": best_source,
+            }
+        time.sleep(interval)
+
+
+def _extract_visible_text_with_retry(
+    device: str,
+    dev,
+    *,
+    max_lines: int,
+    min_lines: int = 1,
+    timeout: float,
+    interval: float = 0.5,
+    is_ready: Callable[[str], bool] | None = None,
+) -> tuple[str, dict[str, Any]]:
+    target_lines = max(1, int(min_lines))
+    deadline = _retry_deadline(timeout)
+    best = ""
+    best_source = ""
+    attempts = 0
+    while True:
+        attempts += 1
+        try:
+            text, source = _device_visible_text(dev, max_lines=max_lines)
+            if _content_line_count(text) > _content_line_count(best):
+                best = text
+                best_source = source
+            ready = _content_line_count(text) >= target_lines and (is_ready(text) if is_ready else True)
+            if ready:
+                return text, {
+                    "requested_lines": max_lines,
+                    "target_lines": target_lines,
+                    "returned_lines": _content_line_count(text),
+                    "ready": True,
+                    "attempts": attempts,
+                    "source": source,
+                }
+        except Exception:
+            pass
+        if is_ios_ref(device):
+            ocr_text = _ocr_visible_text(device, max_lines=max_lines)
+            if _content_line_count(ocr_text) > _content_line_count(best):
+                best = ocr_text
+                best_source = "ocr"
+            ready = _content_line_count(ocr_text) >= target_lines and (is_ready(ocr_text) if is_ready else True)
+            if ready:
+                return ocr_text, {
+                    "requested_lines": max_lines,
+                    "target_lines": target_lines,
+                    "returned_lines": _content_line_count(ocr_text),
+                    "ready": True,
+                    "attempts": attempts,
+                    "source": "ocr",
+                }
+        if time.time() >= deadline:
+            ready = _content_line_count(best) >= target_lines and (is_ready(best) if is_ready else True)
+            return best, {
+                "requested_lines": max_lines,
+                "target_lines": target_lines,
+                "returned_lines": _content_line_count(best),
+                "ready": ready,
+                "attempts": attempts,
+                "source": best_source,
+            }
+        time.sleep(interval)
+
+
+def _tap_article_candidate(dev, article: dict[str, Any], *, delay: float = 1.5) -> tuple[str, dict[str, Any]]:
+    center = article.get("center") if isinstance(article.get("center"), dict) else {}
+    if center.get("x") is not None and center.get("y") is not None:
+        dev.tap(int(center["x"]), int(center["y"]), delay=delay)
+        return "center", {}
+
+    bounds = article.get("bounds") if isinstance(article.get("bounds"), dict) else {}
+    if {"x1", "y1", "x2", "y2"} <= set(bounds):
+        x = (int(bounds["x1"]) + int(bounds["x2"])) // 2
+        y = (int(bounds["y1"]) + int(bounds["y2"])) // 2
+        dev.tap(x, y, delay=delay)
+        return "bounds", {}
+
+    raise RuntimeError("article candidate has no URL or tappable geometry")
+
+
+def _open_article_candidate(dev, article: dict[str, Any], *, delay: float = 1.5) -> tuple[str, dict[str, Any]]:
+    url = str(article.get("url") or "").strip()
+    url_errors: list[dict[str, Any]] = []
+    if url:
+        try:
+            navigation = dev.open_url(url, delay=delay)
+            if not isinstance(navigation, dict) or navigation.get("ok", True):
+                return "url", navigation if isinstance(navigation, dict) else {}
+            url_errors.append({"method": "url", "navigation": navigation})
+        except Exception as exc:
+            url_errors.append({"method": "url", "error": str(exc)})
+
+    try:
+        method, navigation = _tap_article_candidate(dev, article, delay=delay)
+        if url_errors:
+            navigation = {**navigation, "fallback_from": "url", "fallback_errors": url_errors}
+        return method, navigation
+    except Exception:
+        if url and url_errors:
+            first = url_errors[0]
+            if "navigation" in first:
+                navigation = first["navigation"]
+                error = navigation.get("error") or navigation.get("state") or "article URL navigation failed"
+                raise RuntimeError(f"article URL navigation failed: {error}")
+            raise RuntimeError(str(first.get("error") or "article URL navigation failed"))
+        raise
+
+
+def _return_to_front_page_after_article(
+    dev, front_page_url: str, source_headline: str, *, delay: float
+) -> dict[str, Any]:
+    result: dict[str, Any] = {"method": "back", "reopened_front_page": False}
+    try:
+        dev.browser_back(delay=1.0)
+    except Exception as exc:
+        result["back_error"] = str(exc)
+
+    try:
+        visible_text = dev.extract_visible_text(max_lines=80)
+    except Exception as exc:
+        result["verification_error"] = str(exc)
+        visible_text = ""
+
+    if visible_text and _article_text_confirms_open_page(visible_text, source_headline=source_headline):
+        navigation = dev.open_url(front_page_url, delay=max(1.0, delay))
+        result["method"] = "open_url"
+        result["reopened_front_page"] = True
+        if isinstance(navigation, dict):
+            result["navigation"] = navigation
+    return result
+
+
+def read_news(
+    device: str,
+    url: str = "https://text.npr.org/",
+    *,
+    max_headlines: int = 5,
+    max_articles: int = 3,
+    bundle_id: str | None = None,
+    wait_s: float = 2.0,
+    save_screenshots: bool = False,
+    out_dir: str | None = None,
+) -> dict[str, Any]:
+    """Open a news page and return headlines plus article snippets.
+
+    This is currently an iOS-first workflow because WDA/WebView extraction can
+    expose article URLs and text. Android agents can still compose the primitive
+    browser tools directly.
+    """
+    if not is_ios_ref(device):
+        return {
+            "ok": False,
+            "platform": "android",
+            "error": "read_news is currently implemented for iOS browser/WebDriver sessions",
+        }
+
+    max_headlines = max(1, int(max_headlines))
+    max_articles = max(0, int(max_articles))
+    wait_s = max(0.0, float(wait_s))
+    out_path = Path(out_dir or "data/ios_chrome_news_smoke")
+    normalized_url = _normalize_url(url)
+    result: dict[str, Any] = {
+        "ok": False,
+        "platform": "ios",
+        "device": device,
+        "bundle_id": bundle_id or "",
+        "url": normalized_url,
+        "headlines": [],
+        "articles": [],
+        "screenshots": {},
+        "extraction": {
+            "headlines": {},
+            "front_page_text": {},
+            "articles": [],
+        },
+        "errors": [],
+    }
+
+    try:
+        dev = get_device(device)
+        _set_ios_bundle_override(dev, bundle_id)
+        result["bundle_id"] = getattr(dev, "bundle_id", bundle_id or "")
+
+        launch_bundle = getattr(dev, "bundle_id", "") or bundle_id or ""
+        if launch_bundle:
+            try:
+                dev.launch_app(launch_bundle)
+            except Exception as exc:
+                result["errors"].append({"stage": "launch", "error": str(exc)})
+
+        navigation = dev.open_url(normalized_url, delay=wait_s)
+        if isinstance(navigation, dict):
+            result["navigation"] = navigation
+        elif wait_s:
+            time.sleep(wait_s)
+
+        if save_screenshots:
+            result["screenshots"]["front_page"] = _save_device_screenshot(dev, out_path / "front_page.png")
+
+        try:
+            result["current_url"] = dev.get_current_url()
+        except Exception as exc:
+            result["errors"].append({"stage": "current_url", "error": str(exc)})
+        front_page_url = str(result.get("current_url") or normalized_url)
+
+        headlines, headline_evidence = _extract_articles_with_retry(
+            device,
+            dev,
+            max_items=max_headlines,
+            min_items=max_headlines,
+            timeout=wait_s,
+        )
+        result["headlines"] = headlines[:max_headlines]
+        result["extraction"]["headlines"] = headline_evidence
+        front_page_text, front_page_evidence = _extract_visible_text_with_retry(
+            device,
+            dev,
+            max_lines=120,
+            min_lines=1,
+            timeout=wait_s,
+        )
+        result["front_page_text"] = _snippet(front_page_text, max_chars=2400)
+        result["extraction"]["front_page_text"] = front_page_evidence
+
+        for index, headline in enumerate(headlines[:max_articles], start=1):
+            should_go_back = False
+            article_result: dict[str, Any] = {
+                "index": index,
+                "source_headline": headline.get("title", ""),
+                "headline_provenance": headline.get("provenance", ""),
+                "opened": False,
+            }
+            article_evidence: dict[str, Any] = {
+                "index": index,
+                "headline_provenance": headline.get("provenance", ""),
+                "headline_has_url": bool(headline.get("url")),
+            }
+            try:
+                open_method, navigation = _open_article_candidate(dev, headline, delay=max(1.0, wait_s))
+                should_go_back = True
+                article_result["open_method"] = open_method
+                article_evidence["open_method"] = open_method
+                if navigation:
+                    article_result["navigation"] = navigation
+                elif wait_s:
+                    time.sleep(wait_s)
+                if save_screenshots:
+                    article_result["screenshot"] = _save_device_screenshot(dev, out_path / f"article_{index}.png")
+                article_current_url = ""
+                same_url_as_front_page = False
+                try:
+                    article_current_url = dev.get_current_url()
+                    article_result["current_url"] = article_current_url
+                except Exception as exc:
+                    article_result["current_url_error"] = str(exc)
+                same_url_as_front_page = bool(article_current_url) and _urls_equivalent(
+                    article_current_url, front_page_url
+                )
+                visible_text, text_evidence = _extract_visible_text_with_retry(
+                    device,
+                    dev,
+                    max_lines=160,
+                    min_lines=1,
+                    timeout=wait_s,
+                    is_ready=lambda text, source_headline=headline.get("title", ""): _article_text_has_body(
+                        text,
+                        source_headline=str(source_headline or ""),
+                    ),
+                )
+                text_evidence["body_ready"] = _article_text_has_body(
+                    visible_text,
+                    source_headline=str(headline.get("title", "") or ""),
+                )
+                if same_url_as_front_page and not _article_text_confirms_open_page(
+                    visible_text,
+                    source_headline=str(headline.get("title", "") or ""),
+                ):
+                    should_go_back = False
+                    raise RuntimeError("article navigation stayed on the front page")
+                if same_url_as_front_page:
+                    article_result["url_verification"] = "same_host_article_text"
+                article_evidence["text"] = text_evidence
+                lines = [line.strip() for line in visible_text.splitlines() if line.strip()]
+                article_result["page_title"] = lines[0] if lines else ""
+                article_result["body_snippet"] = _snippet(visible_text, max_chars=2400)
+                article_result["opened"] = True
+            except Exception as exc:
+                article_result["error"] = str(exc)
+                article_evidence["error"] = str(exc)
+                result["errors"].append({"article": headline.get("title", ""), "error": str(exc)})
+            finally:
+                result["articles"].append(article_result)
+                result["extraction"]["articles"].append(article_evidence)
+                if should_go_back:
+                    try:
+                        article_evidence["return"] = _return_to_front_page_after_article(
+                            dev,
+                            normalized_url,
+                            str(headline.get("title") or ""),
+                            delay=wait_s,
+                        )
+                    except Exception as exc:
+                        result["errors"].append({"article": headline.get("title", ""), "back_error": str(exc)})
+
+        requested_articles = min(max_articles, len(result["headlines"]))
+        opened_articles = [article for article in result["articles"] if article.get("opened")]
+        articles_with_body = [article for article in opened_articles if _article_has_body(article)]
+        completion = {
+            "requested_headlines": max_headlines,
+            "headlines_found": len(result["headlines"]),
+            "headline_target_met": len(result["headlines"]) >= max_headlines,
+            "requested_articles": requested_articles,
+            "articles_opened": len(opened_articles),
+            "articles_with_body": len(articles_with_body),
+            "article_target_met": requested_articles == 0 or len(articles_with_body) >= requested_articles,
+        }
+        completion["workflow_complete"] = (
+            bool(result["headlines"])
+            and bool(completion["headline_target_met"])
+            and bool(completion["article_target_met"])
+        )
+        result["completion"] = completion
+        result["ok"] = bool(completion["workflow_complete"])
+        if not result["ok"]:
+            result["errors"].append(
+                {
+                    "stage": "success_criteria",
+                    "error": "News workflow did not extract the requested article body text",
+                    "completion": completion,
+                }
+            )
+        return result
+    except Exception as exc:
+        result["error"] = str(exc)
+        result["errors"].append({"stage": "workflow", "error": str(exc)})
+        return result
+
+
+def dumps(result: dict[str, Any]) -> str:
+    return json.dumps(result, indent=2)

--- a/gitd/services/crm_lookup.py
+++ b/gitd/services/crm_lookup.py
@@ -1,0 +1,94 @@
+"""Local CRM lookup helpers shared by MCP and in-process agents.
+
+Read-only views over the local contact/message tables: a fact sheet for a
+single contact and a list of contacts with unread messages. No network calls,
+no writes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def crm_lookup_contact(handle: str, db_path: str | Path | None = None) -> str:
+    """Return a text fact sheet for one stored contact."""
+    from gitd.db import DEFAULT_DB, get_connection
+
+    h = handle.strip()
+    if not h.startswith("@"):
+        h = "@" + h
+    conn = get_connection(Path(db_path) if db_path else DEFAULT_DB)
+    try:
+        row = conn.execute("SELECT * FROM influencers WHERE handle = ?", (h,)).fetchone()
+        if not row:
+            return f"No contact record for {h}"
+        out = [
+            f"HANDLE:    {row['handle']}",
+            f"FOLLOWERS: {row['followers']:,}" if row["followers"] else "FOLLOWERS: ?",
+            f"FOLLOWING: {row['following']:,}" if row["following"] else "FOLLOWING: ?",
+            f"LIKES:     {row['total_likes']:,}" if row["total_likes"] else "LIKES: ?",
+            f"NICHE:     {row['niche'] or '-'}",
+            f"BIO:       {row['bio'] or '-'}",
+        ]
+        if row["caption"]:
+            sample = row["caption"][:120].replace("\n", " ")
+            out.append(f"SAMPLE:    {sample}...")
+
+        contact = conn.execute(
+            "SELECT ol.*, s.name AS strategy_name FROM outreach_log ol "
+            "LEFT JOIN outreach_strategies s ON s.id = ol.strategy_id "
+            "WHERE ol.influencer_id = ?",
+            (row["id"],),
+        ).fetchone()
+        if contact:
+            out.append("")
+            out.append("CONTACT STATUS:")
+            out.append(f"  Status:       {contact['status']}")
+            out.append(f"  Contacted via: @{contact['source_account'] or '?'}")
+            out.append(f"  Contacted at:  {contact['contacted_at'] or contact['updated_at']}")
+            if contact["deal_status"]:
+                out.append(f"  Deal:          {contact['deal_status']}")
+            if contact["notes"]:
+                out.append(f"  Notes:         {contact['notes']}")
+        else:
+            out.append("")
+            out.append("CONTACT STATUS: never contacted")
+
+        bare = row["handle"].lstrip("@")
+        msg = conn.execute(
+            "SELECT * FROM inbox_replies WHERE handle = ? OR handle LIKE ?",
+            (bare, f"%{bare}%"),
+        ).fetchone()
+        if msg:
+            out.append("")
+            out.append("CONVERSATION:")
+            out.append(f"  Last msg:   {msg['last_msg']}")
+            out.append(f"  Status:     {msg['status']}")
+            out.append(f"  Unread:     {msg['unread']}")
+            out.append(f"  First seen: {msg['first_seen_at']}")
+            out.append(f"  Last seen:  {msg['last_seen_at']}")
+        return "\n".join(out)
+    finally:
+        conn.close()
+
+
+def crm_list_unread_messages(db_path: str | Path | None = None) -> str:
+    """Return contacts with unread messages sorted by recency."""
+    from gitd.db import DEFAULT_DB, get_connection
+
+    conn = get_connection(Path(db_path) if db_path else DEFAULT_DB)
+    try:
+        rows = conn.execute(
+            "SELECT handle, unread, last_msg, last_seen_at "
+            "FROM inbox_replies WHERE unread > 0 ORDER BY last_seen_at DESC"
+        ).fetchall()
+        if not rows:
+            return "0 unread"
+        out = [f"{len(rows)} unread:"]
+        for r in rows:
+            preview = (r["last_msg"] or "").replace("\n", " ")[:80]
+            out.append(f"  [{r['unread']}] {r['handle']:<35} - {preview}")
+            out.append(f"      seen: {r['last_seen_at']}")
+        return "\n".join(out)
+    finally:
+        conn.close()

--- a/gitd/services/device_context.py
+++ b/gitd/services/device_context.py
@@ -14,9 +14,21 @@ import io
 import json
 import re
 import subprocess
+import urllib.parse
 import urllib.request
 
 from gitd.bots.common.adb import Device
+from gitd.bots.common.device import get_device, is_ios_ref
+from gitd.bots.common.ios import remote_xpc_manual_recovery
+
+
+def _platform(device: str) -> str:
+    return "ios" if is_ios_ref(device) else "android"
+
+
+def _device_payload(device: str, payload: dict) -> dict:
+    return {"device": device, "platform": _platform(device), **payload}
+
 
 # ── Phone state ──────────────────────────────────────────────────────────────
 
@@ -24,6 +36,8 @@ from gitd.bots.common.adb import Device
 def get_phone_state(device: str) -> dict:
     """Current app, package, activity, keyboard state, focused element.
     Uses Portal if available, falls back to dumpsys."""
+    if is_ios_ref(device):
+        return get_device(device).get_phone_state()
     dev = Device(device)
     port = dev._ensure_portal_forward()
     if port:
@@ -47,34 +61,227 @@ def get_phone_state(device: str) -> dict:
     return {}
 
 
+_APP_STATE_NAMES = {
+    0: "not_installed",
+    1: "not_running",
+    2: "running_background_suspended",
+    3: "running_background",
+    4: "running_foreground",
+}
+
+
+def _android_current_package(dev: Device) -> str:
+    try:
+        out = dev.adb("shell", "dumpsys", "window", "windows", timeout=5)
+        m = re.search(r"mCurrentFocus.*?(\S+)/\S+", out)
+        if m:
+            return m.group(1)
+    except Exception:
+        pass
+    try:
+        out = dev.adb("shell", "dumpsys", "activity", "activities", timeout=5)
+        m = re.search(r"mResumedActivity.*?\s([A-Za-z0-9_.]+)/\S+", out)
+        if m:
+            return m.group(1)
+    except Exception:
+        pass
+    return ""
+
+
+def app_state(device: str, package: str) -> dict:
+    """Return installed/running/foreground state for an Android package or iOS bundle id."""
+    if not package:
+        return {
+            "ok": False,
+            "device": device,
+            "platform": "ios" if is_ios_ref(device) else "android",
+            "error": "package required",
+        }
+
+    if is_ios_ref(device):
+        ios_dev = get_device(device)
+        raw_state = int(ios_dev.app_state(package))
+        state = _APP_STATE_NAMES.get(raw_state, "unknown")
+        return {
+            "ok": True,
+            "device": device,
+            "platform": "ios",
+            "package": package,
+            "bundle_id": package,
+            "state": state,
+            "raw_state": raw_state,
+            "installed": raw_state > 0,
+            "running": raw_state in {2, 3, 4},
+            "foreground": raw_state == 4,
+            "source": "appium_queryAppState",
+        }
+
+    dev = Device(device)
+    installed = False
+    running = False
+    foreground = False
+    current_package = _android_current_package(dev)
+    try:
+        installed = bool(dev.adb("shell", "pm", "path", package, timeout=5).strip())
+    except Exception:
+        installed = False
+    if current_package == package:
+        installed = True
+        foreground = True
+    if installed:
+        try:
+            running = bool(dev.adb("shell", "pidof", package, timeout=5).strip())
+        except Exception:
+            running = False
+        if foreground:
+            running = True
+    raw_state = 0 if not installed else (4 if foreground else (3 if running else 1))
+    return {
+        "ok": True,
+        "device": device,
+        "platform": "android",
+        "package": package,
+        "state": _APP_STATE_NAMES[raw_state],
+        "raw_state": raw_state,
+        "installed": installed,
+        "running": running,
+        "foreground": foreground,
+        "current_package": current_package,
+        "source": "adb",
+    }
+
+
+_ANDROID_APP_NAMES = {
+    "com.zhiliaoapp.musically": "TikTok",
+    "com.instagram.android": "Instagram",
+    "com.facebook.katana": "Facebook",
+    "com.facebook.orca": "Messenger",
+    "com.whatsapp": "WhatsApp",
+    "com.twitter.android": "X (Twitter)",
+    "com.snapchat.android": "Snapchat",
+    "com.google.android.youtube": "YouTube",
+    "com.google.android.apps.youtube.music": "YouTube Music",
+    "com.google.android.apps.maps": "Google Maps",
+    "com.google.android.gm": "Gmail",
+    "com.google.android.apps.photos": "Google Photos",
+    "com.google.android.apps.docs": "Google Drive",
+    "com.android.chrome": "Chrome",
+    "com.android.vending": "Play Store",
+    "org.telegram.messenger": "Telegram",
+    "com.discord": "Discord",
+    "com.reddit.frontpage": "Reddit",
+    "com.spotify.music": "Spotify",
+    "com.amazon.mShop.android.shopping": "Amazon",
+    "com.tinder": "Tinder",
+    "com.bumble.app": "Bumble",
+    "co.hinge.app": "Hinge",
+    "com.nordvpn.android": "NordVPN",
+    "com.anydesk.adcontrol.ad1": "AnyDesk",
+    "com.google.android.calendar": "Calendar",
+    "com.google.android.contacts": "Contacts",
+    "com.google.android.dialer": "Phone",
+    "com.android.camera": "Camera",
+    "com.sec.android.app.camera": "Camera",
+    "com.android.settings": "Settings",
+    "com.android.calculator2": "Calculator",
+    "com.android.deskclock": "Clock",
+    "com.sec.android.gallery3d": "Gallery",
+    "com.samsung.android.messaging": "Messages",
+    "com.samsung.android.dialer": "Phone",
+    "com.samsung.android.app.notes": "Samsung Notes",
+}
+
+
+def _guess_android_app_name(package: str) -> str:
+    known = _ANDROID_APP_NAMES.get(package)
+    if known:
+        return known
+    last = package.split(".")[-1] if package else ""
+    return last.replace("_", " ").replace("-", " ").title() or package
+
+
+def list_apps(device: str, query: str = "", *, verify: bool = True, include_system: bool = True) -> list[dict]:
+    """Return app inventory entries with a stable {name, package, platform} shape."""
+    needle = (query or "").strip().lower()
+    if is_ios_ref(device):
+        apps = get_device(device).list_apps(query=query, verify=verify)
+        return [
+            {
+                **app,
+                "package": app.get("package") or app.get("bundle_id", ""),
+                "bundle_id": app.get("bundle_id") or app.get("package", ""),
+                "platform": "ios",
+            }
+            for app in apps
+        ]
+
+    dev = Device(device)
+    args = ["shell", "pm", "list", "packages"]
+    if not include_system:
+        args.append("-3")
+    raw = dev.adb(*args, timeout=15)
+    packages = sorted(pkg.replace("package:", "").strip() for pkg in raw.splitlines() if pkg.startswith("package:"))
+    apps = []
+    for package in packages:
+        entry = {
+            "name": _guess_android_app_name(package),
+            "package": package,
+            "bundle_id": "",
+            "platform": "android",
+            "verified": True,
+            "installed": True,
+        }
+        if needle and needle not in entry["name"].lower() and needle not in package.lower():
+            continue
+        apps.append(entry)
+    apps.sort(key=lambda app: (app["name"].lower(), app["package"]))
+    return apps
+
+
+def list_packages(device: str, *, include_system: bool = False) -> list[str]:
+    apps = list_apps(device, include_system=include_system)
+    if is_ios_ref(device):
+        return [app["bundle_id"] for app in apps if app.get("bundle_id")]
+    return [app["package"] for app in apps if app.get("package")]
+
+
 # ── Screenshots ──────────────────────────────────────────────────────────────
 
 
+def _raw_screenshot_bytes(device: str) -> bytes:
+    if is_ios_ref(device):
+        return get_device(device).take_screenshot()
+    return subprocess.check_output(["adb", "-s", device, "exec-out", "screencap", "-p"], timeout=10)
+
+
 def screenshot(device: str, half_res: bool = True, quality: int = 50) -> dict:
-    """Take screenshot via ADB screencap. Returns {image: base64, width, height}."""
+    """Take screenshot from the platform backend. Returns {image, width, height, device, platform}."""
     from PIL import Image
 
-    raw = subprocess.check_output(["adb", "-s", device, "exec-out", "screencap", "-p"], timeout=10)
+    raw = _raw_screenshot_bytes(device)
     img = Image.open(io.BytesIO(raw)).convert("RGB")
     if half_res:
         img = img.resize((img.width // 2, img.height // 2), Image.NEAREST)
     buf = io.BytesIO()
     img.save(buf, format="JPEG", quality=quality)
-    return {
-        "image": base64.b64encode(buf.getvalue()).decode(),
-        "width": img.width,
-        "height": img.height,
-    }
+    return _device_payload(
+        device,
+        {
+            "image": base64.b64encode(buf.getvalue()).decode(),
+            "width": img.width,
+            "height": img.height,
+        },
+    )
 
 
 def screenshot_annotated(device: str) -> dict:
     """Screenshot with our own numbered element overlay drawn server-side.
     Each interactive element gets a colored badge with its index number.
-    Returns {image: base64, width, height}."""
+    Returns {image, width, height, device, platform}."""
     from PIL import Image, ImageDraw, ImageFont
 
     # Take screenshot
-    raw = subprocess.check_output(["adb", "-s", device, "exec-out", "screencap", "-p"], timeout=10)
+    raw = _raw_screenshot_bytes(device)
     img = Image.open(io.BytesIO(raw)).convert("RGB")
     draw = ImageDraw.Draw(img)
 
@@ -129,36 +336,42 @@ def screenshot_annotated(device: str) -> dict:
     # Encode
     buf = io.BytesIO()
     img.save(buf, format="JPEG", quality=70)
-    return {
-        "image": base64.b64encode(buf.getvalue()).decode(),
-        "width": img.width,
-        "height": img.height,
-    }
+    return _device_payload(
+        device,
+        {
+            "image": base64.b64encode(buf.getvalue()).decode(),
+            "width": img.width,
+            "height": img.height,
+        },
+    )
 
 
 def screenshot_cropped(device: str, x1: int, y1: int, x2: int, y2: int, quality: int = 70) -> dict:
     """Screenshot a specific region of the screen.
-    Coordinates are in device pixels. Returns {image: base64, width, height}."""
+    Coordinates are in device pixels. Returns {image, width, height, device, platform}."""
     from PIL import Image
 
-    raw = subprocess.check_output(["adb", "-s", device, "exec-out", "screencap", "-p"], timeout=10)
+    raw = _raw_screenshot_bytes(device)
     img = Image.open(io.BytesIO(raw)).convert("RGB")
     cropped = img.crop((x1, y1, x2, y2))
     buf = io.BytesIO()
     cropped.save(buf, format="JPEG", quality=quality)
-    return {
-        "image": base64.b64encode(buf.getvalue()).decode(),
-        "width": cropped.width,
-        "height": cropped.height,
-    }
+    return _device_payload(
+        device,
+        {
+            "image": base64.b64encode(buf.getvalue()).decode(),
+            "width": cropped.width,
+            "height": cropped.height,
+        },
+    )
 
 
 # ── XML / Element tree ───────────────────────────────────────────────────────
 
 
 def get_screen_xml(device: str, max_length: int = 50000) -> str:
-    """Raw UI XML dump from uiautomator. Use get_screen_tree() for LLM-friendly format."""
-    dev = Device(device)
+    """Raw Android UIAutomator XML or normalized iOS WDA XML."""
+    dev = get_device(device)
     xml = dev.dump_xml()
     return xml[:max_length] if xml else ""
 
@@ -166,7 +379,7 @@ def get_screen_xml(device: str, max_length: int = 50000) -> str:
 def get_interactive_elements(device: str, interactive_only: bool = True) -> list[dict]:
     """Interactive UI elements as a JSON-serializable list.
     Each element: {idx, text, content_desc, resource_id, class, bounds, center, clickable, scrollable}."""
-    dev = Device(device)
+    dev = get_device(device)
     xml = dev.dump_xml()
     if not xml:
         return []
@@ -217,7 +430,7 @@ def get_screen_tree(device: str, max_nodes: int = 80) -> str:
     """
     import xml.etree.ElementTree as ET
 
-    dev = Device(device)
+    dev = get_device(device)
     xml_str = dev.dump_xml()
     if not xml_str:
         return "(empty screen)"
@@ -321,7 +534,7 @@ def _get_ocr():
 
 def ocr_screen(device: str) -> list[dict]:
     """OCR the full device screen. Returns [{text, conf, x, y}] sorted top-to-bottom."""
-    raw = subprocess.check_output(["adb", "-s", device, "exec-out", "screencap", "-p"], timeout=10)
+    raw = _raw_screenshot_bytes(device)
     ocr = _get_ocr()
     result = ocr(raw)
     if not result or not result.txts:
@@ -341,7 +554,7 @@ def ocr_region(device: str, x1: int, y1: int, x2: int, y2: int) -> list[dict]:
     Returns [{text, conf, x, y, w, h}] where x/y are relative to the crop."""
     from PIL import Image
 
-    raw = subprocess.check_output(["adb", "-s", device, "exec-out", "screencap", "-p"], timeout=10)
+    raw = _raw_screenshot_bytes(device)
     img = Image.open(io.BytesIO(raw))
     cropped = img.crop((x1, y1, x2, y2))
     ocr = _get_ocr()
@@ -359,6 +572,40 @@ def ocr_region(device: str, x1: int, y1: int, x2: int, y2: int) -> list[dict]:
 
 
 # ── Overlay ──────────────────────────────────────────────────────────────────
+
+
+def speak_text(device: str, text: str, rate: float = 1.0) -> str:
+    """Make the phone speak text aloud via its TTS engine.
+
+    Android: ADB forward → Ghost Portal app HTTP /speak. Works from PC (ADB
+    forward → portal HTTP) and on-device (same HTTP, loopback); requires the
+    Ghost portal app to be running on the phone.
+    iOS: WDA /wda/speak (AVSpeechSynthesizer) via Appium, no companion app.
+    Returns 'speaking' on success, or an error string.
+    """
+    if is_ios_ref(device):
+        try:
+            return str(get_device(device).speak(text, rate=rate))
+        except Exception as e:
+            return f"error: {e}"
+    dev = Device(device)
+    port = dev._ensure_portal_forward()
+    if not port:
+        return "error: portal app not reachable — is the Ghost portal running on the phone?"
+    try:
+        payload = json.dumps({"text": text, "rate": rate}).encode()
+        req = urllib.request.Request(
+            f"http://localhost:{port}/speak",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        resp = json.loads(urllib.request.urlopen(req, timeout=5).read())
+        if resp.get("status") == "error":
+            return f"error: {resp.get('error', 'unknown')}"
+        return resp.get("result", "ok")
+    except Exception as e:
+        return f"error: {e}"
 
 
 def toggle_overlay(device: str, visible: bool = True) -> bool:
@@ -390,7 +637,7 @@ def classify_screen(device: str) -> dict:
     screen_type is one of: home, search, profile, settings, dialog, error, loading, unknown.
     Uses XML heuristics — no LLM needed."""
     state = get_phone_state(device)
-    dev = Device(device)
+    dev = get_device(device)
     xml = dev.dump_xml() or ""
 
     pkg = state.get("packageName", "")
@@ -432,14 +679,17 @@ def classify_screen(device: str) -> dict:
     elif any(w in xml for w in ["RecyclerView", "ViewPager", "feed"]):
         screen_type = "feed"
 
-    return {
-        "app": app,
-        "package": pkg,
-        "screen_type": screen_type,
-        "has_keyboard": has_keyboard,
-        "activity": state.get("activityName", ""),
-        "details": details,
-    }
+    return _device_payload(
+        device,
+        {
+            "app": app,
+            "package": pkg,
+            "screen_type": screen_type,
+            "has_keyboard": has_keyboard,
+            "activity": state.get("activityName", ""),
+            "details": details,
+        },
+    )
 
 
 # ── Clipboard ────────────────────────────────────────────────────────────────
@@ -447,6 +697,11 @@ def classify_screen(device: str) -> dict:
 
 def clipboard_get(device: str) -> str:
     """Get current clipboard text from device."""
+    if is_ios_ref(device):
+        try:
+            return get_device(device).clipboard_get()
+        except Exception:
+            return ""
     dev = Device(device)
     try:
         return dev.adb("shell", "am", "broadcast", "-a", "clipper.get", timeout=3).strip()
@@ -462,8 +717,29 @@ def clipboard_get(device: str) -> str:
 
 
 def clipboard_set(device: str, text: str) -> bool:
-    """Set clipboard text on device."""
+    """Set clipboard text on device via Ghost portal (ClipboardManager)."""
+    if is_ios_ref(device):
+        try:
+            return bool(get_device(device).clipboard_set(text))
+        except Exception:
+            return False
     dev = Device(device)
+    port = dev._ensure_portal_forward()
+    if port:
+        try:
+            payload = json.dumps({"text": text}).encode()
+            req = urllib.request.Request(
+                f"http://localhost:{port}/clipboard",
+                data=payload,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            resp = json.loads(urllib.request.urlopen(req, timeout=3).read())
+            if resp.get("result") == "clipboard_set":
+                return True
+        except Exception:
+            pass
+    # Fallback: Clipper broadcast (requires Clipper app installed)
     try:
         dev.adb("shell", "am", "broadcast", "-a", "clipper.set", "-e", "text", text, timeout=3)
         return True
@@ -477,6 +753,11 @@ def clipboard_set(device: str, text: str) -> bool:
 def get_notifications(device: str) -> list[dict]:
     """Get active notifications from the notification panel.
     Returns [{package, title, text, time}]."""
+    if is_ios_ref(device):
+        try:
+            return get_device(device).get_notifications()
+        except Exception:
+            return []
     dev = Device(device)
     try:
         out = dev.adb("shell", "dumpsys", "notification", "--noredact", timeout=10)
@@ -505,6 +786,11 @@ def get_notifications(device: str) -> list[dict]:
 
 def open_notifications(device: str) -> bool:
     """Pull down the notification shade."""
+    if is_ios_ref(device):
+        try:
+            return bool(get_device(device).open_notifications())
+        except Exception:
+            return False
     dev = Device(device)
     try:
         dev.adb("shell", "cmd", "statusbar", "expand-notifications", timeout=3)
@@ -515,6 +801,11 @@ def open_notifications(device: str) -> bool:
 
 def clear_notifications(device: str) -> bool:
     """Dismiss all notifications."""
+    if is_ios_ref(device):
+        try:
+            return bool(get_device(device).clear_notifications())
+        except Exception:
+            return False
     dev = Device(device)
     try:
         dev.adb("shell", "service", "call", "notification", "1", timeout=3)
@@ -565,7 +856,7 @@ def find_on_screen(device: str, text: str) -> dict | None:
     """Find specific text on screen and return its location.
     Searches XML elements first (fast), falls back to OCR (slower).
     Returns {text, x, y, w, h, method} or None if not found."""
-    dev = Device(device)
+    dev = get_device(device)
     xml = dev.dump_xml()
     if xml:
         # Search in XML text + content-desc
@@ -627,9 +918,227 @@ def build_llm_context(
 
 # ── Device health check ──────────────────────────────────────────────────────
 
+_IOS_HEALTH_RECOVERY: dict[str, dict] = {
+    "appium_down": {
+        "code": "start_appium",
+        "summary": "Appium is not reachable at the configured URL.",
+        "steps": [
+            "Start Appium with the XCUITest driver, for example: appium --address 127.0.0.1 --port 4723",
+            "Verify IOS_APPIUM_URL points to the running server.",
+            "Re-run /api/phone/devices?probe=deep or /api/phone/health/ios:<udid>.",
+        ],
+    },
+    "configured_unreachable": {
+        "code": "check_ios_device_config",
+        "summary": "The iOS device ref or Appium/WDA configuration is inconsistent.",
+        "steps": [
+            "Confirm the ref is ios:<udid> and the UDID appears in xcrun xctrace list devices.",
+            "Check IOS_DEVICE_UDID, IOS_DEVICES_JSON, IOS_APPIUM_URL, IOS_WDA_URL, and per-device ports.",
+            "Use a shallow device list first, then a deep probe after config is corrected.",
+        ],
+    },
+    "remote_xpc_tunnel_unavailable": {
+        "code": "restart_remote_xpc_tunnel",
+        "summary": "The iPhone is paired, but Appium cannot reach the XCUITest RemoteXPC tunnel.",
+        "steps": [
+            "Stop any stale root-owned XCUITest tunnel process for the device.",
+            "Start a fresh tunnel with: sudo appium driver run xcuitest tunnel-creation --udid <udid>",
+            "Verify the tunnel registry returns a current entry at /remotexpc/tunnels/<udid>, then rerun the health probe.",
+        ],
+    },
+    "locked": {
+        "code": "unlock_and_trust_device",
+        "summary": "The iPhone is locked, not trusted, or Developer Mode/UI Automation is blocked.",
+        "steps": [
+            "Unlock the iPhone and keep it awake.",
+            "Accept the Trust This Computer prompt if shown.",
+            "Confirm Developer Mode and UI Automation are enabled, then retry the health probe.",
+        ],
+    },
+    "wda_signing_failed": {
+        "code": "fix_wda_signing",
+        "summary": "WebDriverAgent could not be built, signed, installed, or launched by Xcode/Appium.",
+        "steps": [
+            "Set IOS_XCODE_ORG_ID, IOS_XCODE_SIGNING_ID, and IOS_UPDATED_WDA_BUNDLE_ID for the device/team.",
+            "If the device reports the Developer App certificate is not trusted, open iOS Settings > General > VPN & Device Management and trust the developer certificate.",
+            "Unlock the device and manually run a WDA build once if Xcode needs account/device registration.",
+            "Set IOS_SHOW_XCODE_LOG=true for detailed xcodebuild output, then retry with /api/phone/health/ios:<udid>.",
+        ],
+    },
+    "wda_launch_timeout": {
+        "code": "fix_wda_launch_timeout",
+        "summary": "Appium is reachable, but WebDriverAgent did not finish launching before the session timeout.",
+        "steps": [
+            "Keep the iPhone unlocked and awake while WDA is building and launching.",
+            "Inspect the Appium/Xcode log for signing, provisioning, or device-lock prompts that occurred during session creation.",
+            "Increase IOS_APPIUM_TIMEOUT and IOS_WDA_LAUNCH_TIMEOUT for first-time WDA builds, then retry the health probe.",
+        ],
+    },
+    "session_error": {
+        "code": "reset_session",
+        "summary": "The cached Appium session is stale or WDA stopped responding.",
+        "steps": [
+            "Call /api/phone/health/ios:<udid>/fix with issue=reset_session.",
+            "If the next probe still fails, restart Appium and rerun the XCUITest tunnel for the device.",
+        ],
+    },
+    "error": {
+        "code": "reset_session",
+        "summary": "Ghost hit an unexpected iOS health-check error.",
+        "steps": [
+            "Reset the Appium session and retry.",
+            "If the error persists, inspect the Appium server log and WDA setup.",
+        ],
+    },
+}
+
+
+def _ios_recovery_for_state(state: str) -> dict:
+    recovery = dict(_IOS_HEALTH_RECOVERY.get(state) or {})
+    if not recovery:
+        return {"code": "", "summary": "iOS Appium/WDA session is usable.", "steps": []}
+    recovery["state"] = state
+    return recovery
+
+
+def ios_recovery_for_state(state: str) -> dict:
+    return _ios_recovery_for_state(state)
+
+
+def _is_local_http_appium_url(appium_url: str) -> bool:
+    parsed = urllib.parse.urlparse(appium_url or "")
+    scheme = parsed.scheme or "http"
+    host = parsed.hostname or "127.0.0.1"
+    return scheme == "http" and host in {"127.0.0.1", "localhost", "::1"}
+
+
+def ios_device_health(device: str, ios_dev=None) -> dict:
+    try:
+        ios_dev = ios_dev or get_device(device)
+        status = ios_dev.probe(deep=True).to_dict()
+        state = status.get("state", "session_error")
+        checks = status.get("checks") or {}
+        screenshot_bytes = checks.get("screenshot_bytes") or 0
+        source_bytes = checks.get("source_bytes") or 0
+        appium_status_code = checks.get("appium_status_code")
+        appium_reachable = state != "appium_down"
+        if isinstance(appium_status_code, int):
+            appium_reachable = appium_status_code < 400
+        recovery = _ios_recovery_for_state(state)
+        if state == "remote_xpc_tunnel_unavailable":
+            try:
+                recovery = remote_xpc_manual_recovery(
+                    status.get("udid") or device, checks.get("remote_xpc_tunnel") or {}
+                )
+            except Exception:
+                recovery = _ios_recovery_for_state(state)
+        elif state == "appium_down":
+            appium_url = status.get("appium_url") or getattr(ios_dev, "appium_url", "")
+            auto_fixable = _is_local_http_appium_url(str(appium_url))
+            recovery = {
+                **recovery,
+                "auto_fixable": auto_fixable,
+                "manual_action_required": not auto_fixable,
+                "requires_sudo": False,
+            }
+        recommended_fix = recovery.get("code", "")
+        return {
+            "serial": device,
+            "connection": {"type": "appium-wda", "status": state},
+            "platform": "ios",
+            "appium": {
+                "url": status.get("appium_url", ""),
+                "session_id": status.get("session_id", ""),
+                "reachable": appium_reachable,
+                "state": state,
+                "message": status.get("message", ""),
+                "status_code": appium_status_code,
+            },
+            "wda": {
+                "session": status.get("session_id", ""),
+                "ready": state == "available",
+                "active_app": status.get("active_app") or {},
+                "screen_size": status.get("screen_size") or {},
+                "screenshot_ok": bool(screenshot_bytes),
+                "source_ok": bool(source_bytes),
+                "mjpeg_url": ios_dev.mjpeg_url,
+                "mjpeg_settings": ios_dev.mjpeg_settings,
+                "checks": status.get("checks") or {},
+            },
+            "recommended_fix": recommended_fix,
+            "recovery": recovery,
+            "device_info": status,
+        }
+    except Exception as e:
+        recovery = _ios_recovery_for_state("error")
+        return {
+            "serial": device,
+            "connection": {"type": "appium-wda", "status": "error"},
+            "platform": "ios",
+            "appium": {"reachable": False, "message": str(e), "state": "error"},
+            "wda": {"session": "", "screenshot_ok": False, "source_ok": False, "checks": {"error": str(e)}},
+            "recommended_fix": recovery["code"],
+            "recovery": recovery,
+            "error": str(e),
+        }
+
+
+def _ios_state_for_fix(issue: str) -> str:
+    for state, recovery in _IOS_HEALTH_RECOVERY.items():
+        if recovery.get("code") == issue:
+            return state
+    return ""
+
+
+def fix_device_health(device: str, issue: str) -> dict:
+    """Apply a recovery action returned by device_health()."""
+    issue = (issue or "").strip()
+    platform = "ios" if is_ios_ref(device) else "android"
+    if not issue:
+        return {"ok": False, "platform": platform, "error": "issue is required"}
+
+    if is_ios_ref(device):
+        if issue == "start_appium":
+            return get_device(device).start_appium_server()
+        if issue in {"reset_session", "appium_session", "wda_session"}:
+            get_device(device).reset_session()
+            return {"ok": True, "platform": "ios", "issue": issue, "message": "iOS Appium session reset"}
+        if issue == "restart_remote_xpc_tunnel":
+            return get_device(device).restart_remote_xpc_tunnel()
+
+        state = _ios_state_for_fix(issue)
+        if state:
+            recovery = _ios_recovery_for_state(state)
+            return {
+                "ok": False,
+                "platform": "ios",
+                "issue": issue,
+                "manual_action_required": True,
+                "message": recovery["summary"],
+                "recovery": recovery,
+            }
+        return {"ok": False, "platform": "ios", "issue": issue, "error": f"Unknown iOS health fix: {issue}"}
+
+    if issue in {"portal_service", "portal_install", "portal"}:
+        from gitd.routers.streaming import portal_fix
+
+        result = portal_fix(device)
+        if isinstance(result, dict):
+            result.setdefault("platform", "android")
+            result.setdefault("issue", issue)
+        return result
+    if issue == "screen_wake":
+        subprocess.run(
+            ["adb", "-s", device, "shell", "input", "keyevent", "KEYCODE_WAKEUP"], capture_output=True, timeout=3
+        )
+        return {"ok": True, "platform": "android", "issue": issue, "message": "Screen woken"}
+    return {"ok": False, "platform": "android", "issue": issue, "error": f"Unknown Android health fix: {issue}"}
+
 
 def device_health(device: str) -> dict:
     """Comprehensive device health check. Returns status for every subsystem."""
+    if is_ios_ref(device):
+        return ios_device_health(device)
     dev = Device(device)
     health = {"serial": device}
 
@@ -871,16 +1380,19 @@ def fingerprint_screen(device: str) -> dict:
     pkg = state.get("packageName", "")
     activity = state.get("activityName", "")
 
-    return {
-        "package": pkg,
-        "activity": activity,
-        "screen_type": classify_screen(device).get("screen_type", "unknown"),
-        "is_launcher": "launcher" in activity.lower() if activity else False,
-        "has_keyboard": state.get("keyboardVisible", False),
-        "interactive_count": len(elements),
-        "element_signatures": [f"{e.get('class', '')}.{e.get('resource_id', '')}" for e in elements[:20]],
-        "hash": _fingerprint_hash(pkg, activity, elements),
-    }
+    return _device_payload(
+        device,
+        {
+            "package": pkg,
+            "activity": activity,
+            "screen_type": classify_screen(device).get("screen_type", "unknown"),
+            "is_launcher": "launcher" in activity.lower() if activity else False,
+            "has_keyboard": state.get("keyboardVisible", False),
+            "interactive_count": len(elements),
+            "element_signatures": [f"{e.get('class', '')}.{e.get('resource_id', '')}" for e in elements[:20]],
+            "hash": _fingerprint_hash(pkg, activity, elements),
+        },
+    )
 
 
 def _fingerprint_hash(pkg: str, activity: str, elements: list[dict]) -> str:
@@ -900,4 +1412,4 @@ def validate_fingerprint(device: str, expected: dict) -> dict:
     for key in ("package", "activity", "screen_type", "is_launcher"):
         if key in expected and current.get(key) != expected[key]:
             mismatches.append({"field": key, "expected": expected[key], "actual": current.get(key)})
-    return {"valid": len(mismatches) == 0, "mismatches": mismatches, "current": current}
+    return _device_payload(device, {"valid": len(mismatches) == 0, "mismatches": mismatches, "current": current})

--- a/gitd/services/emulator_service.py
+++ b/gitd/services/emulator_service.py
@@ -1,11 +1,11 @@
 """
-Emulator Service — lifecycle management (create/start/stop/delete/snapshots).
+Emulator Service — Docker+KVM lifecycle management (create/start/stop/delete/snapshots).
 
+Replaces the native Android SDK AVD backend with budtmo/docker-android containers.
 Discovery helpers live in _emulator_helpers; pool logic in _emulator_pool.
 """
 
 import logging
-import shutil
 import subprocess
 import threading
 import time
@@ -13,168 +13,156 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import Optional
 
-from gitd.services import _emulator_helpers as _eh
+import gitd.services._emulator_helpers as _eh
 from gitd.services._emulator_helpers import (
     ADB_BIN,
-    AVD_HOME,
-    AVDMANAGER,
-    EMULATOR_BIN,
+    DOCKER_IMAGE,
     EmulatorConfig,  # noqa: F401 — re-exported for routers
     _adb,
-    _has_cmdline_tools,
-    _has_emulator,
+    _docker,
+    _has_docker,
+    _has_kvm,
     _run,
+    next_available_port,
 )
 from gitd.services._emulator_pool import EmulatorPool
 
 logger = logging.getLogger(__name__)
 
-
-# ── EmulatorManager ──────────────────────────────────────────────────────────
+# ── EmulatorManager ───────────────────────────────────────────────────────────
 
 
 class EmulatorManager:
-    """Manage Android emulator lifecycle."""
+    """Manage Android emulator lifecycle via Docker+KVM."""
 
     def __init__(self):
-        self._procs: dict[str, subprocess.Popen] = {}  # serial -> Popen
+        # _procs kept for API compatibility — unused in Docker mode
+        self._procs: dict = {}
         self._lock = threading.Lock()
 
-    # ── Discovery (delegated to _emulator_helpers) ────────────────────────
+    # ── Discovery ─────────────────────────────────────────────────────────
+
     def check_prerequisites(self) -> dict:
-        """Check what SDK tools are available."""
+        """Check Docker + KVM availability."""
         return _eh.check_prerequisites()
 
     def list_system_images(self) -> list[dict]:
-        """List installed system images by scanning the SDK directory."""
+        """Return available Docker-based Android images."""
         return _eh.list_system_images()
 
-    def install_system_image(self, api_level: int, target: str = "google_apis_playstore", arch: str = "x86_64") -> dict:
-        """Download a system image via sdkmanager. Requires cmdline-tools."""
+    def install_system_image(self, api_level: int, target: str = "google_apis_playstore", arch: str = "") -> dict:
+        """Pull the Docker emulator image."""
         return _eh.install_system_image(api_level, target, arch)
 
     def list_avds(self) -> list[dict]:
-        """List all created AVDs by reading .ini files from AVD_HOME."""
+        """List all ghost-labelled emulator containers."""
         return _eh.list_avds(self.list_running())
 
     def list_running(self) -> list[dict]:
-        """List running emulators with serials and AVD names."""
+        """List running emulator containers reachable via ADB."""
         return _eh.list_running(self._procs, self._lock)
 
-    # ── Lifecycle ────────────────────────────────────────────────────────
+    # ── Lifecycle ──────────────────────────────────────────────────────────
+
     def create(self, config: EmulatorConfig) -> dict:
-        """Create a new AVD. Requires cmdline-tools (avdmanager)."""
-        if not _has_cmdline_tools():
+        """Create (and start) a Docker-based Android emulator container.
+
+        In Docker mode 'create' == 'create + start' because containers don't
+        have the AVD-vs-running distinction.  The container is started
+        immediately; boot polling happens in a background thread.
+        """
+        if not _has_docker():
             return {
                 "ok": False,
-                "error": (
-                    "cmdline-tools not installed. Install with:\n"
-                    f"  {EMULATOR_BIN.parent.parent}/cmdline-tools or download from "
-                    "https://developer.android.com/studio#command-tools\n"
-                    'Then: sdkmanager --install "cmdline-tools;latest"'
-                ),
+                "error": "Docker daemon not reachable. Make sure Docker is running.",
+            }
+        if not _has_kvm():
+            return {
+                "ok": False,
+                "error": "/dev/kvm not found. KVM must be enabled for hardware-accelerated emulation.",
             }
 
-        # Check system image exists
-        if not config.system_image_dir().exists():
-            return {"ok": False, "error": f"System image not found: {config.system_image_pkg()}. Install it first."}
-
-        # Check if AVD already exists
+        # Check for name collision
         existing = [a["name"] for a in self.list_avds()]
         if config.name in existing:
-            return {"ok": False, "error": f'AVD "{config.name}" already exists.'}
+            return {"ok": False, "error": f'Emulator "{config.name}" already exists.'}
 
-        cmd = [
-            str(AVDMANAGER),
-            "create",
-            "avd",
-            "-n",
-            config.name,
-            "-k",
-            config.system_image_pkg(),
-            "-d",
-            config.device_profile,
-            "--force",
-        ]
+        with self._lock:
+            used_ports = _eh._used_host_ports()
+        host_port = next_available_port(used_ports)
+
         try:
-            r = _run(cmd, timeout=60, input="no\n", check=False)
-            if r.returncode != 0:
-                return {"ok": False, "error": r.stderr[-500:] or r.stdout[-500:]}
-        except (subprocess.SubprocessError, OSError) as e:
-            return {"ok": False, "error": str(e)}
+            client = _docker()
+            container = client.containers.run(
+                DOCKER_IMAGE,
+                detach=True,
+                name=config.name,
+                devices=["/dev/kvm:/dev/kvm"],
+                environment={
+                    "EMULATOR_DEVICE": config.device_profile,
+                    "WEB_VNC": "false",
+                },
+                ports={f"{_eh.CONTAINER_PORT}/tcp": host_port},
+                labels={
+                    _eh.CONTAINER_LABEL: _eh.CONTAINER_LABEL_VALUE,
+                    "ghost.name": config.name,
+                    "ghost.device_profile": config.device_profile,
+                    "ghost.api_level": str(config.api_level),
+                },
+            )
+        except Exception as e:
+            return {"ok": False, "error": f"Docker run failed: {e}"}
 
-        # Patch config.ini with custom settings
-        self._patch_avd_config(config)
+        serial = f"localhost:{host_port}"
 
-        return {"ok": True, "name": config.name, "config": asdict(config)}
+        # Boot watcher in background
+        boot_thread = threading.Thread(
+            target=self._wait_for_boot_and_setup,
+            args=(serial, config.name),
+            daemon=True,
+        )
+        boot_thread.start()
 
-    def _patch_avd_config(self, config: EmulatorConfig):
-        """Update AVD config.ini with our settings."""
-        # Find the config.ini — check both naming conventions
-        for avd_dir_name in [config.name, config.name.replace(" ", "_")]:
-            config_ini = AVD_HOME / f"{avd_dir_name}.avd" / "config.ini"
-            if config_ini.exists():
-                break
-        else:
-            return
-
-        text = config_ini.read_text()
-        patches = {
-            "hw.ramSize": str(config.ram_mb),
-            "disk.dataPartition.size": f"{config.disk_mb}M",
-            "hw.lcd.width": config.resolution.split("x")[0],
-            "hw.lcd.height": config.resolution.split("x")[1],
-            "hw.lcd.density": str(config.dpi),
-            "hw.gpu.enabled": "yes",
-            "hw.gpu.mode": config.gpu,
-            "hw.cpu.ncore": str(config.cores),
+        return {
+            "ok": True,
+            "name": config.name,
+            "container_id": container.short_id,
+            "serial": serial,
+            "host_port": host_port,
+            "status": "booting",
+            "config": asdict(config),
         }
-        lines = text.splitlines()
-        existing_keys = set()
-        new_lines = []
-        for line in lines:
-            if "=" in line:
-                key = line.split("=", 1)[0].strip()
-                if key in patches:
-                    new_lines.append(f"{key}={patches[key]}")
-                    existing_keys.add(key)
-                    continue
-            new_lines.append(line)
-        # Add missing keys
-        for k, v in patches.items():
-            if k not in existing_keys:
-                new_lines.append(f"{k}={v}")
-        config_ini.write_text("\n".join(new_lines) + "\n")
+
+    def _wait_for_boot_and_setup(self, serial: str, name: str):
+        """Connect ADB and wait for boot, then run automation setup."""
+        # Give the container a moment to initialise its QEMU process
+        time.sleep(10)
+        try:
+            # Connect ADB to the TCP endpoint
+            _run([ADB_BIN, "connect", serial], timeout=15, check=False)
+            self._wait_for_boot(serial, timeout=240)
+            self.setup_for_automation(serial)
+            logger.info("Emulator %s (%s) is ready", name, serial)
+        except Exception as e:
+            logger.error("Emulator %s (%s) boot/setup failed: %s", name, serial, e)
 
     def delete(self, name: str) -> dict:
-        """Delete an AVD."""
-        # Stop it first if running
-        running = {info["name"]: info["serial"] for info in self.list_running()}
-        if name in running:
-            self.stop(running[name])
+        """Stop and remove a Docker emulator container."""
+        # Disconnect ADB first if it was connected
+        for info in self.list_running():
+            if info["name"] == name and info.get("serial"):
+                try:
+                    _run([ADB_BIN, "disconnect", info["serial"]], timeout=5, check=False)
+                except Exception:
+                    pass
 
-        if _has_cmdline_tools():
-            try:
-                r = _run([str(AVDMANAGER), "delete", "avd", "-n", name], timeout=30, check=False)
-                if r.returncode == 0:
-                    return {"ok": True, "name": name}
-                return {"ok": False, "error": r.stderr[-500:]}
-            except (subprocess.SubprocessError, OSError) as e:
-                return {"ok": False, "error": str(e)}
-        else:
-            # Manual deletion — remove .ini and .avd directory
-            ini_file = AVD_HOME / f"{name}.ini"
-            avd_dir = AVD_HOME / f"{name}.avd"
-            deleted = []
-            if ini_file.exists():
-                ini_file.unlink()
-                deleted.append(str(ini_file))
-            if avd_dir.exists():
-                shutil.rmtree(avd_dir)
-                deleted.append(str(avd_dir))
-            if deleted:
-                return {"ok": True, "name": name, "deleted": deleted}
-            return {"ok": False, "error": f'AVD "{name}" not found at {AVD_HOME}'}
+        try:
+            client = _docker()
+            container = client.containers.get(name)
+            container.remove(force=True)
+            return {"ok": True, "name": name}
+        except Exception as e:
+            return {"ok": False, "error": str(e)}
 
     def start(
         self,
@@ -182,110 +170,84 @@ class EmulatorManager:
         headless: bool = False,
         gpu: str = "auto",
         cold_boot: bool = False,
-        extra_args: list[str] = None,
+        extra_args: list[str] | None = None,
     ) -> dict:
-        """Start an emulator. Returns {serial, pid, port, name}.
+        """Start a stopped Docker emulator container.
 
-        For headless mode, defaults to swiftshader_indirect GPU (more reliable).
-        Use cold_boot=True to skip snapshot loading (fixes ADB offline issues).
+        If the container doesn't exist yet, returns an error directing the
+        caller to use create() first.  In Docker mode headless/gpu/extra_args
+        are accepted for API compatibility but are no-ops.
         """
-        if not _has_emulator():
-            return {"ok": False, "error": f"Emulator binary not found at {EMULATOR_BIN}"}
-
-        # Check AVD exists
-        avd_names = [a["name"] for a in self.list_avds()]
-        if name not in avd_names:
-            return {"ok": False, "error": f'AVD "{name}" does not exist. Available: {avd_names}'}
-
-        # Check if already running
-        for info in self.list_running():
-            if info["name"] == name:
-                return {"ok": True, "already_running": True, **info}
-
-        # Default to swiftshader for headless (host GPU needs display)
-        effective_gpu = gpu
-        if headless and gpu == "auto":
-            effective_gpu = "swiftshader_indirect"
-
-        port = self._next_available_port()
-        cmd = [
-            str(EMULATOR_BIN),
-            "-avd",
-            name,
-            "-port",
-            str(port),
-            "-no-audio",
-            "-no-boot-anim",
-            "-gpu",
-            effective_gpu,
-        ]
-        if headless:
-            cmd.append("-no-window")
-        if cold_boot:
-            cmd.append("-no-snapshot-load")
-        if extra_args:
-            cmd.extend(extra_args)
+        if not _has_docker():
+            return {"ok": False, "error": "Docker daemon not reachable."}
 
         try:
-            proc = subprocess.Popen(
-                cmd,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.PIPE,
-                start_new_session=True,
+            client = _docker()
+            container = client.containers.get(name)
+        except Exception:
+            return {
+                "ok": False,
+                "error": (f'Container "{name}" not found. Use POST /api/emulators to create it first.'),
+            }
+
+        if container.status == "running":
+            info = _eh._container_to_info(container)
+            return {"ok": True, "already_running": True, **info}
+
+        # Re-start a stopped container
+        try:
+            container.start()
+            container.reload()
+        except Exception as e:
+            return {"ok": False, "error": f"Failed to start container: {e}"}
+
+        info = _eh._container_to_info(container)
+        serial = info.get("serial")
+        if serial:
+            boot_thread = threading.Thread(
+                target=self._wait_for_boot_and_setup,
+                args=(serial, name),
+                daemon=True,
             )
-        except (subprocess.SubprocessError, OSError) as e:
-            return {"ok": False, "error": f"Failed to launch emulator: {e}"}
-
-        serial = f"emulator-{port}"
-        with self._lock:
-            self._procs[serial] = proc
-
-        # Wait for boot in background — return immediately with serial
-        # Caller can poll /api/emulators/running or check boot status
-        boot_thread = threading.Thread(
-            target=self._wait_for_boot_and_setup,
-            args=(serial, name, proc),
-            daemon=True,
-        )
-        boot_thread.start()
+            boot_thread.start()
 
         return {
             "ok": True,
-            "serial": serial,
-            "port": port,
-            "pid": proc.pid,
             "name": name,
+            "serial": serial,
+            "host_port": info.get("host_port"),
             "status": "booting",
         }
 
-    def _wait_for_boot_and_setup(self, serial: str, name: str, proc: subprocess.Popen):
-        """Wait for emulator to boot, then run automation setup."""
-        try:
-            self._wait_for_boot(serial, timeout=180)
-            self.setup_for_automation(serial)
-        except Exception as e:
-            logger.error("%s (%s) boot/setup failed: %s", serial, name, e)
-
     def stop(self, serial: str) -> dict:
-        """Stop an emulator gracefully."""
+        """Stop a running emulator by its ADB serial (localhost:PORT).
+
+        Disconnects ADB and stops (but does not remove) the container so it
+        can be restarted quickly.
+        """
         try:
-            _run([ADB_BIN, "-s", serial, "emu", "kill"], timeout=10, check=False)
-        except (subprocess.SubprocessError, OSError):
+            _run([ADB_BIN, "disconnect", serial], timeout=5, check=False)
+        except Exception:
             pass
 
-        # Also terminate the process if we tracked it
-        with self._lock:
-            proc = self._procs.pop(serial, None)
-        if proc and proc.poll() is None:
-            try:
-                proc.terminate()
-                proc.wait(timeout=10)
-            except (subprocess.SubprocessError, OSError):
-                proc.kill()
+        # Find the container by matching host port
+        try:
+            host_port = int(serial.split(":")[-1])
+        except ValueError:
+            return {"ok": False, "error": f"Cannot parse port from serial: {serial}"}
 
-        # Give ADB time to deregister
-        time.sleep(1)
-        return {"ok": True, "serial": serial}
+        try:
+            client = _docker()
+            containers = client.containers.list(filters={"label": f"{_eh.CONTAINER_LABEL}={_eh.CONTAINER_LABEL_VALUE}"})
+            for c in containers:
+                for bindings in (c.ports or {}).values():
+                    if bindings and any(int(b.get("HostPort", -1)) == host_port for b in bindings):
+                        c.stop(timeout=15)
+                        return {"ok": True, "serial": serial, "container": c.name}
+        except Exception as e:
+            return {"ok": False, "error": str(e)}
+
+        return {"ok": False, "error": f"No running container found for serial {serial}"}
 
     def get_boot_status(self, serial: str) -> dict:
         """Check if an emulator has finished booting."""
@@ -296,7 +258,8 @@ class EmulatorManager:
         except (subprocess.SubprocessError, OSError):
             return {"serial": serial, "booted": False, "error": "not reachable"}
 
-    # ── Setup ────────────────────────────────────────────────────────────
+    # ── Setup ──────────────────────────────────────────────────────────────
+
     def setup_for_automation(self, serial: str) -> dict:
         """Configure emulator for automation after boot."""
         commands = [
@@ -308,7 +271,7 @@ class EmulatorManager:
             ("shell", "settings", "put", "system", "accelerometer_rotation", "0"),
             # Max screen timeout
             ("shell", "settings", "put", "system", "screen_off_timeout", "2147483647"),
-            # Stay awake while charging (emulator is always "charging")
+            # Stay awake while charging (container is always "charging")
             ("shell", "settings", "put", "global", "stay_on_while_plugged_in", "3"),
         ]
         results = []
@@ -327,47 +290,46 @@ class EmulatorManager:
         except subprocess.CalledProcessError as e:
             return {"ok": False, "error": e.stderr[-300:]}
 
-    # ── Snapshots ────────────────────────────────────────────────────────
+    # ── Snapshots ──────────────────────────────────────────────────────────
+    # budtmo/docker-android doesn't support AVD snapshots; these return
+    # informative messages rather than hard errors so the API surface is intact.
+
     def snapshot_save(self, serial: str, name: str = "automation_ready") -> dict:
-        """Save emulator state snapshot."""
-        try:
-            _run([ADB_BIN, "-s", serial, "emu", "avd", "snapshot", "save", name], timeout=30, check=False)
-            return {"ok": True, "serial": serial, "snapshot": name}
-        except (subprocess.SubprocessError, OSError) as e:
-            return {"ok": False, "error": str(e)}
+        """Snapshot not supported in Docker mode — returns advisory message."""
+        return {
+            "ok": False,
+            "serial": serial,
+            "snapshot": name,
+            "error": "Snapshots are not supported in Docker emulator mode.",
+        }
 
     def snapshot_load(self, serial: str, name: str = "automation_ready") -> dict:
-        """Restore emulator from snapshot."""
-        try:
-            _run([ADB_BIN, "-s", serial, "emu", "avd", "snapshot", "load", name], timeout=30, check=False)
-            return {"ok": True, "serial": serial, "snapshot": name}
-        except (subprocess.SubprocessError, OSError) as e:
-            return {"ok": False, "error": str(e)}
+        """Snapshot not supported in Docker mode — returns advisory message."""
+        return {
+            "ok": False,
+            "serial": serial,
+            "snapshot": name,
+            "error": "Snapshots are not supported in Docker emulator mode.",
+        }
 
     def list_snapshots(self, serial: str) -> dict:
-        """List available snapshots for a running emulator."""
-        try:
-            r = _run([ADB_BIN, "-s", serial, "emu", "avd", "snapshot", "list"], timeout=10, check=False)
-            return {"ok": True, "serial": serial, "output": r.stdout}
-        except (subprocess.SubprocessError, OSError) as e:
-            return {"ok": False, "error": str(e)}
+        """Snapshot not supported in Docker mode."""
+        return {
+            "ok": False,
+            "serial": serial,
+            "output": "",
+            "error": "Snapshots are not supported in Docker emulator mode.",
+        }
 
-    # ── Internals ────────────────────────────────────────────────────────
+    # ── Internals ──────────────────────────────────────────────────────────
+
     def _next_available_port(self) -> int:
-        """Find next free even port starting from 5554."""
-        used_ports = set()
-        for info in self.list_running():
-            port_str = info["serial"].replace("emulator-", "")
-            try:
-                used_ports.add(int(port_str))
-            except ValueError:
-                pass
-        port = 5554
-        while port in used_ports:
-            port += 2
-        return port
+        """Find next free host port for a new container."""
+        with self._lock:
+            used = _eh._used_host_ports()
+        return next_available_port(used)
 
-    def _wait_for_boot(self, serial: str, timeout: int = 180):
+    def _wait_for_boot(self, serial: str, timeout: int = 240):
         """Poll until device reports boot complete."""
         deadline = time.time() + timeout
         while time.time() < deadline:
@@ -375,13 +337,13 @@ class EmulatorManager:
                 r = _run([ADB_BIN, "-s", serial, "shell", "getprop", "sys.boot_completed"], timeout=5, check=False)
                 if r.stdout.strip() == "1":
                     return True
-            except (subprocess.SubprocessError, OSError):
+            except Exception:
                 pass
-            time.sleep(2)
+            time.sleep(3)
         raise TimeoutError(f"{serial} did not boot within {timeout}s")
 
 
-# ── Singletons ───────────────────────────────────────────────────────────────
+# ── Singletons ────────────────────────────────────────────────────────────────
 _manager: Optional[EmulatorManager] = None
 _pool: Optional[EmulatorPool] = None
 

--- a/gitd/services/job_engine.py
+++ b/gitd/services/job_engine.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import subprocess
+import sys
 from datetime import datetime, timedelta
 
 from sqlalchemy import text
@@ -20,6 +21,7 @@ from gitd.services._job_helpers import (
     _parse_job_summary,
     archive_to_runs,
     finish_job,
+    resolve_script,
 )
 
 logger = logging.getLogger(__name__)
@@ -57,7 +59,7 @@ def _build_scheduled_cmd(job_type: str, config: dict, phone: str | None) -> list
             cmd = [
                 "python3",
                 "-u",
-                str(script_dir / "bots" / "tiktok" / "crawl_runner.py"),
+                str(resolve_script("bots/tiktok/crawl_runner.py")),
                 "--label",
                 str(label),
                 "--n-hashtags",
@@ -88,7 +90,7 @@ def _build_scheduled_cmd(job_type: str, config: dict, phone: str | None) -> list
             cmd = [
                 "python3",
                 "-u",
-                str(script_dir / "bots" / "tiktok" / "scraper.py"),
+                str(resolve_script("bots/tiktok/scraper.py")),
                 query,
                 "--tab",
                 str(tab),
@@ -110,7 +112,7 @@ def _build_scheduled_cmd(job_type: str, config: dict, phone: str | None) -> list
         cmd = [
             "python3",
             "-u",
-            str(script_dir / "bots" / "tiktok" / "outreach.py"),
+            str(resolve_script("bots/tiktok/outreach.py")),
             "--strategy-id",
             str(sid),
             "--delay",
@@ -134,7 +136,7 @@ def _build_scheduled_cmd(job_type: str, config: dict, phone: str | None) -> list
     elif job_type == "post":
         video = config.get("video", "")
         action = config.get("action", "draft")
-        cmd = ["python3", "-u", str(script_dir / "bots" / "tiktok" / "upload.py")]
+        cmd = ["python3", "-u", str(resolve_script("bots/tiktok/upload.py"))]
         if video:
             cmd.append(video)
         else:
@@ -154,7 +156,7 @@ def _build_scheduled_cmd(job_type: str, config: dict, phone: str | None) -> list
             cmd += ["--account", config["account"]]
         return cmd
     elif job_type == "publish_draft":
-        cmd = ["python3", "-u", str(script_dir / "bots" / "tiktok" / "upload.py")]
+        cmd = ["python3", "-u", str(resolve_script("bots/tiktok/upload.py"))]
         if phone:
             cmd += ["--device", phone]
         if config.get("draft_tag"):
@@ -170,7 +172,7 @@ def _build_scheduled_cmd(job_type: str, config: dict, phone: str | None) -> list
     elif job_type in ("content_gen", "content_plan"):
         days = config.get("days", 1)
         ppd = config.get("posts_per_day", 3)
-        agent_script = _SCRIPT_DIR / "agent" / "agent_core.py"
+        agent_script = resolve_script("agent/agent_core.py")
         cmd = [
             "python3",
             "-u",
@@ -192,7 +194,7 @@ def _build_scheduled_cmd(job_type: str, config: dict, phone: str | None) -> list
             cmd += ["--platform", config["platform"]]
         return cmd
     elif job_type == "inbox_scan":
-        cmd = ["python3", "-u", str(script_dir / "bots" / "tiktok" / "inbox_scanner.py")]
+        cmd = ["python3", "-u", str(resolve_script("bots/tiktok/inbox_scanner.py"))]
         if phone:
             cmd += ["--device", phone]
         max_scrolls = config.get("max_scrolls", 80)
@@ -201,7 +203,7 @@ def _build_scheduled_cmd(job_type: str, config: dict, phone: str | None) -> list
             cmd += ["--account", config["account"]]
         return cmd
     elif job_type == "perf_scan":
-        cmd = ["python3", "-u", str(script_dir / "bots" / "tiktok" / "perf_scanner.py")]
+        cmd = ["python3", "-u", str(resolve_script("bots/tiktok/perf_scanner.py"))]
         if phone:
             cmd += ["--device", phone]
         num_posts = config.get("num_posts", 10)
@@ -214,7 +216,7 @@ def _build_scheduled_cmd(job_type: str, config: dict, phone: str | None) -> list
             cmd += ["--account", config["account"]]
         return cmd
     elif job_type == "engage":
-        cmd = ["python3", "-u", str(script_dir / "bots" / "tiktok" / "engage.py")]
+        cmd = ["python3", "-u", str(resolve_script("bots/tiktok/engage.py"))]
         if phone:
             cmd += ["--device", phone]
         if config.get("duration"):
@@ -233,7 +235,7 @@ def _build_scheduled_cmd(job_type: str, config: dict, phone: str | None) -> list
     elif job_type == "app_explore":
         script = script_dir / "skills" / "auto_creator.py"
         package = config.get("package", "")
-        cmd = ["python3", "-u", str(script), "--package", package]
+        cmd = [sys.executable, "-u", str(script), "--package", package]
         if phone:
             cmd += ["--device", phone]
         if config.get("max_depth"):
@@ -246,13 +248,16 @@ def _build_scheduled_cmd(job_type: str, config: dict, phone: str | None) -> list
             cmd += ["--output", config["output"]]
         return cmd
     elif job_type in ("skill_workflow", "skill_action"):
-        skill_name = config.get("skill", "tiktok")
-        target = config.get("workflow") or config.get("action", "")
+        if _skill_config_preflight(job_type, config):
+            return None
+        skill_name = str(config.get("skill") or "").strip()
+        target_key = "workflow" if job_type == "skill_workflow" else "action"
+        target = str(config.get(target_key) or "").strip()
         params = config.get("params", {})
         run_type = "workflow" if job_type == "skill_workflow" else "action"
         runner = script_dir / "skills" / "_run_skill.py"
         cmd = [
-            "python3",
+            sys.executable,
             "-u",
             str(runner),
             "--skill",
@@ -271,11 +276,125 @@ def _build_scheduled_cmd(job_type: str, config: dict, phone: str | None) -> list
 # ── Job launch / kill ───────────────────────────────────────────────────────
 
 
+_TIKTOK_JOB_TYPES = {"crawl", "outreach", "post", "publish_draft", "perf_scan", "engage", "inbox_scan"}
+_TIKTOK_SKILL_NAMES = {"tiktok", "tiktok_ios"}
+
+
+def _job_uses_tiktok_account(job_type: str, config: dict | None) -> bool:
+    if job_type in _TIKTOK_JOB_TYPES:
+        return True
+    if job_type not in ("skill_workflow", "skill_action"):
+        return False
+    skill_name = str((config or {}).get("skill") or "").strip()
+    return skill_name in _TIKTOK_SKILL_NAMES
+
+
+def _job_platform_preflight(phone: str | None, job_type: str) -> str | None:
+    if not phone:
+        return None
+    try:
+        from gitd.bots.common.device import is_ios_ref
+    except Exception:
+        return None
+    if is_ios_ref(phone) and job_type in _TIKTOK_JOB_TYPES:
+        return f"{job_type} jobs are Android-only until the iOS TikTok workflow is ported"
+    return None
+
+
+def _skill_config_preflight(job_type: str, config: dict) -> str | None:
+    if job_type not in ("skill_workflow", "skill_action"):
+        return None
+    skill_name = str((config or {}).get("skill") or "").strip()
+    if not skill_name:
+        return f"{job_type} jobs require config.skill"
+    target_key = "workflow" if job_type == "skill_workflow" else "action"
+    target = str((config or {}).get(target_key) or "").strip()
+    if not target:
+        return f"{job_type} jobs require config.{target_key}"
+    params = (config or {}).get("params", {})
+    if params is not None and not isinstance(params, dict):
+        return f"{job_type} jobs require config.params to be an object"
+    return None
+
+
+def _account_preflight(phone: str | None, job_type: str, config: dict) -> str | None:
+    """Verify the expected TikTok account is active before running.
+
+    Returns an error message string if the job should be blocked, or None
+    if it should proceed. Non-TikTok jobs always pass.
+
+    Detection failures (no premium installed, can't detect) do NOT block —
+    we log and proceed. Only an *observed mismatch* blocks the job.
+    """
+    if not _job_uses_tiktok_account(job_type, config):
+        return None
+    expected = (config or {}).get("account")
+    if not expected or not phone:
+        return None
+    try:
+        from gitd.services.account_health import expected_account_matches
+
+        check = expected_account_matches(phone, expected)
+    except Exception as e:
+        logger.warning("preflight skipped (error): %s", e)
+        return None
+    if check["ok"]:
+        if check.get("reason"):
+            logger.warning("preflight passed with caveat: %s", check["reason"])
+        return None
+    return check["reason"] or "account mismatch"
+
+
+def _skill_platform_preflight(phone: str | None, job_type: str, config: dict) -> str | None:
+    if job_type not in ("skill_workflow", "skill_action"):
+        return None
+    try:
+        import yaml
+
+        from gitd.skills.platforms import skill_platform_error, skill_supports_device
+
+        skill_name = config.get("skill", "tiktok")
+        meta_path = _SCRIPT_DIR / "skills" / skill_name / "skill.yaml"
+        meta = yaml.safe_load(meta_path.read_text()) if meta_path.exists() else {}
+        meta = meta or {}
+        device = phone or _BOT_DEVICE
+        if not skill_supports_device(meta, device):
+            return skill_platform_error(skill_name, meta, device)["message"]
+    except Exception as exc:
+        logger.warning("skill platform preflight skipped: %s", exc)
+    return None
+
+
 def _launch_scheduled_job(db, job_row: dict):
     """Launch a queued job subprocess."""
     job_id = job_row["id"]
     phone = job_row.get("phone_serial")
     config = json.loads(job_row.get("config_json") or "{}")
+
+    config_err = _skill_config_preflight(job_row["job_type"], config)
+    if config_err:
+        finish_job(db, job_id, "failed", error_msg=f"preflight: {config_err}")
+        archive_to_runs(db, job_id)
+        return
+
+    platform_err = _job_platform_preflight(phone, job_row["job_type"])
+    if platform_err:
+        finish_job(db, job_id, "failed", error_msg=f"preflight: {platform_err}")
+        archive_to_runs(db, job_id)
+        return
+
+    # Pre-flight: refuse to start if the wrong TikTok account is active.
+    preflight_err = _account_preflight(phone, job_row["job_type"], config)
+    if preflight_err:
+        finish_job(db, job_id, "failed", error_msg=f"preflight: {preflight_err}")
+        archive_to_runs(db, job_id)
+        return
+    skill_preflight_err = _skill_platform_preflight(phone, job_row["job_type"], config)
+    if skill_preflight_err:
+        finish_job(db, job_id, "failed", error_msg=f"preflight: {skill_preflight_err}")
+        archive_to_runs(db, job_id)
+        return
+
     cmd = _build_scheduled_cmd(job_row["job_type"], config, phone)
     if not cmd:
         finish_job(db, job_id, "failed", error_msg=f"unsupported job_type: {job_row['job_type']}")

--- a/gitd/services/llm_backoff.py
+++ b/gitd/services/llm_backoff.py
@@ -1,0 +1,163 @@
+"""Rate-limit backoff + effort-scaled timeouts for LLM calls.
+
+Purely additive robustness: on a clean call these helpers are a passthrough;
+they only change behaviour when a provider raises a rate-limit / overloaded
+error, in which case we wait and retry instead of failing the turn.
+
+Distilled from the AndroidWorld agent harness (`_call_claude` / `_is_rate_limited`).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable
+from typing import TypeVar
+
+log = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+# Exponential backoff schedule (seconds). A run that trips the API's rate limit
+# waits progressively longer rather than giving up on the first 429.
+DEFAULT_BACKOFF = (15, 30, 60, 120, 240)
+
+# Shorter schedule for INTERACTIVE (SSE) chats: a long silent wait makes idle
+# proxies drop the stream and the UI look dead. Cap total backoff at ~105s and
+# let the user retry rather than stalling a live chat for minutes.
+INTERACTIVE_BACKOFF = (15, 30, 60)
+
+# Max SSE silence during a backoff wait. Waits longer than this are sliced so a
+# keepalive activity event goes out at least this often, keeping proxies + UI
+# from treating the stream as dead mid-wait.
+KEEPALIVE_SLICE_S = 10
+
+_RATE_LIMIT_MARKERS = (
+    "rate limit",
+    "rate_limit",
+    "ratelimit",
+    "429",
+    "overloaded",
+    "retry-after",
+    "usage limit",
+    "too many requests",
+    "quota",
+    "529",
+)
+
+# Wall-clock ceiling for a single LLM call, scaled by model tier. A bigger model
+# reasons longer, so a fixed short timeout would cut it off mid-thought; a small
+# model that hasn't returned in minutes is hung. Mirrors the effort→seconds map
+# in the AW harness, keyed on Ghost's model names instead of an effort flag.
+_EFFORT_TIMEOUTS = {
+    "opus": 420,
+    "sonnet": 300,
+    "haiku": 240,
+}
+# Fallback for models we don't recognise (vLLM/gemma, on-device, future ids).
+# MUST stay >= the SDK's own default (600s) so wiring an explicit timeout can
+# never SHORTEN a call that previously relied on the SDK default — a vLLM model
+# under load can legitimately take minutes to first token.
+_DEFAULT_TIMEOUT = 600
+
+
+def is_rate_limited(err: str | None) -> bool:
+    """True if an error string looks like a provider rate-limit / overload."""
+    s = (err or "").lower()
+    return any(marker in s for marker in _RATE_LIMIT_MARKERS)
+
+
+def effort_timeout(model: str | None) -> int:
+    """Wall-clock timeout (seconds) for one LLM call, scaled by model tier.
+
+    Matches on a substring so full ids (``claude-opus-4-...``,
+    ``anthropic/claude-sonnet-4``) resolve to the right tier.
+    """
+    m = (model or "").lower()
+    for tier, seconds in _EFFORT_TIMEOUTS.items():
+        if tier in m:
+            return seconds
+    return _DEFAULT_TIMEOUT
+
+
+def backoff_stream(
+    fn: Callable[[], T],
+    *,
+    backoff: tuple[int, ...] = INTERACTIVE_BACKOFF,
+    sleep: Callable[[float], None] = time.sleep,
+):
+    """Generator variant of :func:`call_with_backoff` for SSE provider loops.
+
+    Yields ``{"type": "activity", "content": ...}`` events during rate-limit
+    waits — sliced to at most ``KEEPALIVE_SLICE_S`` apart so a live chat stream
+    never goes silent long enough for an idle proxy to drop it. The FINAL yielded
+    item is ``{"__result__": <fn() return value>}``; callers pull that out and
+    forward every other event to the client:
+
+        for ev in backoff_stream(lambda: client.create(...)):
+            if "__result__" in ev:
+                resp = ev["__result__"]
+            else:
+                yield ev
+
+    Same retry policy as :func:`call_with_backoff`: only rate-limit errors
+    retry; anything else (and schedule exhaustion) re-raises for the caller's
+    existing ``except`` to surface as an error event.
+    """
+    attempt = 0
+    while True:
+        try:
+            yield {"__result__": fn()}
+            return
+        except Exception as e:  # noqa: BLE001 — re-raised below if not retryable
+            if not is_rate_limited(str(e)) or attempt >= len(backoff):
+                raise
+            wait = backoff[attempt]
+            remaining = wait
+            while remaining > 0:
+                yield {
+                    "type": "activity",
+                    "content": (f"⏳ Rate-limited — waiting {remaining}s (retry {attempt + 1}/{len(backoff)})..."),
+                }
+                slice_s = min(KEEPALIVE_SLICE_S, remaining)
+                sleep(slice_s)
+                remaining -= slice_s
+            attempt += 1
+
+
+def call_with_backoff(
+    fn: Callable[[], T],
+    *,
+    backoff: tuple[int, ...] = DEFAULT_BACKOFF,
+    on_wait: Callable[[int, int, str], None] | None = None,
+    sleep: Callable[[float], None] = time.sleep,
+) -> T:
+    """Call ``fn`` and, on a rate-limit error, wait + retry with backoff.
+
+    Non-rate-limit exceptions propagate immediately — a bad request or auth
+    failure should not be retried five times. On exhausting the schedule the
+    last rate-limit exception is re-raised so callers surface a real error.
+
+    ``on_wait(attempt, wait_seconds, err)`` is called before each sleep (for
+    progress reporting). ``sleep`` is injectable so tests don't actually wait.
+    """
+    attempt = 0
+    while True:
+        try:
+            return fn()
+        except Exception as e:  # noqa: BLE001 — re-raised below if not retryable
+            if not is_rate_limited(str(e)) or attempt >= len(backoff):
+                raise
+            wait = backoff[attempt]
+            if on_wait is not None:
+                on_wait(attempt + 1, wait, str(e))
+            else:
+                log.warning(
+                    "LLM rate-limited (%s); backoff %ss (%d/%d)",
+                    str(e)[:80],
+                    wait,
+                    attempt + 1,
+                    len(backoff),
+                )
+            sleep(wait)
+            attempt += 1

--- a/gitd/services/marketing_lookup.py
+++ b/gitd/services/marketing_lookup.py
@@ -1,0 +1,98 @@
+"""Marketing lead lookup helpers shared by MCP and in-process agents."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def lookup_lead(handle: str, db_path: str | Path | None = None) -> str:
+    """Return a text fact sheet for one influencer lead."""
+    from gitd.db import DEFAULT_DB, get_connection
+
+    h = handle.strip()
+    if not h.startswith("@"):
+        h = "@" + h
+    conn = get_connection(Path(db_path) if db_path else DEFAULT_DB)
+    try:
+        inf = conn.execute("SELECT * FROM influencers WHERE handle = ?", (h,)).fetchone()
+        if not inf:
+            return f"No influencer record for {h}"
+        out = [
+            f"HANDLE:    {inf['handle']}",
+            f"PROFILE:   https://www.tiktok.com/{inf['handle']}",
+            f"FOLLOWERS: {inf['followers']:,}" if inf["followers"] else "FOLLOWERS: ?",
+            f"FOLLOWING: {inf['following']:,}" if inf["following"] else "FOLLOWING: ?",
+            f"LIKES:     {inf['total_likes']:,}" if inf["total_likes"] else "LIKES: ?",
+            f"NICHE:     {inf['niche'] or '-'}",
+            f"BIO:       {inf['bio'] or '-'}",
+            f"FOUND VIA: {inf['source_query'] or '-'} (scraped {inf['scraped_at'] or '?'})",
+        ]
+        if inf["total_likes"] and inf["followers"]:
+            try:
+                ratio = inf["total_likes"] / inf["followers"]
+                out.append(f"ENGAGEMENT: {ratio:.1f} likes/follower")
+            except (ZeroDivisionError, TypeError):
+                pass
+        if inf["caption"]:
+            sample = inf["caption"][:120].replace("\n", " ")
+            out.append(f"SAMPLE:    {sample}...")
+
+        ol = conn.execute(
+            "SELECT ol.*, s.name AS strategy_name FROM outreach_log ol "
+            "LEFT JOIN outreach_strategies s ON s.id = ol.strategy_id "
+            "WHERE ol.influencer_id = ?",
+            (inf["id"],),
+        ).fetchone()
+        if ol:
+            out.append("")
+            out.append("OUTREACH:")
+            out.append(f"  Status:    {ol['status']}")
+            out.append(f"  Sent from: @{ol['source_account'] or '?'}")
+            out.append(f"  Contacted: {ol['contacted_at'] or ol['updated_at']}")
+            out.append(f"  Strategy:  {ol['strategy_name'] or ol['strategy_id']}")
+            if ol["deal_status"]:
+                out.append(f"  Deal:      {ol['deal_status']}")
+            if ol["notes"]:
+                out.append(f"  Notes:     {ol['notes']}")
+        else:
+            out.append("")
+            out.append("OUTREACH:  never contacted")
+
+        bare = inf["handle"].lstrip("@")
+        ir = conn.execute(
+            "SELECT * FROM inbox_replies WHERE handle = ? OR handle LIKE ?",
+            (bare, f"%{bare}%"),
+        ).fetchone()
+        if ir:
+            out.append("")
+            out.append("CONVERSATION:")
+            out.append(f"  Last msg:  {ir['last_msg']}")
+            out.append(f"  Status:    {ir['status']}")
+            out.append(f"  Unread:    {ir['unread']}")
+            out.append(f"  First seen: {ir['first_seen_at']}")
+            out.append(f"  Last seen:  {ir['last_seen_at']}")
+        return "\n".join(out)
+    finally:
+        conn.close()
+
+
+def list_unread_leads(db_path: str | Path | None = None) -> str:
+    """Return unread influencer replies sorted by recency."""
+    from gitd.db import DEFAULT_DB, get_connection
+
+    conn = get_connection(Path(db_path) if db_path else DEFAULT_DB)
+    try:
+        rows = conn.execute(
+            "SELECT handle, unread, last_msg, last_seen_at "
+            "FROM inbox_replies WHERE unread > 0 ORDER BY last_seen_at DESC"
+        ).fetchall()
+        if not rows:
+            return "0 unread"
+        out = [f"{len(rows)} unread:"]
+        for r in rows:
+            preview = (r["last_msg"] or "").replace("\n", " ")[:80]
+            out.append(f"  [{r['unread']}] {r['handle']:<35} - {preview}")
+            out.append(f"      seen: {r['last_seen_at']}")
+        return "\n".join(out)
+    finally:
+        conn.close()

--- a/gitd/services/observability.py
+++ b/gitd/services/observability.py
@@ -1,0 +1,499 @@
+"""Observability — local SQLite tracing (always on) + optional Langfuse forward.
+
+Two storage backends, fronted by the same helpers so the chat providers don't
+care which is wired:
+
+- **Local** (`gitd.db` `traces` + `trace_spans`) — always on. Powers the in-app
+  Traces tab. Survives Mac reboots, works offline, no external deps.
+- **Langfuse** — opt-in, activated when `LANGFUSE_PUBLIC_KEY` is set. Useful for
+  centralized cross-device aggregation, leaderboards, eval scoring.
+
+Both write the same trace shape, so flipping between them is just a config
+change. Tracing every chat turn means every helper here gets called dozens
+of times per session — they MUST be cheap and exception-safe.
+
+Public surface (unchanged from prior version, so wiring in chat providers
+doesn't move):
+    trace_chat_turn(...)        contextmanager — opens trace handle
+    span_tool_call(...)         contextmanager — opens span handle (rarely used; helpers below cover the common case)
+    record_generation(...)      records llm-call generation under a trace
+    record_tool_result(...)     ends a tool span with output (success or error)
+    set_trace_output(...)       sets the trace's final assistant reply
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from typing import Any, Iterator, Optional
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def _truncate(s: Any, limit: int = 4000) -> str:
+    """JSON-stringify and truncate. Keeps the DB rows bounded."""
+    try:
+        text = s if isinstance(s, str) else json.dumps(s, default=str)
+    except Exception:
+        text = str(s)
+    return text if len(text) <= limit else text[:limit] + "…[truncated]"
+
+
+# ── Trace handle — what the providers see ─────────────────────────────────────
+
+
+class _TraceHandle:
+    """Lightweight wrapper passed to `with` blocks. Holds local trace_id and
+    optional Langfuse handle. Methods called by the chat providers fan out to
+    both storages; failures in either are swallowed so observability can never
+    crash a chat turn.
+    """
+
+    __slots__ = ("local_id", "lf_handle", "_open_spans", "_started")
+
+    def __init__(self, local_id: str, lf_handle: Optional[Any]):
+        self.local_id = local_id
+        self.lf_handle = lf_handle
+        self._open_spans: dict[str, dict] = {}  # span_key → state
+        self._started = time.time()
+
+    # -- spans --
+    def span(self, *, name: str, input: Any = None, kind: str = "tool") -> "_SpanHandle":
+        """Open a span. Returned handle is what's passed to record_tool_result.
+
+        Caller controls the shape of `input` — pass it through to Langfuse
+        verbatim; existing callers already wrap as {"args": tool_args}."""
+        local_span = _local_span_open(self.local_id, kind=kind, name=name, input_obj=input)
+        lf_span = None
+        if self.lf_handle is not None:
+            try:
+                lf_span = self.lf_handle.span(name=name, input=input)
+            except Exception:
+                pass
+        return _SpanHandle(local_id=local_span, lf_handle=lf_span)
+
+    # -- generations (single-shot, no open/close pair) --
+    def record_generation(
+        self,
+        *,
+        model: str,
+        prompt: str,
+        output: str,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        cost_usd: float = 0.0,
+    ) -> None:
+        _local_generation(
+            self.local_id,
+            model=model,
+            prompt=prompt,
+            output=output,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_usd=cost_usd,
+        )
+        if self.lf_handle is not None:
+            try:
+                self.lf_handle.generation(
+                    name="llm-call",
+                    model=model,
+                    input=prompt,
+                    output=output,
+                    usage={
+                        "input": input_tokens,
+                        "output": output_tokens,
+                        "total": input_tokens + output_tokens,
+                        "unit": "TOKENS",
+                    },
+                    metadata={"cost_usd": cost_usd} if cost_usd else None,
+                )
+            except Exception:
+                pass
+
+    # -- final output --
+    def set_output(self, output: str) -> None:
+        _local_trace_set_output(self.local_id, output)
+        if self.lf_handle is not None:
+            try:
+                self.lf_handle.update(output=output)
+            except Exception:
+                pass
+
+
+class _SpanHandle:
+    __slots__ = ("local_id", "lf_handle", "_started")
+
+    def __init__(self, local_id: int, lf_handle: Optional[Any]):
+        self.local_id = local_id
+        self.lf_handle = lf_handle
+        self._started = time.time()
+
+
+# ── Local SQLite writers ──────────────────────────────────────────────────────
+
+
+def _local_trace_open(
+    *, conversation_id: str, provider: str, model: str, device: str, source: str, user_input: str
+) -> str:
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import Trace
+
+    trace_id = uuid.uuid4().hex
+    db = SessionLocal()
+    try:
+        db.add(
+            Trace(
+                id=trace_id,
+                conversation_id=conversation_id or None,
+                provider=provider,
+                model=model,
+                device=device,
+                source=source,
+                user_input=_truncate(user_input, 8000),
+                status="running",
+                started_at=_now_iso(),
+            )
+        )
+        db.commit()
+    except Exception:
+        try:
+            db.rollback()  # noqa: E701
+        except Exception:
+            pass  # noqa: E701
+    finally:
+        db.close()
+    return trace_id
+
+
+def _local_trace_close(trace_id: str, *, status: str, duration_ms: int, error_text: str = "") -> None:
+    """Close a trace — only touches lifecycle fields. Token/cost totals are
+    accumulated by `_local_trace_accumulate_tokens` during the run, so we
+    must not overwrite them here."""
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import Trace
+
+    db = SessionLocal()
+    try:
+        t = db.get(Trace, trace_id)
+        if t:
+            t.status = status
+            t.duration_ms = duration_ms
+            t.error_text = _truncate(error_text, 2000) if error_text else ""
+            t.ended_at = _now_iso()
+            db.commit()
+    except Exception:
+        try:
+            db.rollback()  # noqa: E701
+        except Exception:
+            pass  # noqa: E701
+    finally:
+        db.close()
+
+
+def _local_trace_set_output(trace_id: str, output: str) -> None:
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import Trace
+
+    db = SessionLocal()
+    try:
+        t = db.get(Trace, trace_id)
+        if t:
+            t.final_output = _truncate(output, 16000)
+            db.commit()
+    except Exception:
+        try:
+            db.rollback()  # noqa: E701
+        except Exception:
+            pass  # noqa: E701
+    finally:
+        db.close()
+
+
+def _local_span_open(trace_id: str, *, kind: str, name: str, input_obj: Any) -> int:
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import TraceSpan
+
+    db = SessionLocal()
+    span_id = 0
+    try:
+        span = TraceSpan(
+            trace_id=trace_id,
+            kind=kind,
+            name=name,
+            input_json=_truncate(input_obj) if input_obj is not None else "",
+            started_at=_now_iso(),
+        )
+        db.add(span)
+        db.commit()
+        span_id = span.id
+    except Exception:
+        try:
+            db.rollback()  # noqa: E701
+        except Exception:
+            pass  # noqa: E701
+    finally:
+        db.close()
+    return span_id
+
+
+def _local_span_close(span_id: int, *, output_obj: Any, error: bool, duration_ms: int) -> None:
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import TraceSpan
+
+    if not span_id:
+        return
+    db = SessionLocal()
+    try:
+        s = db.get(TraceSpan, span_id)
+        if s:
+            s.output_json = _truncate(output_obj) if output_obj is not None else ""
+            s.level = "ERROR" if error else "DEFAULT"
+            s.ended_at = _now_iso()
+            s.duration_ms = duration_ms
+            db.commit()
+    except Exception:
+        try:
+            db.rollback()  # noqa: E701
+        except Exception:
+            pass  # noqa: E701
+    finally:
+        db.close()
+
+
+def _local_generation(
+    trace_id: str, *, model: str, prompt: str, output: str, input_tokens: int, output_tokens: int, cost_usd: float
+) -> None:
+    """LLM generations are stored as spans with kind='generation'. Single-shot
+    write — no open/close needed since we already have all the data."""
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import TraceSpan
+
+    db = SessionLocal()
+    try:
+        now = _now_iso()
+        db.add(
+            TraceSpan(
+                trace_id=trace_id,
+                kind="generation",
+                name="llm-call",
+                input_json=_truncate({"prompt": prompt, "model": model}, 16000),
+                output_json=_truncate(
+                    {
+                        "output": output,
+                        "input_tokens": input_tokens,
+                        "output_tokens": output_tokens,
+                        "cost_usd": cost_usd,
+                    },
+                    16000,
+                ),
+                started_at=now,
+                ended_at=now,
+            )
+        )
+        db.commit()
+    except Exception:
+        try:
+            db.rollback()  # noqa: E701
+        except Exception:
+            pass  # noqa: E701
+    finally:
+        db.close()
+
+
+# ── Optional Langfuse client ──────────────────────────────────────────────────
+
+_lf_client = None
+_lf_init_done = False
+
+
+def _lf_get_client():
+    """Lazily build a Langfuse client. If LANGFUSE_PUBLIC_KEY isn't set, returns
+    None forever and we skip the remote path entirely."""
+    global _lf_client, _lf_init_done
+    if _lf_init_done:
+        return _lf_client
+    _lf_init_done = True
+    pk = os.environ.get("LANGFUSE_PUBLIC_KEY", "").strip()
+    sk = os.environ.get("LANGFUSE_SECRET_KEY", "").strip()
+    if not pk or not sk:
+        return None
+    try:
+        from langfuse import Langfuse
+
+        _lf_client = Langfuse(
+            public_key=pk,
+            secret_key=sk,
+            host=os.environ.get("LANGFUSE_HOST", "http://localhost:3000"),
+        )
+    except Exception:
+        _lf_client = None
+    return _lf_client
+
+
+def is_langfuse_enabled() -> bool:
+    return _lf_get_client() is not None
+
+
+# ── Public API — what the chat providers call ─────────────────────────────────
+
+
+@contextmanager
+def trace_chat_turn(
+    *, session_id: str, user_message: str, provider: str, model: str, device: str, source: str = "mac"
+) -> Iterator[Optional[_TraceHandle]]:
+    """Open a trace for a full chat turn. Always returns a handle (never None
+    now that local tracing is always on). The handle's methods fan out to both
+    backends; the caller doesn't need to know which is enabled."""
+    local_id = _local_trace_open(
+        conversation_id=session_id,
+        provider=provider,
+        model=model,
+        device=device,
+        source=source,
+        user_input=user_message,
+    )
+
+    lf_handle = None
+    lf = _lf_get_client()
+    if lf is not None:
+        try:
+            lf_handle = lf.trace(
+                name=f"chat:{provider}",
+                session_id=session_id,
+                input={"message": user_message},
+                metadata={"provider": provider, "model": model, "device": device, "source": source},
+                tags=[provider, source],
+            )
+        except Exception:
+            pass
+
+    handle = _TraceHandle(local_id=local_id, lf_handle=lf_handle)
+    started = time.time()
+    error_text = ""
+    status = "success"
+    try:
+        yield handle
+    except Exception as e:
+        status = "error"
+        error_text = str(e)
+        raise
+    finally:
+        duration_ms = int((time.time() - started) * 1000)
+        _local_trace_close(
+            local_id,
+            status=status,
+            duration_ms=duration_ms,
+            error_text=error_text,
+        )
+        if lf is not None:
+            try:
+                if lf_handle is not None:
+                    lf_handle.update(metadata={"duration_s": round(duration_ms / 1000, 2)})
+                lf.flush()
+            except Exception:
+                pass
+
+
+@contextmanager
+def span_tool_call(trace: Optional[_TraceHandle], tool_name: str, tool_args: Any) -> Iterator[Optional[_SpanHandle]]:
+    """Less-used helper — most providers manage span lifecycle inline so they
+    can attach the result to the right span by tool_use_id. Kept for symmetry."""
+    if trace is None:
+        yield None
+        return
+    span = trace.span(name=f"tool:{tool_name}", input=tool_args)
+    started = time.time()
+    try:
+        yield span
+    finally:
+        _local_span_close(
+            span.local_id,
+            output_obj=None,
+            error=False,
+            duration_ms=int((time.time() - started) * 1000),
+        )
+
+
+def record_generation(
+    trace: Optional[_TraceHandle],
+    *,
+    model: str,
+    prompt: str,
+    output: str,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cost_usd: float = 0.0,
+) -> None:
+    if trace is None:
+        return
+    trace.record_generation(
+        model=model,
+        prompt=prompt,
+        output=output,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cost_usd=cost_usd,
+    )
+    # Also update the trace-level token + cost totals so the list view shows them.
+    _local_trace_accumulate_tokens(trace.local_id, input_tokens, output_tokens, cost_usd)
+
+
+def _local_trace_accumulate_tokens(trace_id: str, input_tokens: int, output_tokens: int, cost_usd: float) -> None:
+    """For multi-turn LLM models that emit several `record_generation` calls
+    per trace (e.g. on-device Gemma's tool loop), accumulate totals."""
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import Trace
+
+    if not (input_tokens or output_tokens or cost_usd):
+        return
+    db = SessionLocal()
+    try:
+        t = db.get(Trace, trace_id)
+        if t:
+            t.input_tokens = (t.input_tokens or 0) + int(input_tokens)
+            t.output_tokens = (t.output_tokens or 0) + int(output_tokens)
+            t.cost_usd = (t.cost_usd or 0.0) + float(cost_usd)
+            db.commit()
+    except Exception:
+        try:
+            db.rollback()  # noqa: E701
+        except Exception:
+            pass  # noqa: E701
+    finally:
+        db.close()
+
+
+def record_tool_result(span: Optional[_SpanHandle], result: str, error: bool = False) -> None:
+    if span is None:
+        return
+    duration_ms = int((time.time() - span._started) * 1000)
+    _local_span_close(span.local_id, output_obj={"result": result[:4000]}, error=error, duration_ms=duration_ms)
+    if span.lf_handle is not None:
+        try:
+            span.lf_handle.update(
+                output={"result": result[:2000]},
+                level="ERROR" if error else "DEFAULT",
+            )
+            span.lf_handle.end()
+        except Exception:
+            pass
+
+
+def set_trace_output(trace: Optional[_TraceHandle], output: str) -> None:
+    if trace is None or not output:
+        return
+    trace.set_output(output)
+
+
+# Back-compat alias for old code paths.
+def is_enabled() -> bool:
+    """Local tracing is always enabled. Kept for callers that gate logic on this."""
+    return True

--- a/gitd/services/phone_recording.py
+++ b/gitd/services/phone_recording.py
@@ -1,0 +1,250 @@
+"""Cross-platform phone screen recording helpers."""
+
+from __future__ import annotations
+
+import re
+import signal
+import subprocess
+import threading
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from gitd.bots.common.device import get_device, is_ios_ref
+
+RECORDINGS_DIR = Path(__file__).resolve().parent.parent.parent / "data" / "phone_recordings"
+RECORDINGS_DIR.mkdir(parents=True, exist_ok=True)
+
+_active: dict[str, dict[str, Any]] = {}
+_lock = threading.Lock()
+
+
+def safe_recording_name(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "_", value).strip("_") or "device"
+
+
+def _recording_device_ref(device_safe: str) -> str:
+    if device_safe.startswith("ios_") and len(device_safe) > 4:
+        return "ios:" + device_safe[4:]
+    return device_safe
+
+
+def _parse_recording_name(filename: str) -> dict[str, str]:
+    stem = Path(filename).stem
+    match = re.match(r"^(?P<device>.+?)_(?P<date>\d{8})_(?P<time>\d{6})$", stem)
+    if not match:
+        return {"device_ref": "", "device_safe": ""}
+    device_safe = match.group("device")
+    return {"device_ref": _recording_device_ref(device_safe), "device_safe": device_safe}
+
+
+def _new_filename(device: str) -> str:
+    stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    return f"{safe_recording_name(device)}_{stamp}.mp4"
+
+
+def _platform(device: str) -> str:
+    return "ios" if is_ios_ref(device) else "android"
+
+
+def _recording_path(filename: str, recordings_dir: Path | str | None = None) -> Path:
+    name = Path(filename).name
+    if name != filename:
+        raise ValueError("invalid recording filename")
+    root = Path(recordings_dir) if recordings_dir is not None else RECORDINGS_DIR
+    root.mkdir(parents=True, exist_ok=True)
+    return root / name
+
+
+def start_recording(device: str, filename: str = "", recordings_dir: Path | str | None = None) -> dict:
+    """Start recording a device screen.
+
+    iOS records WDA MJPEG through ffmpeg. Android records on-device with
+    `screenrecord`, then pulls the MP4 when stopped.
+    """
+    if not device:
+        return {"ok": False, "error": "device required"}
+    with _lock:
+        existing = _active.get(device)
+        if existing and existing["proc"].poll() is None:
+            return {
+                "ok": False,
+                "error": "recording already running",
+                "device": device,
+                "platform": existing["platform"],
+                "filename": existing["filename"],
+            }
+
+        name = safe_recording_name(filename) if filename else _new_filename(device)
+        if not name.endswith(".mp4"):
+            name += ".mp4"
+        local_path = _recording_path(name, recordings_dir=recordings_dir)
+        platform = _platform(device)
+
+        if platform == "ios":
+            mjpeg_url = get_device(device).mjpeg_url
+            cmd = [
+                "ffmpeg",
+                "-y",
+                "-loglevel",
+                "error",
+                "-f",
+                "mjpeg",
+                "-i",
+                mjpeg_url,
+                "-an",
+                "-c:v",
+                "libx264",
+                "-pix_fmt",
+                "yuv420p",
+                str(local_path),
+            ]
+            proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            entry = {
+                "device": device,
+                "platform": platform,
+                "mode": "wda-mjpeg",
+                "filename": name,
+                "local_path": str(local_path),
+                "device_path": "",
+                "mjpeg_url": mjpeg_url,
+                "proc": proc,
+                "started_at": time.time(),
+            }
+        else:
+            device_path = f"/sdcard/ghost_recording_{safe_recording_name(device)}_{int(time.time())}.mp4"
+            proc = subprocess.Popen(
+                ["adb", "-s", device, "shell", "screenrecord", device_path],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            entry = {
+                "device": device,
+                "platform": platform,
+                "mode": "adb-screenrecord",
+                "filename": name,
+                "local_path": str(local_path),
+                "device_path": device_path,
+                "mjpeg_url": "",
+                "proc": proc,
+                "started_at": time.time(),
+            }
+        _active[device] = entry
+        return _entry_status(entry)
+
+
+def _stop_process(entry: dict[str, Any]) -> None:
+    proc = entry["proc"]
+    if entry["platform"] == "ios":
+        proc.terminate()
+    else:
+        proc.send_signal(signal.SIGINT)
+    try:
+        proc.wait(timeout=15)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            pass
+
+
+def stop_recording(device: str) -> dict:
+    if not device:
+        return {"ok": False, "error": "device required"}
+    with _lock:
+        entry = _active.get(device)
+        if not entry:
+            return {"ok": False, "device": device, "platform": _platform(device), "error": "recording not running"}
+        _stop_process(entry)
+        local_path = Path(entry["local_path"])
+        if entry["platform"] == "android":
+            try:
+                subprocess.run(
+                    ["adb", "-s", device, "pull", entry["device_path"], str(local_path)],
+                    timeout=30,
+                    check=True,
+                    capture_output=True,
+                )
+                subprocess.run(
+                    ["adb", "-s", device, "shell", "rm", entry["device_path"]],
+                    timeout=5,
+                    capture_output=True,
+                )
+            except (subprocess.SubprocessError, OSError) as e:
+                _active.pop(device, None)
+                return {
+                    **_entry_status(entry, running=False),
+                    "ok": False,
+                    "error": f"failed to pull recording: {e}",
+                }
+        _active.pop(device, None)
+        saved = local_path.exists() and local_path.stat().st_size > 0
+        return {
+            **_entry_status(entry, running=False),
+            "ok": bool(saved),
+            "saved": bool(saved),
+            "size_bytes": local_path.stat().st_size if saved else 0,
+            "url": f"/api/phone/recording/{entry['filename']}" if saved else "",
+            "error": "" if saved else "recording file was not created",
+        }
+
+
+def _entry_status(entry: dict[str, Any], running: bool | None = None) -> dict:
+    proc = entry["proc"]
+    if running is None:
+        running = proc.poll() is None
+    return {
+        "ok": True,
+        "device": entry["device"],
+        "platform": entry["platform"],
+        "mode": entry["mode"],
+        "running": running,
+        "filename": entry["filename"],
+        "path": entry["local_path"],
+        "started_at": entry["started_at"],
+        "duration_s": round(max(0, time.time() - entry["started_at"]), 2),
+        "mjpeg_url": entry.get("mjpeg_url", ""),
+    }
+
+
+def recording_status(device: str) -> dict:
+    with _lock:
+        entry = _active.get(device)
+        if not entry:
+            return {"ok": True, "device": device, "platform": _platform(device), "running": False}
+        return _entry_status(entry)
+
+
+def list_recordings() -> list[dict]:
+    items = []
+    for path in sorted(RECORDINGS_DIR.glob("*.mp4"), key=lambda p: p.stat().st_mtime, reverse=True):
+        stat = path.stat()
+        parsed = _parse_recording_name(path.name)
+        device_ref = parsed["device_ref"]
+        items.append(
+            {
+                "name": path.name,
+                "size_bytes": stat.st_size,
+                "size_mb": round(stat.st_size / 1_048_576, 2),
+                "date": datetime.fromtimestamp(stat.st_mtime).strftime("%Y-%m-%d %H:%M:%S"),
+                "url": f"/api/phone/recording/{path.name}",
+                "device_ref": device_ref,
+                "platform": _platform(device_ref) if device_ref else "",
+            }
+        )
+    return items
+
+
+def recording_file(filename: str) -> Path:
+    path = _recording_path(filename)
+    if not path.exists() or not path.is_file():
+        raise FileNotFoundError(filename)
+    return path
+
+
+def delete_recording(filename: str) -> dict:
+    path = recording_file(filename)
+    path.unlink()
+    return {"ok": True, "deleted": path.name}

--- a/gitd/services/scheduler_service.py
+++ b/gitd/services/scheduler_service.py
@@ -9,6 +9,7 @@ Public API:
     stop()   — set the stop flag (thread exits on next iteration)
 """
 
+import json
 import logging
 import os
 import signal
@@ -33,9 +34,12 @@ except ImportError:
     _content_plan_tick = None  # Premium feature
 from gitd.services.job_engine import (
     _is_job_due,
+    _job_platform_preflight,
     _kill_scheduled_job,
     _phone_procs,
     _process_phone_queue,
+    _skill_config_preflight,
+    _skill_platform_preflight,
 )
 
 logger = logging.getLogger(__name__)
@@ -96,6 +100,94 @@ def _wifi_reconnect_tick(db):
 
 
 # ── Main tick ───────────────────────────────────────────────────────────────
+
+
+def _coerce_config(value) -> dict:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+            return parsed if isinstance(parsed, dict) else {}
+        except Exception:
+            return {}
+    return {}
+
+
+def _scheduled_job_preflight_error(sched: dict) -> str | None:
+    """Return the first scheduler preflight error that should block enqueue."""
+    job_type = str(sched.get("job_type") or "")
+    phone = sched.get("phone_serial")
+    config = _coerce_config(sched.get("config_json"))
+
+    message = _skill_config_preflight(job_type, config)
+    if message:
+        return message
+
+    message = _job_platform_preflight(phone, job_type)
+    if message:
+        return message
+
+    return _skill_platform_preflight(phone, job_type, config)
+
+
+def _record_blocked_scheduled_job(db, sched: dict, reason: str, now: datetime) -> int:
+    """Record a due scheduled job that failed preflight before entering queue."""
+    ts = now.strftime("%Y-%m-%d %H:%M:%S")
+    config_json = sched.get("config_json") or "{}"
+    if isinstance(config_json, dict):
+        config_json = json.dumps(config_json)
+    db.execute(
+        text(
+            "INSERT INTO job_runs "
+            "(scheduled_job_id, phone_serial, job_type, priority, config_json, status, "
+            "enqueued_at, started_at, finished_at, duration_s, exit_code, error_msg, trigger) "
+            "VALUES (:scheduled_job_id, :phone_serial, :job_type, :priority, :config_json, :status, "
+            ":enqueued_at, :started_at, :finished_at, :duration_s, :exit_code, :error_msg, :trigger)"
+        ),
+        {
+            "scheduled_job_id": sched.get("id"),
+            "phone_serial": sched.get("phone_serial"),
+            "job_type": sched.get("job_type"),
+            "priority": sched.get("priority", 2),
+            "config_json": config_json,
+            "status": "failed",
+            "enqueued_at": ts,
+            "started_at": ts,
+            "finished_at": ts,
+            "duration_s": 0,
+            "exit_code": None,
+            "error_msg": f"preflight: {reason}",
+            "trigger": "scheduled",
+        },
+    )
+    run_id = db.execute(text("SELECT last_insert_rowid()")).scalar()
+    db.commit()
+    return int(run_id)
+
+
+def _enqueue_due_schedule(db, sched: dict, now: datetime) -> dict:
+    reason = _scheduled_job_preflight_error(sched)
+    if reason:
+        run_id = _record_blocked_scheduled_job(db, sched, reason, now)
+        logger.warning(
+            "Scheduled job #%s (%s) blocked before enqueue: %s",
+            sched.get("id"),
+            sched.get("job_type"),
+            reason,
+        )
+        return {"ok": False, "run_id": run_id, "error": reason}
+
+    queue_id = _enqueue_job(
+        db,
+        scheduled_job_id=sched["id"],
+        phone_serial=sched.get("phone_serial"),
+        job_type=sched["job_type"],
+        priority=sched.get("priority", 2),
+        config_json=sched.get("config_json", "{}"),
+        max_duration_s=sched.get("max_duration_s", 3600),
+    )
+    return {"ok": True, "queue_id": queue_id}
 
 
 def _scheduler_tick():
@@ -159,17 +251,8 @@ def _scheduler_tick():
                         o["job_type"],
                         pid,
                     )
-                    orphan_summary = ""
                     log_file = o.get("log_file") or f"/tmp/sched_job_{o['id']}.log"
-                    try:
-                        with open(log_file, "r", errors="replace") as lf:
-                            all_lines = lf.readlines()
-                        for line in reversed(all_lines[-10:]):
-                            if "[done]" in line:
-                                orphan_summary = line.strip().split("[done]")[-1].strip()
-                                break
-                    except (FileNotFoundError, OSError):
-                        pass
+                    orphan_summary = _parse_job_summary(o["id"], log_path=log_file)
                     try:
                         os.waitpid(pid, os.WNOHANG)
                     except (ChildProcessError, OSError):
@@ -184,15 +267,7 @@ def _scheduler_tick():
             for s in scheds:
                 s = dict(s)
                 if _is_job_due(s, now, db):
-                    _enqueue_job(
-                        db,
-                        scheduled_job_id=s["id"],
-                        phone_serial=s.get("phone_serial"),
-                        job_type=s["job_type"],
-                        priority=s.get("priority", 2),
-                        config_json=s.get("config_json", "{}"),
-                        max_duration_s=s.get("max_duration_s", 3600),
-                    )
+                    _enqueue_due_schedule(db, s, now)
 
             # 2. Collect all phones with pending/running work
             phones = set()

--- a/gitd/services/skill_creation.py
+++ b/gitd/services/skill_creation.py
@@ -1,0 +1,115 @@
+"""Shared helpers for creating recorded mobile automation skills."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from gitd.skills.platforms import normalize_platforms
+
+_MISSING = object()
+
+
+def _json_or_value(value: Any, default: Any = _MISSING) -> Any:
+    if value is None:
+        if default is _MISSING:
+            return None
+        return default
+    if isinstance(value, str):
+        if not value.strip():
+            if default is _MISSING:
+                return None
+            return default
+        return json.loads(value)
+    return value
+
+
+def _platform_list(platforms: Any, *, app_package: str, ios_bundle_id: str) -> list[str]:
+    if isinstance(platforms, str):
+        raw_text = platforms.strip()
+        if not raw_text:
+            raw = []
+        else:
+            try:
+                raw = json.loads(raw_text)
+            except json.JSONDecodeError:
+                raw = [p.strip() for p in raw_text.split(",")]
+    else:
+        raw = _json_or_value(platforms, default=[])
+    if isinstance(raw, str):
+        raw = [p.strip() for p in raw.split(",")]
+    parsed = normalize_platforms(raw)
+    if parsed:
+        return parsed
+    return ["ios"] if ios_bundle_id and not app_package else ["android"]
+
+
+def create_recorded_skill(
+    *,
+    name: str,
+    steps: Any,
+    app_package: str = "",
+    android_package: str | None = None,
+    platforms: Any = "",
+    ios_bundle_id: str = "",
+    elements_ios: Any = None,
+    elements_android: Any = None,
+    skills_dir: str | Path | None = None,
+    description_prefix: str = "Auto-generated skill with",
+) -> dict[str, Any]:
+    """Create a recorded skill directory with platform-aware metadata."""
+    skill_name = name.strip()
+    parsed_steps = _json_or_value(steps, default=[])
+    if not skill_name or not parsed_steps:
+        raise ValueError("name and steps required")
+
+    app_package = app_package or ""
+    android_package_source = android_package if android_package is not None else app_package
+    ios_bundle_id = ios_bundle_id or ""
+    parsed_platforms = _platform_list(platforms, app_package=app_package, ios_bundle_id=ios_bundle_id)
+
+    android_package_meta = android_package_source if "android" in parsed_platforms else ""
+    ios_target = ios_bundle_id
+    if "ios" in parsed_platforms and not ios_target:
+        ios_target = app_package
+    app_package_meta = app_package if "android" in parsed_platforms else ""
+
+    base_dir = Path(skills_dir) if skills_dir is not None else Path(__file__).resolve().parents[1] / "skills"
+    skill_dir = base_dir / skill_name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "actions").mkdir(exist_ok=True)
+    (skill_dir / "workflows").mkdir(exist_ok=True)
+
+    meta = {
+        "name": skill_name,
+        "version": "1.0.0",
+        "app_package": app_package_meta,
+        "android_package": android_package_meta,
+        "ios_bundle_id": ios_target,
+        "platforms": parsed_platforms,
+        "description": f"{description_prefix} {len(parsed_steps)} steps",
+    }
+    (skill_dir / "skill.yaml").write_text(yaml.dump(meta, default_flow_style=False))
+    (skill_dir / "workflows" / "recorded.json").write_text(json.dumps(parsed_steps, indent=2))
+    (skill_dir / "__init__.py").write_text(f'"""Skill: {skill_name}"""\n')
+
+    parsed_elements_android = _json_or_value(elements_android)
+    if parsed_elements_android is not None:
+        (skill_dir / "elements.yaml").write_text(yaml.dump(parsed_elements_android, default_flow_style=False))
+
+    parsed_elements_ios = _json_or_value(elements_ios)
+    if parsed_elements_ios is not None:
+        (skill_dir / "elements_ios.yaml").write_text(yaml.dump(parsed_elements_ios, default_flow_style=False))
+
+    return {
+        "ok": True,
+        "skill": skill_name,
+        "steps": len(parsed_steps),
+        "dir": str(skill_dir),
+        "platforms": parsed_platforms,
+        "metadata": meta,
+        "message": f"Skill '{skill_name}' created at skills/{skill_name}/ with {len(parsed_steps)} steps for {', '.join(parsed_platforms)}",
+    }

--- a/gitd/services/sub_agent.py
+++ b/gitd/services/sub_agent.py
@@ -1,0 +1,102 @@
+"""One-shot vision sub-agent — a fresh LLM call over cached frames (bencher #4).
+
+For image-heavy subtasks (transcribing a playing video, reading a burst of
+frames) the master agent shouldn't carry N screenshots in its own context. This
+spawns a SEPARATE, stateless Anthropic vision call over the frames and returns
+only its text answer, keeping the master's context lean.
+
+Pairs with ``screenshot_sequence`` (bencher #5), which captures the frames via
+per-frame screencap and caches them for this to read.
+
+Backend: the Anthropic API (the vision path). Requires ``ANTHROPIC_API_KEY`` — if
+absent (e.g. running under the claude-code subscription provider, which has no API
+key), it degrades gracefully with an explanatory string rather than raising, so a
+master turn that calls it never crashes.
+
+Cost note: each call sends up to ``MAX_SUB_AGENT_FRAMES`` images to the API. Frames
+are subsampled to the caller's ``max_frames`` (capped here) to bound spend.
+"""
+
+from __future__ import annotations
+
+import os
+
+SUB_AGENT_PROMPT = (
+    "You are a focused vision sub-agent. You are given a set of image frames (in "
+    "time order) and a task from the main agent. Do ONLY that task and reply with a "
+    "concise, exact result — no preamble, no explanation. For transcription: output "
+    "exactly what is asked (e.g. the comma-separated strings in order), reading each "
+    "frame's text character-for-character. If consecutive frames show the same text, "
+    "list it ONCE."
+)
+
+# Cost/latency ceiling: never send more than this many images in one sub-call,
+# regardless of what the caller asks for.
+MAX_SUB_AGENT_FRAMES = 60
+
+# Vision-capable default; override with SUB_AGENT_MODEL. Sonnet is a good
+# cost/quality point for frame transcription (cheaper than Opus, strong vision).
+_DEFAULT_MODEL = "claude-sonnet-5"
+
+
+def _model() -> str:
+    return os.environ.get("SUB_AGENT_MODEL", "").strip() or _DEFAULT_MODEL
+
+
+def _subsample(frames: list[str], max_frames: int) -> list[str]:
+    """Uniformly subsample ``frames`` down to at most ``max_frames`` (order-preserving)."""
+    cap = max(1, min(int(max_frames), MAX_SUB_AGENT_FRAMES))
+    if len(frames) <= cap:
+        return list(frames)
+    idxs = sorted({int(i * len(frames) / cap) for i in range(cap)})
+    return [frames[i] for i in idxs]
+
+
+def _anthropic_vision_call(system: str, content: list, model: str) -> str:
+    """Single stateless Anthropic vision call; returns the concatenated text.
+
+    Separated out so tests can monkeypatch it without an API key or network.
+    """
+    import anthropic
+
+    client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY", ""))
+    resp = client.messages.create(
+        model=model,
+        max_tokens=1024,
+        system=system,
+        messages=[{"role": "user", "content": content}],
+    )
+    parts = [block.text for block in resp.content if getattr(block, "type", None) == "text"]
+    return "".join(parts).strip()
+
+
+def run_sub_agent(task: str, frames_b64: list[str], *, model: str | None = None, max_frames: int = 60) -> str:
+    """Run the vision sub-agent over ``frames_b64`` for ``task``; return its text.
+
+    Never raises: missing key / API errors come back as an explanatory string so a
+    master agent turn keeps going. Frames are base64 JPEG (as produced by
+    ``get_screenshot_b64`` / ``screenshot_sequence``).
+    """
+    if not task or not task.strip():
+        return "sub_agent: missing 'task'"
+    if not frames_b64:
+        return "sub_agent: no frames available — run screenshot_sequence first"
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        return (
+            "sub_agent unavailable: no ANTHROPIC_API_KEY set. sub_agent runs a one-shot "
+            "Anthropic vision call, which needs an API key (it is not available under the "
+            "claude-code subscription provider). Set ANTHROPIC_API_KEY to enable it."
+        )
+
+    frames = _subsample(frames_b64, max_frames)
+    content: list = []
+    for i, fb in enumerate(frames):
+        content.append({"type": "text", "text": f"[Frame {i + 1}/{len(frames)}]"})
+        content.append({"type": "image", "source": {"type": "base64", "media_type": "image/jpeg", "data": fb}})
+    content.append({"type": "text", "text": task})
+
+    try:
+        answer = _anthropic_vision_call(SUB_AGENT_PROMPT, content, model or _model())
+    except Exception as e:  # noqa: BLE001 — surfaced to the master as text, never crashes the turn
+        return f"sub_agent error: {e}"
+    return answer or "sub_agent: (empty response)"

--- a/gitd/services/tool_platforms.py
+++ b/gitd/services/tool_platforms.py
@@ -1,0 +1,239 @@
+"""Platform support metadata for agent and MCP tools."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+PlatformSupport = Literal["cross_platform", "android_only", "ios_supported", "ios_planned"]
+
+
+@dataclass(frozen=True)
+class ToolPlatformInfo:
+    name: str
+    support: PlatformSupport
+    notes: str = ""
+
+    def supports(self, platform: str) -> bool:
+        platform = platform.lower()
+        if self.support == "cross_platform":
+            return platform in {"android", "ios"}
+        if self.support == "android_only":
+            return platform == "android"
+        if self.support == "ios_supported":
+            return platform == "ios"
+        if self.support == "ios_planned":
+            return platform == "android"
+        return False
+
+    def to_dict(self) -> dict[str, str | bool]:
+        return {
+            "name": self.name,
+            "support": self.support,
+            "android": self.supports("android"),
+            "ios": self.supports("ios"),
+            "notes": self.notes,
+        }
+
+
+_CROSS_PLATFORM = {
+    "list_devices": "Lists Android ADB devices and configured iOS Appium devices.",
+    "screenshot": "Uses Android screencap or Appium screenshot.",
+    "screenshot_annotated": "Draws labels from the normalized platform UI tree.",
+    "screenshot_cropped": "Crops screenshots from either backend.",
+    "start_screen_recording": "Android adb screenrecord or iOS WDA MJPEG captured through ffmpeg.",
+    "stop_screen_recording": "Stops Android adb screenrecord or iOS WDA MJPEG/ffmpeg recording.",
+    "screen_recording_status": "Reports active cross-platform phone screen recording status.",
+    "get_stream_info": "Returns effective Android Portal/H264/screencap or iOS WDA MJPEG stream metadata.",
+    "get_elements": "Uses normalized Android/iOS element shape.",
+    "get_screen_tree": "Uses normalized Android/iOS XML.",
+    "get_screen_xml": "Returns Android uiautomator XML or normalized iOS WDA XML.",
+    "get_phone_state": "Uses Android state probes or iOS activeAppInfo/window state.",
+    "device_health": "Checks Android Portal/device subsystems or iOS Appium/WDA health with actionable recovery steps.",
+    "fix_device_health": "Applies Android Portal/screen fixes or iOS Appium/WDA recovery actions returned by device_health.",
+    "classify_screen": "Runs against normalized state/tree data.",
+    "find_on_screen": "Searches normalized XML with OCR fallback.",
+    "ocr_screen": "Runs OCR on platform screenshot bytes.",
+    "ocr_region": "Runs OCR on cropped screenshot bytes.",
+    "tap": "Routes to ADB input tap or WDA pointer actions.",
+    "tap_element": "Taps normalized element centers.",
+    "swipe": "Routes to ADB input swipe or WDA pointer actions.",
+    "type_text": "Routes to ADB input text or WDA keys/value.",
+    "type_unicode": "Routes to Android unicode input or iOS WDA text entry.",
+    "press_back": "Best-effort back action on each platform.",
+    "press_home": "Uses Android HOME keyevent or iOS mobile: pressButton.",
+    "press_key": "Shared key facade with per-platform key support.",
+    "launch_app": "Launches Android packages or iOS bundle ids.",
+    "force_stop": "Force-stops Android packages or terminates iOS bundle ids.",
+    "app_state": "Checks installed/running/foreground state for Android packages or iOS bundle ids.",
+    "open_camera": "Android camera launcher or best-effort iOS Camera app launch/mode selection.",
+    "long_press": "Routes to ADB/Portal or WDA pointer actions.",
+    "web_search": "Android VIEW intent or iOS Appium browser navigation.",
+    "open_url": "Android VIEW intent or iOS Appium browser navigation.",
+    "browser_back": "Android back or iOS browser/WDA back fallback.",
+    "wait_for_text": "Android screen search or iOS visible text wait.",
+    "extract_visible_text": "Android normalized text extraction or iOS WebView/native/OCR text extraction.",
+    "extract_articles": "Best-effort article/headline extraction on either platform, with OCR fallback on iOS.",
+    "search_apps": "Android package manager or iOS configured/common bundle inventory with Appium verification.",
+    "list_apps": "Android package manager or iOS configured/common bundle inventory with Appium verification.",
+    "list_packages": "Android package manager or iOS configured/common bundle inventory with Appium verification.",
+    "list_skills": "Lists skills with platform metadata.",
+    "run_skill": "Runs platform-aware skills when the skill supports the target platform.",
+    "run_workflow": "Runs platform-aware skills when the skill supports the target platform.",
+    "run_action": "Runs platform-aware skill actions when supported.",
+    "clipboard_get": "Uses Android clipboard helpers or Appium clipboard extensions on iOS.",
+    "clipboard_set": "Uses Android clipboard helpers or Appium clipboard extensions on iOS.",
+    "paste_text": "Android clipboard paste keyevent or iOS clipboard plus WDA text insertion into the focused field.",
+    "get_notifications": "Android dumpsys notifications or iOS Notification Center text extraction through WDA.",
+    "open_notifications": "Android statusbar expansion or iOS Notification Center swipe gesture.",
+    "clear_notifications": "Android notification service clear or best-effort iOS Clear control tap.",
+    "explore_app": "BFS explorer over Android uiautomator XML or normalized iOS WDA XML with iOS tree/screenshot state identity.",
+    "create_skill": "Creates recorded skills with Android package or iOS bundle metadata and per-platform element files.",
+    "lookup_lead": "Device-neutral marketing data lookup.",
+    "list_unread_leads": "Device-neutral marketing inbox lookup.",
+    "run_flow": "Batched execution of allow-listed tools; each step routes per-platform.",
+    "crm_lookup_contact": "Device-neutral local CRM contact lookup.",
+    "crm_list_unread_messages": "Device-neutral local CRM unread-message listing.",
+    "chain": "Runs a sequence of sub-actions; each sub-action routes to its own platform backend.",
+    "screenshot_sequence": "Captures a screenshot burst via the per-platform screenshot path.",
+    "sub_agent": "Device-neutral vision sub-call over cached frames.",
+    "wait": "Device-neutral delay.",
+    "speak_text": "Android Portal-app TTS, or iOS WDA /wda/speak (AVSpeechSynthesizer) via GhostAgent-patched WebDriverAgent.",
+}
+
+_IOS_SUPPORTED = {
+    "get_current_url": "Currently implemented through iOS WebDriver/WebView state; Android current URL support is not exposed yet.",
+    "read_news": "iOS Chrome/WebDriver news-reading workflow that opens headlines and extracts article snippets.",
+}
+
+_IOS_PLANNED = {}
+
+_ANDROID_ONLY = {
+    "shell": "ADB shell has no iOS equivalent.",
+    "list_crashes": "Reads the Android logcat crash buffer; iOS needs syslog/CrashReporter support.",
+    "get_crash": "Reads the Android logcat crash buffer; iOS needs syslog/CrashReporter support.",
+    "launch_intent": "Android intents have no iOS equivalent.",
+    "toggle_overlay": "Portal overlay is Android-only.",
+    # NOTE: speak_text is classified cross_platform above (iOS gained WDA
+    # /wda/speak on feat/ios-ondevice); intentionally not android_only here.
+}
+
+
+TOOL_PLATFORM_SUPPORT: dict[str, ToolPlatformInfo] = {
+    **{name: ToolPlatformInfo(name, "cross_platform", notes) for name, notes in _CROSS_PLATFORM.items()},
+    **{name: ToolPlatformInfo(name, "ios_supported", notes) for name, notes in _IOS_SUPPORTED.items()},
+    **{name: ToolPlatformInfo(name, "ios_planned", notes) for name, notes in _IOS_PLANNED.items()},
+    **{name: ToolPlatformInfo(name, "android_only", notes) for name, notes in _ANDROID_ONLY.items()},
+}
+
+
+def tool_platform_info(name: str) -> ToolPlatformInfo:
+    return TOOL_PLATFORM_SUPPORT.get(
+        name,
+        ToolPlatformInfo(name, "ios_planned", "No explicit platform audit entry yet."),
+    )
+
+
+def tools_for_support(support: PlatformSupport) -> list[str]:
+    return sorted(name for name, info in TOOL_PLATFORM_SUPPORT.items() if info.support == support)
+
+
+def supports_platform(name: str, platform: str) -> bool:
+    return tool_platform_info(name).supports(platform)
+
+
+def platform_error(name: str, platform: str) -> dict[str, str | bool]:
+    info = tool_platform_info(name)
+    if info.support == "android_only":
+        error = f"{name} is Android-only and is not supported for {platform}"
+    elif info.support == "ios_planned":
+        error = f"{name} is not supported for {platform} yet; iOS support is planned"
+    elif info.support == "ios_supported":
+        error = f"{name} is currently implemented only for iOS"
+    else:
+        error = f"{name} does not support {platform}"
+    return {"ok": False, "platform": platform, "error": error, "support": info.support, "notes": info.notes}
+
+
+def platform_error_text(name: str, platform: str) -> str:
+    error = platform_error(name, platform)
+    return f"ERROR: {error['error']}"
+
+
+# ── Docs: generated platform-support matrix ──────────────────────────────────
+# Emits the per-tool Android/iOS support matrix as Markdown straight from the
+# classification above, so the public docs table never drifts from code. This is
+# the CLASSIFICATION only — docs overlay a "hardware-confirmed on iOS" badge on
+# top (some tools are classified cross-platform but not yet exercised on real WDA,
+# and several fall back to OCR on iOS due to the weaker accessibility tree).
+#   run:  python -m gitd.services.tool_platforms > tool-support.generated.md
+
+_BADGE = {
+    ("android_only", "android"): "✅",
+    ("android_only", "ios"): "⚠️ n/a",
+    ("cross_platform", "android"): "✅",
+    ("cross_platform", "ios"): "✅",
+    ("ios_supported", "android"): "⚠️ n/a",
+    ("ios_supported", "ios"): "✅",
+    ("ios_planned", "android"): "✅",
+    ("ios_planned", "ios"): "🔜",
+}
+
+_SUPPORT_HEADING = {
+    "cross_platform": "Cross-platform (Android + iOS)",
+    "ios_supported": "iOS-first",
+    "ios_planned": "Android now, iOS planned",
+    "android_only": "Android-only",
+}
+
+
+def _row(info: ToolPlatformInfo) -> str:
+    android = _BADGE[(info.support, "android")]
+    ios = _BADGE[(info.support, "ios")]
+    notes = (info.notes or "").replace("|", "\\|")
+    return f"| `{info.name}` | {android} | {ios} | {notes} |"
+
+
+def render_matrix_markdown(*, mdx: bool = False) -> str:
+    """Render the full tool platform-support matrix as Markdown.
+
+    Grouped by support class, each group a table with an Android / iOS badge and
+    the per-tool note. Badges: ✅ supported · 🔜 iOS planned · ⚠️ n/a (not
+    applicable on that platform). Deterministic (sorted) so regenerating in CI
+    produces a stable diff.
+
+    ``mdx=True`` emits the generated-file header as an MDX comment (``{/* */}``)
+    instead of an HTML comment (``<!-- -->``), which is invalid in MDX. The table
+    body is identical (GitHub-flavored Markdown tables render in both).
+    """
+    header = [
+        "GENERATED from gitd/services/tool_platforms.py — do not edit by hand.",
+        "Regenerate: python -m gitd.services.tool_platforms" + (" --mdx" if mdx else ""),
+    ]
+    comment = ["{/* " + " ".join(header) + " */}"] if mdx else ["<!-- " + header[0], "     " + header[1] + " -->"]
+    lines = [
+        *comment,
+        "",
+        "Legend: ✅ supported · 🔜 iOS planned · ⚠️ n/a (platform can't support it).",
+        "Classification only — overlay a 'hardware-confirmed on iOS' badge separately;",
+        "several cross-platform tools fall back to OCR on iOS (weaker a11y tree).",
+    ]
+    for support in ("cross_platform", "ios_supported", "ios_planned", "android_only"):
+        names = tools_for_support(support)
+        if not names:
+            continue
+        lines += [
+            "",
+            f"### {_SUPPORT_HEADING[support]} ({len(names)})",
+            "",
+            "| Tool | Android | iOS | Notes |",
+            "| --- | :---: | :---: | --- |",
+        ]
+        lines += [_row(TOOL_PLATFORM_SUPPORT[name]) for name in names]
+    return "\n".join(lines) + "\n"
+
+
+if __name__ == "__main__":  # pragma: no cover — docs build entry point
+    import sys
+
+    sys.stdout.write(render_matrix_markdown(mdx="--mdx" in sys.argv[1:]))

--- a/gitd/services/web_search.py
+++ b/gitd/services/web_search.py
@@ -1,0 +1,102 @@
+"""Robust web search: pick a browser, fire a VIEW intent, fall back gracefully.
+
+Used by both `mcp_server.web_search` (claude-code MCP) and `agent_tools.web_search`
+(on-device Gemma) so the behavior is identical regardless of which agent stack
+is driving.
+
+Strategy:
+1. Build a search URL for the chosen engine.
+2. Probe `pm list packages` once to find which browsers are installed.
+3. Try each candidate in priority order via `am start ... -p <pkg>`.
+4. If all known browsers fail (or none are installed), fall back to a bare
+   VIEW intent and let Android resolve it.
+5. As a last resort (e.g. on devices with NO browser at all — possible on
+   stripped-down vendor builds), open the Play Store search for "browser".
+"""
+
+from __future__ import annotations
+
+import urllib.parse
+from typing import Optional
+
+from gitd.bots.common.adb import Device
+
+# Priority order. Chrome is overwhelmingly the default on Android, but plenty
+# of devices ship Samsung Internet (Galaxy) or Vivo's stripped builds. Keeping
+# this list explicit lets us announce in the result string which one we used.
+_BROWSER_CANDIDATES: list[tuple[str, str]] = [
+    ("Chrome", "com.android.chrome"),
+    ("Firefox", "org.mozilla.firefox"),
+    ("Samsung Internet", "com.sec.android.app.sbrowser"),
+    ("Edge", "com.microsoft.emmx"),
+    ("Brave", "com.brave.browser"),
+    ("Opera", "com.opera.browser"),
+    ("Opera GX", "com.opera.gx"),
+    ("Vivaldi", "com.vivaldi.browser"),
+    ("DuckDuckGo Browser", "com.duckduckgo.mobile.android"),
+]
+
+_ENGINE_URLS = {
+    "google": "https://www.google.com/search?q=",
+    "ddg": "https://duckduckgo.com/?q=",
+    "duckduckgo": "https://duckduckgo.com/?q=",
+    "bing": "https://www.bing.com/search?q=",
+    "brave": "https://search.brave.com/search?q=",
+}
+
+
+def _installed_packages(dev: Device) -> set[str]:
+    """One ADB call → set of all installed package names."""
+    try:
+        out = dev.adb("shell", "pm", "list", "packages", timeout=10)
+    except Exception:
+        return set()
+    return {ln.removeprefix("package:").strip() for ln in out.splitlines() if ln.startswith("package:")}
+
+
+def _try_open(dev: Device, url: str, package: Optional[str]) -> bool:
+    """Run `am start ... -d <url>` (optionally scoped to a package). Return True on success."""
+    cmd = ["shell", "am", "start", "-a", "android.intent.action.VIEW", "-d", url]
+    if package:
+        cmd += ["-p", package]
+    try:
+        out = dev.adb(*cmd, timeout=8)
+    except Exception:
+        return False
+    # `am start` exits 0 even when the intent is unresolved, so we have to
+    # parse stdout. The strings below are stable across Android 8+.
+    bad = ("Error:", "java.lang.SecurityException", "no activities found")
+    return not any(s in (out or "") for s in bad)
+
+
+def open_search(device: str, query: str, engine: str = "google") -> str:
+    """Open a search results page in the best available browser. Returns a
+    human-readable status string the LLM (and the user) sees.
+    """
+    if not query.strip():
+        return "web_search error: empty query"
+
+    base = _ENGINE_URLS.get(engine.lower(), _ENGINE_URLS["google"])
+    url = base + urllib.parse.quote(query)
+    dev = Device(device)
+    installed = _installed_packages(dev)
+
+    # 1. Walk the priority list, skipping browsers that aren't installed.
+    for friendly, pkg in _BROWSER_CANDIDATES:
+        if pkg not in installed:
+            continue
+        if _try_open(dev, url, pkg):
+            return f"Opened {friendly} → {engine} search for: {query}"
+
+    # 2. No known browser worked (or none installed) — let Android resolve it.
+    if _try_open(dev, url, package=None):
+        return f"Opened default browser → {engine} search for: {query}"
+
+    # 3. Last resort: nudge the user to install one. Open the Play Store
+    # search for "browser" so they're one tap from a fix.
+    store_url = "market://search?q=browser&c=apps"
+    _try_open(dev, store_url, package=None)
+    return (
+        "web_search failed: no browser handled the VIEW intent. "
+        "Opened Play Store to install one. (Tried: " + ", ".join(p for _, p in _BROWSER_CANDIDATES) + ")"
+    )

--- a/gitd/skills/_base/actions/core.py
+++ b/gitd/skills/_base/actions/core.py
@@ -1,9 +1,10 @@
 """Core shared actions — tap, swipe, type, wait, launch, screenshot, dismiss popup."""
 from __future__ import annotations
 
+from pathlib import Path
 import time
-import re
-from gitd.skills.base import Action, ActionResult, Element
+
+from gitd.skills.base import Action, ActionResult, Element, _device_is_ios
 
 
 class TapElement(Action):
@@ -35,6 +36,10 @@ class SwipeDirection(Action):
 
     def execute(self) -> ActionResult:
         cx, cy = 540, 1200  # default center for 1080x2400
+        if _device_is_ios(self.device) and hasattr(self.device, 'get_screen_size'):
+            width, height = self.device.get_screen_size()
+            if width and height:
+                cx, cy = width // 2, height // 2
         d = self.distance
         dirs = {
             'up':    (cx, cy, cx, cy - d),
@@ -52,16 +57,21 @@ class SwipeDirection(Action):
 class TypeText(Action):
     """Type text into the currently focused input field."""
     name = 'type_text'
-    description = 'Type text via ADB input'
+    description = 'Type text into the focused field'
 
     def __init__(self, device, elements, *, text: str, **kwargs):
         super().__init__(device, elements)
         self.text = text
 
     def execute(self) -> ActionResult:
-        # Escape special chars for shell
-        escaped = self.text.replace(' ', '%s').replace("'", "\\'").replace('"', '\\"')
-        self.device.adb("shell", "input", "text", escaped)
+        if _device_is_ios(self.device) and hasattr(self.device, 'type_text'):
+            self.device.type_text(self.text)
+        elif all(ord(c) < 128 for c in self.text):
+            from gitd.bots.common.adb import input_text_arg
+
+            self.device.adb("shell", "input", "text", input_text_arg(self.text))
+        else:
+            self.device.type_unicode(self.text)
         time.sleep(0.3)
         return ActionResult(success=True, data={'text': self.text})
 
@@ -90,9 +100,9 @@ class WaitForElement(Action):
 
 
 class LaunchApp(Action):
-    """Launch an app by package name."""
+    """Launch an app by Android package name or iOS bundle id."""
     name = 'launch_app'
-    description = 'Start an Android app'
+    description = 'Start an Android app or iOS bundle'
 
     def __init__(self, device, elements, *, package: str, activity: str | None = None, **kwargs):
         super().__init__(device, elements)
@@ -100,6 +110,10 @@ class LaunchApp(Action):
         self.activity = activity
 
     def execute(self) -> ActionResult:
+        if _device_is_ios(self.device) and hasattr(self.device, 'launch_app'):
+            self.device.launch_app(self.package)
+            time.sleep(2)
+            return ActionResult(success=True, data={'bundle_id': self.package})
         if self.activity:
             self.device.adb("shell", "am", "start", "-n", f"{self.package}/{self.activity}")
         else:
@@ -110,6 +124,11 @@ class LaunchApp(Action):
         return ActionResult(success=True, data={'package': self.package})
 
     def postcondition(self) -> bool:
+        if _device_is_ios(self.device) and hasattr(self.device, 'app_state'):
+            try:
+                return int(self.device.app_state(self.package)) == 4
+            except Exception:
+                return False
         # Verify app is in foreground
         output = self.device.adb("shell", "dumpsys", "window", timeout=5)
         return self.package in output
@@ -126,6 +145,12 @@ class TakeScreenshot(Action):
     max_retries = 1
 
     def execute(self) -> ActionResult:
+        if _device_is_ios(self.device) and hasattr(self.device, 'take_screenshot'):
+            path = Path(self.output_path)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(self.device.take_screenshot())
+            return ActionResult(success=True, data={'path': self.output_path})
+
         import subprocess
         self.device.adb("shell", "screencap", "-p", "/sdcard/screenshot.png")
         subprocess.run(["adb", "-s", self.device.serial, "pull",
@@ -146,7 +171,7 @@ class DismissPopup(Action):
 
 
 class PressBack(Action):
-    """Press the Android back button."""
+    """Press the platform back/navigation control."""
     name = 'press_back'
     description = 'Press back'
     max_retries = 1
@@ -157,12 +182,15 @@ class PressBack(Action):
 
 
 class PressHome(Action):
-    """Press the Android home button."""
+    """Press the platform home button."""
     name = 'press_home'
     description = 'Press home'
     max_retries = 1
 
     def execute(self) -> ActionResult:
-        self.device.adb("shell", "input", "keyevent", "KEYCODE_HOME")
+        if _device_is_ios(self.device) and hasattr(self.device, 'press_key'):
+            self.device.press_key('HOME')
+        else:
+            self.device.adb("shell", "input", "keyevent", "KEYCODE_HOME")
         time.sleep(0.5)
         return ActionResult(success=True)

--- a/gitd/skills/_base/skill.yaml
+++ b/gitd/skills/_base/skill.yaml
@@ -1,7 +1,10 @@
 name: base
-description: Shared actions usable by any Android app skill
+description: Shared actions usable by Android and iOS app skills
 version: "1.0.0"
 app_package: null
+platforms:
+  - android
+  - ios
 exports:
   actions:
     - tap_element

--- a/gitd/skills/_run_skill.py
+++ b/gitd/skills/_run_skill.py
@@ -8,7 +8,24 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from gitd.bots.common.adb import Device
+from gitd.bots.common.device import get_device
+from gitd.skills.platforms import (
+    skill_platform_error_text,
+    skill_supports_device,
+    skill_target_for_device,
+)
+
+
+def _load_skill_metadata(skill: str) -> dict:
+    try:
+        import yaml
+
+        meta_path = Path(__file__).parent / skill / 'skill.yaml'
+        if meta_path.exists():
+            return yaml.safe_load(meta_path.read_text()) or {}
+    except Exception:
+        pass
+    return {}
 
 
 # ── Skill run tracking ──────────────────────────────────────────────────
@@ -27,9 +44,9 @@ def _record_start(device: str, skill: str, target_type: str, target_name: str,
             meta_path = Path(__file__).parent / skill / 'skill.yaml'
             if meta_path.exists():
                 meta = yaml.safe_load(meta_path.read_text()) or {}
-                pkg = meta.get('app_package')
+                pkg = skill_target_for_device(meta, device)
                 if pkg:
-                    app_ver = Device(device).get_app_version(pkg)
+                    app_ver = get_device(device).get_app_version(pkg)
         except Exception:
             pass
         row = SkillRun(
@@ -127,7 +144,12 @@ def main():
     import time
 
     params = json.loads(args.params)
-    dev = Device(args.device)
+    skill_meta = _load_skill_metadata(args.skill)
+    if not skill_supports_device(skill_meta, args.device):
+        print(skill_platform_error_text(args.skill, skill_meta, args.device), file=sys.stderr)
+        sys.exit(2)
+
+    dev = get_device(args.device)
 
     # Build engine config from CLI flags
     from gitd.skills.base import EngineConfig
@@ -164,7 +186,7 @@ def main():
         meta_path = skill_dir / 'skill.yaml'
         if meta_path.exists():
             meta = yaml.safe_load(meta_path.read_text()) or {}
-            wf.app_package = meta.get('app_package', '') or ''
+            wf.app_package = skill_target_for_device(meta, args.device) or ''
             wf._popup_detectors = meta.get('popup_detectors') or None
         if engine_cfg:
             wf.engine = engine_cfg
@@ -210,14 +232,13 @@ def main():
         sys.exit(0 if result.success else 1)
 
     elif args.action:
-        action_cls = s.get_action(args.action)
-        if not action_cls:
+        action = s.get_action(args.action, dev, **params)
+        if not action:
             dur = (_time.time() - t0) * 1000
             _record_finish(run_id, False, dur, f'Action not found: {args.action}')
             print(f'Action not found: {args.action}', file=sys.stderr)
             sys.exit(1)
         print(f'Running action: {args.action}')
-        action = action_cls(dev, s.elements, **params)
         result = action.run()
         dur = (_time.time() - t0) * 1000
         _record_finish(run_id, result.success, dur, result.error)

--- a/gitd/skills/auto_creator.py
+++ b/gitd/skills/auto_creator.py
@@ -13,7 +13,6 @@ import argparse
 import hashlib
 import json
 import logging
-import os
 import subprocess
 import sys
 import time
@@ -26,7 +25,7 @@ from xml.etree import ElementTree as ET
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from gitd.bots.common.adb import Device
+from gitd.bots.common.device import get_device, is_ios_ref
 
 log = logging.getLogger(__name__)
 
@@ -143,12 +142,20 @@ def xml_structure_hash(xml_str: str) -> str:
     return hashlib.md5(skel.encode()).hexdigest()[:12]
 
 
+def ios_state_hash(package: str, activity: str, xml_str: str, screenshot: bytes | None = None) -> str:
+    """Hash iOS state identity from app identity, normalized tree, and pixels."""
+    xml_hash = xml_structure_hash(xml_str)
+    screenshot_hash = hashlib.md5(screenshot or b"").hexdigest()[:12] if screenshot else ""
+    material = "|".join(["ios", package or "", activity or "", xml_hash, screenshot_hash])
+    return hashlib.md5(material.encode()).hexdigest()[:12]
+
+
 # ── Explorer ─────────────────────────────────────────────────────────────────
 
 class AppExplorer:
     """BFS explorer that navigates through an app's UI states."""
 
-    def __init__(self, dev: Device, package: str, output_dir: str, max_depth: int = 3,
+    def __init__(self, dev: Any, package: str, output_dir: str, max_depth: int = 3,
                  max_states: int = 50, settle_time: float = 1.5):
         self.dev = dev
         self.package = package
@@ -165,6 +172,10 @@ class AppExplorer:
         (self.output_dir / "screenshots").mkdir(parents=True, exist_ok=True)
         (self.output_dir / "xml").mkdir(parents=True, exist_ok=True)
 
+    @property
+    def platform(self) -> str:
+        return "ios" if is_ios_ref(getattr(self.dev, "serial", "")) else "android"
+
     def _log_progress(self, msg: str):
         """Append a timestamped message to the progress log."""
         ts = time.strftime('%H:%M:%S')
@@ -176,7 +187,13 @@ class AppExplorer:
     def _write_progress(self, current_depth: int = 0):
         """Write progress.json for the dashboard to poll."""
         total_transitions = sum(len(s.transitions) for s in self.states.values())
+        current_activity = next(reversed(self.states.values())).activity if self.states else ""
         progress = {
+            "device": getattr(self.dev, "serial", ""),
+            "package": self.package,
+            "platform": self.platform,
+            "output_dir": str(self.output_dir),
+            "current_activity": current_activity,
             "states_found": len(self.states),
             "max_states": self.max_states,
             "transitions": total_transitions,
@@ -191,6 +208,18 @@ class AppExplorer:
 
     def _get_activity(self) -> str:
         """Get current foreground activity."""
+        if self.platform == "ios":
+            try:
+                state = self.dev.get_phone_state()
+                return (
+                    state.get("bundleId")
+                    or state.get("bundle_id")
+                    or state.get("packageName")
+                    or state.get("currentApp")
+                    or "unknown"
+                )
+            except Exception:
+                return "unknown"
         try:
             out = subprocess.check_output(
                 ["adb", "-s", self.dev.serial, "shell",
@@ -209,6 +238,40 @@ class AppExplorer:
             pass
         return "unknown"
 
+    def _launch_app(self) -> None:
+        if self.platform == "ios":
+            self.dev.launch_app(self.package)
+            time.sleep(self.settle_time)
+            return
+        subprocess.run(
+            ["adb", "-s", self.dev.serial, "shell", "am", "force-stop", self.package],
+            timeout=5, capture_output=True
+        )
+        time.sleep(0.5)
+        subprocess.run(
+            ["adb", "-s", self.dev.serial, "shell",
+             "monkey", "-p", self.package, "-c", "android.intent.category.LAUNCHER", "1"],
+            timeout=15, capture_output=True
+        )
+        time.sleep(8)  # Apps need time to load past splash/animations
+
+    def _go_back(self) -> None:
+        if self.platform == "ios" and hasattr(self.dev, "browser_back"):
+            try:
+                self.dev.browser_back(delay=0)
+                return
+            except Exception:
+                pass
+        self.dev.back(delay=0)
+
+    def _screenshot_bytes(self) -> bytes:
+        if self.platform == "ios":
+            return self.dev.take_screenshot()
+        return subprocess.check_output(
+            ["adb", "-s", self.dev.serial, "exec-out", "screencap", "-p"],
+            timeout=10
+        )
+
     def _capture_state(self, depth: int) -> AppState | None:
         """Dump XML + screenshot, create AppState if new."""
         time.sleep(self.settle_time)
@@ -218,7 +281,19 @@ class AppExplorer:
             log.warning("Empty XML dump, skipping")
             return None
 
-        state_id = xml_structure_hash(xml_str)
+        activity = self._get_activity()
+        screenshot_bytes: bytes | None = None
+        if self.platform == "ios":
+            try:
+                screenshot_bytes = self._screenshot_bytes()
+            except Exception as e:
+                log.warning(f"Screenshot failed: {e}")
+
+        state_id = (
+            ios_state_hash(self.package, activity, xml_str, screenshot_bytes)
+            if self.platform == "ios"
+            else xml_structure_hash(xml_str)
+        )
 
         # Already visited?
         if state_id in self.states:
@@ -231,16 +306,13 @@ class AppExplorer:
         # Screenshot
         ss_path = self.output_dir / "screenshots" / f"{state_id}.png"
         try:
-            data = subprocess.check_output(
-                ["adb", "-s", self.dev.serial, "exec-out", "screencap", "-p"],
-                timeout=10
-            )
-            ss_path.write_bytes(data)
+            if screenshot_bytes is None:
+                screenshot_bytes = self._screenshot_bytes()
+            ss_path.write_bytes(screenshot_bytes)
         except Exception as e:
             log.warning(f"Screenshot failed: {e}")
 
         elements = extract_interactive_elements(xml_str)
-        activity = self._get_activity()
 
         state = AppState(
             state_id=state_id,
@@ -269,26 +341,17 @@ class AppExplorer:
         """Run BFS exploration. Returns state graph as dict."""
         log.info(f"Starting BFS exploration of {self.package}")
         log.info(f"  Device: {self.dev.serial}")
+        log.info(f"  Platform: {self.platform}")
         log.info(f"  Max depth: {self.max_depth}, Max states: {self.max_states}")
         log.info(f"  Output: {self.output_dir}")
 
-        self._log_progress(f"Starting exploration of {self.package}")
+        self._log_progress(f"Starting {self.platform} exploration of {self.package}")
         self._write_progress(0)
 
         # Launch app
         log.info("Launching app...")
         self._log_progress("Launching app...")
-        subprocess.run(
-            ["adb", "-s", self.dev.serial, "shell", "am", "force-stop", self.package],
-            timeout=5, capture_output=True
-        )
-        time.sleep(0.5)
-        subprocess.run(
-            ["adb", "-s", self.dev.serial, "shell",
-             "monkey", "-p", self.package, "-c", "android.intent.category.LAUNCHER", "1"],
-            timeout=15, capture_output=True
-        )
-        time.sleep(8)  # Apps need time to load past splash/animations
+        self._launch_app()
 
         # Capture initial state
         initial = self._capture_state(depth=0)
@@ -340,7 +403,7 @@ class AppExplorer:
                     state.transitions[elem_key] = "error"
 
                 # Navigate back
-                self.dev.back(delay=0)
+                self._go_back()
                 time.sleep(self.settle_time)
 
                 # Verify we're back (check state hasn't drifted)
@@ -348,11 +411,11 @@ class AppExplorer:
                 if back_state and back_state.state_id != state_id:
                     log.warning(f"  Back didn't return to {state_id}, now at {back_state.state_id}")
                     # Try one more back
-                    self.dev.back(delay=0)
+                    self._go_back()
                     time.sleep(self.settle_time)
                     retry = self._capture_state(depth)
                     if retry and retry.state_id != state_id:
-                        log.warning(f"  Still lost after double-back. Stopping this state.")
+                        log.warning("  Still lost after double-back. Stopping this state.")
                         break
 
                 if len(self.states) >= self.max_states:
@@ -363,6 +426,11 @@ class AppExplorer:
         graph = {
             "package": self.package,
             "device": self.dev.serial,
+            "platform": self.platform,
+            "state_identity": {
+                "android": ["xml_structure_hash"],
+                "ios": ["bundle_id", "activity", "xml_structure_hash", "screenshot_hash"],
+            },
             "max_depth": self.max_depth,
             "total_states": len(self.states),
             "total_transitions": sum(len(s.transitions) for s in self.states.values()),
@@ -392,8 +460,8 @@ class AppExplorer:
 
 def main():
     parser = argparse.ArgumentParser(description="Auto Skill Creator — BFS app explorer")
-    parser.add_argument("--package", required=True, help="App package name")
-    parser.add_argument("--device", required=True, help="ADB device serial")
+    parser.add_argument("--package", required=True, help="Android package name or iOS bundle id")
+    parser.add_argument("--device", required=True, help="ADB serial or ios:<udid> device ref")
     parser.add_argument("--max-depth", type=int, default=3, help="Max BFS depth (default: 3)")
     parser.add_argument("--max-states", type=int, default=50, help="Max states to discover (default: 50)")
     parser.add_argument("--output", help="Output directory (default: data/app_explorer/<package>/)")
@@ -403,7 +471,7 @@ def main():
     logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(name)s] %(message)s")
 
     output_dir = args.output or f"data/app_explorer/{args.package}"
-    dev = Device(args.device)
+    dev = get_device(args.device)
     explorer = AppExplorer(
         dev=dev,
         package=args.package,
@@ -414,7 +482,7 @@ def main():
     )
 
     graph = explorer.explore()
-    print(f"\nExploration complete:")
+    print("\nExploration complete:")
     print(f"  States: {graph.get('total_states', 0)}")
     print(f"  Transitions: {graph.get('total_transitions', 0)}")
     print(f"  Output: {output_dir}/state_graph.json")

--- a/gitd/skills/base.py
+++ b/gitd/skills/base.py
@@ -16,8 +16,20 @@ from pathlib import Path
 from typing import Any
 
 from gitd.bots.common.adb import Device
+from gitd.bots.common.device import is_ios_ref
+from gitd.skills.platforms import (
+    skill_android_package,
+    skill_ios_bundle_id,
+    skill_platforms,
+    skill_supports_device,
+    skill_target_for_device,
+)
 
 log = logging.getLogger(__name__)
+
+
+def _device_is_ios(device: Any) -> bool:
+    return is_ios_ref(getattr(device, 'serial', str(device)))
 
 
 # ── Result ────────────────────────────────────────────────────────────────────
@@ -64,7 +76,7 @@ class Element:
                     return device.bounds_center(bounds)
         # Fallback to class name
         if self.class_name:
-            bounds = device.find_bounds(xml, resource_id=self.class_name)
+            bounds = device.find_bounds(xml, class_name=self.class_name)
             if bounds:
                 return device.bounds_center(bounds)
         # Last resort: fixed coords
@@ -79,7 +91,7 @@ class Element:
             content_desc=d.get('content_desc'),
             text=d.get('text'),
             resource_id=d.get('resource_id'),
-            class_name=d.get('class_name'),
+            class_name=d.get('class_name') or d.get('class'),
             x=d.get('x'),
             y=d.get('y'),
         )
@@ -125,6 +137,7 @@ class Action(ABC):
                                 duration_ms=(time.time() - t0) * 1000)
 
         last_error = None
+        last_data = {}
         for attempt in range(1, self.max_retries + 1):
             try:
                 result = self.execute()
@@ -133,17 +146,20 @@ class Action(ABC):
                     return result
                 if not result:
                     last_error = result.error or f'{self.name}: execute returned failure'
+                    last_data = result.data
                 else:
                     last_error = f'{self.name}: postcondition failed'
+                    last_data = result.data
                     self.rollback()
             except Exception as e:
                 last_error = f'{self.name}: {e}'
+                last_data = {}
                 log.warning(f'Action {self.name} attempt {attempt} failed: {e}')
 
             if attempt < self.max_retries:
                 time.sleep(self.retry_delay)
 
-        return ActionResult(success=False, error=last_error,
+        return ActionResult(success=False, error=last_error, data=last_data,
                             duration_ms=(time.time() - t0) * 1000)
 
     def find_element(self, name: str, xml: str | None = None) -> tuple[int, int] | None:
@@ -216,6 +232,14 @@ class Workflow:
         """Phase 0-2: Wake screen, back-spam to home, press Home."""
         cfg = self.engine
         dev = self.device
+        if _device_is_ios(dev):
+            log.info(f'[{self.name}] Returning iOS device to Home')
+            try:
+                dev.press_key('HOME')
+            except Exception:
+                pass
+            time.sleep(cfg.home_settle)
+            return
         log.info(f'[{self.name}] Waking screen, back ×{cfg.back_count}')
         dev.adb('shell', 'input', 'keyevent', 'KEYCODE_WAKEUP')
         time.sleep(0.5)
@@ -231,6 +255,10 @@ class Workflow:
             return
         dev = self.device
         log.info(f'[{self.name}] Launching {self.app_package}')
+        if _device_is_ios(dev):
+            dev.launch_app(self.app_package)
+            time.sleep(self.engine.launch_settle)
+            return
         dev.adb('shell', 'monkey', '-p', self.app_package,
                 '-c', 'android.intent.category.LAUNCHER', '1')
         time.sleep(self.engine.launch_settle)
@@ -242,6 +270,8 @@ class Workflow:
         xml = self.device.dump_xml()
         if not xml:
             return False
+        if not hasattr(self.device, 'dismiss_popups'):
+            return False
         dismissed = self.device.dismiss_popups(xml, popups=self._popup_detectors)
         if dismissed:
             log.info(f'[{self.name}] Popup dismissed after {step_name or "startup"}')
@@ -252,6 +282,19 @@ class Workflow:
                     break
                 time.sleep(0.5)
         return dismissed
+
+    def _step_results_data(self, steps: list[Action]) -> list[dict[str, Any]]:
+        """Return compact, serializable action results for scheduler/API evidence."""
+        out: list[dict[str, Any]] = []
+        for action, result in zip(steps, self.results, strict=False):
+            out.append({
+                'name': action.name,
+                'success': result.success,
+                'data': result.data,
+                'error': result.error,
+                'duration_ms': result.duration_ms,
+            })
+        return out
 
     def run(self) -> ActionResult:
         """Execute the full lifecycle: startup → [step → popup detect] → done."""
@@ -266,7 +309,8 @@ class Workflow:
             self._dismiss_popups()
 
         # Execute steps with popup detection between each
-        for action in self.steps():
+        steps = self.steps()
+        for action in steps:
             log.info(f'[{self.name}] Running: {action.name}')
             result = action.run()
             self.results.append(result)
@@ -276,7 +320,8 @@ class Workflow:
                     success=False,
                     error=f'Workflow {self.name} failed at step {action.name}: {result.error}',
                     data={'completed_steps': len(self.results) - 1,
-                          'failed_step': action.name},
+                          'failed_step': action.name,
+                          'step_results': self._step_results_data(steps)},
                     duration_ms=(time.time() - t0) * 1000,
                 )
             # Popup detection after each step
@@ -286,7 +331,8 @@ class Workflow:
 
         return ActionResult(
             success=True,
-            data={'completed_steps': len(self.results)},
+            data={'completed_steps': len(self.results),
+                  'step_results': self._step_results_data(steps)},
             duration_ms=(time.time() - t0) * 1000,
         )
 
@@ -313,8 +359,11 @@ class RecordedStepAction(Action):
         if action in ('launch', 'open_app'):
             pkg = step.get('package', '')
             if pkg:
-                self.device.adb('shell', 'am', 'start', '-a', 'android.intent.action.MAIN',
-                                '-c', 'android.intent.category.LAUNCHER', pkg)
+                if _device_is_ios(self.device) and hasattr(self.device, 'launch_app'):
+                    self.device.launch_app(pkg)
+                else:
+                    self.device.adb('shell', 'am', 'start', '-a', 'android.intent.action.MAIN',
+                                    '-c', 'android.intent.category.LAUNCHER', pkg)
         elif action == 'tap' and step.get('element_idx') is not None:
             import re
             import xml.etree.ElementTree as ET
@@ -355,14 +404,19 @@ class RecordedStepAction(Action):
             self.device.tap(step['x'], step['y'])
         elif action == 'type' and step.get('text'):
             text = step['text']
-            if all(ord(c) < 128 for c in text):
+            if _device_is_ios(self.device) and hasattr(self.device, 'type_text'):
+                self.device.type_text(text)
+            elif all(ord(c) < 128 for c in text):
                 self.device.adb('shell', 'input', 'text', text.replace(' ', '%s'))
             else:
                 self.device.type_unicode(text)
         elif action == 'back':
             self.device.back()
         elif action == 'home':
-            self.device.adb('shell', 'input', 'keyevent', 'KEYCODE_HOME')
+            if _device_is_ios(self.device) and hasattr(self.device, 'press_key'):
+                self.device.press_key('HOME')
+            else:
+                self.device.adb('shell', 'input', 'keyevent', 'KEYCODE_HOME')
         elif action == 'swipe':
             self.device.swipe(step.get('x1', 0), step.get('y1', 0),
                               step.get('x2', 0), step.get('y2', 0))
@@ -371,9 +425,13 @@ class RecordedStepAction(Action):
         elif action == 'key':
             key = step.get('key', '')
             if key:
-                if not key.startswith('KEYCODE_'):
+                if _device_is_ios(self.device) and hasattr(self.device, 'press_key'):
+                    self.device.press_key(key)
+                elif not key.startswith('KEYCODE_'):
                     key = 'KEYCODE_' + key
-                self.device.adb('shell', 'input', 'keyevent', key)
+                    self.device.adb('shell', 'input', 'keyevent', key)
+                else:
+                    self.device.adb('shell', 'input', 'keyevent', key)
         else:
             log.warning(f'Unknown recorded action: {action}')
 
@@ -414,6 +472,7 @@ class Skill:
         self.skill_dir = Path(skill_dir)
         self.metadata: dict = {}
         self.elements: dict[str, Element] = {}
+        self._elements_by_file: dict[str, dict[str, Element]] = {}
         self.popup_detectors: list[dict] = []
         self._actions: dict[str, type[Action]] = {}
         self._workflows: dict[str, type[Workflow]] = {}
@@ -430,12 +489,27 @@ class Skill:
                      f' ({len(self.popup_detectors)} popup detectors)')
 
     def _load_elements(self):
-        path = self.skill_dir / 'elements.yaml'
+        self.elements = self._load_elements_file('elements.yaml')
+
+    def _load_elements_file(self, filename: str) -> dict[str, Element]:
+        path = self.skill_dir / filename
+        elements: dict[str, Element] = {}
         if path.exists():
             raw = yaml.safe_load(path.read_text()) or {}
             for name, locators in raw.items():
-                self.elements[name] = Element.from_dict(name, locators)
-            log.info(f'Loaded {len(self.elements)} elements for {self.name}')
+                elements[name] = Element.from_dict(name, locators)
+            log.info(f'Loaded {len(elements)} elements from {filename} for {self.name}')
+        self._elements_by_file[filename] = elements
+        return elements
+
+    def _elements_for_device(self, device: Device | None) -> dict[str, Element]:
+        if device and _device_is_ios(device):
+            if 'elements_ios.yaml' not in self._elements_by_file:
+                self._load_elements_file('elements_ios.yaml')
+            ios_elements = self._elements_by_file.get('elements_ios.yaml', {})
+            if ios_elements:
+                return ios_elements
+        return self.elements
 
     @property
     def name(self) -> str:
@@ -443,7 +517,19 @@ class Skill:
 
     @property
     def app_package(self) -> str:
-        return self.metadata.get('app_package', '')
+        return skill_android_package(self.metadata)
+
+    @property
+    def android_package(self) -> str:
+        return skill_android_package(self.metadata)
+
+    @property
+    def ios_bundle_id(self) -> str:
+        return skill_ios_bundle_id(self.metadata)
+
+    @property
+    def platforms(self) -> list[str]:
+        return skill_platforms(self.metadata)
 
     @property
     def version(self) -> str:
@@ -461,7 +547,7 @@ class Skill:
             return None
         if not device:
             return cls
-        action = cls(device, self.elements, **kwargs)
+        action = cls(device, self._elements_for_device(device), **kwargs)
         action._popup_detectors = self.popup_detectors or None
         return action
 
@@ -471,10 +557,14 @@ class Skill:
             return None
         if not device:
             return cls
-        wf = cls(device, self.elements, **kwargs)
+        wf = cls(device, self._elements_for_device(device), **kwargs)
         wf._popup_detectors = self.popup_detectors or None
-        wf.app_package = self.metadata.get('app_package', '') or ''
+        wf.app_package = skill_target_for_device(self.metadata, getattr(device, 'serial', str(device))) or ''
         return wf
+
+    def supports_device(self, device: Device | str | None) -> bool:
+        serial = getattr(device, 'serial', device)
+        return skill_supports_device(self.metadata, str(serial) if serial else None)
 
     def list_actions(self) -> list[str]:
         return list(self._actions.keys())

--- a/gitd/skills/macro_recorder.py
+++ b/gitd/skills/macro_recorder.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass, field, asdict
 from pathlib import Path
 from typing import Any
 
-from gitd.bots.common.adb import Device
+from gitd.bots.common.device import is_ios_ref
 
 log = logging.getLogger(__name__)
 
@@ -48,6 +48,9 @@ class Macro:
     name: str
     steps: list[MacroStep] = field(default_factory=list)
     device_serial: str = ""
+    platform: str = ""
+    app_package: str = ""
+    ios_bundle_id: str = ""
     recorded_at: str = ""
     duration_s: float = 0.0
 
@@ -55,6 +58,9 @@ class Macro:
         return {
             "name": self.name,
             "device_serial": self.device_serial,
+            "platform": self.platform,
+            "app_package": self.app_package,
+            "ios_bundle_id": self.ios_bundle_id,
             "recorded_at": self.recorded_at,
             "duration_s": self.duration_s,
             "step_count": len(self.steps),
@@ -68,6 +74,9 @@ class Macro:
             name=d["name"],
             steps=steps,
             device_serial=d.get("device_serial", ""),
+            platform=d.get("platform", ""),
+            app_package=d.get("app_package", ""),
+            ios_bundle_id=d.get("ios_bundle_id", ""),
             recorded_at=d.get("recorded_at", ""),
             duration_s=d.get("duration_s", 0.0),
         )
@@ -87,7 +96,7 @@ class Macro:
 class MacroRecorder:
     """Records and replays sequences of device actions."""
 
-    def __init__(self, dev: Device):
+    def __init__(self, dev: Any):
         self.dev = dev
         self._recording = False
         self._start_time = 0.0
@@ -104,14 +113,37 @@ class MacroRecorder:
         self._steps = []
         log.info("Recording started")
 
+    def _app_identity(self) -> tuple[str, str]:
+        try:
+            state = self.dev.get_phone_state()
+        except Exception:
+            state = {}
+        if not isinstance(state, dict):
+            return "", ""
+        package = (
+            state.get("packageName")
+            or state.get("package")
+            or state.get("bundleId")
+            or state.get("bundle_id")
+            or state.get("currentApp")
+            or ""
+        )
+        bundle_id = state.get("bundleId") or state.get("bundle_id") or ""
+        return str(package or ""), str(bundle_id or "")
+
     def stop(self) -> Macro:
         """Stop recording and return the Macro."""
         self._recording = False
         duration = time.time() - self._start_time
+        platform = "ios" if is_ios_ref(getattr(self.dev, "serial", "")) else "android"
+        app_package, ios_bundle_id = self._app_identity()
         macro = Macro(
             name="recording",
             steps=self._steps.copy(),
             device_serial=self.dev.serial,
+            platform=platform,
+            app_package=app_package,
+            ios_bundle_id=ios_bundle_id if platform == "ios" else "",
             recorded_at=time.strftime("%Y-%m-%d %H:%M:%S UTC", time.gmtime()),
             duration_s=round(duration, 2),
         )
@@ -141,7 +173,12 @@ class MacroRecorder:
 
     def type_text(self, text: str, delay=0.3):
         self.record_step("type", text=text)
-        self.dev.adb("shell", "input", "text", text.replace(" ", "%s"))
+        if is_ios_ref(getattr(self.dev, "serial", "")) and hasattr(self.dev, "type_text"):
+            self.dev.type_text(text)
+        else:
+            from gitd.bots.common.adb import input_text_arg
+
+            self.dev.adb("shell", "input", "text", input_text_arg(text))
         time.sleep(delay)
 
     def back(self, delay=1.0):
@@ -150,8 +187,20 @@ class MacroRecorder:
 
     def home(self, delay=0.5):
         self.record_step("home")
-        self.dev.adb("shell", "input", "keyevent", "KEYCODE_HOME")
+        if is_ios_ref(getattr(self.dev, "serial", "")) and hasattr(self.dev, "press_key"):
+            self.dev.press_key("HOME")
+        else:
+            self.dev.adb("shell", "input", "keyevent", "KEYCODE_HOME")
         time.sleep(delay)
+
+    def _replay_back(self, delay: float = 0):
+        if is_ios_ref(getattr(self.dev, "serial", "")) and hasattr(self.dev, "browser_back"):
+            try:
+                self.dev.browser_back(delay=delay)
+                return
+            except Exception:
+                pass
+        self.dev.back(delay=delay)
 
     def wait(self, seconds: float):
         self.record_step("wait", seconds=seconds)
@@ -182,15 +231,22 @@ class MacroRecorder:
                 self.dev.swipe(p["x1"], p["y1"], p["x2"], p["y2"],
                               ms=p.get("ms", 500), delay=0)
             elif action == "type":
-                self.dev.adb("shell", "input", "text",
-                            p["text"].replace(" ", "%s"))
+                if is_ios_ref(getattr(self.dev, "serial", "")) and hasattr(self.dev, "type_text"):
+                    self.dev.type_text(p["text"])
+                else:
+                    from gitd.bots.common.adb import input_text_arg
+
+                    self.dev.adb("shell", "input", "text", input_text_arg(p["text"]))
             elif action == "back":
-                self.dev.back(delay=0)
+                self._replay_back(delay=0)
             elif action == "home":
-                self.dev.adb("shell", "input", "keyevent", "KEYCODE_HOME")
+                if is_ios_ref(getattr(self.dev, "serial", "")) and hasattr(self.dev, "press_key"):
+                    self.dev.press_key("HOME")
+                else:
+                    self.dev.adb("shell", "input", "keyevent", "KEYCODE_HOME")
             elif action == "wait":
                 time.sleep(p.get("seconds", 1.0) / speed)
             else:
                 log.warning(f"  Unknown action: {action}")
 
-        log.info(f"Replay complete")
+        log.info("Replay complete")

--- a/gitd/skills/platforms.py
+++ b/gitd/skills/platforms.py
@@ -1,0 +1,106 @@
+"""Platform compatibility helpers for automation skills."""
+from __future__ import annotations
+
+from typing import Any
+
+from gitd.bots.common.device import is_ios_ref
+
+VALID_PLATFORMS = ("android", "ios")
+
+
+def _clean(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def normalize_platforms(value: Any) -> list[str]:
+    """Normalize a metadata platforms value to ordered supported platform names."""
+    if value is None or value == "":
+        return []
+    raw_values = value if isinstance(value, (list, tuple, set)) else [value]
+    result: list[str] = []
+    for item in raw_values:
+        platform = _clean(item).lower()
+        if platform in VALID_PLATFORMS and platform not in result:
+            result.append(platform)
+    return result
+
+
+def platform_for_device_ref(device: str | None) -> str:
+    return "ios" if device and is_ios_ref(device) else "android"
+
+
+def skill_android_package(metadata: dict[str, Any]) -> str:
+    return _clean(metadata.get("android_package") or metadata.get("app_package"))
+
+
+def skill_ios_bundle_id(metadata: dict[str, Any]) -> str:
+    return _clean(metadata.get("ios_bundle_id"))
+
+
+def skill_platforms(metadata: dict[str, Any] | None) -> list[str]:
+    """Return supported platforms for a skill.
+
+    Legacy skills predate explicit platform metadata. Preserve their behavior by
+    treating skills without iOS metadata as Android skills.
+    """
+    metadata = metadata or {}
+    explicit = normalize_platforms(metadata.get("platforms"))
+    if explicit:
+        return explicit
+
+    inferred: list[str] = []
+    if skill_android_package(metadata):
+        inferred.append("android")
+    if skill_ios_bundle_id(metadata):
+        inferred.append("ios")
+    return inferred or ["android"]
+
+
+def skill_supports_platform(metadata: dict[str, Any] | None, platform: str) -> bool:
+    return platform.lower() in skill_platforms(metadata)
+
+
+def skill_supports_device(metadata: dict[str, Any] | None, device: str | None) -> bool:
+    return skill_supports_platform(metadata, platform_for_device_ref(device))
+
+
+def skill_target_for_device(metadata: dict[str, Any] | None, device: str | None) -> str:
+    metadata = metadata or {}
+    if platform_for_device_ref(device) == "ios":
+        return skill_ios_bundle_id(metadata)
+    return skill_android_package(metadata)
+
+
+def skill_platform_summary(metadata: dict[str, Any] | None) -> dict[str, Any]:
+    metadata = metadata or {}
+    platforms = skill_platforms(metadata)
+    return {
+        "platforms": platforms,
+        "supports_android": "android" in platforms,
+        "supports_ios": "ios" in platforms,
+        "app_package": _clean(metadata.get("app_package")),
+        "android_package": skill_android_package(metadata),
+        "ios_bundle_id": skill_ios_bundle_id(metadata),
+        "platform_limitations": metadata.get("platform_limitations") or {},
+    }
+
+
+def skill_platform_error(skill_name: str, metadata: dict[str, Any] | None, device: str | None) -> dict[str, Any]:
+    platform = platform_for_device_ref(device)
+    supported = skill_platforms(metadata)
+    supported_text = ", ".join(supported) if supported else "none"
+    return {
+        "ok": False,
+        "error": "unsupported_platform",
+        "skill": skill_name,
+        "device": device or "",
+        "platform": platform,
+        "supported_platforms": supported,
+        "message": f"Skill '{skill_name}' does not support {platform}; supported platforms: {supported_text}",
+    }
+
+
+def skill_platform_error_text(skill_name: str, metadata: dict[str, Any] | None, device: str | None) -> str:
+    return f"ERROR: {skill_platform_error(skill_name, metadata, device)['message']}"

--- a/gitd/skills/play_store/actions/core.py
+++ b/gitd/skills/play_store/actions/core.py
@@ -97,10 +97,14 @@ class UninstallApp(Action):
 
     def execute(self) -> ActionResult:
         try:
-            out = self.device.adb('shell', 'pm', 'uninstall', self.package, timeout=30)
+            # pm uninstall reports "Failure [reason]" on its own errors and may
+            # exit nonzero — use adb_soft so we can surface that reason as data
+            # rather than losing it to an exception.
+            res = self.device.adb_soft('shell', 'pm', 'uninstall', self.package, timeout=30)
+            out = (res.stdout + (('\n' + res.stderr) if res.stderr else '')).strip()
             success = 'success' in out.lower()
             return ActionResult(success=success,
-                                data={'status': 'uninstalled' if success else 'failed', 'output': out.strip()})
+                                data={'status': 'uninstalled' if success else 'failed', 'output': out})
         except Exception as e:
             return ActionResult(success=False, error=str(e))
 

--- a/gitd/skills/play_store/skill.yaml
+++ b/gitd/skills/play_store/skill.yaml
@@ -2,6 +2,9 @@ name: play_store
 description: Google Play Store automation — install, uninstall, update apps, check versions
 version: "1.0.0"
 app_package: com.android.vending
+android_package: com.android.vending
+platforms:
+  - android
 
 exports:
   actions:

--- a/gitd/skills/safari/__init__.py
+++ b/gitd/skills/safari/__init__.py
@@ -1,0 +1,19 @@
+"""iOS browser demo skill."""
+from pathlib import Path
+
+from gitd.skills.base import Skill
+
+from .actions.core import OpenBrowser, OpenSafari, OpenUrl, ReadNews, VerifyPage
+from .workflows import OpenGhostSite, ReadNewsWorkflow
+
+
+def load() -> Skill:
+    s = Skill(Path(__file__).parent)
+    s.register_action(OpenBrowser)
+    s.register_action(OpenSafari)
+    s.register_action(OpenUrl)
+    s.register_action(VerifyPage)
+    s.register_action(ReadNews)
+    s.register_workflow(OpenGhostSite)
+    s.register_workflow(ReadNewsWorkflow)
+    return s

--- a/gitd/skills/safari/actions/__init__.py
+++ b/gitd/skills/safari/actions/__init__.py
@@ -1,0 +1,1 @@
+"""Safari action package."""

--- a/gitd/skills/safari/actions/core.py
+++ b/gitd/skills/safari/actions/core.py
@@ -1,0 +1,125 @@
+"""iOS browser demo actions."""
+from __future__ import annotations
+
+import os
+import time
+
+from gitd.bots.common.device import is_ios_ref
+from gitd.skills.base import Action, ActionResult
+
+DEFAULT_BROWSER_BUNDLE_ID = "com.google.chrome.ios"
+
+
+def _default_bundle_id() -> str:
+    return os.getenv("IOS_BUNDLE_ID", DEFAULT_BROWSER_BUNDLE_ID)
+
+
+class OpenBrowser(Action):
+    name = "open_browser"
+    description = "Launch the configured iOS browser"
+    max_retries = 1
+
+    def __init__(self, device, elements=None, bundle_id: str | None = None, **kw):
+        super().__init__(device, elements)
+        self.bundle_id = bundle_id or _default_bundle_id()
+
+    def execute(self) -> ActionResult:
+        if not is_ios_ref(getattr(self.device, "serial", "")):
+            return ActionResult(success=False, error="iOS browser demo skill requires an iOS device ref")
+        self.device.launch_app(self.bundle_id)
+        return ActionResult(success=True, data={"bundle_id": self.bundle_id})
+
+
+class OpenSafari(OpenBrowser):
+    name = "open_safari"
+    description = "Launch the configured iOS browser; kept as a compatibility alias"
+
+
+class OpenUrl(Action):
+    name = "open_url"
+    description = "Open a URL in the active iOS browser"
+    max_retries = 2
+
+    def __init__(self, device, elements=None, url: str = "https://ghostinthedroid.com", **kw):
+        super().__init__(device, elements)
+        self.url = url
+
+    def execute(self) -> ActionResult:
+        if not is_ios_ref(getattr(self.device, "serial", "")):
+            return ActionResult(success=False, error="open_url requires an iOS device ref")
+        url = self.url.strip()
+        if url and "://" not in url:
+            url = "https://" + url
+        self.device.open_url(url)
+        return ActionResult(success=True, data={"url": url})
+
+
+class VerifyPage(Action):
+    name = "verify_page"
+    description = "Verify expected text is visible in the iOS browser source"
+    max_retries = 3
+    retry_delay = 1.0
+
+    def __init__(self, device, elements=None, expected: str = "ghostinthedroid", **kw):
+        super().__init__(device, elements)
+        self.expected = expected
+
+    def execute(self) -> ActionResult:
+        time.sleep(1.0)
+        xml = self.device.dump_xml()
+        if self.expected.lower() in xml.lower():
+            return ActionResult(success=True, data={"expected": self.expected})
+        return ActionResult(success=False, error=f"Expected text not visible: {self.expected}")
+
+
+class ReadNews(Action):
+    name = "read_news"
+    description = "Open a news site in iOS Chrome/browser and extract headlines plus article snippets"
+    max_retries = 1
+
+    def __init__(
+        self,
+        device,
+        elements=None,
+        url: str = "https://text.npr.org/",
+        max_headlines: int = 5,
+        max_articles: int = 3,
+        bundle_id: str | None = None,
+        wait_s: float = 2.0,
+        save_screenshots: bool = False,
+        out_dir: str | None = None,
+        **kw,
+    ):
+        super().__init__(device, elements)
+        self.url = url
+        self.max_headlines = max_headlines
+        self.max_articles = max_articles
+        self.bundle_id = bundle_id or _default_bundle_id()
+        self.wait_s = wait_s
+        self.save_screenshots = save_screenshots
+        self.out_dir = out_dir
+
+    def execute(self) -> ActionResult:
+        serial = getattr(self.device, "serial", "")
+        if not is_ios_ref(serial):
+            return ActionResult(success=False, error="read_news requires an iOS device ref")
+
+        from gitd.services.browser import read_news
+
+        result = read_news(
+            serial,
+            self.url,
+            max_headlines=self.max_headlines,
+            max_articles=self.max_articles,
+            bundle_id=self.bundle_id,
+            wait_s=self.wait_s,
+            save_screenshots=self.save_screenshots,
+            out_dir=self.out_dir,
+        )
+        if result.get("ok"):
+            return ActionResult(success=True, data=result)
+        return ActionResult(
+            success=False,
+            data=result,
+            error=result.get("error") or "read_news did not return headlines",
+        )

--- a/gitd/skills/safari/elements_ios.yaml
+++ b/gitd/skills/safari/elements_ios.yaml
@@ -1,0 +1,9 @@
+address_field:
+  content_desc: "Address"
+  class_name: "XCUIElementTypeTextField"
+tab_overview:
+  content_desc: "Tabs"
+  class_name: "XCUIElementTypeButton"
+share:
+  content_desc: "Share"
+  class_name: "XCUIElementTypeButton"

--- a/gitd/skills/safari/skill.yaml
+++ b/gitd/skills/safari/skill.yaml
@@ -1,0 +1,43 @@
+name: safari
+description: Configurable iOS Chrome/browser smoke automation
+version: "0.1.0"
+app_package: ""
+ios_bundle_id: com.google.chrome.ios
+platforms:
+  - ios
+
+exports:
+  actions:
+    - open_browser
+    - open_safari
+    - open_url
+    - verify_page
+    - read_news
+  workflows:
+    - open_ghost_site
+    - read_news
+
+default_params:
+  actions:
+    open_browser:
+      bundle_id: "com.google.chrome.ios"
+    open_url:
+      url: "https://ghostinthedroid.com"
+    verify_page:
+      expected: "ghostinthedroid"
+    read_news:
+      url: "https://text.npr.org/"
+      max_headlines: 5
+      max_articles: 3
+      bundle_id: "com.google.chrome.ios"
+  workflows:
+    open_ghost_site:
+      url: "https://ghostinthedroid.com"
+      bundle_id: "com.google.chrome.ios"
+    read_news:
+      url: "https://text.npr.org/"
+      max_headlines: 5
+      max_articles: 3
+      bundle_id: "com.google.chrome.ios"
+      save_screenshots: true
+      out_dir: "data/ios_chrome_news_smoke"

--- a/gitd/skills/safari/workflows.py
+++ b/gitd/skills/safari/workflows.py
@@ -1,0 +1,74 @@
+"""iOS browser demo workflows."""
+from __future__ import annotations
+
+from gitd.skills.base import Action, EngineConfig, Workflow
+
+from .actions.core import OpenBrowser, OpenUrl, ReadNews, VerifyPage, _default_bundle_id
+
+
+class OpenGhostSite(Workflow):
+    name = "open_ghost_site"
+    description = "Open ghostinthedroid.com in the configured iOS browser"
+    engine = EngineConfig(back_count=0, launch_settle=1.0, skip_popup_detect=True)
+
+    def __init__(
+        self,
+        device,
+        elements=None,
+        url: str = "https://ghostinthedroid.com",
+        bundle_id: str | None = None,
+        **kw,
+    ):
+        super().__init__(device, elements)
+        self.url = url
+        self.bundle_id = bundle_id or _default_bundle_id()
+
+    def steps(self) -> list[Action]:
+        return [
+            OpenBrowser(self.device, self.elements, bundle_id=self.bundle_id),
+            OpenUrl(self.device, self.elements, url=self.url),
+            VerifyPage(self.device, self.elements, expected="ghostinthedroid"),
+        ]
+
+
+class ReadNewsWorkflow(Workflow):
+    name = "read_news"
+    description = "Read headlines and article snippets from a text-friendly news site in iOS Chrome/browser"
+    engine = EngineConfig(back_count=0, auto_launch=False, skip_popup_detect=True)
+
+    def __init__(
+        self,
+        device,
+        elements=None,
+        url: str = "https://text.npr.org/",
+        max_headlines: int = 5,
+        max_articles: int = 3,
+        bundle_id: str | None = None,
+        wait_s: float = 2.0,
+        save_screenshots: bool = False,
+        out_dir: str | None = None,
+        **kw,
+    ):
+        super().__init__(device, elements)
+        self.url = url
+        self.max_headlines = max_headlines
+        self.max_articles = max_articles
+        self.bundle_id = bundle_id or _default_bundle_id()
+        self.wait_s = wait_s
+        self.save_screenshots = save_screenshots
+        self.out_dir = out_dir
+
+    def steps(self) -> list[Action]:
+        return [
+            ReadNews(
+                self.device,
+                self.elements,
+                url=self.url,
+                max_headlines=self.max_headlines,
+                max_articles=self.max_articles,
+                bundle_id=self.bundle_id,
+                wait_s=self.wait_s,
+                save_screenshots=self.save_screenshots,
+                out_dir=self.out_dir,
+            )
+        ]

--- a/gitd/skills/send_gmail_email/skill.yaml
+++ b/gitd/skills/send_gmail_email/skill.yaml
@@ -1,6 +1,9 @@
 app_package: com.google.android.gm
+android_package: com.google.android.gm
 description: Auto-generated skill from 6 recorded steps
 name: send_gmail_email
+platforms:
+- android
 version: 1.0.0
 
 default_params:

--- a/gitd/skills/test_pic/skill.yaml
+++ b/gitd/skills/test_pic/skill.yaml
@@ -1,4 +1,6 @@
 app_package: ''
 description: Auto-generated skill from 3 recorded steps
 name: test_pic
+platforms:
+- android
 version: 1.0.0

--- a/gitd/skills/tiktok/actions/core.py
+++ b/gitd/skills/tiktok/actions/core.py
@@ -98,7 +98,9 @@ class TypeAndSearch(Action):
         if pos:
             self.device.tap(*pos, delay=0.3)
         # Clear and type
-        self.device.adb("shell", "input", "text", self.query.replace(' ', '%s'))
+        from gitd.bots.common.adb import input_text_arg
+
+        self.device.adb("shell", "input", "text", input_text_arg(str(self.query)))
         time.sleep(0.5)
         self.device.press_enter()
         time.sleep(2)

--- a/gitd/skills/tiktok/skill.yaml
+++ b/gitd/skills/tiktok/skill.yaml
@@ -1,7 +1,10 @@
 name: tiktok
-description: TikTok automation skill — upload, crawl, outreach, engage, analytics
+description: TikTok automation skill — open, search, navigate, upload your own drafts
 version: "1.0.0"
 app_package: com.zhiliaoapp.musically
+android_package: com.zhiliaoapp.musically
+platforms:
+  - android
 app_version_tested: "44.3.3"
 exports:
   actions:
@@ -12,10 +15,7 @@ exports:
     - dismiss_popup
   workflows:
     - upload_video
-    - crawl_hashtag
-    - send_dm
-    - scrape_analytics
-    - engage_fyp
+    - publish_draft
 
 # Default parameters — pre-filled in the UI run modal
 popup_detectors:
@@ -23,7 +23,7 @@ popup_detectors:
     button: "Save draft"
     label: "Draft resume overlay"
   - detect: "connect with people"
-    button: "Don\u2019t allow"
+    button: "Don’t allow"
     label: "Contacts access popup"
   - detect: "access to your Facebook"
     button: "Don't allow"
@@ -55,40 +55,11 @@ default_params:
   actions:
     type_and_search:
       query: "#cats"
-    comment_on_post:
-      text: "Great content! 🔥"
-    tap_user:
-      index: 0
-    type_message:
-      text: "Hey! Love your content"
   workflows:
-    send_dm:
-      username: "@username"
-      message: "Hey! I love your content, would love to collab"
-    crawl_hashtag:
-      query: "#fyp"
-      label: "general"
-      tab: "top"
-      passes: 5
-    crawl_users:
-      query: "#cats"
-      label: "general"
-      passes: 5
     upload_video:
       video_path: "/sdcard/DCIM/video.mp4"
       caption: "Check this out!"
       hashtags: "#fyp #viral"
       as_draft: false
-    scrape_analytics:
-      account: "@myaccount"
-    engage_fyp:
-      like: true
-      comment: ""
-      follow: false
-    scan_inbox:
-      account: "@myaccount"
-    continuous_scrape:
-      label: "niche"
-      passes_per_tag: 5
     publish_draft:
       draft_tag: ""

--- a/gitd/skills/tiktok_ios/__init__.py
+++ b/gitd/skills/tiktok_ios/__init__.py
@@ -1,0 +1,32 @@
+"""TikTok iOS smoke skill."""
+from pathlib import Path
+
+from gitd.skills.base import Skill
+
+from .actions import (
+    CaptureVisibleText,
+    DismissPopup,
+    NavigateToProfile,
+    OpenApp,
+    TapSearch,
+    TypeAndSearch,
+    VerifyVisibleText,
+    WaitVisibleText,
+)
+from .workflows import OpenAppSmoke, ProfileSmoke, SearchSmoke
+
+
+def load() -> Skill:
+    s = Skill(Path(__file__).parent)
+    s.register_action(OpenApp)
+    s.register_action(DismissPopup)
+    s.register_action(TapSearch)
+    s.register_action(TypeAndSearch)
+    s.register_action(NavigateToProfile)
+    s.register_action(CaptureVisibleText)
+    s.register_action(VerifyVisibleText)
+    s.register_action(WaitVisibleText)
+    s.register_workflow(OpenAppSmoke)
+    s.register_workflow(SearchSmoke)
+    s.register_workflow(ProfileSmoke)
+    return s

--- a/gitd/skills/tiktok_ios/actions/__init__.py
+++ b/gitd/skills/tiktok_ios/actions/__init__.py
@@ -1,0 +1,22 @@
+"""TikTok iOS action exports."""
+from gitd.skills.tiktok_ios.actions.core import (
+    CaptureVisibleText,
+    DismissPopup,
+    NavigateToProfile,
+    OpenApp,
+    TapSearch,
+    TypeAndSearch,
+    VerifyVisibleText,
+    WaitVisibleText,
+)
+
+__all__ = [
+    "CaptureVisibleText",
+    "DismissPopup",
+    "NavigateToProfile",
+    "OpenApp",
+    "TapSearch",
+    "TypeAndSearch",
+    "VerifyVisibleText",
+    "WaitVisibleText",
+]

--- a/gitd/skills/tiktok_ios/actions/core.py
+++ b/gitd/skills/tiktok_ios/actions/core.py
@@ -1,0 +1,240 @@
+"""TikTok iOS actions backed by normalized WDA XML."""
+from __future__ import annotations
+
+import re
+import time
+
+from gitd.bots.common.device import is_ios_ref
+from gitd.skills.base import Action, ActionResult
+
+TIKTOK_IOS_BUNDLE_ID = "com.zhiliaoapp.musically"
+_POPUP_LABELS = (
+    r"\bnot now\b",
+    r"\bdon(?:'|\u2019)t allow\b",
+    r"\bskip\b",
+    r"\bclose\b",
+    r"\bcancel\b",
+    r"\bcontinue\b",
+    r"\bok\b",
+)
+
+
+def _is_ios_device(device) -> bool:
+    return is_ios_ref(getattr(device, "serial", ""))
+
+
+def _node_label(device, node: str) -> str:
+    return " ".join(
+        [
+            device.node_text(node),
+            device.node_content_desc(node),
+            device.node_rid(node),
+        ]
+    ).strip()
+
+
+def _tap_matching_node(device, patterns: tuple[str, ...], *, delay: float = 0.8) -> bool:
+    compiled = [re.compile(pattern, re.I) for pattern in patterns if pattern]
+    xml = device.dump_xml()
+    for node in device.nodes(xml):
+        label = _node_label(device, node)
+        if label and any(pattern.search(label) for pattern in compiled):
+            return bool(device.tap_node(node, delay=delay))
+    return False
+
+
+class OpenApp(Action):
+    name = "open_app"
+    description = "Launch TikTok on iOS"
+    max_retries = 1
+
+    def execute(self) -> ActionResult:
+        if not _is_ios_device(self.device):
+            return ActionResult(success=False, error="tiktok_ios requires an iOS device ref")
+        self.device.launch_app(TIKTOK_IOS_BUNDLE_ID)
+        time.sleep(2)
+        return ActionResult(success=True, data={"bundle_id": TIKTOK_IOS_BUNDLE_ID})
+
+
+class DismissPopup(Action):
+    name = "dismiss_popup"
+    description = "Dismiss common TikTok iOS popups when visible"
+    max_retries = 1
+
+    def execute(self) -> ActionResult:
+        if not _is_ios_device(self.device):
+            return ActionResult(success=False, error="dismiss_popup requires an iOS device ref")
+        dismissed = _tap_matching_node(self.device, _POPUP_LABELS, delay=0.8)
+        return ActionResult(success=True, data={"dismissed": dismissed})
+
+
+class TapSearch(Action):
+    name = "tap_search"
+    description = "Tap TikTok iOS search control"
+
+    def execute(self) -> ActionResult:
+        if not _is_ios_device(self.device):
+            return ActionResult(success=False, error="tap_search requires an iOS device ref")
+        if not _tap_matching_node(self.device, ("\\bsearch\\b",), delay=1.0):
+            return ActionResult(success=False, error="Search control not found")
+        return ActionResult(success=True)
+
+
+class TypeAndSearch(Action):
+    name = "type_and_search"
+    description = "Type a query into TikTok iOS search and submit"
+
+    def __init__(self, device, elements=None, query: str = "", **kwargs):
+        super().__init__(device, elements)
+        self.query = query
+
+    def execute(self) -> ActionResult:
+        if not _is_ios_device(self.device):
+            return ActionResult(success=False, error="type_and_search requires an iOS device ref")
+        if not self.query:
+            return ActionResult(success=False, error="No query provided")
+        _tap_matching_node(self.device, ("search", "search or enter", "search field"), delay=0.3)
+        self.device.type_text(self.query)
+        self.device.press_enter()
+        time.sleep(2)
+        return ActionResult(success=True, data={"query": self.query})
+
+
+class NavigateToProfile(Action):
+    name = "navigate_to_profile"
+    description = "Tap TikTok iOS Profile tab"
+
+    def execute(self) -> ActionResult:
+        if not _is_ios_device(self.device):
+            return ActionResult(success=False, error="navigate_to_profile requires an iOS device ref")
+        if not _tap_matching_node(self.device, ("\\bprofile\\b", "\\bme\\b"), delay=1.0):
+            return ActionResult(success=False, error="Profile tab not found")
+        return ActionResult(success=True)
+
+
+class CaptureVisibleText(Action):
+    name = "capture_visible_text"
+    description = "Capture visible TikTok iOS text for workflow evidence"
+
+    def __init__(self, device, elements=None, max_lines: int = 80, **kwargs):
+        super().__init__(device, elements)
+        self.max_lines = max(1, int(max_lines))
+
+    def execute(self) -> ActionResult:
+        if not _is_ios_device(self.device):
+            return ActionResult(success=False, error="capture_visible_text requires an iOS device ref")
+        if hasattr(self.device, "extract_visible_text"):
+            text = self.device.extract_visible_text(max_lines=self.max_lines)
+        else:
+            xml = self.device.dump_xml()
+            lines: list[str] = []
+            seen: set[str] = set()
+            for node in self.device.nodes(xml):
+                label = _node_label(self.device, node)
+                if not label or label in seen:
+                    continue
+                seen.add(label)
+                lines.append(label)
+                if len(lines) >= self.max_lines:
+                    break
+            text = "\n".join(lines)
+        lines = [line.strip() for line in text.splitlines() if line.strip()][: self.max_lines]
+        return ActionResult(
+            success=True,
+            data={
+                "text": "\n".join(lines),
+                "lines": lines,
+                "line_count": len(lines),
+            },
+        )
+
+
+class WaitVisibleText(Action):
+    name = "wait_visible_text"
+    description = "Wait until expected TikTok iOS text is visible"
+    max_retries = 1
+
+    def __init__(
+        self,
+        device,
+        elements=None,
+        expected: str = "TikTok",
+        timeout: float = 8.0,
+        interval: float = 0.5,
+        max_lines: int = 300,
+        **kwargs,
+    ):
+        super().__init__(device, elements)
+        self.expected = expected
+        self.timeout = max(0.0, float(timeout))
+        self.interval = max(0.1, float(interval))
+        self.max_lines = max(1, int(max_lines))
+
+    def _visible_text(self) -> str:
+        if hasattr(self.device, "wait_for_text"):
+            try:
+                return self.device.wait_for_text(self.expected, timeout=self.timeout, interval=self.interval)
+            except TypeError:
+                return self.device.wait_for_text(self.expected, timeout=self.timeout)
+        if hasattr(self.device, "extract_visible_text"):
+            return self.device.extract_visible_text(max_lines=self.max_lines)
+        return self.device.dump_xml()
+
+    def execute(self) -> ActionResult:
+        if not _is_ios_device(self.device):
+            return ActionResult(success=False, error="wait_visible_text requires an iOS device ref")
+        if not self.expected:
+            return ActionResult(success=False, error="No expected text provided")
+
+        deadline = time.time() + self.timeout
+        last_text = ""
+        attempts = 0
+        while True:
+            attempts += 1
+            try:
+                last_text = self._visible_text()
+            except Exception as exc:
+                last_text = str(exc)
+            if self.expected.lower() in last_text.lower():
+                lines = [line.strip() for line in last_text.splitlines() if line.strip()]
+                return ActionResult(
+                    success=True,
+                    data={
+                        "expected": self.expected,
+                        "attempts": attempts,
+                        "line_count": len(lines),
+                        "visible_text": "\n".join(lines[: min(12, len(lines))]),
+                    },
+                )
+            if time.time() >= deadline:
+                break
+            time.sleep(min(self.interval, max(0.0, deadline - time.time())))
+
+        lines = [line.strip() for line in last_text.splitlines() if line.strip()]
+        return ActionResult(
+            success=False,
+            error=f"Expected text not visible: {self.expected}",
+            data={
+                "expected": self.expected,
+                "attempts": attempts,
+                "line_count": len(lines),
+                "visible_text": "\n".join(lines[: min(12, len(lines))]),
+            },
+        )
+
+
+class VerifyVisibleText(Action):
+    name = "verify_visible_text"
+    description = "Verify expected text appears in TikTok iOS XML"
+    max_retries = 2
+    retry_delay = 1.0
+
+    def __init__(self, device, elements=None, expected: str = "TikTok", **kwargs):
+        super().__init__(device, elements)
+        self.expected = expected
+
+    def execute(self) -> ActionResult:
+        xml = self.device.dump_xml()
+        if self.expected.lower() in xml.lower():
+            return ActionResult(success=True, data={"expected": self.expected})
+        return ActionResult(success=False, error=f"Expected text not visible: {self.expected}")

--- a/gitd/skills/tiktok_ios/elements_ios.yaml
+++ b/gitd/skills/tiktok_ios/elements_ios.yaml
@@ -1,0 +1,16 @@
+search_tab:
+  content_desc: "Search"
+  text: "Search"
+  class_name: "XCUIElementTypeButton"
+search_field:
+  content_desc: "Search"
+  text: "Search"
+  class_name: "XCUIElementTypeSearchField"
+profile_tab:
+  content_desc: "Profile"
+  text: "Profile"
+  class_name: "XCUIElementTypeButton"
+close:
+  content_desc: "Close"
+  text: "Close"
+  class_name: "XCUIElementTypeButton"

--- a/gitd/skills/tiktok_ios/skill.yaml
+++ b/gitd/skills/tiktok_ios/skill.yaml
@@ -1,0 +1,48 @@
+name: tiktok_ios
+description: TikTok iOS automation smoke skill using Appium/WebDriverAgent
+version: "0.1.0"
+app_package: ""
+ios_bundle_id: com.zhiliaoapp.musically
+platforms:
+  - ios
+
+platform_limitations:
+  ios:
+    - Upload/posting is not implemented yet; this skill validates launch, navigation, popup handling, and search primitives.
+
+exports:
+  actions:
+    - open_app
+    - dismiss_popup
+    - tap_search
+    - type_and_search
+    - navigate_to_profile
+    - capture_visible_text
+    - wait_visible_text
+    - verify_visible_text
+  workflows:
+    - open_app_smoke
+    - search_smoke
+    - profile_smoke
+
+default_params:
+  actions:
+    type_and_search:
+      query: "#fyp"
+    verify_visible_text:
+      expected: "TikTok"
+    wait_visible_text:
+      expected: "TikTok"
+      timeout: 8
+      max_lines: 300
+    capture_visible_text:
+      max_lines: 80
+  workflows:
+    search_smoke:
+      query: "#fyp"
+      max_lines: 80
+      wait_timeout: 8
+    profile_smoke:
+      max_lines: 80
+      expected: "Profile"
+      wait_timeout: 8

--- a/gitd/skills/tiktok_ios/workflows.py
+++ b/gitd/skills/tiktok_ios/workflows.py
@@ -1,0 +1,85 @@
+"""TikTok iOS smoke workflows."""
+from __future__ import annotations
+
+from gitd.skills.base import Action, EngineConfig, Workflow
+
+from .actions import (
+    CaptureVisibleText,
+    DismissPopup,
+    NavigateToProfile,
+    OpenApp,
+    TapSearch,
+    TypeAndSearch,
+    WaitVisibleText,
+)
+
+
+class OpenAppSmoke(Workflow):
+    name = "open_app_smoke"
+    description = "Launch TikTok on iOS and dismiss common first-run prompts"
+    engine = EngineConfig(back_count=0, launch_settle=1.0, skip_popup_detect=True)
+
+    def steps(self) -> list[Action]:
+        return [
+            OpenApp(self.device, self.elements),
+            DismissPopup(self.device, self.elements),
+        ]
+
+
+class SearchSmoke(Workflow):
+    name = "search_smoke"
+    description = "Launch TikTok on iOS, open search, and submit a query"
+    engine = EngineConfig(back_count=0, launch_settle=1.0, skip_popup_detect=True)
+
+    def __init__(
+        self,
+        device,
+        elements=None,
+        query: str = "#fyp",
+        max_lines: int = 80,
+        wait_timeout: float = 8.0,
+        **kwargs,
+    ):
+        super().__init__(device, elements)
+        self.query = query
+        self.max_lines = max_lines
+        self.wait_timeout = wait_timeout
+
+    def steps(self) -> list[Action]:
+        return [
+            OpenApp(self.device, self.elements),
+            DismissPopup(self.device, self.elements),
+            TapSearch(self.device, self.elements),
+            TypeAndSearch(self.device, self.elements, query=self.query),
+            WaitVisibleText(self.device, self.elements, expected=self.query, timeout=self.wait_timeout),
+            CaptureVisibleText(self.device, self.elements, max_lines=self.max_lines),
+        ]
+
+
+class ProfileSmoke(Workflow):
+    name = "profile_smoke"
+    description = "Launch TikTok on iOS, navigate to Profile, and capture visible text evidence"
+    engine = EngineConfig(back_count=0, launch_settle=1.0, skip_popup_detect=True)
+
+    def __init__(
+        self,
+        device,
+        elements=None,
+        max_lines: int = 80,
+        expected: str = "Profile",
+        wait_timeout: float = 8.0,
+        **kwargs,
+    ):
+        super().__init__(device, elements)
+        self.max_lines = max_lines
+        self.expected = expected
+        self.wait_timeout = wait_timeout
+
+    def steps(self) -> list[Action]:
+        return [
+            OpenApp(self.device, self.elements),
+            DismissPopup(self.device, self.elements),
+            NavigateToProfile(self.device, self.elements),
+            WaitVisibleText(self.device, self.elements, expected=self.expected, timeout=self.wait_timeout),
+            CaptureVisibleText(self.device, self.elements, max_lines=self.max_lines),
+        ]

--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -1,0 +1,17 @@
+# Xcode project is generated from project.yml via xcodegen
+*.xcodeproj
+*.xcworkspace
+
+# Build output / DerivedData
+build/
+DerivedData/
+.swiftpm/
+*.xcuserstate
+
+# Models are large; fetched via scripts/fetch-phase0-model.sh, not committed
+models/*.gguf
+GhostLLM/Resources/*.gguf
+
+# macOS
+.DS_Store
+GhostLLM/Info.plist

--- a/ios/ExportOptions-ad-hoc.plist
+++ b/ios/ExportOptions-ad-hoc.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Shareable to registered UDIDs. Needs an ad-hoc provisioning profile
+         (Apple Developer portal) + the device UDIDs added to it. -->
+    <key>method</key>
+    <string>ad-hoc</string>
+    <key>teamID</key>
+    <string>WWD665FH95</string>
+    <key>signingStyle</key>
+    <string>automatic</string>
+    <key>stripSwiftSymbols</key>
+    <true/>
+    <key>compileBitcode</key>
+    <false/>
+    <key>thinning</key>
+    <string>&lt;none&gt;</string>
+</dict>
+</plist>

--- a/ios/ExportOptions-app-store.plist
+++ b/ios/ExportOptions-app-store.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- TestFlight / App Store. Needs an Apple Distribution cert in the signing
+         keychain + an App Store provisioning profile. Upload with `xcrun altool`
+         or Transporter after export. -->
+    <key>method</key>
+    <string>app-store</string>
+    <key>teamID</key>
+    <string>WWD665FH95</string>
+    <key>signingStyle</key>
+    <string>automatic</string>
+    <key>stripSwiftSymbols</key>
+    <true/>
+    <key>uploadSymbols</key>
+    <true/>
+</dict>
+</plist>

--- a/ios/ExportOptions-development.plist
+++ b/ios/ExportOptions-development.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>development</string>
+    <key>teamID</key>
+    <string>WWD665FH95</string>
+    <key>signingStyle</key>
+    <string>automatic</string>
+    <key>stripSwiftSymbols</key>
+    <true/>
+    <key>compileBitcode</key>
+    <false/>
+</dict>
+</plist>

--- a/ios/GhostLLM/Agent/AgentChatView.swift
+++ b/ios/GhostLLM/Agent/AgentChatView.swift
@@ -1,0 +1,197 @@
+import SwiftUI
+import WebKit
+
+struct WebViewContainer: UIViewRepresentable {
+    let webView: WKWebView
+    func makeUIView(context: Context) -> WKWebView { webView }
+    func updateUIView(_ uiView: WKWebView, context: Context) {}
+}
+
+/// Ghost's on-device agent, presented as a chat — matched to the Android app:
+/// a dark green theme, a bubble transcript, and a bottom prompt field. The user
+/// types a task; the on-device LLM drives the phone and reports back in-line.
+struct AgentChatView: View {
+    @StateObject private var vm = InAppAgentViewModel()
+    @State private var draft = ""
+    @FocusState private var inputFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider().overlay(GhostTheme.border)
+            transcript
+            if vm.running || !vm.chat.isEmpty { screenPanel }
+            if !vm.activityLine.isEmpty { activityBar }
+            Divider().overlay(GhostTheme.border)
+            inputBar
+        }
+        .background(GhostTheme.bgBase.ignoresSafeArea())
+        .task {
+            await vm.prepare()
+            let env = ProcessInfo.processInfo.environment
+            // Record hook: GHOST_AUTOTYPE animates the prompt into the field (so a
+            // screen recording shows a user typing), then submits. Opens the WDA
+            // session first so the recorder's MJPEG stream is live before typing.
+            if let g = env["GHOST_GOAL"], !g.isEmpty, env["GHOST_AUTOTYPE"] == "1" {
+                await vm.startCaptureSession()
+                try? await Task.sleep(nanoseconds: 1_800_000_000)  // let the recorder attach
+                inputFocused = true
+                for ch in g {                                       // "type" it out
+                    draft.append(ch)
+                    try? await Task.sleep(nanoseconds: 45_000_000)
+                }
+                try? await Task.sleep(nanoseconds: 600_000_000)
+                send()
+            } else if let g = env["GHOST_GOAL"], !g.isEmpty {
+                await vm.submit(goal: g)
+            }
+        }
+    }
+
+    // MARK: header
+    private var header: some View {
+        HStack(spacing: 10) {
+            Text("👻").font(.system(size: 26))
+                .shadow(color: GhostTheme.accent.opacity(0.5), radius: 6)
+            VStack(alignment: .leading, spacing: 1) {
+                Text("Ghost in the Droid")
+                    .font(.system(size: 18, weight: .bold)).foregroundStyle(GhostTheme.text1)
+                HStack(spacing: 6) {
+                    Circle().fill(statusDot).frame(width: 6, height: 6)
+                    Text(vm.running ? "working" : (vm.ready ? "on-device · \(vm.modelName)" : "loading…"))
+                        .font(.system(size: 11, weight: .semibold)).foregroundStyle(GhostTheme.text2)
+                }
+            }
+            Spacer()
+            Text("on-device").font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(GhostTheme.accent)
+                .padding(.horizontal, 8).padding(.vertical, 4)
+                .background(GhostTheme.accent.opacity(0.12), in: Capsule())
+        }
+        .padding(.horizontal, 14).padding(.vertical, 10)
+        .background(GhostTheme.bgBase)
+    }
+    private var statusDot: Color {
+        vm.running ? GhostTheme.dotWorking : (vm.chat.isEmpty ? GhostTheme.dotIdle : GhostTheme.dotDone)
+    }
+
+    // MARK: transcript
+    private var transcript: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: 8) {
+                    if vm.chat.isEmpty { emptyState.padding(.top, 40) }
+                    ForEach(vm.chat) { bubble(for: $0).id($0.id) }
+                }
+                .padding(12)
+            }
+            .onChange(of: vm.chat.count) { _, _ in
+                if let last = vm.chat.last { withAnimation { proxy.scrollTo(last.id, anchor: .bottom) } }
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Text("Chat with the agent — it runs entirely on this phone.")
+            Text("Try: “open r/LocalLLaMA and summarize the top posts”")
+                .foregroundStyle(GhostTheme.text3)
+        }
+        .font(.system(size: 12)).lineSpacing(4)
+        .foregroundStyle(GhostTheme.text4)
+        .multilineTextAlignment(.center)
+        .frame(maxWidth: .infinity)
+    }
+
+    @ViewBuilder private func bubble(for m: ChatMsg) -> some View {
+        switch m.role {
+        case .user:
+            HStack { Spacer(minLength: 40)
+                Text(m.text).font(.system(size: 13)).foregroundStyle(.white)
+                    .padding(.vertical, 8).padding(.horizontal, 12)
+                    .background(GhostTheme.userBubble,
+                                in: .rect(topLeadingRadius: 12, bottomLeadingRadius: 12, bottomTrailingRadius: 2, topTrailingRadius: 12))
+            }
+        case .assistant:
+            HStack { Text(m.text).font(.system(size: 13)).foregroundStyle(GhostTheme.text1)
+                    .textSelection(.enabled)
+                    .padding(.vertical, 8).padding(.horizontal, 12)
+                    .background(GhostTheme.bgDeep,
+                                in: .rect(topLeadingRadius: 12, bottomLeadingRadius: 2, bottomTrailingRadius: 12, topTrailingRadius: 12))
+                Spacer(minLength: 40) }
+        case .tool:
+            HStack { Text(m.text).font(.system(size: 11, weight: .medium)).foregroundStyle(GhostTheme.toolChip)
+                    .padding(.vertical, 3).padding(.horizontal, 9)
+                    .background(GhostTheme.toolChip.opacity(0.09), in: Capsule())
+                    .overlay(Capsule().stroke(GhostTheme.toolChip.opacity(0.22), lineWidth: 1))
+                Spacer(minLength: 40) }
+        case .error:
+            HStack { Text(m.text).font(.system(size: 11)).foregroundStyle(GhostTheme.stop)
+                    .padding(.vertical, 6).padding(.horizontal, 10)
+                    .background(GhostTheme.stop.opacity(0.08))
+                    .overlay(Rectangle().frame(width: 2).foregroundStyle(GhostTheme.stop), alignment: .leading)
+                    .clipShape(.rect(cornerRadius: 6))
+                Spacer(minLength: 40) }
+        }
+    }
+
+    // MARK: the phone screen the agent drives (its in-app browser)
+    private var screenPanel: some View {
+        WebViewContainer(webView: vm.webView)
+            .frame(height: 220)
+            .overlay(alignment: .topLeading) {
+                Text("agent's screen").font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(GhostTheme.text3)
+                    .padding(.horizontal, 7).padding(.vertical, 3)
+                    .background(GhostTheme.bgCard.opacity(0.9), in: Capsule())
+                    .padding(6)
+            }
+            .background(GhostTheme.bgDeep)
+            .overlay(Rectangle().frame(height: 1).foregroundStyle(GhostTheme.border), alignment: .top)
+    }
+
+    private var activityBar: some View {
+        HStack(spacing: 8) {
+            Circle().fill(GhostTheme.activity).frame(width: 5, height: 5)
+                .opacity(0.9)
+            Text(vm.activityLine).font(.system(size: 10, design: .monospaced))
+                .foregroundStyle(GhostTheme.activity)
+            Spacer()
+        }
+        .padding(.horizontal, 14).padding(.vertical, 6)
+        .background(GhostTheme.bgBase)
+    }
+
+    // MARK: input
+    private var inputBar: some View {
+        HStack(spacing: 8) {
+            TextField("", text: $draft, prompt: Text(vm.running ? "Agent is working… type your next message"
+                                                                 : "Tell the agent what to do…")
+                        .foregroundColor(GhostTheme.text3))
+                .font(.system(size: 13)).foregroundStyle(GhostTheme.text1)
+                .focused($inputFocused)
+                .submitLabel(.send)
+                .onSubmit(send)
+                .padding(.vertical, 9).padding(.horizontal, 12)
+                .background(GhostTheme.bgDeep, in: .rect(cornerRadius: 8))
+                .overlay(RoundedRectangle(cornerRadius: 8).stroke(GhostTheme.border, lineWidth: 1))
+            Button(action: send) {
+                Text(vm.running ? "•••" : "Send")
+                    .font(.system(size: 12, weight: .semibold)).foregroundStyle(.white)
+                    .padding(.vertical, 9).padding(.horizontal, 16)
+                    .background(vm.running ? GhostTheme.text4 : GhostTheme.userBubble, in: .rect(cornerRadius: 8))
+            }
+            .disabled(vm.running || draft.trimmingCharacters(in: .whitespaces).isEmpty || !vm.ready)
+            .opacity((vm.running || draft.trimmingCharacters(in: .whitespaces).isEmpty || !vm.ready) ? 0.4 : 1)
+        }
+        .padding(.horizontal, 12).padding(.vertical, 8)
+        .background(GhostTheme.bgBase)
+    }
+
+    private func send() {
+        let goal = draft
+        guard !goal.trimmingCharacters(in: .whitespaces).isEmpty, !vm.running, vm.ready else { return }
+        draft = ""; inputFocused = false
+        Task { await vm.submit(goal: goal) }
+    }
+}

--- a/ios/GhostLLM/Agent/AgentLoop.swift
+++ b/ios/GhostLLM/Agent/AgentLoop.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// The on-device agent loop: the LLM emits a tool call, we execute it against WDA,
+/// feed the observation back, and repeat until `done` or `maxSteps`. The `decider`
+/// is pluggable so the loop is testable with a scripted decider (no model/phone).
+actor AgentLoop {
+    private let engine: LlamaEngine?
+    private let wda: WDAClient
+    private let useGrammar: Bool
+    private(set) var transcript: [String] = []
+
+    init(engine: LlamaEngine?, wda: WDAClient, useGrammar: Bool = false) {
+        self.engine = engine
+        self.wda = wda
+        self.useGrammar = useGrammar
+    }
+
+    /// `decider` maps the running context to the next ToolCall. Defaults to the LLM.
+    func run(goal: String, maxSteps: Int = 8,
+             decider: (@Sendable (String) async -> ToolCall?)? = nil) async -> String {
+        transcript.removeAll()
+        _ = try? await wda.createSession()
+        var context = "GOAL: \(goal)\n"
+
+        for step in 0..<maxSteps {
+            let call = decider != nil ? await decider!(context) : await llmDecide(context)
+            guard let call else { transcript.append("step \(step): no valid tool call"); break }
+            transcript.append("step \(step): \(call.tool)")
+            switch await execute(call) {
+            case .finished(let s):
+                transcript.append("DONE: \(s)")
+                return s
+            case .observation(let obs):
+                context += "\n> \(call.tool): \(obs)"
+            }
+        }
+        return "max steps reached"
+    }
+
+    private func execute(_ c: ToolCall) async -> AgentToolResult {
+        do {
+            switch AgentTool(rawValue: c.tool) {
+            case .tap:         try await wda.tap(x: c.x ?? 0, y: c.y ?? 0); return .observation("tapped \(c.x ?? 0),\(c.y ?? 0)")
+            case .swipe:       try await wda.swipe(x1: c.x1 ?? 0, y1: c.y1 ?? 0, x2: c.x2 ?? 0, y2: c.y2 ?? 0); return .observation("swiped")
+            case .type:        try await wda.typeText(c.text ?? ""); return .observation("typed")
+            case .pressButton: try await wda.pressButton(c.name ?? "home"); return .observation("pressed \(c.name ?? "home")")
+            case .launchApp:   try await wda.launchApp(bundleId: c.bundleId ?? ""); return .observation("launched \(c.bundleId ?? "")")
+            case .openURL:     try await wda.openURL(c.url ?? ""); return .observation("opened \(c.url ?? "")")
+            case .getUI:       let s = try await wda.source(); return .observation("ui: \(s.prefix(400))")
+            case .done:        return .finished(c.summary ?? "")
+            case .none:        return .observation("unknown tool: \(c.tool)")
+            }
+        } catch {
+            return .observation("error: \(error)")
+        }
+    }
+
+    /// Ask the on-device LLM for the next tool call (JSON). Grammar-constrained
+    /// decoding is the M2 hardening step; for now we instruct + leniently parse.
+    private func llmDecide(_ context: String) async -> ToolCall? {
+        guard let engine else { return nil }
+        let tools = AgentTool.allCases.map { "- " + $0.schemaLine }.joined(separator: "\n")
+        let prompt = """
+        You control an iPhone. Respond with EXACTLY ONE JSON tool call and nothing else.
+        Available tools:
+        \(tools)
+
+        \(context)
+
+        Next tool call:
+        """
+        var out = ""
+        // Instruct-and-parse. Grammar-constrained decoding (toolCallGrammar) is
+        // available but OFF by default: the GBNF needs validation against llama.cpp
+        // on-device (a malformed grammar throws an uncatchable C++ exception), and
+        // Gemma-4 E2B follows the JSON schema well without it. Enable once verified.
+        _ = try? await engine.generate(prompt: prompt, maxTokens: 96, grammar: useGrammar ? toolCallGrammar : nil) { out += $0 }
+        return ToolCall.parse(from: out)
+    }
+}

--- a/ios/GhostLLM/Agent/AgentTools.swift
+++ b/ios/GhostLLM/Agent/AgentTools.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// The tool vocabulary the on-device LLM can call to drive the phone. Maps 1:1
+/// to the WDA REST surface Ghost uses (see docs/ios/AGENT_LOOP_BRIDGE.md).
+enum AgentTool: String, CaseIterable {
+    case tap, swipe, type, pressButton, launchApp, openURL, getUI, done
+
+    var schemaLine: String {
+        switch self {
+        case .tap:         return #"{"tool":"tap","x":<int>,"y":<int>}"#
+        case .swipe:       return #"{"tool":"swipe","x1":<int>,"y1":<int>,"x2":<int>,"y2":<int>}"#
+        case .type:        return #"{"tool":"type","text":"<string>"}"#
+        case .pressButton: return #"{"tool":"pressButton","name":"home|volumeUp|volumeDown"}"#
+        case .launchApp:   return #"{"tool":"launchApp","bundleId":"<string>"}"#
+        case .openURL:     return #"{"tool":"openURL","url":"<string>"}"#
+        case .getUI:       return #"{"tool":"getUI"}"#
+        case .done:        return #"{"tool":"done","summary":"<string>"}"#
+        }
+    }
+}
+
+/// A parsed tool call. Decoded from the model's JSON output (lenient parser).
+struct ToolCall: Codable, Equatable {
+    let tool: String
+    var x: Int? = nil, y: Int? = nil
+    var x1: Int? = nil, y1: Int? = nil, x2: Int? = nil, y2: Int? = nil
+    var text: String? = nil
+    var name: String? = nil
+    var bundleId: String? = nil
+    var url: String? = nil
+    var summary: String? = nil
+    var app: String? = nil
+
+    /// Extract the first JSON object from arbitrary model text and decode it.
+    static func parse(from raw: String) -> ToolCall? {
+        // Extract every {...} object (small models often emit a tentative call then
+        // reconsider to a better one, e.g. read → done).
+        var objs: [String] = []
+        var depth = 0
+        var start: String.Index?
+        var i = raw.startIndex
+        while i < raw.endIndex {
+            let c = raw[i]
+            if c == "{" { if depth == 0 { start = i }; depth += 1 }
+            else if c == "}" { depth -= 1; if depth == 0, let s = start { objs.append(String(raw[s...i])); start = nil } }
+            i = raw.index(after: i)
+        }
+        let calls = objs.compactMap(interpret)
+        // prefer a terminal `done`, else the first valid call
+        return calls.first(where: { $0.tool == "done" }) ?? calls.first
+    }
+
+    /// Decode one object; fall back to regex for slightly-malformed JSON.
+    private static func interpret(_ json: String) -> ToolCall? {
+        if let c = try? JSONDecoder().decode(ToolCall.self, from: Data(json.utf8)) { return c }
+        guard let tool = rx(#""tool"\s*:\s*"([a-zA-Z]+)""#, json) else { return nil }
+        var c = ToolCall(tool: tool)
+        c.url = rx(#""url"\s*:\s*"([^"]*)""#, json)
+        c.text = rx(#""text"\s*:\s*"([^"]*)""#, json)
+        c.summary = rx(#""?summary"?\s*:\s*"?([^"}]+)"#, json)
+        return c
+    }
+
+    private static func rx(_ pattern: String, _ s: String) -> String? {
+        guard let re = try? NSRegularExpression(pattern: pattern),
+              let m = re.firstMatch(in: s, range: NSRange(s.startIndex..., in: s)),
+              let r = Range(m.range(at: 1), in: s) else { return nil }
+        return String(s[r]).trimmingCharacters(in: .whitespaces)
+    }
+}
+
+/// GBNF grammar constraining the model to emit exactly one tool-call JSON object
+/// (llama.cpp `llama_sampler_init_grammar`, root = "root"). Guarantees the output
+/// is parseable by `ToolCall.parse` regardless of model size.
+let toolCallGrammar = #"""
+root  ::= "{" sp "\"tool\"" sp ":" sp tool args sp "}"
+tool  ::= "\"tap\"" | "\"swipe\"" | "\"type\"" | "\"pressButton\"" | "\"launchApp\"" | "\"openURL\"" | "\"getUI\"" | "\"done\""
+args  ::= ( sp "," sp pair )*
+pair  ::= key sp ":" sp val
+key   ::= "\"" [a-zA-Z0-9]+ "\""
+val   ::= str | int
+str   ::= "\"" [^"\\]* "\""
+int   ::= "-"? [0-9]+
+sp    ::= [ \t\n]*
+"""#
+
+enum AgentToolResult {
+    case observation(String)   // fed back to the model
+    case finished(String)      // `done` summary — ends the loop
+}

--- a/ios/GhostLLM/Agent/BGDriveTest.swift
+++ b/ios/GhostLLM/Agent/BGDriveTest.swift
@@ -1,0 +1,91 @@
+import SwiftUI
+
+/// Validates the "drive a real app from the background" architecture end-to-end,
+/// gated on GHOST_BGTEST=1. Logs each stage (prefix BGTEST_) so a --console run can
+/// confirm: keep-alive holds, WDA is reachable on-device (127.0.0.1:8100), launching
+/// X backgrounds us, and CPU inference still runs while backgrounded. If the app were
+/// suspended, the post-background log lines never appear.
+struct BGDriveTestView: View {
+    @State private var lines: [String] = ["starting…"]
+    var body: some View {
+        ScrollView { VStack(alignment: .leading, spacing: 6) {
+            ForEach(Array(lines.enumerated()), id: \.offset) { _, l in
+                Text(l).font(.system(size: 12, design: .monospaced)).foregroundStyle(.green)
+            }
+        }.padding() }
+        .background(Color.black.ignoresSafeArea())
+        .task { await run() }
+    }
+
+    private static let logURL = FileManager.default
+        .urls(for: .documentDirectory, in: .userDomainMask)[0]
+        .appendingPathComponent("bgtest.log")
+
+    private func log(_ s: String) {
+        print("BGTEST_\(s)")
+        Task { @MainActor in lines.append(s) }
+        // Append to a file in Documents — survives suspension, pulled via devicectl
+        // afterward. This is the ground-truth channel (no networking, no permission).
+        let line = "BGTEST_\(s)\n"
+        if let data = line.data(using: .utf8) {
+            if let h = try? FileHandle(forWritingTo: Self.logURL) {
+                h.seekToEndOfFile(); h.write(data); try? h.close()
+            } else {
+                try? line.write(to: Self.logURL, atomically: true, encoding: .utf8)
+            }
+        }
+    }
+
+    private func resetLog() { try? "".write(to: Self.logURL, atomically: true, encoding: .utf8) }
+
+    private func run() async {
+        resetLog()
+        let t0 = Date()
+        func elapsed() -> String { String(format: "%.0fs", Date().timeIntervalSince(t0)) }
+
+        // 1) keep-alive
+        KeepAlive.shared.start()
+        log("KEEPALIVE_STARTED @\(elapsed())")
+
+        // 2) load a CPU engine (Metal is killed in background)
+        do {
+            let spec = ModelRegistry.qwen15
+            guard ModelStore.isAvailable(spec) else { log("MODEL_MISSING"); return }
+            let url = try ModelStore.resolvedURL(for: spec)
+            let engine = try LlamaEngine(modelURL: url, nCtx: 512, nBatch: 256, cpuOnly: true)
+            log("ENGINE_CPU_READY @\(elapsed())")
+
+            // 3) reach WDA on-device and launch X (backgrounds us)
+            let wda = HTTPWDAClient(base: URL(string: "http://127.0.0.1:8100")!)
+            do {
+                _ = try await wda.createSession()
+                log("WDA_SESSION_OK @\(elapsed())")
+                try await wda.launchApp(bundleId: "com.atebits.Tweetie2")
+                log("X_LAUNCHED_now_backgrounded @\(elapsed())")
+            } catch {
+                log("WDA_FAIL \(error) @\(elapsed())")
+            }
+
+            // 4) wait past the ~30s suspension threshold, then prove CPU inference runs
+            try? await Task.sleep(nanoseconds: 40_000_000_000)
+            log("AWOKE_AFTER_SLEEP @\(elapsed())")   // if suspended, this never prints
+            // Run THREE sequential generates to test whether repeated calls on one
+            // engine degrade (the real-app summarize — the 3rd call — emitted 1 token).
+            for i in 1...3 {
+                var out = ""
+                _ = try? await engine.generate(prompt: "Write two short sentences about the number \(i).", maxTokens: 40) { out += $0 }
+                log("GEN\(i)_LEN\(out.count) '\(out.trimmingCharacters(in: .whitespacesAndNewlines).prefix(80))'")
+            }
+
+            // 5) read X's screen via WDA to see if the feed is inspectable
+            do {
+                let src = try await wda.source()
+                log("X_SOURCE_LEN \(src.count) @\(elapsed())")
+            } catch { log("X_SOURCE_FAIL \(error)") }
+
+            log("DONE @\(elapsed())")
+        } catch {
+            log("ENGINE_FAIL \(error)")
+        }
+    }
+}

--- a/ios/GhostLLM/Agent/GhostTheme.swift
+++ b/ios/GhostLLM/Agent/GhostTheme.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+/// One line in the chat transcript. `tool` renders as a subtle chip, the rest as
+/// bubbles (user right-aligned indigo, assistant left-aligned deep, error red).
+enum ChatRole { case user, assistant, tool, error }
+struct ChatMsg: Identifiable { let id = UUID(); let role: ChatRole; let text: String }
+
+/// Ghost brand palette — matched 1:1 to the Android app / dashboard theme
+/// (frontend/src/assets/main.css + portal MainActivity). Dark, green-tinted.
+enum GhostTheme {
+    static let bgBase   = Color(hex: 0x0A0F0C)   // app background (darkest)
+    static let bgCard   = Color(hex: 0x141E17)   // card / panel
+    static let bgDeep   = Color(hex: 0x060A07)   // inset: text field, assistant bubble
+    static let border   = Color(hex: 0x1E2E22)   // borders, dividers
+    static let text1    = Color(hex: 0xE8EDE9)   // primary text
+    static let text2    = Color(hex: 0xBEC8C0)   // secondary (labels)
+    static let text3    = Color(hex: 0x8A9A8D)   // hints, placeholders
+    static let text4    = Color(hex: 0x5A6E5E)   // disabled, empty-state
+    static let accent   = Color(hex: 0x00E5A0)   // brand green — mascot, status
+    static let accentLt = Color(hex: 0x6EFCD0)   // light mint
+    // functional (chat)
+    static let userBubble = Color(hex: 0x6366F1) // indigo — user + Send
+    static let toolChip   = Color(hex: 0x38BDF8) // sky — tool-call chips
+    static let activity   = Color(hex: 0xF59E0B) // amber — thinking indicator
+    static let stop       = Color(hex: 0xEF4444) // red — Stop button
+    static let dotWorking = Color(hex: 0xF59E0B)
+    static let dotDone    = Color(hex: 0x22C55E)
+    static let dotIdle    = Color(hex: 0x475569)
+}
+
+extension Color {
+    init(hex: UInt32) {
+        self.init(.sRGB,
+                  red:   Double((hex >> 16) & 0xFF) / 255,
+                  green: Double((hex >> 8) & 0xFF) / 255,
+                  blue:  Double(hex & 0xFF) / 255,
+                  opacity: 1)
+    }
+}

--- a/ios/GhostLLM/Agent/InAppAgentViewModel.swift
+++ b/ios/GhostLLM/Agent/InAppAgentViewModel.swift
@@ -1,0 +1,406 @@
+import Foundation
+import WebKit
+
+/// A real on-device agent: Gemma emits tool calls that drive an embedded WebView,
+/// autonomously browsing to accomplish a goal. Every decision is the on-device LLM;
+/// the app just executes the tool it chose. Fully on-device, no OS-level driving.
+@MainActor
+final class InAppAgentViewModel: NSObject, ObservableObject, WKNavigationDelegate {
+    @Published var status = "waking up…"
+    @Published var transcript: [String] = []
+    @Published var answer = ""
+    @Published var thinking = false
+    @Published var currentURL = ""
+    // Chat-style surface (Android-matched UI). `chat` is the bubble transcript;
+    // `activityLine` is the amber "what it's doing right now" indicator.
+    @Published var chat: [ChatMsg] = []
+    @Published var activityLine = ""
+    @Published var ready = false      // engine loaded, waiting for a prompt
+    @Published var running = false
+
+    private func say(_ role: ChatRole, _ text: String) { chat.append(ChatMsg(role: role, text: text)) }
+
+    /// True when the goal is about a native app (drive the real phone via WDA)
+    /// rather than a web page (in-app browser).
+    private func isRealAppTask(_ goal: String) -> Bool {
+        let g = goal.lowercased()
+        let apps = ["x app", " x ", "twitter", "my feed", "the x ", "open x"]
+        return apps.contains { g.contains($0) } || g.hasSuffix(" x")
+    }
+    private(set) var modelName = "Qwen2.5 1.5B"
+
+    /// Shared WDA client (one session drives the phone AND serves the MJPEG stream a
+    /// screen recorder reads). RealAppAgent reuses it, so no session eviction.
+    let wda = HTTPWDAClient(base: URL(string: "http://127.0.0.1:8100")!)
+
+    /// Open the WDA session early (enables the MJPEG server) so a recorder can start
+    /// capturing before the user's prompt is even typed.
+    func startCaptureSession() async { _ = try? await wda.createSession() }
+
+    /// Friendly chip label for a tool call (what the phone is doing, in plain words).
+    private func toolLabel(_ c: ToolCall) -> String {
+        switch c.tool {
+        case "open":  return "🌐 open \(prettyHost(c.url ?? ""))"
+        case "read":  return "📄 read the page"
+        case "click": return "👆 tap “\(c.text ?? "")”"
+        case "done":  return "✅ summarize"
+        default:       return "🔧 \(c.tool)"
+        }
+    }
+    private func prettyHost(_ url: String) -> String {
+        guard let h = URLComponents(string: url)?.host else { return url }
+        return h.replacingOccurrences(of: "www.", with: "")
+    }
+
+    let webView: WKWebView
+    private var engine: LlamaEngine?
+    private let downloader = ModelDownloadManager()
+    private var loadCont: CheckedContinuation<Void, Never>?
+    private let maxSteps = 8
+    private var lastCallKey = ""
+    // Counts every (tool+args) call this run — catches loops the consecutive check
+    // misses (e.g. open→read→open→read alternating on a contentless page).
+    private var callCounts: [String: Int] = [:]
+
+    /// GBNF that hard-restricts output to EXACTLY one of the 4 tool shapes with the
+    /// right keys — a 2B model literally cannot emit invalid JSON or a bad tool name
+    /// (per ghost-multi-fleet-dev: grammar wins, not close, for on-device FC).
+    // NOTE: this llama.cpp build's GBNF parser mishandles \" inside string literals
+    // (crashes with 'empty grammar stack'). So we NEVER use \" — the literal quote
+    // comes from a char-class rule q ::= ["], and all other literals are quote-free.
+    // Hard-restricts output to exactly one valid tool call — a 2B model literally
+    // cannot emit invalid JSON or a bad tool name. Quote via q ::= ["] (avoids \").
+    private let webToolGrammar = [
+        #"root  ::= open | read | click | done"#,
+        #"open  ::= "{" q "tool" q ":" q "open" q "," q "url" q ":" q url q "}""#,
+        #"read  ::= "{" q "tool" q ":" q "read" q "}""#,
+        #"click ::= "{" q "tool" q ":" q "click" q "," q "text" q ":" q txt q "}""#,
+        #"done  ::= "{" q "tool" q ":" q "done" q "," q "summary" q ":" q txt q "}""#,
+        #"q     ::= ["]"#,
+        #"url   ::= [a-zA-Z0-9:/._?=&%~#@+-]+"#,
+        #"txt   ::= [a-zA-Z0-9 .,!?;:'()/_-]+"#, "",
+    ].joined(separator: "\n")
+
+    override init() {
+        let cfg = WKWebViewConfiguration()
+        cfg.defaultWebpagePreferences.allowsContentJavaScript = true
+        webView = WKWebView(frame: .zero, configuration: cfg)
+        super.init()
+        webView.navigationDelegate = self
+        // Dark background so the panel doesn't flash white against the dark theme.
+        webView.isOpaque = false
+        webView.backgroundColor = UIColor(red: 0x06/255, green: 0x0A/255, blue: 0x07/255, alpha: 1)
+        webView.scrollView.backgroundColor = webView.backgroundColor
+        // Desktop UA so old.reddit serves the classic layout (a.title post links)
+        // instead of a mobile/search redirect.
+        webView.customUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15"
+    }
+
+    /// Load the model once, then idle — the chat UI waits for a typed prompt.
+    func prepare() async {
+        guard engine == nil else { ready = true; return }
+        StatusServer.shared.start()
+        do {
+            let spec = ModelStore.isAvailable(ModelRegistry.qwen15) ? ModelRegistry.qwen15
+                     : ModelStore.isAvailable(ModelRegistry.phase0) ? ModelRegistry.phase0
+                     : ModelRegistry.qwen15
+            status = "🧠 loading \(spec.displayName)…"
+            let url: URL
+            if ModelStore.isAvailable(spec) {
+                url = try ModelStore.resolvedURL(for: spec)
+            } else {
+                url = try await downloader.ensure(spec) { p in
+                    Task { @MainActor in self.status = "⬇️ downloading model \(Int(p * 100))%…" }
+                }
+            }
+            engine = try LlamaEngine(modelURL: url, nCtx: 1536, nBatch: 768)
+            modelName = spec.displayName
+            let backend = await engine!.backend
+            status = "ready · \(spec.displayName) · \(backend)"
+            ready = true
+        } catch {
+            status = "⚠️ \(error)"
+        }
+    }
+
+    /// Run the agent for a user-typed prompt, emitting chat bubbles + tool chips.
+    func submit(goal: String) async {
+        let goal = goal.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !goal.isEmpty, !running else { return }
+        if engine == nil { await prepare() }
+        print("AGENT_GOAL \(goal)")
+        say(.user, goal)
+        running = true; answer = ""; lastCallKey = ""; callCounts.removeAll()
+        defer { running = false; thinking = false; activityLine = "" }
+
+        // Real-app tasks (open the actual X app etc.) → drive the phone over WDA.
+        // Web tasks stay on the in-app browser below.
+        if isRealAppTask(goal) {
+            KeepAlive.shared.start()
+            let agent = RealAppAgent(engine: engine!, wda: wda)
+            answer = await agent.run(goal: goal) { [weak self] role, text in
+                guard let self else { return }
+                if role == .tool { self.activityLine = text }
+                self.say(role, text)
+            }
+            activityLine = ""; status = "✅ done"
+            KeepAlive.shared.stop()
+            return
+        }
+        do {
+            let spec = ModelRegistry.qwen15
+            status = "🤖 working…"
+            var context = ""
+            for step in 0..<maxSteps {
+                thinking = true
+                activityLine = "🤔 thinking…"
+                StatusServer.shared.update(phase: "thinking(step \(step))", tokS: 0, model: spec.displayName, line: status)
+                guard let call = await decide(goal: goal, context: context) else {
+                    say(.error, "couldn't decide a next step — stopping"); break
+                }
+                thinking = false
+                let key = "\(call.tool)|\(argStr(call))"
+                callCounts[key, default: 0] += 1
+                // anti-loop: same call back-to-back, OR the identical call seen 2+
+                // times total (alternating loops re-fetch the same page for nothing)
+                // → nudge it toward a different tool/arg or done.
+                if key == lastCallKey || callCounts[key, default: 0] >= 2 {
+                    context += "\n(note: \(call.tool) already tried with no new result — use a DIFFERENT tool or argument, or emit done with your summary)"
+                    push("agent", "↻ repeated \(call.tool); nudging")
+                    lastCallKey = ""
+                    continue
+                }
+                lastCallKey = key
+                print("AGENT_TOOL step=\(step) \(call.tool)(\(argStr(call)))")
+                say(.tool, toolLabel(call))
+                activityLine = toolLabel(call)
+                let obs = await execute(call)
+                print("AGENT_OBS \(obs.prefix(1200))")
+                push("tool", "\(call.tool) → \(obs.prefix(160))")
+                StatusServer.shared.update(phase: call.tool, tokS: 0, model: spec.displayName, line: "\(call.tool): \(obs.prefix(80))")
+                if call.tool == "done" {
+                    answer = call.summary ?? obs; status = "✅ done"; activityLine = ""
+                    say(.assistant, answer); print("AGENT_ANSWER \(answer)"); break
+                }
+                // keep context bounded (long prompts are slow + memory-heavy)
+                context = String((context + "\n- \(call.tool)(\(argStr(call))) → \(obs.prefix(450))").suffix(1300))
+            }
+            if answer.isEmpty {
+                // Ran out of steps without a `done`. Rather than give up, force one
+                // final summary from whatever the agent actually observed — a grounded
+                // answer beats "(stopped)", and the observations are the only source.
+                if !context.isEmpty, let engine {
+                    status = "📝 summarizing…"; thinking = true
+                    var summary = ""
+                    let prompt = """
+                    You are Ghost, an on-device agent. Goal: \(goal)
+                    Notes from what you observed while browsing:
+                    \(context.suffix(1200))
+                    Write the final answer to the goal in 2 sentences. Use ONLY facts, topics, and names that literally appear in the notes above; never invent model names, versions, or numbers.
+                    Answer:
+                    """
+                    _ = try? await engine.generate(prompt: prompt, maxTokens: 160) { summary += $0 }
+                    thinking = false
+                    answer = summary.trimmingCharacters(in: .whitespacesAndNewlines)
+                }
+                if answer.isEmpty {
+                    answer = "I couldn't finish that one — the page didn't give me enough to summarize."
+                    status = "⏹ stopped"; say(.error, answer)
+                } else {
+                    status = "✅ done"; say(.assistant, answer)
+                }
+                print("AGENT_ANSWER \(answer)")
+            }
+            activityLine = ""
+            StatusServer.shared.update(phase: "done", tokS: 0, model: spec.displayName, line: status)
+        } catch {
+            status = "⚠️ \(error)"; say(.error, "\(error)")
+        }
+    }
+
+    // MARK: - LLM decides the next tool
+
+    private func decide(goal: String, context: String) async -> ToolCall? {
+        guard let engine else { return nil }
+        let base = """
+        You are a web-browsing agent on a phone. Reply with EXACTLY ONE JSON tool call, nothing else.
+        Tools (pick one):
+        {"tool":"open","url":"https://..."}      open a web page
+        {"tool":"read"}                            read the current page text
+        {"tool":"click","text":"link text"}      click a link containing that text
+        {"tool":"done","summary":"..."}          finish with your answer
+
+        Examples:
+        {"tool":"open","url":"https://old.reddit.com/r/LocalLLaMA/"}
+        {"tool":"done","summary":"The top post is about ..."}
+
+        GOAL: \(goal)
+        Progress so far:\(context.isEmpty ? " nothing yet — open a page first." : context)
+
+        IMPORTANT: As soon as the page text above contains what the goal needs, use
+        {"tool":"done","summary":"..."} — do NOT read the same page again. In the
+        summary, use ONLY facts, topics, and names that literally appear in the page
+        text above; never invent model names, versions, or numbers.
+        Reply with ONE JSON tool call:
+        """
+        let valid = ["open", "read", "click", "done"]
+
+        // GRAMMAR-NARROWING (per ghost-multi-fleet-dev): free THOUGHT reasons + picks
+        // the tool; we parse that choice, then constrain the action grammar to JUST
+        // that tool + its args. The model never picks the branch (that was the loop
+        // failure) — grammar only guarantees valid args.
+        var thought = ""
+        _ = try? await engine.generate(prompt: base + "\nReason in one short sentence, then give the tool call:", maxTokens: 80) { thought += $0 }
+        print("AGENT_THOUGHT<\(thought.prefix(140))>")
+        // URLs the model is ALLOWED to open = those literally present in the goal or
+        // what it has already seen. Without this the constrained fill lets a small
+        // model default the url to example.com (its training-prior "example URL").
+        let allowedURLs = urlsIn(goal + " " + context)
+        if let picked = ToolCall.parse(from: thought), valid.contains(picked.tool),
+           let g = narrowGrammar(for: picked.tool, allowedURLs: allowedURLs) {
+            var action = ""
+            _ = try? await engine.generate(prompt: base + "\nThought: \(thought.prefix(220))\nOutput the \(picked.tool) tool call:", maxTokens: 96, grammar: g) { action += $0 }
+            print("AGENT_ACTION<\(action.prefix(120))>")
+            if let c = ToolCall.parse(from: action), c.tool == picked.tool { return c }
+            return picked   // grammar hiccup → use the thought's own parse
+        }
+
+        // fallback: plain instruct+parse
+        for attempt in 0..<2 {
+            var out = ""
+            _ = try? await engine.generate(prompt: base + (attempt == 0 ? "" : "\nOutput ONLY one JSON tool call.\nJSON:"), maxTokens: 80) { out += $0 }
+            if let call = ToolCall.parse(from: out), valid.contains(call.tool) { return call }
+        }
+        return nil
+    }
+
+    /// Grammar constrained to exactly ONE tool (+ its args). The tool is fixed, so a
+    /// 2B can't mis-commit the branch; only the arg values are model-chosen.
+    private func narrowGrammar(for tool: String, allowedURLs: [String] = []) -> String? {
+        // If we know which URLs are legitimate (present in goal/context), pin the url
+        // rule to an alternation of those exact literals so the model can't fabricate
+        // one (e.g. example.com). Fall back to a free url charclass if we know none.
+        let urlRule: String
+        if tool == "open", !allowedURLs.isEmpty {
+            urlRule = "url ::= " + allowedURLs.map { "\"\($0)\"" }.joined(separator: " | ")
+        } else {
+            urlRule = #"url ::= [a-zA-Z0-9:/._?=&%~#@+-]+"#
+        }
+        let common = [#"q   ::= ["]"#, urlRule,
+                      #"txt ::= [a-zA-Z0-9 .,!?;:'()/_-]+"#, ""]
+        let root: String
+        switch tool {
+        case "open":  root = #"root ::= "{" q "tool" q ":" q "open" q "," q "url" q ":" q url q "}""#
+        case "read":  root = #"root ::= "{" q "tool" q ":" q "read" q "}""#
+        case "click": root = #"root ::= "{" q "tool" q ":" q "click" q "," q "text" q ":" q txt q "}""#
+        case "done":  root = #"root ::= "{" q "tool" q ":" q "done" q "," q "summary" q ":" q txt q "}""#
+        default: return nil
+        }
+        return ([root] + common).joined(separator: "\n")
+    }
+
+    /// Extract distinct http(s) URLs appearing in `text` (trailing punctuation
+    /// stripped). Used to whitelist which pages the agent may open.
+    private func urlsIn(_ text: String) -> [String] {
+        guard let re = try? NSRegularExpression(pattern: #"https?://[^\s"'|}\\]+"#) else { return [] }
+        var seen: [String] = []
+        for m in re.matches(in: text, range: NSRange(text.startIndex..., in: text)) {
+            guard let r = Range(m.range, in: text) else { continue }
+            var u = String(text[r])
+            while let last = u.last, ".,;:)]".contains(last) { u.removeLast() }
+            if !u.isEmpty, !seen.contains(u) { seen.append(u) }
+        }
+        return seen
+    }
+
+    // MARK: - Execute a tool against the WebView
+
+    private func execute(_ c: ToolCall) async -> String {
+        switch c.tool {
+        case "open":
+            guard let s = c.url, let u = normalizedURL(s) else { return "invalid url" }
+            await load(u)
+            return "opened \(currentURL). Page text: \(await readText(1600))"
+        case "read":
+            return "Page text: \(await readText(1600))"
+        case "click":
+            let ok = await clickLink(containing: c.text ?? "")
+            if ok { return "clicked '\(c.text ?? "")'. Now at \(currentURL). Page text: \(await readText(700))" }
+            return "no link matching '\(c.text ?? "")' found. Page text: \(await readText(500))"
+        case "done":
+            return c.summary ?? "done"
+        default:
+            return "unknown tool \(c.tool)"
+        }
+    }
+
+    private func load(_ url: URL) async {
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            loadCont = cont
+            webView.load(URLRequest(url: url))
+        }
+    }
+
+    private func readText(_ limit: Int) async -> String {
+        // Prefer meaningful content (titles/headings/paragraphs) over nav chrome.
+        let js = """
+        (function(){
+          var titles = Array.from(document.querySelectorAll('a.title, [data-testid=post-title], shreddit-post'))
+             .map(function(e){return (e.innerText||'').trim();}).filter(function(x){return x.length>10;});
+          if (titles.length) return 'Reddit posts: ' + titles.slice(0,15).join(' | ');
+          var els = Array.from(document.querySelectorAll('h1, h2, h3, p'))
+             .map(function(e){return (e.innerText||'').trim();}).filter(function(x){return x.length>25;});
+          if (els.length) return els.slice(0,20).join(' | ');
+          return document.body ? document.body.innerText : '';
+        })()
+        """
+        let raw = (try? await webView.evaluateJavaScript(js)) as? String ?? ""
+        let clean = raw.replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "  ", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String(clean.prefix(limit))
+    }
+
+    private func clickLink(containing text: String) async -> Bool {
+        let t = text.replacingOccurrences(of: "'", with: "\\'").lowercased()
+        let js = """
+        (function(){
+          var as = Array.from(document.querySelectorAll('a'));
+          var el = as.find(a => (a.innerText||'').toLowerCase().includes('\(t)'));
+          if (el && el.href) { window.location.href = el.href; return true; }
+          return false;
+        })()
+        """
+        let clicked = (try? await webView.evaluateJavaScript(js)) as? Bool ?? false
+        if clicked { await waitForLoad() }
+        return clicked
+    }
+
+    private func waitForLoad() async {
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in loadCont = cont }
+    }
+
+    // MARK: - helpers
+
+    private func normalizedURL(_ s: String) -> URL? {
+        var str = s.trimmingCharacters(in: .whitespaces)
+        if !str.lowercased().hasPrefix("http") { str = "https://" + str }
+        return URL(string: str)
+    }
+    private func argStr(_ c: ToolCall) -> String { c.url ?? c.text ?? c.summary ?? "" }
+    private func push(_ who: String, _ text: String) { transcript.append("\(who): \(text)") }
+
+    // WKNavigationDelegate
+    nonisolated func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        Task { @MainActor in
+            currentURL = webView.url?.absoluteString ?? ""
+            loadCont?.resume(); loadCont = nil
+        }
+    }
+    nonisolated func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        Task { @MainActor in loadCont?.resume(); loadCont = nil }
+    }
+    nonisolated func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        Task { @MainActor in loadCont?.resume(); loadCont = nil }
+    }
+}

--- a/ios/GhostLLM/Agent/KeepAlive.swift
+++ b/ios/GhostLLM/Agent/KeepAlive.swift
@@ -1,0 +1,43 @@
+import AVFoundation
+
+/// Keeps the app running in the background while it drives another app (X) in the
+/// foreground. An active audio session + the `audio` background mode stops iOS
+/// suspending us; we emit continuous silence (volume 0, mixed with others) so we
+/// never interrupt the user's audio. Without this the on-device agent loop freezes
+/// ~30s after X takes the foreground.
+final class KeepAlive {
+    static let shared = KeepAlive()
+    private let engine = AVAudioEngine()
+    private var running = false
+
+    func start() {
+        guard !running else { return }
+        do {
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(.playback, mode: .default, options: [.mixWithOthers])
+            try session.setActive(true)
+            let fmt = AVAudioFormat(standardFormatWithSampleRate: 44_100, channels: 2)!
+            let src = AVAudioSourceNode { _, _, frameCount, ablPtr in
+                let abl = UnsafeMutableAudioBufferListPointer(ablPtr)
+                for buf in abl { memset(buf.mData, 0, Int(buf.mDataByteSize)) }
+                return noErr
+            }
+            engine.attach(src)
+            engine.connect(src, to: engine.mainMixerNode, format: fmt)
+            engine.mainMixerNode.outputVolume = 0
+            try engine.start()
+            running = true
+            print("KEEPALIVE_ON")
+        } catch {
+            print("KEEPALIVE_ERR \(error)")
+        }
+    }
+
+    func stop() {
+        guard running else { return }
+        engine.stop()
+        try? AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
+        running = false
+        print("KEEPALIVE_OFF")
+    }
+}

--- a/ios/GhostLLM/Agent/MockWDAClient.swift
+++ b/ios/GhostLLM/Agent/MockWDAClient.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Scripted WDA for phone-free testing of the agent loop. Records every call and
+/// returns canned screen state, so the loop's plumbing can be validated on the
+/// simulator with no device.
+actor MockWDAClient: WDAClient {
+    private(set) var calls: [String] = []
+    private let cannedSource: String
+    private let cannedShot: String
+
+    init(source: String = "<XCUIElementTypeButton name=\"Settings\" x=\"100\" y=\"200\"/>",
+         screenshot: String = "iVBORw0KGgo=") {
+        self.cannedSource = source
+        self.cannedShot = screenshot
+    }
+
+    func createSession() async throws -> String { calls.append("createSession"); return "mock-session" }
+    func windowSize() async throws -> (w: Int, h: Int) { calls.append("windowSize"); return (393, 852) }
+    func tap(x: Int, y: Int) async throws { calls.append("tap(\(x),\(y))") }
+    func swipe(x1: Int, y1: Int, x2: Int, y2: Int) async throws { calls.append("swipe(\(x1),\(y1)->\(x2),\(y2))") }
+    func typeText(_ text: String) async throws { calls.append("type(\(text))") }
+    func pressButton(_ name: String) async throws { calls.append("pressButton(\(name))") }
+    func launchApp(bundleId: String) async throws { calls.append("launchApp(\(bundleId))") }
+    func openURL(_ url: String) async throws { calls.append("openURL(\(url))") }
+    func source() async throws -> String { calls.append("source"); return cannedSource }
+    func screenshotBase64() async throws -> String { calls.append("screenshot"); return cannedShot }
+}

--- a/ios/GhostLLM/Agent/RealAppAgent.swift
+++ b/ios/GhostLLM/Agent/RealAppAgent.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// MVP real-app agent: the on-device LLM drives a REAL app (not a web view).
+/// Flow (all on-device): open the app → read its screen → summarize → re-open
+/// Ghost to show the answer. Runs on CPU + keep-alive so it survives while the
+/// target app is foreground (see [[ghost-ios-background-drive]]). ~2 LLM tool
+/// calls (open_app, read) then a summary.
+@MainActor
+final class RealAppAgent {
+    private let engine: LlamaEngine
+    private let wda: WDAClient
+    private let ghostBundle = "com.ghostinthedroid.ghostllm"
+
+    /// Friendly app name → bundle id. The 1.5B names the app; we resolve the id.
+    private let apps: [String: String] = [
+        "x": "com.atebits.Tweetie2", "twitter": "com.atebits.Tweetie2",
+        "reddit": "com.reddit.Reddit", "safari": "com.apple.mobilesafari",
+    ]
+
+    init(engine: LlamaEngine, wda: WDAClient) { self.engine = engine; self.wda = wda }
+
+    struct Progress { let line: (String) -> Void }
+
+    /// Returns the final summary. `emit` streams human-readable progress for the UI.
+    /// The tool steps (open, read) are executed directly; the on-device LLM's job is
+    /// the summary — and we keep it as the engine's FIRST generate, which is reliable
+    /// (repeated generate() calls on one context degrade to a single token on CPU).
+    func run(goal: String, emit: @escaping (ChatRole, String) -> Void) async -> String {
+        func log(_ s: String) { print("XAGENT_\(s)") }
+        do { _ = try await wda.createSession() } catch { log("WDA_FAIL \(error)") }
+
+        // ── Step 1: open the app named in the goal ──────────────────────────
+        let name = appName(in: goal)
+        let bundle = apps[name] ?? "com.atebits.Tweetie2"
+        emit(.tool, "🚀 open \(name.uppercased())")
+        log("OPEN \(name) -> \(bundle)")
+        try? await wda.launchApp(bundleId: bundle)
+        try? await Task.sleep(nanoseconds: 6_000_000_000)  // dwell so X is visibly on screen
+
+        // ── Step 2: read the screen (WDA only — no LLM, works backgrounded) ──
+        emit(.tool, "📄 read the feed")
+        let src = (try? await wda.source()) ?? ""
+        let pageText = Self.extractText(from: src)
+        log("READ srcLen=\(src.count) textLen=\(pageText.count)")
+
+        // ── Step 3: come back to Ghost, THEN summarize on Metal (foreground) ─
+        // The LLM only runs in the foreground: Metal inference is killed in the
+        // background, and CPU inference in this llama.cpp build is unreliable. So we
+        // re-open Ghost first, then summarize with the GPU where it actually works.
+        try? await wda.launchApp(bundleId: ghostBundle)
+        try? await Task.sleep(nanoseconds: 1_200_000_000)  // let Ghost take foreground
+        emit(.tool, "✅ summarize (on-device)")
+        let summary = await summarize(goal: goal, app: name.uppercased(), text: pageText)
+        log("SUMMARY \(summary)")
+        emit(.assistant, summary)
+        return summary
+    }
+
+    /// Which known app the goal refers to (defaults to X).
+    private func appName(in goal: String) -> String {
+        let g = goal.lowercased()
+        return apps.keys.first(where: { g.contains($0) }) ?? "x"
+    }
+
+    private func summarize(goal: String, app: String, text: String) async -> String {
+        guard !text.isEmpty else { return "I opened \(app) but couldn't read anything from the screen." }
+        let prompt = """
+        Here are posts from the \(app) feed:
+        \(text.prefix(1200))
+
+        In two sentences, summarize what people in this feed are posting about. Use \
+        only what appears above; never invent names or numbers.
+        """
+        var out = ""
+        _ = try? await engine.generate(prompt: prompt, maxTokens: 120) { out += $0 }
+        // The 1.5B tends to ramble; keep the first 2 sentences as the answer.
+        return Self.firstSentences(out.trimmingCharacters(in: .whitespacesAndNewlines), 2)
+    }
+
+    /// First `n` sentences of `s` (splits on . ! ? followed by space/newline/end).
+    private static func firstSentences(_ s: String, _ n: Int) -> String {
+        var count = 0, end = s.startIndex
+        var i = s.startIndex
+        while i < s.endIndex {
+            let c = s[i]
+            let next = s.index(after: i)
+            if ".!?".contains(c), (next == s.endIndex || s[next] == " " || s[next] == "\n") {
+                count += 1; end = next
+                if count >= n { return String(s[s.startIndex..<next]).trimmingCharacters(in: .whitespacesAndNewlines) }
+            }
+            i = next
+        }
+        return s
+    }
+
+    // MARK: - Parse a WDA accessibility XML dump into readable feed text
+
+    /// Pull human-readable strings (label/value/name of text-ish elements) out of
+    /// WDA's XML source. X's tree is huge + noisy — keep meaningful lines only.
+    static func extractText(from xml: String) -> String {
+        var seen = Set<String>()
+        var out: [String] = []
+        for attr in ["label", "value", "name"] {
+            guard let re = try? NSRegularExpression(pattern: "\(attr)=\"([^\"]{4,300})\"") else { continue }
+            for m in re.matches(in: xml, range: NSRange(xml.startIndex..., in: xml)) {
+                guard let r = Range(m.range(at: 1), in: xml) else { continue }
+                let s = String(xml[r]).trimmingCharacters(in: .whitespacesAndNewlines)
+                // drop UI-chrome junk and pure numbers/short tokens
+                if s.count < 8 || Double(s) != nil { continue }
+                if ["Home", "Search", "Notifications", "Messages", "Profile", "Tweet", "Post"].contains(s) { continue }
+                if seen.insert(s).inserted { out.append(s) }
+                if out.count >= 40 { break }
+            }
+        }
+        return out.joined(separator: "\n")
+    }
+}

--- a/ios/GhostLLM/Agent/WDAClient.swift
+++ b/ios/GhostLLM/Agent/WDAClient.swift
@@ -1,0 +1,160 @@
+import Foundation
+
+/// Drives a device via WebDriverAgent's REST API. `HTTPWDAClient` talks to a real
+/// WDA (the phone, over Tailscale or localhost); `MockWDAClient` scripts screen
+/// state so the whole agent loop is testable with no device.
+protocol WDAClient {
+    func createSession() async throws -> String
+    func windowSize() async throws -> (w: Int, h: Int)
+    func tap(x: Int, y: Int) async throws
+    func swipe(x1: Int, y1: Int, x2: Int, y2: Int) async throws
+    func typeText(_ text: String) async throws
+    func pressButton(_ name: String) async throws
+    func launchApp(bundleId: String) async throws
+    func openURL(_ url: String) async throws
+    func source() async throws -> String
+    func screenshotBase64() async throws -> String
+}
+
+enum WDAError: Error, CustomStringConvertible {
+    case badStatus(Int, String)
+    case noSession
+    case decode(String)
+    var description: String {
+        switch self {
+        case .badStatus(let c, let b): return "WDA HTTP \(c): \(b.prefix(200))"
+        case .noSession: return "no WDA session"
+        case .decode(let s): return "WDA decode: \(s)"
+        }
+    }
+}
+
+/// Real WDA over HTTP. `base` is e.g. http://<tailscale-ip>:8100 (never commit
+/// the real IP — see docs/ios/AGENT_LOOP_BRIDGE.md).
+actor HTTPWDAClient: WDAClient {
+    private let base: URL
+    private var sessionId: String?
+
+    init(base: URL) { self.base = base }
+
+    @discardableResult
+    func createSession() async throws -> String {
+        if let sid = sessionId { return sid }   // reuse — a second session evicts the first
+        // Enable WDA's MJPEG server on THIS session so a screen recorder can read
+        // :9100 without needing its own (competing) session — one session drives AND
+        // streams, avoiding the eviction that killed capture mid-run.
+        let body: [String: Any] = ["capabilities": ["alwaysMatch": [
+            "appium:mjpegServerPort": 9100,
+        ], "firstMatch": [[:]]]]
+        let v = try await postJSON("/session", body)
+        // sessionId can be top-level or under value
+        if let sid = v["sessionId"] as? String { sessionId = sid }
+        else if let val = v["value"] as? [String: Any], let sid = val["sessionId"] as? String { sessionId = sid }
+        guard let sid = sessionId else { throw WDAError.decode("no sessionId in /session response") }
+        // Tune the stream (best-effort).
+        _ = try? await postJSON("/session/\(sid)/appium/settings",
+            ["settings": ["mjpegServerFramerate": 24, "mjpegServerScreenshotQuality": 60, "mjpegScalingFactor": 100]])
+        return sid
+    }
+
+    func windowSize() async throws -> (w: Int, h: Int) {
+        let v = try await getJSON("/session/\(try sid())/window/size")
+        guard let val = v["value"] as? [String: Any],
+              let w = val["width"] as? Int, let h = val["height"] as? Int else {
+            throw WDAError.decode("window/size")
+        }
+        return (w, h)
+    }
+
+    func tap(x: Int, y: Int) async throws {
+        // W3C actions: move → down → pause → up
+        let action: [String: Any] = ["actions": [[
+            "type": "pointer", "id": "finger1", "parameters": ["pointerType": "touch"],
+            "actions": [
+                ["type": "pointerMove", "duration": 0, "x": x, "y": y],
+                ["type": "pointerDown", "button": 0],
+                ["type": "pause", "duration": 60],
+                ["type": "pointerUp", "button": 0],
+            ],
+        ]]]
+        _ = try await postJSON("/session/\(try sid())/actions", action)
+    }
+
+    func swipe(x1: Int, y1: Int, x2: Int, y2: Int) async throws {
+        let action: [String: Any] = ["actions": [[
+            "type": "pointer", "id": "finger1", "parameters": ["pointerType": "touch"],
+            "actions": [
+                ["type": "pointerMove", "duration": 0, "x": x1, "y": y1],
+                ["type": "pointerDown", "button": 0],
+                ["type": "pointerMove", "duration": 300, "x": x2, "y": y2],
+                ["type": "pointerUp", "button": 0],
+            ],
+        ]]]
+        _ = try await postJSON("/session/\(try sid())/actions", action)
+    }
+
+    func typeText(_ text: String) async throws {
+        // Focus the active element, then set value (WDA types char-by-char).
+        let active = try await postJSON("/session/\(try sid())/element/active", [:])
+        let elemId = ((active["value"] as? [String: Any])?["ELEMENT"] as? String)
+            ?? ((active["value"] as? [String: Any])?["element-6066-11e4-a52e-4f735466cecf"] as? String)
+        if let elemId {
+            _ = try await postJSON("/session/\(try sid())/element/\(elemId)/value", ["value": Array(text.map(String.init))])
+        } else {
+            _ = try await postJSON("/session/\(try sid())/wda/keys", ["value": Array(text.map(String.init))])
+        }
+    }
+
+    func pressButton(_ name: String) async throws {
+        _ = try await postJSON("/session/\(try sid())/wda/pressButton", ["name": name])
+    }
+
+    func launchApp(bundleId: String) async throws {
+        _ = try await postJSON("/session/\(try sid())/wda/apps/launch", ["bundleId": bundleId])
+    }
+
+    func openURL(_ url: String) async throws {
+        _ = try await postJSON("/session/\(try sid())/url", ["url": url])
+    }
+
+    func source() async throws -> String {
+        let v = try await getJSON("/session/\(try sid())/source")
+        return (v["value"] as? String) ?? ""
+    }
+
+    func screenshotBase64() async throws -> String {
+        let v = try await getJSON("/session/\(try sid())/screenshot")
+        return (v["value"] as? String) ?? ""
+    }
+
+    // MARK: - HTTP helpers
+
+    private func sid() throws -> String {
+        guard let sessionId else { throw WDAError.noSession }
+        return sessionId
+    }
+
+    private func getJSON(_ path: String) async throws -> [String: Any] {
+        var req = URLRequest(url: base.appendingPathComponent(path))
+        req.timeoutInterval = 30
+        return try await send(req)
+    }
+
+    private func postJSON(_ path: String, _ body: [String: Any]) async throws -> [String: Any] {
+        var req = URLRequest(url: base.appendingPathComponent(path))
+        req.httpMethod = "POST"
+        req.timeoutInterval = 30
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = try JSONSerialization.data(withJSONObject: body)
+        return try await send(req)
+    }
+
+    private func send(_ req: URLRequest) async throws -> [String: Any] {
+        let (data, resp) = try await URLSession.shared.data(for: req)
+        let code = (resp as? HTTPURLResponse)?.statusCode ?? 0
+        guard (200..<300).contains(code) else {
+            throw WDAError.badStatus(code, String(decoding: data, as: UTF8.self))
+        }
+        return (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
+    }
+}

--- a/ios/GhostLLM/Agent/XDemoView.swift
+++ b/ios/GhostLLM/Agent/XDemoView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+/// Test/demo harness for the real-app agent (GHOST_XDEMO=1): open X → read →
+/// summarize → re-open Ghost. Runs on CPU + keep-alive (survives while X is
+/// foreground). Writes the trajectory to Documents/xagent.log (pull via devicectl)
+/// and shows it on screen once Ghost re-opens.
+struct XDemoView: View {
+    @State private var lines: [ChatMsg] = []
+    private static let logURL = FileManager.default
+        .urls(for: .documentDirectory, in: .userDomainMask)[0].appendingPathComponent("xagent.log")
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("👻 Ghost · real-app agent").font(.headline).foregroundStyle(GhostTheme.accent)
+            ForEach(lines) { m in
+                Text(m.text)
+                    .font(.system(size: 14, design: m.role == .tool ? .monospaced : .default))
+                    .foregroundStyle(m.role == .assistant ? GhostTheme.text1 : GhostTheme.text3)
+            }
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading).padding()
+        .background(GhostTheme.bgBase.ignoresSafeArea())
+        .task { await run() }
+    }
+
+    private func fileLog(_ s: String) {
+        let line = s + "\n"
+        if let h = try? FileHandle(forWritingTo: Self.logURL) { h.seekToEndOfFile(); h.write(Data(line.utf8)); try? h.close() }
+        else { try? line.write(to: Self.logURL, atomically: true, encoding: .utf8) }
+    }
+
+    private func run() async {
+        try? "".write(to: Self.logURL, atomically: true, encoding: .utf8)
+        let goal = ProcessInfo.processInfo.environment["GHOST_GOAL"] ?? "open X and summarize the posts in my feed"
+        fileLog("XAGENT_GOAL \(goal)")
+        // Keep-alive so Ghost keeps running the read/re-open code while X is
+        // foreground (otherwise it suspends and never wakes itself). The LLM still
+        // runs later on Metal, in the foreground, after we re-open Ghost.
+        KeepAlive.shared.start()
+        guard ModelStore.isAvailable(ModelRegistry.qwen15),
+              let url = try? ModelStore.resolvedURL(for: ModelRegistry.qwen15),
+              let engine = try? LlamaEngine(modelURL: url, nCtx: 2048, nBatch: 512) else {  // Metal
+            fileLog("XAGENT_ENGINE_FAIL"); return
+        }
+        fileLog("XAGENT_ENGINE_READY(metal)")
+        let wda = HTTPWDAClient(base: URL(string: "http://127.0.0.1:8100")!)
+        let agent = RealAppAgent(engine: engine, wda: wda)
+        let summary = await agent.run(goal: goal) { role, text in
+            fileLog("XAGENT_\(role == .tool ? "TOOL" : role == .assistant ? "ANSWER" : "MSG") \(text)")
+            Task { @MainActor in lines.append(ChatMsg(role: role, text: text)) }
+        }
+        fileLog("XAGENT_DONE \(summary)")
+        KeepAlive.shared.stop()
+    }
+}

--- a/ios/GhostLLM/App/ChatViewModel.swift
+++ b/ios/GhostLLM/App/ChatViewModel.swift
@@ -1,0 +1,200 @@
+import Foundation
+import SwiftUI
+
+/// Tiny step counter for the scripted agent self-test (safe across the loop's
+/// @Sendable decider closure).
+actor Counter {
+    private var n = 0
+    func next() -> Int { defer { n += 1 }; return n }
+}
+
+struct ChatMessage: Identifiable, Equatable {
+    enum Role { case user, assistant, system }
+    let id = UUID()
+    let role: Role
+    var text: String
+}
+
+/// Drives on-device chat: model load/download/switch + full streaming turns.
+/// One engine instance per loaded model; KV cleared each turn (full history
+/// re-fed — simple + correct for MVP-length chats).
+@MainActor
+final class ChatViewModel: ObservableObject {
+    @Published var messages: [ChatMessage] = []
+    @Published var status: String = "loading model…"
+    @Published var ready = false
+    @Published var generating = false
+    @Published var currentModel: ModelSpec = ModelRegistry.defaultModel
+    @Published var downloadProgress: Double? = nil   // non-nil while downloading
+
+    let models = ModelRegistry.all
+    private var engine: LlamaEngine?
+    private let downloader = ModelDownloadManager()
+    private let systemPrompt = "You are Ghost, a concise helpful assistant running entirely on this iPhone."
+    private let maxTokens = 256
+
+    func loadDefaultModel() async { await load(currentModel) }
+
+    func switchModel(to spec: ModelSpec) async {
+        guard spec.id != currentModel.id || !ready else { return }
+        await load(spec)
+    }
+
+    private func load(_ spec: ModelSpec) async {
+        ready = false
+        engine = nil
+        currentModel = spec
+        do {
+            let url: URL
+            if ModelStore.isAvailable(spec) {
+                url = try ModelStore.resolvedURL(for: spec)
+            } else {
+                status = "downloading \(spec.displayName) (\(spec.sizeLabel))…"
+                downloadProgress = 0
+                var lastDecile = -1
+                url = try await downloader.ensure(spec) { [weak self] p in
+                    let d = Int(p * 10)
+                    if d != lastDecile { lastDecile = d; print("DL_PROGRESS \(spec.id) \(d * 10)%") }
+                    Task { @MainActor in self?.downloadProgress = p }
+                }
+                downloadProgress = nil
+            }
+            status = "loading \(spec.displayName)…"
+            let engine = try LlamaEngine(modelURL: url)
+            self.engine = engine
+            let backend = await engine.backend
+            status = "ready · \(spec.displayName) · \(backend)"
+            ready = true
+        } catch {
+            downloadProgress = nil
+            status = "error: \(error)"
+        }
+    }
+
+    /// Headless proof of the download-on-first-run path: download a model over
+    /// the network into Documents, then load it. Uses the small model URL so the
+    /// mechanism is validated fast (the production Gemma path is identical).
+    func runDownloadSelfTest() async {
+        let spec = ModelSpec(
+            id: "dl-test", displayName: "download self-test",
+            filename: "dltest-\(ModelRegistry.phase0.filename)",
+            url: ModelRegistry.phase0.url, sizeBytes: ModelRegistry.phase0.sizeBytes, bundled: false
+        )
+        try? FileManager.default.removeItem(at: ModelStore.documentsURL(for: spec))
+        var lastDecile = -1
+        do {
+            let url = try await downloader.ensure(spec) { p in
+                let d = Int(p * 10)
+                if d != lastDecile { lastDecile = d; print("DL_TEST_PROGRESS \(d * 10)%") }
+            }
+            let size = (try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int64) ?? -1
+            let inDocs = url.path.contains("/Documents/models/")
+            let engine = try LlamaEngine(modelURL: url)
+            let backend = await engine.backend
+            print("DL_TEST_RESULT ok file=\(url.lastPathComponent) size=\(size ?? -1) in_documents=\(inDocs) loaded_backend=\(backend)")
+        } catch {
+            print("DL_TEST_ERROR \(error)")
+        }
+    }
+
+    /// Phone-free proof of the agent loop: a scripted decider drives MockWDAClient
+    /// (getUI → tap → done); asserts the loop issues the right WDA calls in order
+    /// and terminates. The real loop swaps the mock for HTTPWDAClient + the LLM.
+    func runAgentSelfTest() async {
+        let mock = MockWDAClient()
+        let loop = AgentLoop(engine: nil, wda: mock)
+        let script: [ToolCall] = [
+            ToolCall(tool: "getUI"),
+            ToolCall(tool: "tap", x: 100, y: 200),
+            ToolCall(tool: "done", summary: "tapped Settings"),
+        ]
+        let counter = Counter()
+        let result = await loop.run(goal: "Open Settings", maxSteps: 6) { _ in
+            let i = await counter.next()
+            return i < script.count ? script[i] : nil
+        }
+        let calls = await mock.calls
+        let transcript = await loop.transcript
+        let ok = calls == ["createSession", "source", "tap(100,200)"] && result == "tapped Settings"
+        print("AGENT_TEST_RESULT ok=\(ok) result=<\(result)> calls=\(calls) transcript=\(transcript)")
+    }
+
+    /// Proof that the on-device LLM emits grammar-valid tool calls that drive the
+    /// loop (mock WDA, no phone). Grammar guarantees parseable JSON even from the
+    /// tiny model; the real device swaps MockWDAClient → HTTPWDAClient.
+    func runAgentLLMTest() async {
+        do {
+            let url = try ModelStore.bundledPhase0ModelURL()
+            let engine = try LlamaEngine(modelURL: url)
+            var raw = ""
+            _ = try await engine.generate(
+                prompt: "You control an iPhone. Emit ONE JSON tool call like {\"tool\":\"getUI\"}.\nGOAL: open Settings\nNext tool call:",
+                maxTokens: 64, grammar: nil
+            ) { raw += $0 }
+            let parsed = ToolCall.parse(from: raw)
+            print("AGENT_LLM_RAW=<\(raw)> parsed_tool=\(parsed?.tool ?? "nil") valid_json=\(parsed != nil)")
+
+            let mock = MockWDAClient()
+            let loop = AgentLoop(engine: engine, wda: mock)
+            let result = await loop.run(goal: "Open the Settings app", maxSteps: 3)
+            let calls = await mock.calls
+            let transcript = await loop.transcript
+            print("AGENT_LLM_RESULT result=<\(result)> calls=\(calls) transcript=\(transcript)")
+        } catch {
+            print("AGENT_LLM_ERROR \(error)")
+        }
+    }
+
+    /// Load a model (downloading if needed) and time a fixed generation — the
+    /// on-device performance proof. On the phone the backend is Metal.
+    func runPerf(_ which: String) async {
+        let spec = which == "gemma" ? ModelRegistry.gemma4E2B : ModelRegistry.phase0
+        print("PERF_START model=\(spec.displayName)")
+        await load(spec)
+        guard ready, let engine else { print("PERF_ERROR status=\(status)"); return }
+        do {
+            // warm-up (kernels/graph), then a timed run
+            _ = try await engine.generate(prompt: "Hi", maxTokens: 4) { _ in }
+            let info = try await engine.generate(
+                prompt: "Explain what an iPhone is in two short sentences.",
+                maxTokens: 80
+            ) { _ in }
+            print("PERF_RESULT model=\(spec.displayName) \(info.summary)")
+        } catch {
+            print("PERF_ERROR \(error)")
+        }
+    }
+
+    func send(_ text: String) async {
+        let prompt = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !prompt.isEmpty, !generating, let engine else { return }
+        generating = true
+        defer { generating = false }
+
+        messages.append(ChatMessage(role: .user, text: prompt))
+        let assistantIndex = messages.count
+        messages.append(ChatMessage(role: .assistant, text: ""))
+
+        var turns: [ChatTurn] = [ChatTurn(role: "system", content: systemPrompt)]
+        for m in messages where m.role != .assistant || !m.text.isEmpty {
+            let role = m.role == .user ? "user" : (m.role == .system ? "system" : "assistant")
+            turns.append(ChatTurn(role: role, content: m.text))
+        }
+
+        await engine.resetContext()
+        let formatted = await engine.formatChat(turns)
+        do {
+            let info = try await engine.generate(prompt: formatted, maxTokens: maxTokens) { [weak self] piece in
+                Task { @MainActor in
+                    guard let self, self.messages.indices.contains(assistantIndex) else { return }
+                    self.messages[assistantIndex].text += piece
+                }
+            }
+            status = "ready · \(info.summary)"
+            print("M1_RESULT reply=<\(messages[assistantIndex].text)> \(info.summary)")
+        } catch {
+            messages[assistantIndex].text = "[error: \(error)]"
+            print("M1_ERROR \(error)")
+        }
+    }
+}

--- a/ios/GhostLLM/App/ContentView.swift
+++ b/ios/GhostLLM/App/ContentView.swift
@@ -1,0 +1,127 @@
+import SwiftUI
+
+/// M1 chat UI: a single-window chat backed by the on-device llama.cpp engine.
+/// Streams the assistant reply token-by-token.
+struct ContentView: View {
+    @StateObject private var vm = ChatViewModel()
+    @State private var draft = ""
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            messagesList
+            Divider()
+            composer
+        }
+        .task {
+            let env = ProcessInfo.processInfo.environment
+            // Optional boot-into-a-specific-model (e.g. GHOST_MODEL=gemma for the demo).
+            if env["GHOST_MODEL"] == "gemma" { vm.currentModel = ModelRegistry.gemma4E2B }
+            // Perf tests do their own single load; skip the default to avoid two engines.
+            if env["GHOST_PERF"] == nil {
+                await vm.loadDefaultModel()
+            }
+            // Headless verification: `SIMCTL_CHILD_GHOST_AUTORUN=1` auto-sends a prompt.
+            if ProcessInfo.processInfo.environment["GHOST_AUTORUN"] == "1", vm.ready {
+                await vm.send("Say hello in one short sentence.")
+            }
+            if ProcessInfo.processInfo.environment["GHOST_DL_TEST"] == "1" {
+                await vm.runDownloadSelfTest()
+            }
+            if ProcessInfo.processInfo.environment["GHOST_AGENT_TEST"] == "1" {
+                await vm.runAgentSelfTest()
+            }
+            if ProcessInfo.processInfo.environment["GHOST_AGENT_LLM_TEST"] == "1" {
+                await vm.runAgentLLMTest()
+            }
+            if let perf = ProcessInfo.processInfo.environment["GHOST_PERF"] {
+                await vm.runPerf(perf)   // "smol" | "gemma"
+            }
+        }
+    }
+
+    private var header: some View {
+        VStack(spacing: 4) {
+            HStack {
+                Text("👻 Ghost LLM").font(.headline)
+                Menu {
+                    ForEach(vm.models) { spec in
+                        Button {
+                            Task { await vm.switchModel(to: spec) }
+                        } label: {
+                            Label(
+                                "\(spec.displayName)\(ModelStore.isAvailable(spec) ? "" : " · ↓ \(spec.sizeLabel)")",
+                                systemImage: spec.id == vm.currentModel.id ? "checkmark" : "cpu"
+                            )
+                        }
+                    }
+                } label: {
+                    Image(systemName: "chevron.down.circle").font(.subheadline)
+                }
+                .disabled(vm.generating || vm.downloadProgress != nil)
+            }
+            if let p = vm.downloadProgress {
+                ProgressView(value: p) { Text("downloading… \(Int(p * 100))%").font(.caption2) }
+                    .padding(.horizontal, 24)
+            }
+            Text(vm.status)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 8)
+    }
+
+    private var messagesList: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 10) {
+                    ForEach(vm.messages) { msg in
+                        bubble(for: msg).id(msg.id)
+                    }
+                }
+                .padding(12)
+            }
+            .onChange(of: vm.messages.last?.text) { _, _ in
+                if let last = vm.messages.last { withAnimation { proxy.scrollTo(last.id, anchor: .bottom) } }
+            }
+        }
+    }
+
+    private func bubble(for msg: ChatMessage) -> some View {
+        let isUser = msg.role == .user
+        return HStack {
+            if isUser { Spacer(minLength: 40) }
+            Text(msg.text.isEmpty ? "…" : msg.text)
+                .padding(10)
+                .background(isUser ? Color.accentColor.opacity(0.9) : Color.gray.opacity(0.2))
+                .foregroundStyle(isUser ? .white : .primary)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .frame(maxWidth: .infinity, alignment: isUser ? .trailing : .leading)
+            if !isUser { Spacer(minLength: 40) }
+        }
+    }
+
+    private var composer: some View {
+        HStack(spacing: 8) {
+            TextField("Message (runs on-device)…", text: $draft, axis: .vertical)
+                .textFieldStyle(.roundedBorder)
+                .disabled(!vm.ready || vm.generating)
+                .onSubmit(sendDraft)
+            Button(action: sendDraft) {
+                Image(systemName: "arrow.up.circle.fill").font(.title2)
+            }
+            .disabled(!vm.ready || vm.generating || draft.trimmingCharacters(in: .whitespaces).isEmpty)
+        }
+        .padding(10)
+    }
+
+    private func sendDraft() {
+        let text = draft
+        draft = ""
+        Task { await vm.send(text) }
+    }
+}

--- a/ios/GhostLLM/App/GhostLLMApp.swift
+++ b/ios/GhostLLM/App/GhostLLMApp.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+@main
+struct GhostLLMApp: App {
+    var body: some Scene {
+        WindowGroup {
+            // Agent is the DEFAULT experience (uses its built-in r/LocalLLaMA goal),
+            // so a bare launch — no env vars — runs the real on-device agent cleanly.
+            // Opt out with GHOST_CHAT=1 (plain chat) or GHOST_DEMO=1 (scripted demo).
+            if ProcessInfo.processInfo.environment["GHOST_XDEMO"] == "1" {
+                XDemoView()        // real-app agent: open X → read → summarize
+            } else if ProcessInfo.processInfo.environment["GHOST_BGTEST"] == "1" {
+                BGDriveTestView()  // validate background-drive architecture
+            } else if ProcessInfo.processInfo.environment["GHOST_CHAT"] == "1" {
+                ContentView()
+            } else if ProcessInfo.processInfo.environment["GHOST_DEMO"] == "1" {
+                DemoView()         // scripted hero demo (fetch + summarize)
+            } else {
+                AgentChatView()    // real on-device agent, Android-style chat UI
+            }
+        }
+    }
+}

--- a/ios/GhostLLM/Demo/DemoView.swift
+++ b/ios/GhostLLM/Demo/DemoView.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+
+/// Full-screen demo narrative — designed to read clearly as a per-device tile.
+struct DemoView: View {
+    @StateObject private var vm = DemoViewModel()
+
+    var body: some View {
+        ZStack {
+            LinearGradient(colors: [Color(red: 0.06, green: 0.06, blue: 0.10), .black],
+                           startPoint: .top, endPoint: .bottom).ignoresSafeArea()
+            VStack(alignment: .leading, spacing: 18) {
+                header
+                narrationLine
+                if !vm.postTitle.isEmpty { postCard }
+                if !vm.summary.isEmpty { summaryCard }
+                Spacer()
+                if !vm.stats.isEmpty { footer }
+            }
+            .padding(20)
+        }
+        .task { await vm.run() }
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            Text("👻").font(.system(size: 34))
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Ghost").font(.title2.bold()).foregroundStyle(.white)
+                Text("on-device agent").font(.caption).foregroundStyle(.white.opacity(0.55))
+            }
+            Spacer()
+            badge("A17 Pro · Metal · offline")
+        }
+    }
+
+    private var narrationLine: some View {
+        HStack(spacing: 8) {
+            if !vm.done { ProgressView().tint(.white).scaleEffect(0.8) }
+            Text(vm.narration)
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(.white.opacity(0.9))
+                .animation(.easeInOut, value: vm.narration)
+        }
+    }
+
+    private var postCard: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                Text(vm.subreddit).font(.caption.bold()).foregroundStyle(Color(red: 1, green: 0.4, blue: 0.3))
+                Text("· top post · \(vm.sourceLabel)").font(.caption2).foregroundStyle(.white.opacity(0.4))
+            }
+            Text(vm.postTitle).font(.headline).foregroundStyle(.white).fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.white.opacity(0.06), in: RoundedRectangle(cornerRadius: 14))
+    }
+
+    private var summaryCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label("On-device summary", systemImage: "sparkles")
+                .font(.caption.bold()).foregroundStyle(.white.opacity(0.6))
+            Text(vm.summary)
+                .font(.body)
+                .foregroundStyle(.white)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            LinearGradient(colors: [Color(red: 0.10, green: 0.14, blue: 0.24), Color(red: 0.08, green: 0.09, blue: 0.14)],
+                           startPoint: .topLeading, endPoint: .bottomTrailing),
+            in: RoundedRectangle(cornerRadius: 16)
+        )
+        .overlay(RoundedRectangle(cornerRadius: 16).strokeBorder(.white.opacity(0.08)))
+    }
+
+    private var footer: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "cpu").font(.caption2)
+            Text(vm.stats).font(.caption2.monospaced())
+        }
+        .foregroundStyle(.white.opacity(0.5))
+    }
+
+    private func badge(_ text: String) -> some View {
+        Text(text)
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(.white.opacity(0.85))
+            .padding(.horizontal, 10).padding(.vertical, 5)
+            .background(.white.opacity(0.08), in: Capsule())
+            .overlay(Capsule().strokeBorder(.white.opacity(0.12)))
+    }
+}

--- a/ios/GhostLLM/Demo/DemoViewModel.swift
+++ b/ios/GhostLLM/Demo/DemoViewModel.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// Self-running demo: load Gemma → fetch r/LocalLLaMA thread → summarize on-device,
+/// streaming. Zero external UI-driving — everything is app-owned so the whole run
+/// can be captured in one continuous take (and rendered as a per-device tile).
+@MainActor
+final class DemoViewModel: ObservableObject {
+    @Published var narration = "👻 Waking up Ghost…"
+    @Published var subreddit = "r/LocalLLaMA"
+    @Published var postTitle = ""
+    @Published var summary = ""
+    @Published var stats = ""
+    @Published var backend = ""
+    @Published var sourceLabel = ""
+    @Published var done = false
+
+    private var engine: LlamaEngine?
+    private let downloader = ModelDownloadManager()
+
+    private var modelName = ""
+
+    /// Set the narration line and push a status snapshot for fleet tiles (:8088).
+    private func narrate(_ line: String, phase: String, tokS: Double = 0) {
+        narration = line
+        StatusServer.shared.update(phase: phase, tokS: tokS, model: modelName, line: line)
+    }
+
+    func run() async {
+        StatusServer.shared.start()   // best-effort status endpoint for fleet tiles
+        do {
+            // 1) Load the best available on-device model (Gemma if present;
+            //    else the bundled model; download Gemma only if nothing is local).
+            let spec = ModelStore.isAvailable(ModelRegistry.gemma4E2B) ? ModelRegistry.gemma4E2B
+                     : ModelStore.isAvailable(ModelRegistry.phase0) ? ModelRegistry.phase0
+                     : ModelRegistry.gemma4E2B
+            modelName = spec.displayName
+            narrate("🧠 Loading \(spec.displayName) on-device…", phase: "loading")
+            let url: URL
+            if ModelStore.isAvailable(spec) {
+                url = try ModelStore.resolvedURL(for: spec)
+            } else {
+                url = try await downloader.ensure(spec) { p in
+                    Task { @MainActor in self.narration = "⬇️ Downloading Gemma (\(Int(p * 100))%)…" }
+                }
+            }
+            let engine = try LlamaEngine(modelURL: url)
+            self.engine = engine
+            backend = await engine.backend
+
+            // 2) Fetch the thread (the app itself — no UI driving)
+            narrate("🌐 Opening r/LocalLLaMA…", phase: "fetching")
+            let thread = await RedditFetcher.topThread()
+            subreddit = thread.subreddit
+            postTitle = thread.title
+            sourceLabel = thread.live ? "live" : "cached"
+            narrate("📖 Reading the top post (\(thread.comments.count) comments)…", phase: "reading")
+
+            // 3) Summarize on-device, streaming (short prompt; digest passed programmatically)
+            narrate("✍️ Summarizing 100% on-device — offline-capable…", phase: "summarizing")
+            let digest = thread.comments.prefix(8).joined(separator: "\n- ")
+            let prompt = """
+            Summarize the top comments on this r/LocalLLaMA post in 3 sentences — \
+            the main points and the overall sentiment. Post title: "\(thread.title)".
+            Comments:
+            - \(digest)
+            """
+            let info = try await engine.generate(prompt: prompt, maxTokens: 170) { piece in
+                Task { @MainActor in self.summary += piece }
+            }
+            stats = String(format: "%d→%d tok · %.1f tok/s · %@",
+                           info.promptTokens, info.generatedTokens, info.tokensPerSecond, info.backend)
+            narrate("✅ Summarized on-device — no cloud, no network needed",
+                    phase: "done", tokS: info.tokensPerSecond)
+            done = true
+        } catch {
+            narrate("⚠️ \(error)", phase: "error")
+        }
+    }
+}

--- a/ios/GhostLLM/Demo/RedditFetcher.swift
+++ b/ios/GhostLLM/Demo/RedditFetcher.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+struct RedditThread {
+    let subreddit: String
+    let title: String
+    let comments: [String]
+    let live: Bool   // true if fetched live, false if bundled fallback
+}
+
+/// Fetches the top r/LocalLLaMA thread for demo mode. Tries live Reddit JSON
+/// (works from the phone's residential IP); falls back to a bundled real-thread
+/// snapshot so the hero recording is bulletproof (no network variability).
+enum RedditFetcher {
+    static func topThread(subreddit: String = "LocalLLaMA") async -> RedditThread {
+        if let live = try? await fetchLive(subreddit: subreddit), !live.comments.isEmpty {
+            return live
+        }
+        return bundled()
+    }
+
+    private static func fetchLive(subreddit: String) async throws -> RedditThread {
+        let ua = "GhostLLM-iOS-demo/0.1 (on-device summarizer)"
+        func get(_ url: URL) async throws -> Any {
+            var req = URLRequest(url: url, timeoutInterval: 6)
+            req.setValue(ua, forHTTPHeaderField: "User-Agent")
+            let (data, resp) = try await URLSession.shared.data(for: req)
+            guard (resp as? HTTPURLResponse)?.statusCode == 200 else { throw URLError(.badServerResponse) }
+            return try JSONSerialization.jsonObject(with: data)
+        }
+
+        let listing = try await get(URL(string: "https://www.reddit.com/r/\(subreddit)/hot.json?limit=6&raw_json=1")!)
+        let children = ((( listing as? [String: Any])?["data"] as? [String: Any])?["children"] as? [[String: Any]]) ?? []
+        var post: [String: Any]?
+        for c in children {
+            let d = c["data"] as? [String: Any] ?? [:]
+            if (d["stickied"] as? Bool) != true { post = d; break }
+        }
+        guard let p = post, let permalink = p["permalink"] as? String, let title = p["title"] as? String
+        else { throw URLError(.cannotParseResponse) }
+
+        let thread = try await get(URL(string: "https://www.reddit.com\(permalink).json?limit=20&raw_json=1")!)
+        let arr = thread as? [Any] ?? []
+        let commentsData = (arr.count > 1 ? arr[1] : nil) as? [String: Any]
+        let cChildren = ((commentsData?["data"] as? [String: Any])?["children"] as? [[String: Any]]) ?? []
+        var bodies: [String] = []
+        for c in cChildren {
+            let d = c["data"] as? [String: Any] ?? [:]
+            if let body = d["body"] as? String, body.count > 20, (d["stickied"] as? Bool) != true {
+                bodies.append(body)
+            }
+            if bodies.count >= 8 { break }
+        }
+        guard !bodies.isEmpty else { throw URLError(.cannotParseResponse) }
+        return RedditThread(subreddit: "r/\(subreddit)", title: title, comments: bodies, live: true)
+    }
+
+    private static func bundled() -> RedditThread {
+        guard let url = Bundle.main.url(forResource: "reddit_thread", withExtension: "json"),
+              let data = try? Data(contentsOf: url),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return RedditThread(subreddit: "r/LocalLLaMA", title: "On-device LLMs", comments: ["Running models locally keeps data private."], live: false)
+        }
+        return RedditThread(
+            subreddit: obj["subreddit"] as? String ?? "r/LocalLLaMA",
+            title: obj["title"] as? String ?? "",
+            comments: obj["comments"] as? [String] ?? [],
+            live: false
+        )
+    }
+}

--- a/ios/GhostLLM/Demo/StatusServer.swift
+++ b/ios/GhostLLM/Demo/StatusServer.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Network
+
+/// Tiny best-effort HTTP status endpoint for multi-fleet per-device tiles.
+/// `GET :8088/status` → {phase, tok_s, model, narration_last_line, ts}.
+/// No serials/UDIDs. Failure-tolerant — never affects the demo if it can't bind.
+final class StatusServer: @unchecked Sendable {
+    static let shared = StatusServer()
+    private let queue = DispatchQueue(label: "ghost.status")
+    private var listener: NWListener?
+    private var snapshot = #"{"phase":"idle"}"#
+
+    func start(port: UInt16 = 8088) {
+        queue.async {
+            guard self.listener == nil, let p = NWEndpoint.Port(rawValue: port) else { return }
+            guard let l = try? NWListener(using: .tcp, on: p) else { return }
+            l.newConnectionHandler = { [weak self] c in self?.serve(c) }
+            l.start(queue: self.queue)
+            self.listener = l
+        }
+    }
+
+    func update(phase: String, tokS: Double, model: String, line: String) {
+        let ts = ISO8601DateFormatter().string(from: Date())
+        let obj: [String: Any] = ["phase": phase, "tok_s": tokS, "model": model,
+                                  "narration_last_line": line, "ts": ts]
+        let body = (try? JSONSerialization.data(withJSONObject: obj))
+            .flatMap { String(data: $0, encoding: .utf8) } ?? "{}"
+        queue.async { self.snapshot = body }
+    }
+
+    private func serve(_ conn: NWConnection) {
+        conn.start(queue: queue)
+        conn.receive(minimumIncompleteLength: 1, maximumLength: 4096) { [weak self] _, _, _, _ in
+            let body = self?.snapshot ?? "{}"
+            let resp = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n" +
+                       "Access-Control-Allow-Origin: *\r\nConnection: close\r\n" +
+                       "Content-Length: \(body.utf8.count)\r\n\r\n\(body)"
+            conn.send(content: resp.data(using: .utf8), completion: .contentProcessed { _ in conn.cancel() })
+        }
+    }
+}

--- a/ios/GhostLLM/Engine/InferenceEngine.swift
+++ b/ios/GhostLLM/Engine/InferenceEngine.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Runtime-agnostic inference surface. llama.cpp is the MVP backend (GGUF parity
+/// with the Android on-device path); an MLX backend can conform to this later
+/// without touching call sites — mirrors Android's `Runtime { MEDIAPIPE, LLAMA_CPP }`.
+protocol InferenceEngine: Actor {
+    /// Generate up to `maxTokens`, streaming each decoded piece via `onToken`.
+    /// Returns timing/shape info for the run.
+    func generate(
+        prompt: String,
+        maxTokens: Int,
+        grammar: String?,
+        repeatPenalty: Float,
+        onToken: @Sendable @escaping (String) -> Void
+    ) async throws -> GenerationInfo
+}
+
+/// A single chat turn fed to the template formatter. `role` is "system" |
+/// "user" | "assistant".
+struct ChatTurn {
+    let role: String
+    let content: String
+}
+
+struct GenerationInfo {
+    var promptTokens: Int
+    var generatedTokens: Int
+    var loadMillis: Int
+    var genMillis: Int
+    var backend: String
+    var firstToken: String
+
+    var tokensPerSecond: Double {
+        genMillis > 0 ? Double(generatedTokens) / (Double(genMillis) / 1000.0) : 0
+    }
+
+    var summary: String {
+        String(
+            format: "prompt=%dtok gen=%dtok load=%dms gen=%dms (%.1f tok/s) backend=%@",
+            promptTokens, generatedTokens, loadMillis, genMillis, tokensPerSecond, backend
+        )
+    }
+}
+
+enum InferenceError: Error, CustomStringConvertible {
+    case modelNotFound(String)
+    case loadFailed(String)
+    case contextFailed
+    case tokenizeFailed
+
+    var description: String {
+        switch self {
+        case .modelNotFound(let p): return "model not found: \(p)"
+        case .loadFailed(let p): return "llama_model_load_from_file failed: \(p)"
+        case .contextFailed: return "llama_init_from_model failed"
+        case .tokenizeFailed: return "llama_tokenize failed"
+        }
+    }
+}

--- a/ios/GhostLLM/Engine/LlamaEngine.swift
+++ b/ios/GhostLLM/Engine/LlamaEngine.swift
@@ -1,0 +1,230 @@
+import Foundation
+import LlamaSwift
+
+/// llama.cpp-backed on-device inference. Loads a GGUF and runs greedy decode.
+/// All C pointers are confined to this actor, so they never cross a concurrency
+/// boundary. Metal on device; CPU on the simulator (simulator has no Metal).
+actor LlamaEngine: InferenceEngine {
+    private let model: OpaquePointer
+    private let ctx: OpaquePointer
+    private let vocab: OpaquePointer
+    private let backendName: String
+    private let nBatch: Int32
+    private let loadMillis: Int
+    private(set) var lastStopReason = ""   // diagnostic: why the last generate() stopped
+
+    var backend: String { backendName }
+
+    // llama backend is process-global — init exactly once, never free it (freeing
+    // it while another/future engine exists breaks model switching + perf).
+    private static let backendInit: Void = { llama_backend_init() }()
+
+    /// `cpuOnly` forces CPU inference (n_gpu_layers=0). Needed when the app runs in
+    /// the BACKGROUND (driving another app): iOS kills Metal/GPU command buffers
+    /// submitted from the background, so we must fall back to the CPU there.
+    init(modelURL: URL, nCtx: UInt32 = 2048, nBatch: Int32 = 512, cpuOnly: Bool = false) throws {
+        let t0 = Date()
+        _ = LlamaEngine.backendInit
+
+        var mparams = llama_model_default_params()
+        #if targetEnvironment(simulator)
+        mparams.n_gpu_layers = 0
+        self.backendName = "cpu (simulator)"
+        #else
+        mparams.n_gpu_layers = cpuOnly ? 0 : 99
+        self.backendName = cpuOnly ? "cpu" : "metal"
+        #endif
+
+        guard let m = llama_model_load_from_file(modelURL.path, mparams) else {
+            throw InferenceError.loadFailed(modelURL.lastPathComponent)
+        }
+
+        var cparams = llama_context_default_params()
+        cparams.n_ctx = nCtx
+        cparams.n_batch = UInt32(nBatch)
+        guard let c = llama_init_from_model(m, cparams) else {
+            llama_model_free(m)
+            throw InferenceError.contextFailed
+        }
+
+        self.model = m
+        self.ctx = c
+        self.vocab = llama_model_get_vocab(m)
+        self.nBatch = nBatch
+        self.loadMillis = Int(Date().timeIntervalSince(t0) * 1000)
+    }
+
+    deinit {
+        // Free this engine's model/context; leave the process-global backend alone.
+        llama_free(ctx)
+        llama_model_free(model)
+    }
+
+    /// Format a chat history using the model's built-in chat template (falls back
+    /// to ChatML). `add_ass` appends the assistant-turn opening tokens.
+    func formatChat(_ messages: [ChatTurn]) -> String {
+        let tmpl = llama_model_chat_template(model, nil)  // model's default, or nil
+        // strdup role/content so the C pointers stay valid across the call.
+        var cStrings: [UnsafeMutablePointer<CChar>?] = []
+        var chat: [llama_chat_message] = messages.map { turn in
+            let r = strdup(turn.role)
+            let c = strdup(turn.content)
+            cStrings.append(r); cStrings.append(c)
+            return llama_chat_message(role: r, content: c)
+        }
+        defer { cStrings.forEach { free($0) } }
+
+        var buf = [CChar](repeating: 0, count: 8192)
+        var n = llama_chat_apply_template(tmpl, &chat, messages.count, true, &buf, Int32(buf.count))
+        if n > Int32(buf.count) {
+            buf = [CChar](repeating: 0, count: Int(n) + 1)
+            n = llama_chat_apply_template(tmpl, &chat, messages.count, true, &buf, Int32(buf.count))
+        }
+        guard n > 0 else {
+            // Fallback: raw concatenation if the model ships no supported template.
+            return messages.map { "\($0.role): \($0.content)" }.joined(separator: "\n") + "\nassistant:"
+        }
+        let bytes = buf.prefix(Int(n)).map { UInt8(bitPattern: $0) }
+        return String(decoding: bytes, as: UTF8.self)
+    }
+
+    /// Clear the KV cache so the next prompt starts fresh (we re-feed the full
+    /// templated history each turn — simple + correct for MVP-length chats).
+    func resetContext() {
+        llama_memory_clear(llama_get_memory(ctx), true)
+    }
+
+    /// `repeatPenalty` > 1 discourages repeating recent tokens. Leave the default
+    /// for tool-call decoding, but pass 1.0 for SUMMARIZATION — there the prompt
+    /// holds the source text, and penalizing its tokens makes the model bail to EOS
+    /// after one word (it can't reuse the very words it must summarize).
+    func generate(
+        prompt: String,
+        maxTokens: Int,
+        grammar: String? = nil,
+        repeatPenalty: Float = 1.2,
+        onToken: @Sendable @escaping (String) -> Void
+    ) async throws -> GenerationInfo {
+        // --- Tokenize prompt ---
+        let utf8Count = Int32(prompt.utf8.count)
+        let cap = utf8Count + 1
+        var tokens = [llama_token](repeating: 0, count: Int(cap))
+        let n = llama_tokenize(vocab, prompt, utf8Count, &tokens, cap, /*add_special*/ true, /*parse_special*/ true)
+        guard n > 0 else { throw InferenceError.tokenizeFailed }
+        let promptTokens = Array(tokens.prefix(Int(n)))
+
+        // --- Evaluate prompt ---
+        // Start every generation from a clean KV cache: we always feed positions
+        // from 0, so stale KV entries (e.g. a prior warmup) collide — fatal under
+        // Gemma's sliding-window attention. Makes generate() self-contained.
+        llama_memory_clear(llama_get_memory(ctx), true)
+        var batch = llama_batch_init(nBatch, 0, 1)
+        defer { llama_batch_free(batch) }
+        // Prefill in nBatch-sized chunks so a prompt longer than nBatch can't
+        // overflow the batch buffers (that overran → SIGSEGV). Logits only on the
+        // very last token.
+        let step = Int(nBatch)
+        var pos = 0
+        while pos < promptTokens.count {
+            let end = min(pos + step, promptTokens.count)
+            let chunk = Array(promptTokens[pos..<end])
+            fill(&batch, with: chunk, startPos: Int32(pos))
+            let isLast = end == promptTokens.count
+            if isLast { batch.logits[Int(batch.n_tokens) - 1] = 1 }
+            guard llama_decode(ctx, batch) == 0 else { throw InferenceError.contextFailed }
+            pos = end
+        }
+
+        // --- Decode loop ---
+        // Chain order matters: penalties → grammar → greedy. The grammar mask must
+        // be applied LAST before the selector, or the selector picks an unmasked
+        // token and llama_sampler_accept crashes ('empty grammar stack').
+        let usingGrammar = grammar != nil
+        let chain = llama_sampler_chain_init(llama_sampler_chain_default_params())
+        if repeatPenalty > 1.0 {
+            llama_sampler_chain_add(chain, llama_sampler_init_penalties(256, repeatPenalty, 0.0, 0.0))
+        }
+        if let grammar, let g = llama_sampler_init_grammar(vocab, grammar, "root") {
+            llama_sampler_chain_add(chain, g)
+        }
+        llama_sampler_chain_add(chain, llama_sampler_init_greedy())
+        defer { llama_sampler_free(chain) }
+
+        let genStart = Date()
+        // Next-token position = TOTAL prompt length. (Not batch.n_tokens: after a
+        // chunked prefill that's only the LAST chunk's size, so a prompt longer than
+        // nBatch would place the first generated token at a colliding KV position →
+        // corrupted context → the model emits EOS after one token.)
+        var nCur = Int32(promptTokens.count)
+        var generated = 0
+        var firstToken = ""
+        // In grammar mode, stop after one balanced JSON object: accepting a token
+        // past a completed grammar throws an (uncatchable) C++ exception.
+        var braceDepth = 0
+        var sawOpenBrace = false
+
+        var stopReason = "maxTokens"
+        for _ in 0..<maxTokens {
+            // llama_sampler_sample already calls accept internally — a second accept
+            // double-advances the grammar and crashes ('empty grammar stack').
+            let next = llama_sampler_sample(chain, ctx, -1)
+            if llama_vocab_is_eog(vocab, next) { stopReason = "eog@\(generated)"; break }
+
+            let piece = detokenize(next)
+            if generated == 0 { firstToken = piece }
+            generated += 1
+            onToken(piece)
+
+            if usingGrammar {
+                for ch in piece {
+                    if ch == "{" { braceDepth += 1; sawOpenBrace = true }
+                    else if ch == "}" { braceDepth -= 1 }
+                }
+                if sawOpenBrace && braceDepth <= 0 { stopReason = "grammarDone"; break }
+            }
+
+            // feed the sampled token back in
+            batch.n_tokens = 1
+            batch.token[0] = next
+            batch.pos[0] = nCur
+            batch.n_seq_id[0] = 1
+            if let seqIds = batch.seq_id, let seq0 = seqIds[0] { seq0[0] = 0 }
+            batch.logits[0] = 1
+            nCur += 1
+            guard llama_decode(ctx, batch) == 0 else { stopReason = "decodeFail@\(generated)"; break }
+        }
+        print("GEN_STOP \(stopReason) promptTok=\(promptTokens.count) gen=\(generated)")
+        lastStopReason = stopReason
+
+        let genMillis = Int(Date().timeIntervalSince(genStart) * 1000)
+        return GenerationInfo(
+            promptTokens: promptTokens.count,
+            generatedTokens: generated,
+            loadMillis: loadMillis,
+            genMillis: genMillis,
+            backend: backendName,
+            firstToken: firstToken
+        )
+    }
+
+    // MARK: - helpers
+
+    private func fill(_ batch: inout llama_batch, with toks: [llama_token], startPos: Int32) {
+        batch.n_tokens = Int32(toks.count)
+        for i in 0..<toks.count {
+            batch.token[i] = toks[i]
+            batch.pos[i] = startPos + Int32(i)
+            batch.n_seq_id[i] = 1
+            if let seqIds = batch.seq_id, let seqI = seqIds[i] { seqI[0] = 0 }
+            batch.logits[i] = 0
+        }
+    }
+
+    private func detokenize(_ token: llama_token) -> String {
+        var buf = [CChar](repeating: 0, count: 64)
+        let len = llama_token_to_piece(vocab, token, &buf, Int32(buf.count), 0, false)
+        guard len > 0 else { return "" }
+        let bytes = buf.prefix(Int(len)).map { UInt8(bitPattern: $0) }
+        return String(decoding: bytes, as: UTF8.self)
+    }
+}

--- a/ios/GhostLLM/Engine/ModelDownloadManager.swift
+++ b/ios/GhostLLM/Engine/ModelDownloadManager.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Downloads a model GGUF into Documents/models with progress, using a
+/// URLSessionDownloadTask (efficient for multi-GB files). Skips if already
+/// present. This is the "download-on-first-run" path for the production model.
+final class ModelDownloadManager: NSObject, URLSessionDownloadDelegate {
+    private var session: URLSession!
+    private var spec: ModelSpec?
+    private var progressHandler: ((Double) -> Void)?
+    private var continuation: CheckedContinuation<URL, Error>?
+
+    override init() {
+        super.init()
+        let config = URLSessionConfiguration.default
+        config.waitsForConnectivity = true
+        session = URLSession(configuration: config, delegate: self, delegateQueue: nil)
+    }
+
+    /// Ensure `spec` is on disk, downloading if needed. Returns its local URL.
+    func ensure(_ spec: ModelSpec, onProgress: @escaping (Double) -> Void) async throws -> URL {
+        if let existing = try? ModelStore.resolvedURL(for: spec) { return existing }
+        guard let url = spec.url else { throw InferenceError.modelNotFound(spec.filename) }
+        self.spec = spec
+        self.progressHandler = onProgress
+        return try await withCheckedThrowingContinuation { cont in
+            self.continuation = cont
+            session.downloadTask(with: url).resume()
+        }
+    }
+
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask,
+                    didWriteData bytesWritten: Int64, totalBytesWritten: Int64,
+                    totalBytesExpectedToWrite: Int64) {
+        guard totalBytesExpectedToWrite > 0 else { return }
+        let p = Double(totalBytesWritten) / Double(totalBytesExpectedToWrite)
+        progressHandler?(p)
+    }
+
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask,
+                    didFinishDownloadingTo location: URL) {
+        guard let spec else { return }
+        let dest = ModelStore.documentsURL(for: spec)
+        do {
+            try? FileManager.default.removeItem(at: dest)
+            try FileManager.default.moveItem(at: location, to: dest)
+            continuation?.resume(returning: dest)
+        } catch {
+            continuation?.resume(throwing: error)
+        }
+        continuation = nil
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        if let error {
+            continuation?.resume(throwing: error)
+            continuation = nil
+        }
+    }
+}

--- a/ios/GhostLLM/Engine/ModelRegistry.swift
+++ b/ios/GhostLLM/Engine/ModelRegistry.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// A downloadable / bundled on-device model. Mirrors the Android
+/// `OnDeviceModelRegistry` entries so the two platforms track the same models.
+struct ModelSpec: Identifiable, Equatable {
+    let id: String
+    let displayName: String
+    let filename: String
+    let url: URL?          // nil for bundled-only
+    let sizeBytes: Int64
+    let bundled: Bool      // shipped inside the app bundle
+
+    var sizeLabel: String {
+        ByteCountFormatter.string(fromByteCount: sizeBytes, countStyle: .file)
+    }
+}
+
+enum ModelRegistry {
+    /// Tiny model bundled for offline-out-of-the-box + the Phase 0 pipeline proof.
+    static let phase0 = ModelSpec(
+        id: "smollm2-360m",
+        displayName: "SmolLM2 360M (bundled)",
+        filename: "SmolLM2-360M-Instruct-Q4_K_M.gguf",
+        url: URL(string: "https://huggingface.co/bartowski/SmolLM2-360M-Instruct-GGUF/resolve/main/SmolLM2-360M-Instruct-Q4_K_M.gguf"),
+        sizeBytes: 270_590_880,
+        bundled: true
+    )
+
+    /// Production default — same GGUF the Android registry ships (cross-platform
+    /// parity). Downloaded on first run into the Documents dir.
+    static let gemma4E2B = ModelSpec(
+        id: "gemma-4-e2b",
+        displayName: "Gemma 4 E2B (Q4_K_M)",
+        filename: "gemma-4-E2B-it-Q4_K_M.gguf",
+        url: URL(string: "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_K_M.gguf"),
+        sizeBytes: 3_106_735_776,
+        bundled: false
+    )
+
+    /// Agent model: smaller than Gemma (~1.1 GB, fits alongside a WKWebView without
+    /// Metal OOM) and notably stronger at function-calling per param (ghost-multi-fleet-dev).
+    static let qwen15 = ModelSpec(
+        id: "qwen2.5-1.5b",
+        displayName: "Qwen2.5 1.5B (agent)",
+        filename: "Qwen2.5-1.5B-Instruct-Q4_K_M.gguf",
+        url: URL(string: "https://huggingface.co/bartowski/Qwen2.5-1.5B-Instruct-GGUF/resolve/main/Qwen2.5-1.5B-Instruct-Q4_K_M.gguf"),
+        sizeBytes: 1_120_238_688,
+        bundled: false
+    )
+
+    static let all: [ModelSpec] = [phase0, gemma4E2B, qwen15]
+    static let defaultModel = phase0   // load instantly offline; user can pull Gemma
+}

--- a/ios/GhostLLM/Engine/ModelStore.swift
+++ b/ios/GhostLLM/Engine/ModelStore.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Resolves where a model's GGUF lives: bundled models come from the app bundle;
+/// downloaded models live in Documents/models (survives app updates, user-visible).
+enum ModelStore {
+    static let phase0ModelName = ModelRegistry.phase0.filename.replacingOccurrences(of: ".gguf", with: "")
+
+    static var modelsDir: URL {
+        let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        let dir = docs.appendingPathComponent("models", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    static func documentsURL(for spec: ModelSpec) -> URL {
+        modelsDir.appendingPathComponent(spec.filename)
+    }
+
+    static func isAvailable(_ spec: ModelSpec) -> Bool {
+        (try? resolvedURL(for: spec)) != nil
+    }
+
+    /// The on-disk URL to load from, or throws if the model isn't present yet.
+    static func resolvedURL(for spec: ModelSpec) throws -> URL {
+        if spec.bundled,
+           let u = Bundle.main.url(forResource: spec.filename.replacingOccurrences(of: ".gguf", with: ""), withExtension: "gguf") {
+            return u
+        }
+        let docs = documentsURL(for: spec)
+        if FileManager.default.fileExists(atPath: docs.path) { return docs }
+        throw InferenceError.modelNotFound(spec.filename)
+    }
+
+    // Back-compat for Phase 0 callers.
+    static func bundledPhase0ModelURL() throws -> URL {
+        try resolvedURL(for: ModelRegistry.phase0)
+    }
+}

--- a/ios/GhostLLM/GhostLLM.entitlements
+++ b/ios/GhostLLM/GhostLLM.entitlements
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Extra RAM headroom so a ~1GB model + WKWebView + Metal buffers fit. -->
+    <key>com.apple.developer.kernel.increased-memory-limit</key>
+    <true/>
+</dict>
+</plist>

--- a/ios/GhostLLM/Resources/reddit_thread.json
+++ b/ios/GhostLLM/Resources/reddit_thread.json
@@ -1,0 +1,16 @@
+{
+  "subreddit": "r/LocalLLaMA",
+  "title": "Apple sues OpenAI alleging trade secret theft, says scheme was 'at every level'",
+  "score": 275,
+  "num_comments": 48,
+  "comments": [
+    "From the evidence that I have seen so far in the reportings, Apple has a very strong case.",
+    "Yeah, allegedly a former Apple engineer who left for OpenAI kept his old work laptop, found a bug to access Apple's cloud storage, and sent a message to a colleague \"LOL, I found out I can access the network storage, so funny\" before downloading dozens of confidential files.",
+    "That message - and a bunch of subsequent ones - were sent and logged on Apple\u2019s internal messaging system.",
+    "Sometimes the smartest motherfuckers on the planet can simultaneously be the dumbest motherfuckers on the planet.",
+    "how could someone with this level of stupidity even get a job at apple?",
+    "You mean the company that can't design a proper mouse or can't figure out proper window/app management on their desktop/laptop OS?",
+    "Amusingly, I've met someone from the touchscreen hardware world who Apple ripped off like twice, and hoped they'd exhaust him in court, but eventually he won lots, but it took him ages.",
+    "Apple has infinitely deep pockets, and an ancient grudge against Microsoft (OpenAI's masters), and I doubt OpenAI has many useful patents, so Apple can push this one through I guess.  lol"
+  ]
+}

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,0 +1,82 @@
+# Ghost LLM (iOS) — on-device LLM app
+
+SwiftUI app that runs an LLM **entirely on the iPhone** via **llama.cpp** (GGUF) —
+the iOS mirror of Ghost's Android on-device path. It can chat, drive the phone as
+an agent, and run a self-narrating demo. Design rationale + milestones:
+[`../docs/ios/ONDEVICE_LLM.md`](../docs/ios/ONDEVICE_LLM.md) and
+[`../docs/ios/AGENT_LOOP_BRIDGE.md`](../docs/ios/AGENT_LOOP_BRIDGE.md).
+
+## Layout
+
+```
+ios/
+  project.yml                 # xcodegen spec (SwiftUI, iOS 17+, LlamaSwift dep)
+  GhostLLM/
+    App/                      # GhostLLMApp.swift, ContentView.swift (chat), ChatViewModel
+    Engine/
+      InferenceEngine.swift   # runtime-agnostic protocol (MLX can conform later)
+      LlamaEngine.swift       # llama.cpp actor: load GGUF, sampler chain (penalty+greedy)
+      ModelRegistry.swift     # SmolLM2 (bundled) + Gemma-4 E2B (download-on-first-run)
+      ModelStore.swift        # bundle vs Documents resolution
+      ModelDownloadManager.swift
+    Agent/                    # AgentLoop, WDAClient (+ mock), tool vocab, GBNF grammar
+    Demo/                     # DemoView/DemoViewModel (self-running hero demo),
+                              #   RedditFetcher, StatusServer (:8088 for fleet tiles)
+    Resources/                # bundled GGUF (gitignored) + reddit_thread.json fallback
+  scripts/
+    fetch-phase0-model.sh     # download the tiny bundled model
+    export-ipa.sh             # archive + export a signed .ipa (dev / ad-hoc / app-store)
+  ExportOptions-*.plist       # export configs per distribution method
+```
+
+The `.xcodeproj` is generated (gitignored) — edit `project.yml`, not the project.
+
+## Build & run (simulator)
+
+```bash
+brew install xcodegen                 # one-time
+cd ios
+./scripts/fetch-phase0-model.sh       # downloads the bundled model
+xcodegen generate
+xcodebuild -project GhostLLM.xcodeproj -scheme GhostLLM \
+  -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' \
+  -derivedDataPath build build
+xcrun simctl install booted build/Build/Products/Debug-iphonesimulator/GhostLLM.app
+xcrun simctl launch booted com.ghostinthedroid.ghostllm
+```
+
+Simulator runs on CPU (no Metal); device offloads all layers to Metal.
+
+### Launch flags (env)
+
+- `GHOST_DEMO=1` — self-running hero demo (fetch r/LocalLLaMA + on-device summary)
+- `GHOST_MODEL=gemma` — boot straight into Gemma-4 E2B
+- `GHOST_PERF=smol|gemma` — timed generation, prints `PERF_RESULT … tok/s`
+
+## Deploy to a physical device (autonomous)
+
+Signing is headless via a dedicated keychain (one-time `~/ghost-signing-setup.sh`
+by the Mac owner). After that:
+
+```bash
+~/ghost-deploy-auto.sh                # build + sign + install to the iPhone, no prompts
+```
+
+## IPA / distribution
+
+```bash
+METHOD=development ./scripts/export-ipa.sh   # installs on registered devices (default)
+METHOD=ad-hoc      ./scripts/export-ipa.sh   # shareable to registered UDIDs
+METHOD=app-store   ./scripts/export-ipa.sh   # TestFlight / App Store
+```
+
+`development` works today with the Apple Development cert. `ad-hoc` / `app-store`
+need a **Distribution cert** added to `ghost-signing.keychain-db` + the matching
+provisioning profile — then the same command yields a shareable IPA.
+
+## Status — M0 → M3 complete
+
+On-device on a real iPhone 15 Pro (A17 Pro, Metal): SmolLM2-360M ~51 tok/s,
+**Gemma-4 E2B ~13.7 tok/s**. Chat, model download-on-first-run, agent-drives-WDA,
+and a self-running demo that reads r/LocalLLaMA and summarizes it offline. Hero
+recording + `:8088` fleet-tile status endpoint shipped. See the design doc.

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -1,0 +1,43 @@
+name: GhostLLM
+options:
+  bundleIdPrefix: com.ghostinthedroid
+  createIntermediateGroups: true
+  deploymentTarget:
+    iOS: "17.0"
+packages:
+  LlamaSwift:
+    url: https://github.com/mattt/llama.swift
+    branch: main
+settings:
+  base:
+    SWIFT_VERSION: "5.9"
+    MARKETING_VERSION: "0.1.0"
+    CURRENT_PROJECT_VERSION: "1"
+targets:
+  GhostLLM:
+    type: application
+    platform: iOS
+    deploymentTarget: "17.0"
+    sources:
+      - path: GhostLLM
+    dependencies:
+      - package: LlamaSwift
+    info:
+      path: GhostLLM/Info.plist
+      properties:
+        UILaunchScreen: {}
+        CFBundleDisplayName: Ghost LLM
+        NSLocalNetworkUsageDescription: "Ghost publishes this device's on-device demo status to the fleet dashboard."
+        # Background audio keeps the on-device agent loop alive while it drives a
+        # DIFFERENT app (X) in the foreground — otherwise iOS suspends us in ~30s.
+        UIBackgroundModes: [audio]
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.ghostinthedroid.ghostllm
+        CODE_SIGN_ENTITLEMENTS: GhostLLM/GhostLLM.entitlements
+        CODE_SIGN_STYLE: Automatic
+        # DEVELOPMENT_TEAM is passed on the xcodebuild command line (kept out of
+        # git) — see ios/README.md. Local override: IOS_XCODE_ORG_ID.
+        TARGETED_DEVICE_FAMILY: "1,2"
+        ENABLE_USER_SCRIPT_SANDBOXING: NO
+        # llama.h is a C header (extern "C") — plain C interop is enough.

--- a/ios/scripts/export-ipa.sh
+++ b/ios/scripts/export-ipa.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Autonomously archive + export a signed .ipa (no human, no prompt).
+#
+#   METHOD=development ./scripts/export-ipa.sh   # default: installs on registered devices
+#   METHOD=ad-hoc      ./scripts/export-ipa.sh   # shareable to registered UDIDs (needs ad-hoc profile)
+#   METHOD=app-store   ./scripts/export-ipa.sh   # TestFlight/App Store (needs Distribution cert)
+#
+# development works today with the Apple Development cert in ghost-signing.keychain-db.
+# ad-hoc / app-store need a Distribution cert added to that keychain + the matching
+# provisioning profile (Apple Developer portal). Everything else is identical.
+set -euo pipefail
+
+IOS="$(cd "$(dirname "$0")/.." && pwd)"
+TEAM="${IOS_XCODE_ORG_ID:-WWD665FH95}"
+METHOD="${METHOD:-development}"
+SIGN_KC="$HOME/Library/Keychains/ghost-signing.keychain-db"
+PWFILE="$HOME/.config/ghost/signing-pw"
+ARCHIVE="$IOS/build/GhostLLM.xcarchive"
+OUT="$IOS/build/ipa"
+
+if [ -f "$PWFILE" ] && [ -f "$SIGN_KC" ]; then
+  security unlock-keychain -p "$(cat "$PWFILE")" "$SIGN_KC" 2>/dev/null || true
+  security list-keychains -d user -s "$SIGN_KC" "$HOME/Library/Keychains/login.keychain-db" >/dev/null 2>&1 || true
+fi
+
+cd "$IOS"
+command -v xcodegen >/dev/null 2>&1 && xcodegen generate >/dev/null
+
+echo "== archiving (method=$METHOD) =="
+xcodebuild -project GhostLLM.xcodeproj -scheme GhostLLM \
+  -sdk iphoneos -configuration Release -allowProvisioningUpdates \
+  -archivePath "$ARCHIVE" DEVELOPMENT_TEAM="$TEAM" \
+  OTHER_CODE_SIGN_FLAGS="--keychain $SIGN_KC" archive \
+  2>&1 | grep -iE 'ARCHIVE SUCCEEDED|BUILD FAILED|error:|errSec' | tail -8
+
+[ -d "$ARCHIVE" ] || { echo "ARCHIVE_FAILED"; exit 1; }
+
+PLIST="$IOS/ExportOptions-$METHOD.plist"
+echo "== exporting IPA =="
+rm -rf "$OUT"
+xcodebuild -exportArchive -archivePath "$ARCHIVE" -exportPath "$OUT" \
+  -exportOptionsPlist "$PLIST" -allowProvisioningUpdates \
+  2>&1 | grep -iE 'EXPORT SUCCEEDED|error:|Exported' | tail -8
+
+IPA="$(ls "$OUT"/*.ipa 2>/dev/null | head -1)"
+[ -n "$IPA" ] && echo "IPA_OK: $IPA ($(du -h "$IPA" | cut -f1))" || { echo "EXPORT_FAILED"; exit 1; }

--- a/ios/scripts/fetch-phase0-model.sh
+++ b/ios/scripts/fetch-phase0-model.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Fetches the tiny Phase 0 model (SmolLM2-360M-Instruct Q4_K_M, ~270 MB) used to
+# prove the on-device pipeline in the simulator. The production default
+# (Gemma-4 E2B, Android parity) is downloaded on first run inside the app.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+MODEL="SmolLM2-360M-Instruct-Q4_K_M.gguf"
+URL="https://huggingface.co/bartowski/SmolLM2-360M-Instruct-GGUF/resolve/main/${MODEL}"
+
+mkdir -p models GhostLLM/Resources
+if [[ ! -f "models/${MODEL}" ]]; then
+  echo "Downloading ${MODEL} ..."
+  curl -fL --retry 3 -o "models/${MODEL}" "${URL}"
+fi
+# The app bundles the model as a resource for the simulator Phase 0 proof.
+cp "models/${MODEL}" "GhostLLM/Resources/${MODEL}"
+echo "Model ready: GhostLLM/Resources/${MODEL} ($(stat -f %z "GhostLLM/Resources/${MODEL}") bytes)"

--- a/portal/app/src/main/java/com/ghostinthedroid/portal/GhostHttpServer.kt
+++ b/portal/app/src/main/java/com/ghostinthedroid/portal/GhostHttpServer.kt
@@ -1,15 +1,19 @@
 package com.ghostinthedroid.portal
 
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import android.os.Handler
 import android.os.Looper
+import android.speech.tts.TextToSpeech
 import android.util.Base64
 import android.util.Log
 import fi.iki.elonen.NanoHTTPD
 import org.json.JSONObject
 import java.io.ByteArrayOutputStream
+import java.util.Locale
 
 /**
  * HTTP server on port 8080. API-compatible with what our Python backend expects.
@@ -20,11 +24,32 @@ object GhostHttpServer {
     private const val PORT = 8080
     private var server: Server? = null
 
+    // Shared TTS engine — initialised lazily on first /speak call
+    private var tts: TextToSpeech? = null
+    private var ttsReady = false
+
+    fun initTts(context: Context) {
+        if (tts != null) return
+        tts = TextToSpeech(context) { status ->
+            ttsReady = (status == TextToSpeech.SUCCESS)
+            if (ttsReady) tts?.language = Locale.US
+        }
+    }
+
+    fun speak(text: String, rate: Float = 1.0f): String {
+        val engine = tts ?: return "error: TTS not initialised"
+        if (!ttsReady) return "error: TTS engine not ready"
+        engine.setSpeechRate(rate)
+        engine.speak(text, TextToSpeech.QUEUE_FLUSH, null, "ghost_tts")
+        return "speaking"
+    }
+
     fun start(context: Context) {
         if (server != null) return
         try {
             server = Server(PORT, context)
             server?.start()
+            initTts(context)
             Log.i(TAG, "HTTP server started on port $PORT")
         } catch (e: Exception) {
             Log.e(TAG, "Failed to start: ${e.message}")
@@ -64,6 +89,8 @@ object GhostHttpServer {
                     "/status" -> ok("ok")
                     "/version" -> ok("1.0.0")
                     "/packages" -> handlePackages()
+                    "/speak" -> handleSpeak(body)
+                    "/clipboard" -> handleClipboard(body)
                     "/overlay", "/overlay/toggle" -> handleOverlay(body)
                     "/stream/start" -> handleStreamStart(body)
                     "/stream/stop" -> handleStreamStop(body)
@@ -193,6 +220,25 @@ object GhostHttpServer {
                 GhostWebRtcManager.getInstance(context).handleIceCandidate(candidate, sdpMid, sdpMLineIndex)
             }
             return ok("ICE candidate received")
+        }
+
+        private fun handleClipboard(body: JSONObject): Response {
+            val text = body.optString("text", "")
+            return try {
+                val cm = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                mainHandler.post { cm.setPrimaryClip(ClipData.newPlainText("ghost", text)) }
+                ok("clipboard_set")
+            } catch (e: Exception) {
+                error("clipboard error: ${e.message}")
+            }
+        }
+
+        private fun handleSpeak(body: JSONObject): Response {
+            val text = body.optString("text", "").trim()
+            if (text.isEmpty()) return error("Missing 'text' field")
+            val rate = body.optDouble("rate", 1.0).toFloat().coerceIn(0.5f, 2.0f)
+            val result = GhostHttpServer.speak(text, rate)
+            return ok(result)
         }
 
         // ── Response helpers ────────────────────────────────────────────────

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ghost-in-the-droid"
-version = "1.2.0"
+version = "1.3.0"
 description = "Give any AI agent an Android body. Open-source phone automation via ADB — tap, swipe, type, run skills, scale across devices."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -29,8 +29,10 @@ dependencies = [
     "python-dotenv>=1.0",
     "pyyaml>=6.0",
     "psutil>=5.9",
+    "docker>=7.0",
     "openai>=1.0",
     "mcp>=1.20",
+    "langfuse>=2.0,<3.0",
 ]
 
 [project.urls]
@@ -43,15 +45,20 @@ Issues = "https://github.com/ghost-in-the-droid/android-agent/issues"
 llm = ["anthropic>=0.30"]
 analytics = ["google-analytics-data>=0.18"]
 ocr = ["rapidocr-onnxruntime>=1.3"]
-test = ["playwright>=1.40", "pytest>=7.0"]
+langchain = ["langchain-core>=0.3"]
+llamaindex = ["llama-index-core>=0.11"]
+test = ["playwright>=1.40", "pytest>=7.0", "langchain-core>=0.3", "llama-index-core>=0.11"]
 all = ["ghost-in-the-droid[llm,analytics,ocr,test]"]
 
 [project.scripts]
+ghost = "gitd.ghost_cli:main"
 android-agent = "gitd.cli:main"
+gitd = "gitd.cli:main"
+ghost-in-the-droid = "gitd.cli:main"
 android-agent-mcp = "gitd.mcp_server:main"
 
 [tool.setuptools.packages.find]
-include = ["gitd*"]
+include = ["gitd*", "integrations*"]
 
 [tool.ruff]
 target-version = "py310"

--- a/scripts/ios/.gitignore
+++ b/scripts/ios/.gitignore
@@ -1,0 +1,2 @@
+# Personal config — may hold your UDID / team id / signing identity. Never commit.
+ghost-ios.env

--- a/scripts/ios/README.md
+++ b/scripts/ios/README.md
@@ -1,0 +1,108 @@
+# ghost-ios — iOS device tooling
+
+One command to run the whole iOS device stack for **Ghost in the Droid** on a Mac:
+the RemoteXPC tunnel + Appium + backend + web dashboard + a self-healing
+supervisor, in a single terminal window. Plus preflight (`doctor`), a JSON device
+inventory (`report`), and WDA build/sign helpers.
+
+These are **Mac-fleet-node operational scripts**, not part of the core product. They
+carry **no baked-in identifiers** — everything is auto-detected or set via env / a
+config file.
+
+## Requirements
+
+- **macOS with Xcode + command-line tools** (`xcrun`, `xctrace`, `devicectl`, `codesign`).
+- **A GUI login session.** WDA code-signing needs an interactive desktop session;
+  it fails over SSH/headless (`errSecInternalComponent`). Run these from Terminal
+  on the Mac itself (or a Mac with auto-login to an unlocked desktop).
+- **An Apple Developer account** added in Xcode (a free personal team works; WDA
+  then needs a re-sign every 7 days).
+- **Appium + the XCUITest driver:**
+  ```sh
+  npm i -g appium
+  appium driver install xcuitest
+  ```
+- **The repo's Python + Node deps** (the backend in `../..` and `../../frontend`).
+- An **iPhone with Developer Mode on**, connected via USB and unlocked.
+
+## Install
+
+No install step — run the scripts in place. Optionally put them on your `PATH`:
+
+```sh
+ln -s "$PWD/scripts/ios/ghost-ios" /usr/local/bin/ghost-ios   # optional
+```
+
+Zero-config works when exactly one iPhone is attached and one "Apple Development"
+identity is in your keychain. Otherwise copy the config template and fill in the
+few values it can't detect:
+
+```sh
+cp scripts/ios/ghost-ios.env.example scripts/ios/ghost-ios.env
+$EDITOR scripts/ios/ghost-ios.env       # set IOS_DEVICE_UDID / IOS_XCODE_ORG_ID, etc.
+```
+
+`ghost-ios config` shows what resolved and from where.
+
+## Usage
+
+```
+ghost-ios up          start the whole stack + self-healing tunnel supervisor (main one)
+ghost-ios doctor      preflight: check every known failure point + the fix for each
+ghost-ios status      tunnel / appium / backend / dashboard health
+ghost-ios report      JSON inventory of attached device(s) (for remote-fleet discovery)
+ghost-ios dashboard   start the web dashboard (vite) and open it
+ghost-ios smoke       run the sample Chrome->news smoke test
+ghost-ios speak TEXT  speak TEXT aloud on the phone (native WDA TTS)
+ghost-ios keychain    one-time: grant CLI codesign access to your signing key
+ghost-ios rebuild-wda (re)build + install the patched WebDriverAgent onto the phone
+ghost-ios config      show resolved configuration
+ghost-ios down        stop tunnel + appium + backend
+```
+
+Typical first run:
+
+```sh
+ghost-ios keychain      # once: unlock keychain + grant codesign (prevents mid-build re-lock)
+ghost-ios doctor        # verify every prerequisite is green
+ghost-ios up            # start everything; Ctrl-C tears it down
+```
+
+`ghost-ios report` emits (redacted example):
+
+```json
+{
+  "schema": 1,
+  "host": "mac1",
+  "generated_at": "2026-01-01T00:00Z",
+  "devices": [
+    { "udid": "00008XXX-XXXXXXXXXXXXXXXX", "name": "Demo iPhone",
+      "ref_slug": "demo-iphone", "ios_version": "26.4.2",
+      "wda_up": false, "appium_up": true, "tunnel_up": true }
+  ]
+}
+```
+
+`wda_up` means a WDA session is live *right now* (Appium launches WDA per session);
+readiness for "can I start a session" is `tunnel_up && appium_up`.
+
+## Files
+
+| file | what |
+|------|------|
+| `ghost-ios` | the launcher / supervisor + all subcommands |
+| `doctor.sh` | preflight checks (invoked by `ghost-ios doctor`) |
+| `fix-wda-signing.sh` | clean WDA build + sign + install (fixes keychain-lock codesign failures) |
+| `record-av.sh` | transcode a QuickTime iPhone recording (screen + **audio**) into a demo MP4 |
+| `lib.sh` | shared config resolution + detection (sourced by the above) |
+| `ghost-ios.env.example` | config template — copy to `ghost-ios.env` |
+
+## Notes
+
+- **Native TTS (`speak_text` / `ghost-ios speak`)** needs the GhostAgent WDA patch
+  (`patches/FBCustomCommands.ghostagent.m`) applied to the vendored WebDriverAgent and
+  a rebuild (`ghost-ios rebuild-wda`). `ghost-ios doctor` reports whether it's applied.
+- **iOS 17+** physical devices require the privileged RemoteXPC tunnel (`ghost-ios up`
+  starts + supervises it; it needs `sudo`).
+- To prevent tunnel drops, set the iPhone's **Auto-Lock to Never** while in use.
+- `ghost-ios.env` is git-ignored — it may hold your UDID/team/identity; never commit it.

--- a/scripts/ios/doctor.sh
+++ b/scripts/ios/doctor.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+#
+# doctor.sh — preflight for the iOS device stack. Checks every known failure
+# point (device wedge, developer mode, keychain lock, signing identity, prebuilt
+# WDA, GhostAgent patch, runtime services, tunnel) and prints the fix for each.
+# Fast + read-only. Invoked by `ghost-ios doctor`.
+set -uo pipefail
+
+GHOST_IOS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/ios/lib.sh
+. "$GHOST_IOS_DIR/lib.sh"
+
+fails=0; warns=0
+GRN="[ ok ]" RED="[FAIL]" YEL="[warn]"
+chk(){ printf "  %-6s %-26s %s\n" "$1" "$2" "$3"; }
+
+say "== ghost-ios doctor :: ${DEV_REF} =="
+say "Checks every known failure point before you build/run. (fast, read-only)"
+say ""
+
+require_udid
+
+# 1. GUI vs SSH — codesign needs a GUI (Aqua) session
+if [ -n "${SSH_CONNECTION:-}" ]; then
+  chk "$YEL" "session" "SSH — codesign/WDA-build will fail; build WDA at the Mac console"; warns=$((warns+1))
+else
+  chk "$GRN" "session" "local GUI (codesign OK)"
+fi
+
+# 2. device present (via xctrace — reliable; `devicectl info details` can hang
+#    indefinitely, so we must NOT gate presence on it) + best-effort details.
+if xcrun xctrace list devices 2>/dev/null | awk '/^== Devices ==$/{f=1;next} /^== /{f=0} f' | grep -qF "$IOS_DEVICE_UDID"; then
+  if timeout 8 xcrun devicectl device info details --device "$IOS_DEVICE_UDID" >"$LOG_DIR/doctor-dc.txt" 2>&1; then
+    ver=$(grep -iE "osVersionNumber" "$LOG_DIR/doctor-dc.txt" | head -1 | awk -F: '{print $2}' | xargs)
+    chk "$GRN" "device" "connected (iOS ${ver:-?})"
+    grep -qi "developerModeStatus.*enabled" "$LOG_DIR/doctor-dc.txt" \
+      && chk "$GRN" "developer mode" "enabled" \
+      || chk "$YEL" "developer mode" "not confirmed -> Settings>Privacy>Developer Mode (if WDA won't launch)"
+    warns=$((warns + 0))
+  else
+    chk "$GRN" "device" "connected (devicectl details unavailable — it can hang; non-fatal)"
+  fi
+else
+  chk "$RED" "device" "NOT attached -> plug in via USB + unlock (xcrun xctrace list devices)"; fails=$((fails+1))
+fi
+
+# 3. phone unlocked
+if timeout 8 xcrun devicectl device info lockState --device "$IOS_DEVICE_UDID" 2>/dev/null | grep -qi "unlockedSinceBoot: true"; then
+  chk "$GRN" "phone lock" "unlocked"
+else
+  chk "$YEL" "phone lock" "may be locked -> unlock the iPhone"; warns=$((warns+1))
+fi
+
+# 4. keychain unlocked + no-timeout (codesign readiness)
+kinfo=$(security show-keychain-info "$KEYCHAIN" 2>&1)
+if printf '%s' "$kinfo" | grep -qi "no-timeout"; then
+  chk "$GRN" "keychain" "unlocked, no auto-lock"
+elif printf '%s' "$kinfo" | grep -qi "User interaction is not allowed"; then
+  chk "$RED" "keychain" "LOCKED -> ghost-ios keychain (or fix-wda-signing.sh)"; fails=$((fails+1))
+else
+  chk "$YEL" "keychain" "auto-lock enabled -> ghost-ios keychain (prevents mid-build re-lock)"; warns=$((warns+1))
+fi
+
+# 5. signing identity present
+if [ -n "$IOS_XCODE_SIGNING_ID" ] && security find-identity -v -p codesigning 2>/dev/null | grep -q "$IOS_XCODE_SIGNING_ID"; then
+  chk "$GRN" "signing cert" "present (${IOS_XCODE_SIGNING_ID:0:8}...)"
+elif security find-identity -v -p codesigning 2>/dev/null | grep -qi "Apple Development"; then
+  chk "$YEL" "signing cert" "Apple Development present but IOS_XCODE_SIGNING_ID unset/mismatched"; warns=$((warns+1))
+else
+  chk "$RED" "signing cert" "MISSING -> add Apple ID in Xcode > Settings > Accounts"; fails=$((fails+1))
+fi
+
+# 6. prebuilt WDA .app exists + is signed
+app="$IOS_DERIVED_DATA_PATH/Build/Products/Debug-iphoneos/WebDriverAgentRunner-Runner.app"
+if [ -d "$app" ] && codesign -dv "$app" >/dev/null 2>&1; then
+  chk "$GRN" "prebuilt WDA" "present + signed"
+else
+  chk "$YEL" "prebuilt WDA" "missing -> $GHOST_IOS_DIR/fix-wda-signing.sh (only if using prebuilt WDA)"; warns=$((warns+1))
+fi
+
+# 7. WDA installed on the phone (a live session proves it; else devicectl, slow)
+if wda_up; then
+  chk "$GRN" "WDA on device" "installed (session live)"
+elif timeout 15 xcrun devicectl device info apps --device "$IOS_DEVICE_UDID" --include-all-apps 2>/dev/null | grep -qi "${IOS_UPDATED_WDA_BUNDLE_ID}.xctrunner"; then
+  chk "$GRN" "WDA on device" "installed"
+else
+  chk "$YEL" "WDA on device" "not found (or query slow) -> fix-wda-signing.sh if launch fails"; warns=$((warns+1))
+fi
+
+# 8. GhostAgent /wda/speak patch present in the vendored WDA source (drift detection)
+src="$WDA_SRC/WebDriverAgentLib/Commands/FBCustomCommands.m"
+patch="$GHOST_REPO/patches/FBCustomCommands.ghostagent.m"
+if grep -q "handleSpeak" "$src" 2>/dev/null; then
+  grep -q "usesApplicationAudioSession = NO" "$src" 2>/dev/null \
+    && chk "$GRN" "GhostAgent patch" "/wda/speak + audio fix present" \
+    || chk "$YEL" "GhostAgent patch" "/wda/speak present but audio fix missing -> reapply $patch"
+else
+  chk "$YEL" "GhostAgent patch" "not applied (TTS off) -> cp $patch over the WDA source; rebuild"
+fi
+
+# 9. runtime services
+appium_up && chk "$GRN" "appium :$APPIUM_PORT" "up" || { chk "$YEL" "appium :$APPIUM_PORT" "down -> ghost-ios up"; warns=$((warns+1)); }
+ghost_up  && chk "$GRN" "backend :$GHOST_PORT" "up"  || { chk "$YEL" "backend :$GHOST_PORT" "down -> ghost-ios up"; warns=$((warns+1)); }
+
+# 10. tunnel registry has the device
+if curl -s -m5 "$REG" 2>/dev/null | grep -q '"status":"OK"'; then
+  chk "$GRN" "tunnel :$TUNNEL_PORT" "registry has device"
+else
+  chk "$YEL" "tunnel :$TUNNEL_PORT" "no device entry -> ghost-ios up (supervisor auto-recovers)"; warns=$((warns+1))
+fi
+
+say ""
+if [ "$fails" -gt 0 ]; then say "== $fails blocking issue(s), $warns warning(s) — fix the [FAIL] lines above =="; exit 1
+elif [ "$warns" -gt 0 ]; then say "== ready, $warns warning(s) ([warn] are usually fine / auto-recover) =="; exit 0
+else say "== all green — build & run should work =="; exit 0; fi

--- a/scripts/ios/fix-wda-signing.sh
+++ b/scripts/ios/fix-wda-signing.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# fix-wda-signing.sh — build + sign the (optionally GhostAgent-patched)
+# WebDriverAgent and install it onto the iPhone, cleanly.
+#
+# Why this exists: the WDA build often fails with "Command CodeSign failed"
+# because the login keychain re-locked (a locked keychain blocks codesign even
+# though the partition-list grant is permanent). This unlocks it, does a clean
+# build+sign to a fixed derivedData path, then installs the .app with devicectl
+# so nothing hangs hosting WDA (Appium launches it later via usePrebuiltWDA).
+#
+# Run in YOUR Terminal (a GUI login session), NOT over SSH:
+#   scripts/ios/fix-wda-signing.sh
+#
+# Config is auto-detected or read from env / a config file — see
+# ghost-ios.env.example. Requires: one attached iPhone, an Apple Development
+# signing identity, and an Apple team id (IOS_XCODE_ORG_ID).
+set -uo pipefail
+
+GHOST_IOS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/ios/lib.sh
+. "$GHOST_IOS_DIR/lib.sh"
+
+require_udid
+[ -n "$IOS_XCODE_ORG_ID" ] || { say "ERROR: no Apple team id. Set IOS_XCODE_ORG_ID (see ghost-ios.env.example)."; exit 1; }
+[ -d "$WDA_SRC" ] || { say "ERROR: WebDriverAgent source not found at $WDA_SRC"; say "       Install the driver: appium driver install xcuitest"; exit 1; }
+
+say "Target device : $IOS_DEVICE_UDID"
+say "Team / bundle : $IOS_XCODE_ORG_ID / $IOS_UPDATED_WDA_BUNDLE_ID"
+say "DerivedData   : $IOS_DERIVED_DATA_PATH"
+say ""
+
+read -rs -p "Mac login password> " PW; echo; echo
+say "== 1/4 unlock login keychain + (re)grant codesign access =="
+security unlock-keychain -p "$PW" "$KEYCHAIN" || { say "unlock failed — wrong password?"; exit 1; }
+security set-key-partition-list -S apple-tool:,apple: -s -k "$PW" "$KEYCHAIN" >/dev/null 2>&1
+# One prompt for everything: the login password is also the sudo password, so
+# prime sudo now with it (used only if a CoreDevice reset is needed below). If
+# they differ (rare), this no-ops and sudo prompts later only if actually used.
+sudo -S -v <<<"$PW" 2>/dev/null || true
+unset PW
+say "keychain status:"; security show-keychain-info "$KEYCHAIN" 2>&1 | sed 's/^/   /'
+
+APP="$IOS_DERIVED_DATA_PATH/Build/Products/Debug-iphoneos/WebDriverAgentRunner-Runner.app"
+BLOG="$LOG_DIR/wda-build.log"
+build_once(){
+  rm -rf "$IOS_DERIVED_DATA_PATH"
+  cd "$WDA_SRC"
+  xcodebuild build-for-testing \
+    -project WebDriverAgent.xcodeproj -scheme WebDriverAgentRunner \
+    -destination "id=$IOS_DEVICE_UDID" -derivedDataPath "$IOS_DERIVED_DATA_PATH" -allowProvisioningUpdates \
+    DEVELOPMENT_TEAM="$IOS_XCODE_ORG_ID" PRODUCT_BUNDLE_IDENTIFIER="$IOS_UPDATED_WDA_BUNDLE_ID" \
+    GCC_TREAT_WARNINGS_AS_ERRORS=0 COMPILER_INDEX_STORE_ENABLE=NO 2>&1 | tee "$BLOG" \
+    | grep -iE "CompileC.*FBCustomCommands|CodeSign|BUILD SUCCEEDED|BUILD FAILED|error:|errSec|Device is busy|Timed out waiting" || true
+}
+
+say ""
+say "== 2/4 clean build + sign WDA (~3-5 min, no run) =="
+build_once
+# Auto-heal the "Device is busy (Connecting to)" stale-CoreDevice failure: reset
+# usbmuxd/remoted and retry ONCE, instead of making you run killall by hand.
+if [ ! -d "$APP" ] && grep -qiE "Device is busy|Timed out waiting for all destinations" "$BLOG" 2>/dev/null; then
+  say ""
+  say "-> 'Device is busy' — stale CoreDevice connection. Auto-resetting + retrying once."
+  reset_coredevice
+  say "   unlock the iPhone if it's locked; waiting ~8s for it to re-handshake ..."
+  sleep 8
+  build_once
+fi
+
+if [ ! -d "$APP" ]; then
+  say ""
+  say "BUILD FAILED — no signed .app produced (see errors above)."
+  if grep -qiE "Device is busy|Timed out waiting" "$BLOG" 2>/dev/null; then
+    say "Still 'Device is busy' after a CoreDevice reset: UNLOCK the iPhone, replug"
+    say "USB, make sure nothing else (ghost-ios up / Xcode) is using it, and rerun."
+  else
+    say "If you saw 'CodeSign failed / errSecInternalComponent', the keychain is"
+    say "still locked or you're not in a GUI Terminal session (codesign needs one)."
+  fi
+  exit 1
+fi
+
+say ""
+say "== 3/4 install the signed WDA onto the phone (keep it unlocked) =="
+xcrun devicectl device install app --device "$IOS_DEVICE_UDID" "$APP" 2>&1 | tail -4
+
+say ""
+say "== 4/4 done =="
+say "WDA is signed + installed and the keychain is unlocked so Appium can (re)launch"
+say "it. Point the backend at it with IOS_USE_PREBUILT_WDA=true and"
+say "IOS_DERIVED_DATA_PATH=$IOS_DERIVED_DATA_PATH (ghost-ios sets these for you)."

--- a/scripts/ios/ghost-ios
+++ b/scripts/ios/ghost-ios
@@ -1,0 +1,339 @@
+#!/usr/bin/env bash
+#
+# ghost-ios — one command to run the whole iOS device stack for Ghost in the Droid.
+#
+# Collapses the RemoteXPC tunnel + Appium + backend + dashboard + a self-healing
+# supervisor into ONE terminal window. Run it from your own Terminal (a GUI login
+# session) so codesign can reach your signing key. It prompts for sudo once (the
+# RemoteXPC tunnel needs root) and keeps everything alive until you Ctrl-C.
+#
+#   ghost-ios up          start the stack + self-healing tunnel supervisor (main one)
+#   ghost-ios doctor      preflight: check every known failure point + the fix for each
+#   ghost-ios status      show tunnel / appium / backend / dashboard health
+#   ghost-ios report      machine-readable JSON inventory of attached device(s)
+#   ghost-ios dashboard   start the web dashboard (vite) and open it
+#   ghost-ios smoke       run the sample Chrome->news smoke test
+#   ghost-ios speak TEXT  speak TEXT aloud on the phone (native WDA TTS)
+#   ghost-ios keychain    one-time: grant CLI codesign access to your signing key
+#   ghost-ios rebuild-wda (re)build+install the patched WebDriverAgent onto the phone
+#   ghost-ios down        stop tunnel + appium + backend
+#   ghost-ios config      show the resolved configuration (and where it came from)
+#   ghost-ios help        this help
+#
+# Configuration is auto-detected where possible; override via environment or a
+# config file — see ghost-ios.env.example. No settings are baked into this script.
+set -uo pipefail
+
+GHOST_IOS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/ios/lib.sh
+. "$GHOST_IOS_DIR/lib.sh"
+
+SUDO_KEEPALIVE=""
+# sudo strips PATH; hand the tunnel daemon its node + appium back.
+SUDO_PATH="$(dirname "${APPIUM_BIN:-/usr/local/bin/appium}"):/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+# health probes (appium_up/ghost_up/vite_up/tunnel_up/wda_up) come from lib.sh
+
+# ------------------------------- lifecycle -----------------------------------
+start_appium(){
+  appium_up && { say "[appium ] already running"; return; }
+  [ -n "$APPIUM_BIN" ] || { say "ERROR: appium not found (npm i -g appium; appium driver install xcuitest)"; exit 1; }
+  say "[appium ] starting on :$APPIUM_PORT ..."
+  ( export PATH="$(dirname "$APPIUM_BIN"):$PATH"
+    nohup "$APPIUM_BIN" --port "$APPIUM_PORT" --log-timestamp --relaxed-security >"$LOG_DIR/appium.log" 2>&1 & )
+}
+
+start_ghost(){
+  ghost_up && { say "[ghost  ] already running"; return; }
+  say "[ghost  ] starting backend on :$GHOST_PORT ..."
+  ( cd "$GHOST_REPO"; export_backend_env
+    nohup "$PYBIN" run.py >"$LOG_DIR/ghost.log" 2>&1 & )
+}
+
+start_tunnel(){
+  say "[tunnel ] (re)starting RemoteXPC tunnel ..."
+  sudo pkill -f "tunnel-creation --udid ${IOS_DEVICE_UDID}" 2>/dev/null; sleep 1
+  sudo env "PATH=$SUDO_PATH" "$APPIUM_BIN" driver run xcuitest tunnel-creation \
+    --udid "$IOS_DEVICE_UDID" --disconnect-retry-max-attempts 0 --disconnect-retry-interval-ms 2000 \
+    >"$LOG_DIR/tunnel.log" 2>&1 &
+}
+
+reap_orphans(){
+  # Kill strays from previous or duplicate runs BEFORE starting — orphaned tunnel
+  # daemons fight over the device (usbmux "no USB device") and duplicate
+  # supervisors thrash the RemoteXPC address, killing streams.
+  local others
+  others=$(pgrep -f "bash .*/ghost-ios up" 2>/dev/null | grep -v "^$$\$" || true)
+  if [ -n "$others" ]; then
+    say "[reap  ] killing other 'ghost-ios up' supervisor(s): $(echo "$others")"
+    echo "$others" | xargs -r kill -9 2>/dev/null || true
+  fi
+  pgrep -f "tunnel-creation" >/dev/null 2>&1 && { say "[reap  ] killing stray tunnel daemon(s)"; sudo pkill -9 -f "tunnel-creation" 2>/dev/null || true; }
+  pgrep -f "run\.py" >/dev/null 2>&1 && { say "[reap  ] killing stale backend (run.py)"; pkill -9 -f "run\.py" 2>/dev/null || true; }
+  lsof -nP -iTCP:${GHOST_PORT} -sTCP:LISTEN 2>/dev/null | awk 'NR>1{print $2}' | xargs -r kill -9 2>/dev/null || true
+  sleep 1
+}
+
+teardown(){
+  echo; say "[ghost-ios] shutting down ..."
+  [ -n "$SUDO_KEEPALIVE" ] && kill "$SUDO_KEEPALIVE" 2>/dev/null
+  sudo pkill -f "tunnel-creation --udid ${IOS_DEVICE_UDID}" 2>/dev/null
+  pkill -f "appium --port ${APPIUM_PORT}" 2>/dev/null
+  pkill -f "run\.py" 2>/dev/null
+  say "[ghost-ios] tunnel + appium + backend stopped (dashboard left running)."
+  exit 0
+}
+
+# ------------------------------- commands ------------------------------------
+cmd_up(){
+  require_udid
+  say "== ghost-ios up :: $DEV_REF =="
+  [ -n "$APPIUM_BIN" ] || { say "ERROR: appium not found (npm i -g appium; appium driver install xcuitest)"; exit 1; }
+  # `devicectl device info details` HANGS indefinitely (esp. right after an iPhone
+  # reboot while CoreDevice re-pairs) — never gate startup on it. Use xctrace
+  # (reliable) for presence, bounded by timeout.
+  timeout 12 xcrun xctrace list devices 2>/dev/null | grep -qF "$IOS_DEVICE_UDID" \
+    || say "[warn ] iPhone not visible yet — plug in via USB + unlock (continuing anyway)"
+  say "[tip  ] prevent tunnel drops: iPhone > Settings > Display & Brightness > Auto-Lock > Never"
+  sudo -v || { say "sudo is required (the tunnel needs root)"; exit 1; }
+  reap_orphans
+  ( while kill -0 "$$" 2>/dev/null; do sudo -n true 2>/dev/null; sleep 45; done ) & SUDO_KEEPALIVE=$!
+  trap teardown INT TERM
+  start_appium; start_ghost; start_tunnel
+  if ! vite_up && [ -d "$GHOST_REPO/frontend" ]; then
+    say "[dash   ] starting web dashboard on :$VITE_PORT ..."
+    ( cd "$GHOST_REPO/frontend"; [ -d node_modules ] || npm install >"$LOG_DIR/npm.log" 2>&1
+      nohup npm run dev >"$LOG_DIR/vite.log" 2>&1 & )
+  fi
+  say "[ghost-ios] supervising — Ctrl-C stops everything."
+  say "[ghost-ios] dashboard: http://localhost:${VITE_PORT}/"
+  local last="" miss=0 restarts=0 onusb
+  while true; do
+    sleep 3
+    if tunnel_up; then
+      [ "$last" != up ] && say "[$(ts)] tunnel UP   device reachable"
+      last=up; miss=0; restarts=0
+    else
+      miss=$((miss+1))
+      ioreg -p IOUSB 2>/dev/null | grep -qi iPhone && onusb=1 || onusb=0
+      if [ "$last" != down ]; then
+        [ "$onusb" = 1 ] && say "[$(ts)] tunnel DOWN  (USB present — recovering)" \
+                          || say "[$(ts)] tunnel DOWN  (iPhone OFF USB — reseat/clean the port)"
+      fi
+      last=down
+      if [ "$miss" -ge 3 ]; then
+        if [ "$onusb" = 0 ]; then
+          # physical disconnect — restarting the tunnel is pointless until it's back
+          say "[$(ts)] waiting for iPhone to re-appear on USB (physical — check cable/port)"
+          miss=0
+        else
+          restarts=$((restarts+1))
+          if [ "$restarts" -ge 3 ]; then
+            # tunnel daemon restarts aren't recovering => CoreDevice/usbmux wedged.
+            # Reset the device-connection stack (auto-restarts) — what a manual
+            # ghost-ios restart was clearing by hand.
+            say "[$(ts)] tunnel wedged after $restarts restarts — resetting usbmuxd/remoted/CoreDeviceService"
+            reset_coredevice; restarts=0; sleep 3
+          fi
+          say "[$(ts)] restarting tunnel daemon"; start_tunnel; miss=0
+        fi
+      fi
+    fi
+  done
+}
+
+cmd_status(){
+  say "== ghost-ios status =="
+  tunnel_up && say "tunnel :$TUNNEL_PORT   UP"   || say "tunnel :$TUNNEL_PORT   DOWN"
+  appium_up && say "appium :$APPIUM_PORT    UP"  || say "appium :$APPIUM_PORT    DOWN (ghost-ios up)"
+  ghost_up  && say "ghost  :$GHOST_PORT    UP"   || say "ghost  :$GHOST_PORT    DOWN (ghost-ios up)"
+  vite_up   && say "dash   :$VITE_PORT    UP"    || say "dash   :$VITE_PORT    DOWN (ghost-ios dashboard)"
+}
+
+cmd_config(){
+  say "== ghost-ios config (resolved) =="
+  say "repo            $GHOST_REPO"
+  say "python          $PYBIN"
+  say "device udid     ${IOS_DEVICE_UDID:-<unset — attach one iPhone or set IOS_DEVICE_UDID>}"
+  say "team id         ${IOS_XCODE_ORG_ID:-<unset>}"
+  say "signing id      ${IOS_XCODE_SIGNING_ID:-<unset>}"
+  say "wda bundle id   $IOS_UPDATED_WDA_BUNDLE_ID"
+  say "derived data    $IOS_DERIVED_DATA_PATH"
+  say "appium          ${APPIUM_BIN:-<not found>}"
+  say "ports           appium=$APPIUM_PORT ghost=$GHOST_PORT tunnel=$TUNNEL_PORT vite=$VITE_PORT wda=$WDA_PORT"
+  say "config file     ${GHOST_IOS_ENV:-$GHOST_IOS_DIR/ghost-ios.env or ~/.config/ghost-ios.env (if present)}"
+}
+
+cmd_report(){
+  # Machine-readable inventory of attached iOS device(s) for remote-fleet
+  # discovery (docs/ios/REMOTE_DRIVE.md). FAST + degrades gracefully: booleans
+  # are sub-second curls; identity comes from `xctrace list devices` (~1.7s,
+  # reliable — `devicectl device info details` can hang), cached so a slow/absent
+  # xctrace still yields a full record.
+  require_udid
+  local wda tun app host gen rawline cache
+  tunnel_up && tun=true || tun=false
+  appium_up && app=true || app=false
+  wda_up && wda=true || wda=false      # true == a WDA session is live right now
+  rawline="$(timeout 12 xcrun xctrace list devices 2>/dev/null | grep -F "$IOS_DEVICE_UDID" | head -1)"
+  host="$(hostname -s 2>/dev/null)"
+  gen="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
+  cache="$LOG_DIR/device-identity-${IOS_DEVICE_UDID}.json"
+  UDID="$IOS_DEVICE_UDID" RAWLINE="$rawline" CACHE="$cache" WDA="$wda" TUN="$tun" APP="$app" \
+  HOST="$host" GEN="$gen" /usr/bin/python3 - <<'PY'
+import json, os, re
+udid = os.environ.get("UDID",""); raw = os.environ.get("RAWLINE",""); cache = os.environ.get("CACHE","")
+def slug(s):
+    s = re.sub(r"[’'\"]", "", s or "")       # drop apostrophes
+    return re.sub(r"[^a-z0-9]+", "-", s.lower()).strip("-")
+name, ver = "", ""
+if raw:
+    head = raw.split("("+udid)[0].rstrip()         # strip trailing " (udid)"
+    m = re.match(r"^(.*)\(([^)]+)\)\s*$", head)     # "<name> (<version>)"
+    if m: name, ver = m.group(1).strip(), m.group(2).strip()
+    else: name = head.strip()
+if name:
+    try: json.dump({"device_name":name,"ios_version":ver}, open(cache,"w"))
+    except Exception: pass
+elif cache and os.path.exists(cache):
+    try:
+        c = json.load(open(cache)); name = c.get("device_name",""); ver = ver or c.get("ios_version","")
+    except Exception: pass
+name = name or "iPhone"
+dev = {"udid": udid, "name": name, "ref_slug": slug(name) or "iphone", "ios_version": ver,
+       "wda_up": os.environ.get("WDA")=="true", "appium_up": os.environ.get("APP")=="true",
+       "tunnel_up": os.environ.get("TUN")=="true"}
+print(json.dumps({"schema":1,"host":os.environ.get("HOST",""),"generated_at":os.environ.get("GEN",""),
+                  "devices":[dev]}, indent=2))
+PY
+}
+
+cmd_smoke(){
+  require_udid
+  cd "$GHOST_REPO"; export_backend_env
+  "$PYBIN" scripts/ios_chrome_news_smoke.py --device "$DEV_REF" \
+    --bundle-id "${IOS_BROWSER_BUNDLE_ID:-com.google.chrome.ios}" --url "${SMOKE_URL:-https://text.npr.org/}" --skip-health
+}
+
+cmd_speak(){
+  require_udid
+  cd "$GHOST_REPO"; export_backend_env
+  GHOST_DEV_REF="$DEV_REF" GHOST_SPEAK_TEXT="${*:-Hello from Ghost on iOS}" "$PYBIN" -c \
+    "import os; from gitd.services.device_context import speak_text; print(speak_text(os.environ['GHOST_DEV_REF'], os.environ['GHOST_SPEAK_TEXT'], 1.0))"
+}
+
+cmd_dashboard(){
+  [ -d "$GHOST_REPO/frontend" ] || { say "no frontend/ in $GHOST_REPO"; exit 1; }
+  if ! vite_up; then
+    say "[dash] starting web dashboard ..."
+    ( cd "$GHOST_REPO/frontend"; [ -d node_modules ] || npm install; nohup npm run dev >"$LOG_DIR/vite.log" 2>&1 & )
+    for _ in $(seq 1 15); do vite_up && break; sleep 1; done
+  fi
+  open "http://localhost:${VITE_PORT}/" 2>/dev/null
+  say "dashboard: http://localhost:${VITE_PORT}/"
+}
+
+cmd_record(){
+  # Silent screen capture from WDA MJPEG :9100 -> MP4 (H.264 yuv420p, portrait).
+  # This is the pipeline BASELINE (record_demo.py phone_mp4). For demos that need
+  # the phone's AUDIO (e.g. an app talking), use record-quicktime.sh instead —
+  # WDA MJPEG carries no audio. Usage: ghost-ios record [seconds] [--out PATH]
+  require_udid
+  local secs="" out="/tmp/ios_demo_rec.mp4"
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --out) out="$2"; shift 2 ;;
+      *) secs="$1"; shift ;;
+    esac
+  done
+  local src="http://127.0.0.1:9100"
+  if ! curl -sf -o /dev/null -m3 "$src" 2>/dev/null; then
+    say "[record] MJPEG :9100 not up — warming a WDA session ..."
+    curl -s -m45 "http://127.0.0.1:${GHOST_PORT}/api/phone/screenshot?device=${DEV_REF}" >/dev/null 2>&1 &
+    for _ in $(seq 1 20); do curl -sf -o /dev/null -m2 "$src" 2>/dev/null && break; sleep 1; done
+  fi
+  curl -sf -o /dev/null -m3 "$src" 2>/dev/null || { say "[record] MJPEG :9100 unavailable — is the stack up (ghost-ios up)?"; exit 1; }
+  say "[record] $src -> $out ${secs:+(${secs}s)}  (silent; Ctrl-C to stop + finalize)"
+  # curl feeds ffmpeg's mpjpeg (multipart) demuxer; even-dimension scale for libx264.
+  local tflag=""; [ -n "$secs" ] && tflag="-t $secs"
+  # shellcheck disable=SC2086
+  curl -sN "$src" | ffmpeg -y -loglevel warning -f mpjpeg -i - -an \
+    -vf "scale=trunc(iw/2)*2:trunc(ih/2)*2" -c:v libx264 -pix_fmt yuv420p $tflag "$out"
+  say "[record] saved $out ($([ -s "$out" ] && stat -f%z "$out" || echo 0) bytes)"
+}
+
+cmd_reset(){
+  # Manual CoreDevice/usbmux reset for the "Device is busy (Connecting to)" wedge.
+  require_udid
+  reset_coredevice
+  say "Done. Unlock the iPhone and give it ~5s to re-handshake, then retry."
+}
+
+cmd_keychain(){
+  say "One-time: grant command-line codesign access to your Apple Development key."
+  read -rs -p "Mac login password> " PW; echo
+  security unlock-keychain -p "$PW" "$KEYCHAIN"
+  security set-key-partition-list -S apple-tool:,apple: -s -k "$PW" "$KEYCHAIN" >/dev/null
+  unset PW
+  say "Done."
+}
+
+cmd_rebuild_wda(){
+  require_udid
+  [ -n "$IOS_XCODE_ORG_ID" ] || { say "ERROR: no Apple team id. Set IOS_XCODE_ORG_ID (see ghost-ios.env.example)."; exit 1; }
+  [ -d "$WDA_SRC" ] || { say "WDA project not found at $WDA_SRC (appium driver install xcuitest)"; exit 1; }
+  cd "$WDA_SRC"
+  say "Rebuilding WebDriverAgent onto $IOS_DEVICE_UDID (keep the iPhone unlocked) ..."
+  xcodebuild build-for-testing test-without-building \
+    -project WebDriverAgent.xcodeproj -scheme WebDriverAgentRunner \
+    -destination "id=$IOS_DEVICE_UDID" -allowProvisioningUpdates \
+    DEVELOPMENT_TEAM="$IOS_XCODE_ORG_ID" PRODUCT_BUNDLE_IDENTIFIER="$IOS_UPDATED_WDA_BUNDLE_ID" \
+    GCC_TREAT_WARNINGS_AS_ERRORS=0 COMPILER_INDEX_STORE_ENABLE=NO \
+    | grep -iE "CompileC.*FBCustomCommands|CodeSign|Installing|TEST BUILD|BUILD SUCCEEDED|BUILD FAILED|error:" || true
+}
+
+cmd_doctor(){ "$GHOST_IOS_DIR/doctor.sh"; }
+
+cmd_help(){
+  cat <<EOF
+ghost-ios — one command to run the whole iOS device stack for Ghost in the Droid.
+
+Run from your own Terminal (a GUI login session) so codesign can reach your
+signing key. It prompts for sudo once (the RemoteXPC tunnel needs root) and keeps
+everything alive + self-healing until you Ctrl-C.
+
+  ghost-ios up          start the stack + self-healing tunnel supervisor (main one)
+  ghost-ios doctor      preflight: check every known failure point + the fix for each
+  ghost-ios status      show tunnel / appium / backend / dashboard health
+  ghost-ios report      JSON inventory of attached device(s)
+  ghost-ios dashboard   start the web dashboard (vite) and open it
+  ghost-ios smoke       run the sample Chrome->news smoke test
+  ghost-ios speak TEXT  speak TEXT aloud on the phone (native WDA TTS)
+  ghost-ios keychain    one-time: grant CLI codesign access to your signing key
+  ghost-ios rebuild-wda (re)build+install the patched WebDriverAgent onto the phone
+  ghost-ios reset       reset usbmuxd/remoted (fixes "Device is busy (Connecting to)")
+  ghost-ios record [s]  capture the screen to an MP4 (silent; WDA MJPEG). audio -> record-av.sh
+  ghost-ios config      show resolved configuration
+  ghost-ios down        stop tunnel + appium + backend
+
+Config is auto-detected or set via env / a config file — see ghost-ios.env.example.
+Device: \${IOS_DEVICE_UDID:-<auto-detected>}   Logs: $LOG_DIR/
+EOF
+}
+
+case "${1:-help}" in
+  up)              cmd_up ;;
+  status|st)       cmd_status ;;
+  config|cfg)      cmd_config ;;
+  report)          cmd_report ;;
+  dashboard|dash)  cmd_dashboard ;;
+  smoke)           cmd_smoke ;;
+  speak)           shift; cmd_speak "$@" ;;
+  doctor|dr)       cmd_doctor ;;
+  rebuild-wda|wda) cmd_rebuild_wda ;;
+  keychain)        cmd_keychain ;;
+  reset)           cmd_reset ;;
+  record)          shift; cmd_record "$@" ;;
+  down|stop)       teardown ;;
+  *)               cmd_help ;;
+esac

--- a/scripts/ios/ghost-ios.env.example
+++ b/scripts/ios/ghost-ios.env.example
@@ -1,0 +1,53 @@
+# ghost-ios configuration — copy to `ghost-ios.env` (same dir) or
+# `~/.config/ghost-ios.env`, or point $GHOST_IOS_ENV at it. Everything here is
+# OPTIONAL: with one iPhone attached and one "Apple Development" identity in your
+# keychain, ghost-ios auto-detects all of it. Set values to override detection or
+# to run zero-touch (no xctrace/security probing at startup).
+#
+# These are the same IOS_* variables the backend reads, so exporting them in your
+# shell works too. Run `ghost-ios config` to see what resolved and from where.
+
+# --- device ---------------------------------------------------------------
+# The 40-hex or 8-16-hex UDID of your iPhone. Auto-detected when exactly one
+# physical device is attached; REQUIRED if you have 0 or several.
+#   find it: xcrun xctrace list devices
+# IOS_DEVICE_UDID=00008XXX-XXXXXXXXXXXXXXXX
+
+# --- signing (only needed to BUILD/sign WDA) ------------------------------
+# Apple team id (the 10-char OU on your Apple Development cert). Auto-detected
+# best-effort; set it if `ghost-ios rebuild-wda` / fix-wda-signing.sh can't find it.
+# IOS_XCODE_ORG_ID=XXXXXXXXXX
+# SHA-1 of your "Apple Development" codesigning identity. Auto-detected from the
+# login keychain. Set it to pin a specific identity.
+#   list them: security find-identity -v -p codesigning
+# IOS_XCODE_SIGNING_ID=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+# The bundle id WDA is (re)signed under. Must be unique to your team; the default
+# is a placeholder — set your own (e.g. com.yourorg.WebDriverAgentRunner).
+# IOS_UPDATED_WDA_BUNDLE_ID=com.example.WebDriverAgentRunner
+# Where the prebuilt/signed WDA lives (fix-wda-signing.sh builds here; the backend
+# reuses it via IOS_USE_PREBUILT_WDA=true).
+# IOS_DERIVED_DATA_PATH=$HOME/Library/Developer/Xcode/DerivedData/wda-ghost
+
+# --- paths / repo ---------------------------------------------------------
+# Repo root. Defaults to two levels above scripts/ios/ (i.e. this checkout).
+# GHOST_REPO=/path/to/android-agent
+# Appium binary. Auto-detected from PATH / common npm-global locations.
+# APPIUM_BIN=/opt/homebrew/bin/appium
+# Log directory (default /tmp/ghost-ios).
+# GHOST_IOS_LOG_DIR=/tmp/ghost-ios
+
+# --- ports (override only on conflict) ------------------------------------
+# APPIUM_PORT=4723
+# GHOST_PORT=5055
+# TUNNEL_PORT=42314
+# VITE_PORT=6175
+# WDA_PORT=8100
+
+# --- misc -----------------------------------------------------------------
+# Browser bundle id + URL used by `ghost-ios smoke`.
+# IOS_BROWSER_BUNDLE_ID=com.google.chrome.ios
+# SMOKE_URL=https://text.npr.org/
+# MJPEG stream tuning (half-res / 25fps / q65 — smoother than full-res Retina).
+# IOS_MJPEG_SCALING_FACTOR=50
+# IOS_MJPEG_SERVER_FRAMERATE=25
+# IOS_MJPEG_SERVER_SCREENSHOT_QUALITY=65

--- a/scripts/ios/lib.sh
+++ b/scripts/ios/lib.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# lib.sh — shared config resolution + detection for the ghost-ios iOS tooling.
+#
+# Sourced by ghost-ios and fix-wda-signing.sh. Resolves every setting from, in
+# order of precedence:
+#   1. the environment (IOS_* vars — the same ones the backend reads)
+#   2. an optional config file: $GHOST_IOS_ENV, ./ghost-ios.env, or
+#      ~/.config/ghost-ios.env  (copy ghost-ios.env.example to start)
+#   3. auto-detection (single attached device, signing identity, appium path)
+#
+# There are NO hardcoded personal identifiers. Zero-config works when exactly one
+# iPhone is attached and one "Apple Development" identity is in your keychain;
+# otherwise set the few IOS_* vars in a config file once.
+
+# The caller exports GHOST_IOS_DIR (the directory these scripts live in).
+: "${GHOST_IOS_DIR:?lib.sh: set GHOST_IOS_DIR before sourcing}"
+
+# --- optional config file (first that exists wins) ---------------------------
+for _cfg in "${GHOST_IOS_ENV:-}" "$GHOST_IOS_DIR/ghost-ios.env" "$HOME/.config/ghost-ios.env"; do
+  [ -n "$_cfg" ] && [ -f "$_cfg" ] && { # shellcheck disable=SC1090
+    . "$_cfg"; break; }
+done
+
+# --- repo root (two levels above scripts/ios/, overridable) ------------------
+GHOST_REPO="${GHOST_REPO:-$(cd "$GHOST_IOS_DIR/../.." 2>/dev/null && pwd)}"
+
+# --- detection helpers (only run when the corresponding var is unset) ---------
+detect_udid(){
+  # Exactly-one attached physical iOS device via xctrace (~1.7s, reliable —
+  # `devicectl device info details` can hang). Prints nothing if 0 or >1 so the
+  # user is told to set IOS_DEVICE_UDID explicitly. Simulators (UUIDs with 4
+  # dashes) and the Mac host line are excluded.
+  local sect ids
+  # ONLY the online "== Devices ==" section — stop at the next "== ..." header so
+  # "== Devices Offline ==" (e.g. an unplugged iPad) and "== Simulators ==" are
+  # excluded. Drop the Mac host line (its id is a 4-dash UUID anyway).
+  sect="$(timeout 12 xcrun xctrace list devices 2>/dev/null | awk '/^== Devices ==$/{f=1;next} /^== /{f=0} f')"
+  ids="$(printf '%s\n' "$sect" | grep -iv 'Mac' \
+        | grep -oE '[0-9A-Fa-f]{8}-[0-9A-Fa-f]{16}|[0-9A-Fa-f]{40}' | sort -u)"
+  [ "$(printf '%s' "$ids" | grep -c .)" = "1" ] && printf '%s' "$ids"
+}
+
+detect_signing_id(){
+  # SHA-1 of the "Apple Development" codesigning identity in the login keychain.
+  security find-identity -v -p codesigning 2>/dev/null \
+    | grep -i 'Apple Development' | head -1 | grep -oE '[0-9A-F]{40}' | head -1
+}
+
+detect_team(){
+  # Apple team id = OU of the Apple Development cert. Best-effort.
+  security find-certificate -a -c 'Apple Development' -p 2>/dev/null \
+    | openssl x509 -noout -subject -nameopt multiline 2>/dev/null \
+    | awk -F'= ' '/organizationalUnitName/{print $2; exit}'
+}
+
+detect_appium(){
+  command -v appium 2>/dev/null && return 0
+  local p
+  for p in "$HOME/.npm-global/bin/appium" /opt/homebrew/bin/appium /usr/local/bin/appium; do
+    [ -x "$p" ] && { printf '%s\n' "$p"; return 0; }
+  done
+}
+
+# --- resolved config (env/file win; detection fills the gaps) ----------------
+IOS_DEVICE_UDID="${IOS_DEVICE_UDID:-$(detect_udid)}"
+IOS_XCODE_SIGNING_ID="${IOS_XCODE_SIGNING_ID:-$(detect_signing_id)}"
+IOS_XCODE_ORG_ID="${IOS_XCODE_ORG_ID:-$(detect_team)}"
+IOS_UPDATED_WDA_BUNDLE_ID="${IOS_UPDATED_WDA_BUNDLE_ID:-com.example.WebDriverAgentRunner}"
+IOS_DERIVED_DATA_PATH="${IOS_DERIVED_DATA_PATH:-$HOME/Library/Developer/Xcode/DerivedData/wda-ghost}"
+APPIUM_BIN="${APPIUM_BIN:-$(detect_appium)}"
+KEYCHAIN="${KEYCHAIN:-$HOME/Library/Keychains/login.keychain-db}"
+
+# ports (overridable)
+APPIUM_PORT="${APPIUM_PORT:-4723}"
+GHOST_PORT="${GHOST_PORT:-5055}"
+TUNNEL_PORT="${TUNNEL_PORT:-42314}"
+VITE_PORT="${VITE_PORT:-6175}"
+WDA_PORT="${WDA_PORT:-8100}"
+
+# derived
+DEV_REF="ios:${IOS_DEVICE_UDID}"
+REG="http://127.0.0.1:${TUNNEL_PORT}/remotexpc/tunnels/${IOS_DEVICE_UDID}"
+LOG_DIR="${GHOST_IOS_LOG_DIR:-/tmp/ghost-ios}"; mkdir -p "$LOG_DIR"
+WDA_SRC="$HOME/.appium/node_modules/appium-xcuitest-driver/node_modules/appium-webdriveragent"
+if [ -x "$GHOST_REPO/.venv/bin/python" ]; then PYBIN="$GHOST_REPO/.venv/bin/python"; else PYBIN="python3"; fi
+
+# --- small shared utilities --------------------------------------------------
+say(){ printf '%s\n' "$*"; }
+ts(){ date '+%H:%M:%S'; }
+
+# --- health probes (shared by ghost-ios + doctor.sh) -------------------------
+appium_up(){ curl -sf -m3 "http://127.0.0.1:${APPIUM_PORT}/status" >/dev/null 2>&1; }
+ghost_up(){  curl -sf -m8 "http://127.0.0.1:${GHOST_PORT}/api/health" >/dev/null 2>&1; }
+vite_up(){   curl -sf -m3 "http://localhost:${VITE_PORT}/" >/dev/null 2>&1; }  # vite binds IPv6 ::1
+tunnel_up(){ curl -s -m5 "$REG" 2>/dev/null | grep -q '"status":"OK"'; }
+wda_up(){    curl -sf -m3 "http://127.0.0.1:${WDA_PORT}/status" >/dev/null 2>&1; }
+
+require_udid(){
+  [ -n "$IOS_DEVICE_UDID" ] && return 0
+  say "ERROR: no iOS device UDID. Attach exactly one iPhone (USB, unlocked) so it"
+  say "       can be auto-detected, or set IOS_DEVICE_UDID (see ghost-ios.env.example)."
+  say "       Attached devices:"; xcrun xctrace list devices 2>/dev/null | sed -n '/== Devices ==/,/== Simulators ==/p' | sed 's/^/         /'
+  exit 1
+}
+
+reset_coredevice(){
+  # Clear a stale CoreDevice/usbmux connection — the cause of xcodebuild's
+  # "Device is busy (Connecting to ...)" / "Timed out waiting for all
+  # destinations". Bounces the whole device-connection stack (usbmux + remoted
+  # + CoreDeviceService); all auto-restart via launchd. Briefly drops USB
+  # devices. Needs sudo (caller should `sudo -v` first for a seamless prompt).
+  say "[reset ] bouncing usbmuxd + remoted + CoreDeviceService (they auto-restart) ..."
+  sudo killall -9 usbmuxd remoted 2>/dev/null || true
+  sudo pkill -9 -f CoreDeviceService 2>/dev/null || true
+}
+
+export_backend_env(){
+  # Hand the backend the same iOS knobs the tuned setup uses. Only non-empty
+  # identity vars are exported so an unset value falls through to app defaults.
+  local v
+  for v in IOS_DEVICE_UDID IOS_XCODE_ORG_ID IOS_UPDATED_WDA_BUNDLE_ID IOS_XCODE_SIGNING_ID IOS_DERIVED_DATA_PATH; do
+    [ -n "${!v:-}" ] && export "${v?}"
+  done
+  export IOS_USE_PREBUILT_WDA="${IOS_USE_PREBUILT_WDA:-true}"
+  # MJPEG stream tuning: half-res + 25fps + q65 → far smoother than full-res Retina.
+  export IOS_MJPEG_SCALING_FACTOR="${IOS_MJPEG_SCALING_FACTOR:-50}"
+  export IOS_MJPEG_SERVER_FRAMERATE="${IOS_MJPEG_SERVER_FRAMERATE:-25}"
+  export IOS_MJPEG_SERVER_SCREENSHOT_QUALITY="${IOS_MJPEG_SERVER_SCREENSHOT_QUALITY:-65}"
+}

--- a/scripts/ios/record-av.sh
+++ b/scripts/ios/record-av.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# record-av.sh — turn a QuickTime iPhone screen recording (screen + the phone's
+# real SYSTEM AUDIO) into the pipeline-ready demo MP4.
+#
+# Why QuickTime and not WDA MJPEG: the demo needs the phone's actual audio (an app
+# talking, TTS, notifications). WDA MJPEG (:9100) is video-only, and the iPhone
+# only exposes to the Mac as a screen-capture device via CoreMediaIO — which is
+# exactly what QuickTime records. Since a demo is a RECORDING (not a live stream),
+# latency is irrelevant, so we use this crisp full-res + audio path.
+#
+# CAPTURE (manual, ~1 min, in your GUI session):
+#   1. QuickTime Player  >  File  >  New Movie Recording
+#   2. Click the  ⌄  next to the red record button  ->  select your iPhone for
+#      BOTH "Camera" and "Microphone" (the iPhone screen + audio then appear)
+#   3. Hit record, run the demo (the agent drives the phone), hit stop
+#   4. File > Save  (e.g. ~/Desktop/duolingo.mov)
+#
+# THEN transcode to the pipeline mp4:
+#   scripts/ios/record-av.sh ~/Desktop/duolingo.mov
+#   scripts/ios/record-av.sh                 # auto-picks the newest .mov in ~/Desktop, ~/Movies
+#
+# Output: /tmp/ios_demo_rec.mp4 (or --out PATH) — H.264 High, yuv420p, 30fps,
+# AAC audio, portrait, even dimensions. Full-res/crisp by default (composite
+# downscales with Lanczos); pass --half for a ~half-res, smaller file.
+set -uo pipefail
+
+IN=""; OUT="/tmp/ios_demo_rec.mp4"; HALF=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --out) OUT="$2"; shift 2 ;;
+    --half) HALF=1; shift ;;
+    -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+    *) IN="$1"; shift ;;
+  esac
+done
+
+if [ -z "$IN" ]; then
+  IN="$(ls -t "$HOME"/Desktop/*.mov "$HOME"/Movies/*.mov 2>/dev/null | head -1)"
+  [ -n "$IN" ] && echo "[record-av] auto-selected newest recording: $IN"
+fi
+[ -f "$IN" ] || { echo "ERROR: no input .mov. Record one in QuickTime (see --help) or pass a path."; exit 1; }
+
+# fps=30 to match the pipeline. Default keeps NATIVE resolution (1179x2556 for
+# iPhone 15 Pro — matches the video-editor bezel calibration, no frames.json
+# retune): PAD to even rather than scale, so native pixels stay crisp (yuv420p
+# needs even dims; the ≤1px pad lands under the bezel frame). --half resamples
+# to ~half for a smaller file.
+if [ -n "$HALF" ]; then
+  VF="scale=trunc(iw/4)*2:trunc(ih/4)*2,fps=30"
+else
+  VF="pad=ceil(iw/2)*2:ceil(ih/2)*2,fps=30"
+fi
+
+echo "[record-av] transcoding $IN -> $OUT  (crisp H.264 High + AAC audio, 30fps${HALF:+, half-res})"
+ffmpeg -y -loglevel warning -i "$IN" \
+  -vf "$VF" \
+  -c:v libx264 -profile:v high -pix_fmt yuv420p -crf 18 -preset slow \
+  -c:a aac -b:a 192k -movflags +faststart \
+  "$OUT"
+
+if [ -s "$OUT" ]; then
+  echo "[record-av] saved $OUT ($(stat -f%z "$OUT") bytes)"
+  echo "[record-av] streams:"; ffprobe -v error -show_entries stream=codec_type,codec_name,width,height -of default=nw=1 "$OUT" 2>/dev/null | sed 's/^/   /'
+  ffprobe -v error -select_streams a -show_entries stream=codec_name "$OUT" 2>/dev/null | grep -q . \
+    && echo "[record-av] ✅ audio track present" \
+    || echo "[record-av] ⚠️  NO audio track — did you pick the iPhone as the Microphone in QuickTime?"
+else
+  echo "[record-av] ❌ transcode produced no file"; exit 1
+fi

--- a/scripts/ios_chrome_news_smoke.py
+++ b/scripts/ios_chrome_news_smoke.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Run an iOS Chrome news-reading smoke workflow through Appium/WDA.
+
+The workflow intentionally uses Ghost's iOS device backend primitives rather
+than private Appium client helpers so it validates the same path used by MCP,
+REST, skills, and agent tools.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from gitd.bots.common.device import get_device
+from gitd.bots.common.ios import (
+    IOS_PREFIX,
+    IOSDevice,
+    configured_ios_udids,
+    discover_host_ios_devices,
+    ios_config_for_udid,
+    known_ios_udids,
+    strip_ios_prefix,
+)
+from gitd.services.browser import read_news
+from gitd.services.device_context import fix_device_health, ios_device_health
+
+
+def _device_ref(value: str) -> str:
+    return value if value.startswith(IOS_PREFIX) else f"{IOS_PREFIX}{value}"
+
+
+def _default_device(value: str, *, include_simulators: bool = True) -> str:
+    if value:
+        return value
+    known = known_ios_udids(include_simulators=include_simulators)
+    return known[0] if known else ""
+
+
+def _discovery_plan(selected_device: str = "", *, include_simulators: bool = True) -> dict:
+    selected_udid = strip_ios_prefix(selected_device) if selected_device else ""
+    configured = configured_ios_udids()
+    host_devices = discover_host_ios_devices(include_simulators=include_simulators)
+    host_by_udid = {item["udid"]: item for item in host_devices}
+    udids: list[str] = []
+    for value in [selected_udid, *configured, *(item["udid"] for item in host_devices)]:
+        udid = strip_ios_prefix(str(value or ""))
+        if udid and udid not in udids:
+            udids.append(udid)
+
+    devices = []
+    for udid in udids:
+        cfg = ios_config_for_udid(udid)
+        host = host_by_udid.get(udid, {})
+        source = host.get("source") or ("configured" if udid in configured else "explicit")
+        devices.append(
+            {
+                "device": _device_ref(udid),
+                "udid": udid,
+                "selected": udid == selected_udid if selected_udid else udid == (udids[0] if udids else ""),
+                "source": source,
+                "host_state": host.get("state", ""),
+                "device_name": host.get("name") or cfg.device_name,
+                "platform_version": cfg.platform_version or host.get("platform_version", ""),
+                "appium_url": cfg.appium_url,
+                "bundle_id": cfg.bundle_id,
+                "browser_name": cfg.browser_name,
+                "wda_url": cfg.wda_url,
+                "mjpeg_server_port": cfg.mjpeg_server_port,
+                "mjpeg_screenshot_url": cfg.mjpeg_screenshot_url,
+                "mjpeg_settings": cfg.mjpeg_settings(),
+                "capabilities": cfg.capabilities(),
+            }
+        )
+    selected = next((item for item in devices if item["selected"]), None)
+    return {
+        "ok": bool(devices),
+        "selected_device": selected["device"] if selected else "",
+        "devices": devices,
+        "include_simulators": include_simulators,
+    }
+
+
+def _preflight_health(device: str, bundle_id: str) -> dict:
+    ios_dev = IOSDevice(device, bundle_id=bundle_id or None)
+    return ios_device_health(device, ios_dev)
+
+
+def _health_failure_error(health: dict | None) -> str:
+    if not health:
+        return "iOS Appium/WDA health preflight failed"
+    state = str(
+        (health.get("connection") or {}).get("status")
+        or (health.get("appium") or {}).get("state")
+        or "unavailable"
+    )
+    message = str((health.get("appium") or {}).get("message") or health.get("error") or "").strip()
+    recovery = health.get("recovery") or {}
+    summary = str(recovery.get("summary") or "").strip()
+    recommended_fix = str(health.get("recommended_fix") or recovery.get("code") or "").strip()
+    parts = [f"iOS Appium/WDA health preflight failed: {state}"]
+    if message:
+        parts.append(message)
+    elif summary:
+        parts.append(summary)
+    if recommended_fix:
+        parts.append(f"recommended fix: {recommended_fix}")
+    return " - ".join(parts)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Open Chrome on iOS, read NPR text headlines, and sample articles")
+    parser.add_argument("--device", default=os.getenv("IOS_DEVICE_UDID", ""), help="iOS UDID or ios:<udid>")
+    parser.add_argument(
+        "--bundle-id",
+        default=os.getenv("IOS_BUNDLE_ID", "com.google.chrome.ios"),
+        help="iOS browser bundle id, default com.google.chrome.ios",
+    )
+    parser.add_argument("--url", default="https://text.npr.org/")
+    parser.add_argument("--max-headlines", type=int, default=5)
+    parser.add_argument("--max-articles", type=int, default=3)
+    parser.add_argument("--wait", type=float, default=2.0)
+    parser.add_argument("--out-dir", default="data/ios_chrome_news_smoke")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print resolved device/config plan without creating an Appium/WDA session",
+    )
+    parser.add_argument(
+        "--list-devices",
+        action="store_true",
+        help="Print configured and host-discovered iOS devices without running the smoke workflow",
+    )
+    parser.add_argument(
+        "--no-simulators",
+        action="store_true",
+        help="Exclude booted simulators from dry-run/list discovery",
+    )
+    parser.add_argument("--skip-health", action="store_true", help="Skip the Appium/WDA health preflight")
+    parser.add_argument(
+        "--fix-health",
+        action="store_true",
+        help="Apply device_health.recommended_fix once, then re-run the health preflight before reading news",
+    )
+    parser.add_argument("--close", action="store_true", help="Delete the Appium session before exiting")
+    args = parser.parse_args()
+
+    if args.dry_run or args.list_devices:
+        args.device = _default_device(args.device, include_simulators=not args.no_simulators)
+        plan = _discovery_plan(args.device, include_simulators=not args.no_simulators)
+        plan.update(
+            {
+                "workflow": "read_news",
+                "url": args.url,
+                "requested_bundle_id": args.bundle_id,
+                "max_headlines": args.max_headlines,
+                "max_articles": args.max_articles,
+                "wait_s": args.wait,
+                "out_dir": args.out_dir,
+            }
+        )
+        print(json.dumps(plan, indent=2))
+        return 0 if plan.get("ok") else 2
+
+    args.device = _default_device(args.device)
+    if not args.device:
+        print("IOS_DEVICE_UDID or --device is required", file=sys.stderr)
+        return 2
+
+    out_dir = Path(args.out_dir)
+    device = _device_ref(args.device)
+
+    try:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        result_path = out_dir / "result.json"
+        health_path = out_dir / "health.json"
+        preflight_health = None
+        health_fix = None
+        if not args.skip_health:
+            preflight_health = _preflight_health(device, args.bundle_id)
+            health_path.write_text(json.dumps(preflight_health, indent=2), encoding="utf-8")
+            state = str(preflight_health.get("connection", {}).get("status") or "")
+            if state != "available" and args.fix_health:
+                fix_issue = str(preflight_health.get("recommended_fix") or "")
+                if fix_issue:
+                    health_fix = fix_device_health(device, fix_issue)
+                    (out_dir / "health_fix.json").write_text(json.dumps(health_fix, indent=2), encoding="utf-8")
+                    preflight_health = _preflight_health(device, args.bundle_id)
+                    health_path.write_text(json.dumps(preflight_health, indent=2), encoding="utf-8")
+                    state = str(preflight_health.get("connection", {}).get("status") or "")
+            if state != "available":
+                result = {
+                    "ok": False,
+                    "platform": "ios",
+                    "device": device,
+                    "stage": "health",
+                    "error": _health_failure_error(preflight_health),
+                    "health": preflight_health,
+                    "health_fix": health_fix,
+                    "health_json": str(health_path),
+                    "health_fix_json": str(out_dir / "health_fix.json") if health_fix is not None else "",
+                    "result_json": str(result_path),
+                }
+                result_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+                print(json.dumps(result, indent=2))
+                return 1
+        result = read_news(
+            device,
+            args.url,
+            max_headlines=args.max_headlines,
+            max_articles=args.max_articles,
+            bundle_id=args.bundle_id,
+            wait_s=args.wait,
+            save_screenshots=True,
+            out_dir=str(out_dir),
+        )
+        if preflight_health is not None:
+            result["health"] = preflight_health
+            result["health_json"] = str(health_path)
+        if health_fix is not None:
+            result["health_fix"] = health_fix
+            result["health_fix_json"] = str(out_dir / "health_fix.json")
+        result["result_json"] = str(result_path)
+        result_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+        print(json.dumps(result, indent=2))
+        return 0 if result.get("ok") and result.get("headlines") else 1
+    finally:
+        if args.close:
+            get_device(device).close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ios_safari_smoke.py
+++ b/scripts/ios_safari_smoke.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Smoke test an iOS browser/app through Appium/WebDriverAgent.
+
+Usage:
+  IOS_DEVICE_UDID=<udid> IOS_APPIUM_URL=http://127.0.0.1:4723 \
+    IOS_BUNDLE_ID=com.google.chrome.ios python scripts/ios_safari_smoke.py
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from gitd.bots.common.ios import IOS_PREFIX, IOSDevice, known_ios_udids
+from gitd.services.device_context import get_screen_tree
+
+
+def _device_ref(value: str) -> str:
+    return value if value.startswith(IOS_PREFIX) else f"{IOS_PREFIX}{value}"
+
+
+def _default_device(value: str) -> str:
+    if value:
+        return value
+    known = known_ios_udids()
+    return known[0] if known else ""
+
+
+def verify_smoke(state: dict, tree: str, bundle_id: str) -> list[str]:
+    """Return a list of failure descriptions (empty = smoke passed)."""
+    failures: list[str] = []
+    fg = str(state.get("packageName") or state.get("bundle_id") or "")
+    if bundle_id and fg and fg != bundle_id:
+        failures.append(f"foreground app is {fg!r}, expected {bundle_id!r}")
+    if not fg:
+        failures.append("no foreground app reported in phone state")
+    content_lines = [ln for ln in (tree or "").splitlines() if ln.strip()]
+    if len(content_lines) < 3:
+        failures.append(f"screen tree looks empty ({len(content_lines)} lines) — page did not render")
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Launch an iOS browser/app using the iOS backend")
+    parser.add_argument("--device", default=os.getenv("IOS_DEVICE_UDID", ""), help="iOS UDID or ios:<udid>")
+    parser.add_argument(
+        "--bundle-id",
+        default=os.getenv("IOS_BUNDLE_ID", "com.google.chrome.ios"),
+        help="iOS bundle id to launch, for example com.google.chrome.ios",
+    )
+    parser.add_argument(
+        "--browser-name",
+        default=os.getenv("IOS_BROWSER_NAME", ""),
+        help="Optional Appium browserName. Leave empty for native bundle-id automation.",
+    )
+    parser.add_argument("--url", default="https://ghostinthedroid.com")
+    parser.add_argument("--no-open-url", action="store_true", help="Only launch the app; do not call WebDriver /url")
+    parser.add_argument("--screenshot-out", default="", help="Optional path to write the final PNG screenshot")
+    parser.add_argument("--close", action="store_true", help="Delete the Appium session before exiting")
+    args = parser.parse_args()
+
+    args.device = _default_device(args.device)
+    if not args.device:
+        print("IOS_DEVICE_UDID or --device is required", file=sys.stderr)
+        return 2
+
+    device = _device_ref(args.device)
+    dev = IOSDevice(device, bundle_id=args.bundle_id, browser_name=args.browser_name)
+    try:
+        dev.launch_app(args.bundle_id)
+        if not args.no_open_url:
+            dev.open_url(args.url)
+            time.sleep(2)
+
+        state = dev.get_phone_state()
+        print(json.dumps(state, indent=2))
+        tree = get_screen_tree(device, max_nodes=40)
+        print("\n[Screen tree]")
+        print(tree)
+
+        # Real pass/fail checks — this script used to exit 0 no matter what,
+        # which made it pass-when-broken. A smoke test must be able to fail.
+        failures = verify_smoke(state, tree, args.bundle_id)
+        if failures:
+            for f in failures:
+                print(f"SMOKE FAIL: {f}", file=sys.stderr)
+            return 1
+
+        if args.screenshot_out:
+            out = Path(args.screenshot_out)
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_bytes(dev.take_screenshot())
+            print(f"\nScreenshot: {out}")
+    finally:
+        if args.close:
+            dev.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/privacy/FORBIDDEN.txt
+++ b/scripts/privacy/FORBIDDEN.txt
@@ -1,0 +1,49 @@
+# Ghost in the Droid — forbidden-pattern list for recording/artifact audits.
+#
+# Every demo recording and every committed showcase artifact is scanned
+# against this list (see scripts/privacy/scrub.py and .github/workflows/privacy.yml).
+# A single hit blocks the output / fails the PR.
+#
+# Format:
+#   - one pattern per line
+#   - lines starting with '#' and blank lines are ignored
+#   - plain lines are case-insensitive substring matches
+#   - lines starting with 're:' are Python regexes (case-insensitive)
+#
+# This file is committed and intentionally GENERIC — it must never itself
+# contain personal identifiers, real hostnames, or real device serials.
+# Put those in scripts/privacy/FORBIDDEN.local.txt (gitignored); scrub.py
+# loads both automatically. See scripts/privacy/RECORDING_CHECKLIST.md.
+
+# ── Real user home directories (a leaked path = a leaked username) ──
+# Lookbehind keeps prose like "wake/home/launch" from matching; ghost/demo/
+# agent/user/runner are non-identifying demo & CI usernames.
+re:(?<![\w/])/Users/(?!ghost\b|demo\b|agent\b|user\b|runner\b)[a-z0-9_.-]+
+re:(?<![\w/])/home/(?!ghost\b|demo\b|agent\b|user\b|runner\b)[a-z0-9_.-]+
+re:(?<![\w/])/Volumes/[A-Za-z0-9_.-]+
+
+# ── Personal-machine hostnames ──
+re:[A-Za-z]+s-MacBook[A-Za-z-]*
+re:[A-Za-z]+s-iPhone[A-Za-z-]*
+re:[a-z0-9-]+\.coredevice\.local
+
+# ── API keys / tokens / secrets ──
+re:sk-[A-Za-z0-9_-]{16,}
+re:sk-ant-[A-Za-z0-9_-]+
+re:AIza[0-9A-Za-z_-]{16,}
+re:ghp_[A-Za-z0-9]{16,}
+re:github_pat_[A-Za-z0-9_]{16,}
+re:gsk_[A-Za-z0-9]{16,}
+re:xox[bap]-[A-Za-z0-9-]+
+re:AKIA[0-9A-Z]{16}
+re:-----BEGIN [A-Z ]*PRIVATE KEY-----
+
+# ── Credentials in output ──
+re:password\s*[:=]\s*(?!<REDACTED)\S+
+re:Pwnd\w*
+
+# ── Private repos of this org (only android-agent is public) ──
+# Note: the bare module name ghost_premium is NOT forbidden — the public/
+# premium split is documented architecture; only repo URLs are a leak.
+re:github\.com/ghost-in-the-droid/(?!android-agent\b)[A-Za-z0-9_.-]+
+ghost-mirror

--- a/scripts/privacy/RECORDING_CHECKLIST.md
+++ b/scripts/privacy/RECORDING_CHECKLIST.md
@@ -1,0 +1,75 @@
+# Pre-Recording Privacy Checklist
+
+Every showcase recording session MUST walk this list top to bottom.
+The pipeline (`scripts/record_demo.py`) automates what it can and hard-blocks
+on its OCR gates, but several items are physical/manual — the gate can only
+catch what ends up as readable text on screen.
+
+## 1. The device
+
+- [ ] Fresh factory reset **or** a dedicated demo profile — never a personal
+      daily-driver session
+- [ ] No personal accounts logged in anywhere (Google account name shows up in
+      Settings, Play Store, share sheets). Sign into demo accounts only, e.g.
+      `ghost-demo@…`
+- [ ] No personal photos, messages, contacts, or calendar entries on the device
+- [ ] Clear app data for every app the demo touches (`pm clear <pkg>` or the
+      `clear_app` setup step in spec.yaml)
+- [ ] Wallpaper set to the Ghost brand wallpaper (manual until a
+      `_brand/wallpaper.png` + automated swap lands)
+- [ ] Airplane mode + a generic hotspot ("Ghost Demo") if the demo needs
+      network — never a personally-named home/office SSID
+
+## 2. What the pipeline enforces automatically
+
+Run through `record_demo.py` — never record by hand. It will:
+
+- enable Do-Not-Disturb and clear all notifications
+- hide the status bar (immersive mode, best-effort per Android version)
+- clear recents
+- take a pre-record screenshot, OCR it, and **refuse to start** if anything on
+  screen matches the forbidden lists
+- run every terminal command with a scrubbed environment (no `*_API_KEY`,
+  `*_TOKEN`, `*_SECRET`, … variables survive into the recording)
+- rewrite the terminal cast (paths → `~`, serials → `<ANDROID_DEVICE>`,
+  hostnames → `ghost-dev-*`, key-shaped strings → `<REDACTED_KEY>`)
+- OCR 30 frames of the final render and **refuse to output** on any hit
+
+## 3. The forbidden lists
+
+- `scripts/privacy/FORBIDDEN.txt` — committed, **generic patterns only**
+  (home-dir shapes, key prefixes, private-repo URLs). Never put a real name,
+  hostname, or serial in this file: the repo is public, so the list itself
+  would be the leak.
+- `scripts/privacy/FORBIDDEN.local.txt` — gitignored, same format. This is
+  where the recording operator's real identifiers go (username, hostnames,
+  device serials, project names that must never appear). **Create it before
+  your first session** — `record_demo.py` warns loudly when it's missing.
+- Append patterns freely; plain lines are case-insensitive substrings,
+  `re:`-prefixed lines are regexes.
+
+## 4. After recording
+
+- [ ] Watch the output once, full-screen, before committing — OCR misses
+      low-contrast/small text, **and the OCR gate samples at most 30 frames
+      at 2-second intervals: anything that flashes on the phone for under
+      ~2s (a notification sliding in, a toast, an autofill hint) can slip
+      between sampled frames.** The cast scan is the strong text gate for the
+      terminal side, and DND/notification prep + the brand wallpaper swap
+      mitigate the flash risk on the phone — but the human watch-through is
+      the only gate for sub-2s phone content. **Do not attempt demos whose
+      script requires sensitive content to flash briefly on screen**
+- [ ] Devices with a PIN/pattern must be unlocked by hand before recording —
+      the pipeline's auto-unlock only clears swipe-only lock screens (the
+      pre-record OCR screenshot captures whatever is actually displayed)
+- [ ] `python3 scripts/privacy/scrub.py --check <files>` over any hand-edited
+      artifacts (snippets, docs, screenshots)
+- [ ] CI (`.github/workflows/privacy.yml`) greps every PR as defense-in-depth;
+      do not rely on it as the primary gate
+
+## 5. iOS (manual for now)
+
+QuickTime "New Movie Recording" pointed at the iPhone. Before hitting record:
+same device hygiene as §1, plus hide the menu bar clock on the Mac if any of
+the Mac screen is captured. The terminal side still goes through
+`record_demo.py`'s scrubbers.

--- a/scripts/privacy/ocr_check.py
+++ b/scripts/privacy/ocr_check.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""ocr_check.py — OCR-scan images and videos against the forbidden lists.
+
+The grep guard (privacy.yml) covers text files; this covers the binary
+showcase artifacts (demo.webm, poster.png, brand cards) that text grep
+cannot see. Same fail-closed contract as record_demo.py's gate: a file
+that yields zero scannable frames is an ERROR, never a pass.
+
+Usage:
+    python3 scripts/privacy/ocr_check.py FILE [FILE...]
+    python3 scripts/privacy/ocr_check.py --all-showcase   # every webm/png under site/public/showcase
+
+Exit codes: 0 clean, 1 forbidden hit or unscannable input, 2 tooling missing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from privacy.scrub import load_forbidden, scan_text  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SHOWCASE = REPO_ROOT / "site" / "public" / "showcase"
+IMAGE_EXT = {".png", ".jpg", ".jpeg", ".webp"}
+VIDEO_EXT = {".webm", ".mp4", ".gif", ".mov"}
+
+
+def ocr(png: Path) -> str:
+    r = subprocess.run(["tesseract", str(png), "stdout"],
+                       capture_output=True, text=True)
+    if r.returncode != 0:
+        print(f"ERROR: tesseract failed on {png}: {r.stderr.strip()[:200]}")
+        sys.exit(1)
+    return r.stdout or ""
+
+
+def frames_of(path: Path, tmp: Path) -> list[Path]:
+    """The file itself for images; up to 30 frames at 2s intervals (plus the
+    first frame, so sub-2s clips still yield something) for videos."""
+    if path.suffix.lower() in IMAGE_EXT:
+        return [path]
+    out = tmp / path.stem
+    out.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["ffmpeg", "-y", "-v", "error", "-i", str(path),
+         "-vf", "select='eq(n\\,0)+not(mod(t\\,2))'", "-vsync", "vfr",
+         "-frames:v", "30", str(out / "f%03d.png")],
+        capture_output=True, text=True)
+    return sorted(out.glob("f*.png"))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("files", nargs="*", type=Path)
+    ap.add_argument("--all-showcase", action="store_true",
+                    help="scan every image/video under site/public/showcase")
+    args = ap.parse_args()
+
+    for tool in ("tesseract", "ffmpeg"):
+        if not shutil.which(tool):
+            print(f"ERROR: {tool} not on PATH")
+            return 2
+
+    files = list(args.files)
+    if args.all_showcase:
+        files += [p for p in SHOWCASE.rglob("*")
+                  if p.suffix.lower() in IMAGE_EXT | VIDEO_EXT]
+    files = [f for f in files if f.suffix.lower() in IMAGE_EXT | VIDEO_EXT]
+    if not files:
+        print("nothing to scan (no image/video inputs)")
+        return 0
+
+    patterns = load_forbidden()
+    bad = 0
+    with tempfile.TemporaryDirectory(prefix="ocr_check_") as td:
+        for f in files:
+            frames = frames_of(f, Path(td))
+            if not frames:
+                print(f"ERROR: {f}: no scannable frames — refusing to pass unscanned media")
+                bad += 1
+                continue
+            hits = []
+            for fr in frames:
+                for src, m in scan_text(ocr(fr), patterns):
+                    shown = m if len(m) <= 6 else m[:3] + "…"
+                    hits.append(f"pattern {src!r} matched ({shown}) in frame {fr.name}")
+            if hits:
+                for h in hits:
+                    print(f"FORBIDDEN {f}: {h}")
+                bad += len(hits)
+            else:
+                print(f"clean: {f} ({len(frames)} frame(s))")
+    if bad:
+        print(f"\n{bad} problem(s) — see scripts/privacy/RECORDING_CHECKLIST.md")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/privacy/scrub.py
+++ b/scripts/privacy/scrub.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Privacy scrubber for the Ghost showcase recording pipeline.
+
+Two jobs:
+
+1. SUBSTITUTE — rewrite text (asciinema .cast files, generated snippets) so
+   real paths, hostnames, device serials, and secrets become neutral
+   placeholders before anything is rendered.
+
+2. SCAN — check text (OCR output of rendered video frames, committed files)
+   against the forbidden-pattern lists and report every hit. A hit means the
+   artifact must not ship.
+
+Pattern lists:
+    scripts/privacy/FORBIDDEN.txt        committed, generic patterns only
+    scripts/privacy/FORBIDDEN.local.txt  gitignored, personal identifiers
+
+CLI:
+    python3 scripts/privacy/scrub.py --check FILE [FILE...]   scan files, exit 1 on any hit
+    python3 scripts/privacy/scrub.py --scrub IN OUT           substitution pass IN -> OUT
+    python3 scripts/privacy/scrub.py --scrub-cast IN OUT      scrub an asciinema v2 .cast
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+PRIVACY_DIR = Path(__file__).resolve().parent
+
+# ── Substitutions ─────────────────────────────────────────────────────────────
+# Order matters: earlier rules win (e.g. specific hostnames before generic paths).
+
+SUBSTITUTIONS: list[tuple[re.Pattern, str]] = [
+    # Personal-machine hostnames → neutral demo hosts
+    (re.compile(r"[A-Za-z]+s-MacBook[A-Za-z-]*(\.local)?"), "ghost-dev-mac"),
+    (re.compile(r"[a-z0-9-]+\.coredevice\.local"), "<device-hostname>"),
+    (re.compile(r"\bckl-linux\b"), "ghost-dev-linux"),
+    (re.compile(r"\bckl-mac\b"), "ghost-dev-mac"),
+    # Home directories → ~
+    (re.compile(r"/Users/[A-Za-z0-9_.-]+"), "~"),
+    (re.compile(r"/home/[A-Za-z0-9_.-]+"), "~"),
+    (re.compile(r"/Volumes/[A-Za-z0-9_.-]+"), "/Volumes/<VOLUME>"),
+    # iOS UDIDs (8-4-4-4-12 hex)
+    (
+        re.compile(r"\b[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}\b"),
+        "<IPHONE_UDID>",
+    ),
+    # iOS UDIDs (modern A12+ format: 8 hex - 16 hex, e.g. 00008030-0011223344556677),
+    # optionally with an ios: prefix from ghost device specs
+    (
+        re.compile(r"\b(?:ios:)?[0-9A-Fa-f]{8}-[0-9A-Fa-f]{16}\b"),
+        "<IPHONE_UDID>",
+    ),
+    # API keys / tokens
+    (re.compile(r"sk-ant-[A-Za-z0-9_-]+"), "<REDACTED_KEY>"),
+    (re.compile(r"sk-[A-Za-z0-9_-]{16,}"), "<REDACTED_KEY>"),
+    (re.compile(r"AIza[0-9A-Za-z_-]{16,}"), "<REDACTED_KEY>"),
+    (re.compile(r"ghp_[A-Za-z0-9]{16,}"), "<REDACTED_KEY>"),
+    (re.compile(r"github_pat_[A-Za-z0-9_]{16,}"), "<REDACTED_KEY>"),
+    (re.compile(r"gsk_[A-Za-z0-9]{16,}"), "<REDACTED_KEY>"),
+    (re.compile(r"xox[bap]-[A-Za-z0-9-]+"), "<REDACTED_KEY>"),
+    (re.compile(r"AKIA[0-9A-Z]{16}"), "<REDACTED_KEY>"),
+    # Sensitive env assignments shown in output (env dumps, exports)
+    (
+        re.compile(
+            r"\b([A-Z0-9_]*(?:API_KEY|TOKEN|SECRET|PASSWORD|CREDENTIALS)[A-Z0-9_]*)=\S+"
+        ),
+        r"\1=<REDACTED>",
+    ),
+    # Passwords in prose
+    (re.compile(r"(?i)\b(password\s*[:=]\s*)\S+"), r"\1<REDACTED>"),
+    (re.compile(r"\bPwnd\w*"), "<REDACTED>"),
+]
+
+
+def scrub_text(text: str, extra: list[tuple[str, str]] | None = None) -> str:
+    """Apply all substitution rules (plus per-run extras like real device
+    serials -> <ANDROID_DEVICE>) to a block of text."""
+    for literal, repl in extra or []:
+        text = text.replace(literal, repl)
+    for pat, repl in SUBSTITUTIONS:
+        text = pat.sub(repl, text)
+    return text
+
+
+def scrub_cast(
+    src: Path,
+    dst: Path,
+    extra: list[tuple[str, str]] | None = None,
+    cols: int | None = None,
+    rows: int | None = None,
+) -> None:
+    """Scrub an asciinema v2 cast (JSON-lines: header, then [t, type, data]
+    events). Rewrites every output event and the header (env/title can leak
+    SHELL paths and hostnames). Optionally force header width/height so the
+    render size is deterministic regardless of the recording terminal."""
+    out_lines = []
+    with src.open() as f:
+        header = json.loads(f.readline())
+        header.pop("env", None)
+        if "title" in header:
+            header["title"] = scrub_text(header["title"], extra)
+        if cols:
+            header["width"] = cols
+        if rows:
+            header["height"] = rows
+        out_lines.append(json.dumps(header))
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            ev = json.loads(line)
+            if isinstance(ev, list) and len(ev) == 3 and isinstance(ev[2], str):
+                ev[2] = scrub_text(ev[2], extra)
+            out_lines.append(json.dumps(ev))
+    dst.write_text("\n".join(out_lines) + "\n")
+
+
+def scrubbed_env(base: dict) -> dict:
+    """A minimal, safe environment for demo subprocesses: keeps what commands
+    need to run, drops anything that smells like a credential."""
+    keep_exact = {
+        "PATH", "TERM", "LANG", "LC_ALL", "SHELL", "COLUMNS", "LINES",
+        "PYTHONPATH", "PYTHONUNBUFFERED", "VIRTUAL_ENV", "ANDROID_SERIAL",
+    }
+    secret = re.compile(r"KEY|TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|AUTH", re.I)
+    env = {k: v for k, v in base.items() if k in keep_exact and not secret.search(k)}
+    env["HOME"] = base.get("HOME", "/tmp")
+    env["PS1"] = r"ghost@demo \W $ "
+    return env
+
+
+# ── Forbidden-pattern scanning ────────────────────────────────────────────────
+
+def load_forbidden(extra_paths: list[Path] | None = None) -> list[tuple[str, re.Pattern]]:
+    """Load FORBIDDEN.txt + FORBIDDEN.local.txt (if present) + any extras.
+    Returns (source_line, compiled_regex) pairs. Plain lines become
+    case-insensitive substring matches; 're:' lines are raw regexes."""
+    paths = [PRIVACY_DIR / "FORBIDDEN.txt", PRIVACY_DIR / "FORBIDDEN.local.txt"]
+    paths += extra_paths or []
+    patterns: list[tuple[str, re.Pattern]] = []
+    for p in paths:
+        if not p.exists():
+            continue
+        for raw in p.read_text().splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("re:"):
+                patterns.append((line, re.compile(line[3:], re.I)))
+            else:
+                patterns.append((line, re.compile(re.escape(line), re.I)))
+    return patterns
+
+
+def scan_text(text: str, patterns=None) -> list[tuple[str, str]]:
+    """Return [(pattern_line, matched_text), ...] for every forbidden hit."""
+    patterns = patterns if patterns is not None else load_forbidden()
+    hits = []
+    for src, pat in patterns:
+        m = pat.search(text)
+        if m:
+            hits.append((src, m.group(0)))
+    return hits
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    mode = ap.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check", nargs="+", metavar="FILE", help="scan files for forbidden patterns")
+    mode.add_argument("--scrub", nargs=2, metavar=("IN", "OUT"), help="substitution pass on a text file")
+    mode.add_argument("--scrub-cast", nargs=2, metavar=("IN", "OUT"), help="scrub an asciinema .cast file")
+    args = ap.parse_args()
+
+    if args.check:
+        patterns = load_forbidden()
+        bad = False
+        for f in args.check:
+            text = Path(f).read_text(errors="replace")
+            for src, matched in scan_text(text, patterns):
+                # Never echo the matched secret itself in full
+                shown = matched if len(matched) <= 6 else matched[:3] + "…"
+                print(f"FORBIDDEN {f}: pattern {src!r} matched ({shown})")
+                bad = True
+        if bad:
+            return 1
+        print(f"clean: {len(args.check)} file(s)")
+        return 0
+
+    if args.scrub:
+        src, dst = map(Path, args.scrub)
+        dst.write_text(scrub_text(src.read_text(errors="replace")))
+        print(f"scrubbed {src} -> {dst}")
+        return 0
+
+    src, dst = map(Path, args.scrub_cast)
+    scrub_cast(src, dst)
+    print(f"scrubbed cast {src} -> {dst}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/record_demo.py
+++ b/scripts/record_demo.py
@@ -1,0 +1,1169 @@
+#!/usr/bin/env python3
+"""record_demo.py — "Ghost records Ghost": spec-driven showcase demo recorder.
+
+Reads a demo definition (marketing copy from site/public/showcase/copy.yaml,
+recording mechanics from site/public/showcase/<demo>/spec.yaml), records the
+phone screen and the terminal simultaneously while executing the demo
+timeline, then composites everything into a branded WebM:
+
+    [ terminal (asciinema→agg) | phone-in-device-frame ]
+    + burned captions + 1s intro card + 1s outro card
+
+Outputs (only after the privacy OCR gate passes):
+    site/public/showcase/<demo>/demo.webm
+    site/public/showcase/<demo>/poster.png
+    site/public/showcase/<demo>/snippet.py
+
+Usage:
+    python3 scripts/record_demo.py --demo langchain [--serial SERIAL]
+    python3 scripts/record_demo.py --demo langchain --dry-run   # validate only
+    python3 scripts/record_demo.py --list
+
+Privacy: this script refuses to place any output into site/public/ unless the
+rendered video passes an OCR scan against scripts/privacy/FORBIDDEN.txt (+
+FORBIDDEN.local.txt). See scripts/privacy/RECORDING_CHECKLIST.md.
+
+spec.yaml schema (recording mechanics; marketing copy lives in copy.yaml):
+
+    demo: langchain                 # must match a copy.yaml id
+    device: android                 # android | ios | both
+    duration_target_s: 60
+    platform_notes: ""              # free text, printed before recording
+    record_size: null               # optional WxH for adb screenrecord --size
+    setup:                          # device prep before recording starts
+      - step: kill_all_apps
+      - step: launch_app
+        args: {package: com.sec.android.app.popupcalculator}
+    timeline:                       # what happens while recording
+      - t: 0
+        caption: "One pip install gives your agent 40+ phone tools"
+        action: terminal_type
+        args: {cmd: "gitd doctor"}
+      - t: 12
+        action: phone_tap
+        args: {x: 540, y: 1200}
+      - t: 20
+        action: wait_for_phone
+        args: {seconds: 5}
+    outro:
+      cta_line: "pip install ghost-in-the-droid"
+      cta_link: "https://ghostinthedroid.com"
+    highlight_window: {start_s: 8, end_s: 15}
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import shlex
+import socket
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from privacy.scrub import (  # noqa: E402
+    load_forbidden, scan_text, scrub_cast, scrub_text, scrubbed_env,
+)
+
+SHOWCASE_DIR = REPO_ROOT / "site" / "public" / "showcase"
+BRAND_DIR = SHOWCASE_DIR / "_brand"
+
+# ── Render constants ──────────────────────────────────────────────────────────
+CANVAS_W, CANVAS_H = 1920, 1080
+FPS = 30
+INTRO_S = 1.0
+OUTRO_S = 1.0
+TERM_COLS, TERM_ROWS = 100, 24
+TERM_X, TERM_W = 40, 1346          # 1346 = native agg width @ font 22 — the
+                                   # terminal video is NEVER rescaled (sharpness)
+TERM_Y = 256                       # video top; window chrome spans y 208-1034;
+                                   # headline block lives at y 36-160 (C-prime-4)
+FRAME_X_OFFSET = 689               # phone bezel right edge lands at x=1880 →
+                                   # 40px right margin, matching the left margin
+TYPE_DELAY_S = 0.005               # simulated keystroke interval — fast; long
+                                   # CLI commands must not eat demo runtime
+BG_HEX = "070a08"                  # canvas darker than the terminal body
+                                   # (#0d130e) so the window separates
+
+TIMELINE_ACTIONS = {
+    "terminal_type", "terminal_exec", "wait_for_phone", "phone_tap",
+    "phone_swipe", "phone_key", "phone_screenshot_pause", "sleep",
+    "show_phone",  # phone_only: passive caption beat (the agent is driven out-of-band)
+}
+SETUP_STEPS = {"kill_all_apps", "wake_unlock", "launch_app", "clear_app",
+               "install_apk", "shell", "airplane_mode_on"}
+DEVICES = {"android", "ios", "both"}
+
+
+def log(msg: str) -> None:
+    print(f"[record_demo] {msg}", flush=True)
+
+
+def die(msg: str) -> "NoReturn":  # noqa: F821
+    print(f"[record_demo] ERROR: {msg}", file=sys.stderr, flush=True)
+    sys.exit(1)
+
+
+def run(cmd: list[str], desc: str, heavy: bool = False, **kw) -> subprocess.CompletedProcess:
+    """Run a pipeline tool, failing loudly. heavy=True runs under nice -19 so
+    renders never starve the box."""
+    if heavy:
+        cmd = ["nice", "-n", "19"] + cmd
+    r = subprocess.run(cmd, capture_output=True, text=True, **kw)
+    if r.returncode != 0:
+        die(f"{desc} failed (exit {r.returncode}):\n{r.stderr[-2000:]}")
+    return r
+
+
+# ── Spec loading & validation ─────────────────────────────────────────────────
+
+def load_copy() -> dict:
+    copy_path = SHOWCASE_DIR / "copy.yaml"
+    if not copy_path.exists():
+        die(f"missing {copy_path} (marketing source of truth)")
+    data = yaml.safe_load(copy_path.read_text())
+    return {d["id"]: d for d in data.get("demos", [])}
+
+
+def load_spec(demo: str) -> dict:
+    """Join recording spec (spec.yaml) with marketing copy (copy.yaml)."""
+    copy = load_copy()
+    if demo not in copy:
+        die(f"demo '{demo}' not found in copy.yaml (ids: {', '.join(sorted(copy))})")
+    spec_path = SHOWCASE_DIR / demo / "spec.yaml"
+    if not spec_path.exists():
+        die(f"missing recording spec {spec_path}")
+    spec = yaml.safe_load(spec_path.read_text())
+    if not isinstance(spec, dict):
+        die(f"{spec_path} is not a mapping")
+
+    c = copy[demo]
+    spec.setdefault("demo", demo)
+    spec.setdefault("title", c.get("title", demo))
+    spec["_copy"] = c
+    if "outro" not in spec:
+        ctas = c.get("ctas") or []
+        spec["outro"] = {
+            "cta_line": "pip install ghost-in-the-droid",
+            "cta_link": ctas[0]["url"] if ctas else "https://ghostinthedroid.com",
+        }
+    return spec
+
+
+def validate_spec(spec: dict) -> list[str]:
+    """Return a list of validation errors (empty = valid)."""
+    errs: list[str] = []
+    demo = spec.get("demo", "")
+
+    if spec.get("device") not in DEVICES:
+        errs.append(f"device must be one of {sorted(DEVICES)}, got {spec.get('device')!r}")
+    dur = spec.get("duration_target_s")
+    if not isinstance(dur, (int, float)) or dur <= 0:
+        errs.append("duration_target_s must be a positive number")
+
+    timeline = spec.get("timeline")
+    if not isinstance(timeline, list) or not timeline:
+        errs.append("timeline must be a non-empty list")
+        timeline = []
+    prev_t = -1.0
+    for i, step in enumerate(timeline):
+        where = f"timeline[{i}]"
+        if not isinstance(step, dict):
+            errs.append(f"{where}: not a mapping")
+            continue
+        t = step.get("t")
+        if not isinstance(t, (int, float)) or t < 0:
+            errs.append(f"{where}: t must be a non-negative number")
+        elif t < prev_t:
+            errs.append(f"{where}: t={t} goes backwards (prev {prev_t})")
+        else:
+            prev_t = float(t)
+        action = step.get("action")
+        if action not in TIMELINE_ACTIONS:
+            errs.append(f"{where}: unknown action {action!r} (known: {sorted(TIMELINE_ACTIONS)})")
+        args = step.get("args", {})
+        if not isinstance(args, dict):
+            errs.append(f"{where}: args must be a mapping")
+            args = {}
+        if action in ("terminal_type", "terminal_exec") and not args.get("cmd"):
+            errs.append(f"{where}: {action} needs args.cmd")
+        if action in ("wait_for_phone", "phone_screenshot_pause", "sleep") \
+                and not isinstance(args.get("seconds"), (int, float)):
+            errs.append(f"{where}: {action} needs numeric args.seconds")
+        if action == "phone_tap" and not (
+                isinstance(args.get("x"), (int, float)) and isinstance(args.get("y"), (int, float))):
+            errs.append(f"{where}: phone_tap needs numeric args.x/args.y")
+        if action == "phone_swipe" and not all(
+                isinstance(args.get(k), (int, float)) for k in ("x1", "y1", "x2", "y2")):
+            errs.append(f"{where}: phone_swipe needs numeric x1/y1/x2/y2")
+        if action == "phone_key" and not args.get("key"):
+            errs.append(f"{where}: phone_key needs args.key (e.g. KEYCODE_HOME)")
+        cap = step.get("caption")
+        if cap is not None and not isinstance(cap, str):
+            errs.append(f"{where}: caption must be a string")
+
+    for i, s in enumerate(spec.get("setup") or []):
+        if not isinstance(s, dict) or s.get("step") not in SETUP_STEPS:
+            errs.append(f"setup[{i}]: step must be one of {sorted(SETUP_STEPS)}")
+        elif s["step"] == "launch_app" and not (s.get("args") or {}).get("package"):
+            errs.append(f"setup[{i}]: launch_app needs args.package")
+
+    env_extra = spec.get("env") or {}
+    if not isinstance(env_extra, dict):
+        errs.append("env must be a mapping of extra variables for demo commands")
+    else:
+        secret = re.compile(r"KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL", re.I)
+        for k, v in env_extra.items():
+            if secret.search(str(k)) or scan_text(f"{k}={v}"):
+                errs.append(f"env.{k}: secret-shaped or forbidden — demo env must be safe to show on screen")
+
+    hw = spec.get("highlight_window")
+    if not isinstance(hw, dict) or not all(
+            isinstance(hw.get(k), (int, float)) for k in ("start_s", "end_s")):
+        errs.append("highlight_window needs numeric start_s/end_s")
+    else:
+        length = hw["end_s"] - hw["start_s"]
+        if length <= 0:
+            errs.append("highlight_window end_s must be > start_s")
+        elif not (4 <= length <= 10):
+            errs.append(f"highlight_window is {length:.1f}s — sizzle reel wants 6-8s (4-10 tolerated)")
+        if isinstance(dur, (int, float)) and hw.get("end_s", 0) > dur:
+            errs.append("highlight_window ends after duration_target_s")
+
+    if prev_t and isinstance(dur, (int, float)) and prev_t > dur:
+        errs.append(f"last timeline step t={prev_t} exceeds duration_target_s={dur}")
+
+    # Brand assets this demo's render needs
+    for asset in (BRAND_DIR / f"intro-{demo}.png", BRAND_DIR / "outro.png",
+                  BRAND_DIR / "asciinema-ghost.json", BRAND_DIR / "frames.json",
+                  BRAND_DIR / "frame-pixel8.png"):
+        if not asset.exists():
+            errs.append(f"missing brand asset {asset.relative_to(REPO_ROOT)}")
+    return errs
+
+
+def timeline_end(spec: dict) -> float:
+    """Seconds of content: last step's t plus that step's own duration."""
+    last = spec["timeline"][-1]
+    tail = (last.get("args") or {}).get("seconds", 0) if last["action"] != "terminal_type" else 8
+    return float(last["t"]) + float(tail) + 2.0
+
+
+# ── Tool checks ───────────────────────────────────────────────────────────────
+
+def check_tools(need_ocr: bool = True) -> list[str]:
+    missing = [t for t in ("asciinema", "agg", "ffmpeg", "adb") if not shutil.which(t)]
+    if need_ocr and not shutil.which("tesseract"):
+        missing.append("tesseract")
+    return missing
+
+
+# ── Phone helpers ─────────────────────────────────────────────────────────────
+
+def get_device(serial: str | None):
+    from gitd.bots.common.adb import Device  # lazy: not needed for --dry-run
+    out = subprocess.run(["adb", "devices"], capture_output=True, text=True).stdout
+    attached = [l.split()[0] for l in out.splitlines()[1:] if l.strip().endswith("device")]
+    if serial is None:
+        serial = os.environ.get("ANDROID_SERIAL")
+    if serial is None:
+        if len(attached) != 1:
+            die(f"pass --serial: {len(attached)} devices attached")
+        serial = attached[0]
+    if serial not in attached:
+        die(f"device {serial} not attached (attached: {attached or 'none'})")
+    return Device(serial)
+
+
+def phone_privacy_prep(dev, workdir: Path, patterns) -> dict:
+    """Best-effort device hygiene before recording (#787). Returns a dict of
+    settings we changed so they can be restored afterwards. Hard-fails only on
+    the OCR gate — everything else degrades to a warning + checklist item."""
+    restore: dict[str, str] = {}
+
+    def soft(desc, *args):
+        r = dev.adb_soft("shell", *args)
+        if r.returncode != 0:
+            log(f"  (soft-fail, do manually if needed) {desc}: {r.stderr or r.stdout}")
+        return r
+
+    log("phone prep: wake+unlock, DND on, clear notifications, hide status bar, clear recents")
+    # Best-effort unlock so we never record a lock screen (works for no-PIN /
+    # swipe-only screens; PIN-locked devices must be unlocked by hand — the
+    # pre-record OCR screenshot below is taken of whatever is actually shown)
+    soft("wake", "input", "keyevent", "KEYCODE_WAKEUP")
+    time.sleep(0.4)
+    soft("dismiss keyguard", "input", "keyevent", "82")
+    soft("swipe up", "input", "swipe", "540", "1800", "540", "700", "200")
+    restore["zen_mode"] = dev.adb_soft("shell", "settings", "get", "global", "zen_mode").stdout or "0"
+    soft("enable DND", "settings", "put", "global", "zen_mode", "1")
+    soft("clear notifications", "service", "call", "notification", "1")
+    restore["policy_control"] = dev.adb_soft(
+        "shell", "settings", "get", "global", "policy_control").stdout or "null"
+    soft("hide status bar", "settings", "put", "global", "policy_control", "immersive.status=*")
+    soft("clear recents", "am", "kill-all")
+    # Time freeze needs root on production builds — try, warn on failure.
+    soft("disable auto time", "settings", "put", "global", "auto_time", "0")
+    # Keep the screen awake for the whole take: a long on-device / agent run
+    # (e.g. langchain harvest, on-device inference) can outlast the display
+    # timeout, and a slept screen returns BLACK screencaps → empty OCR → the
+    # agent reads nothing ('Not found'). svc power stayon holds it on.
+    restore["stay_on"] = dev.adb_soft(
+        "shell", "settings", "get", "global", "stay_on_while_plugged_in").stdout or "0"
+    soft("keep screen awake", "svc", "power", "stayon", "true")
+
+    # Pre-record screenshot → OCR gate: refuse to record a dirty screen.
+    shot = workdir / "prep_check.png"
+    with shot.open("wb") as f:
+        subprocess.run(["adb", "-s", dev.serial, "exec-out", "screencap", "-p"],
+                       stdout=f, check=True)
+    text = ocr_png(shot)
+    hits = scan_text(text, patterns)
+    if hits:
+        for src, m in hits:
+            log(f"  FORBIDDEN on screen before recording: {src!r} matched {m[:3]}…")
+        die("phone screen shows forbidden content — clean the device (see "
+            "scripts/privacy/RECORDING_CHECKLIST.md) and retry")
+    log("phone prep: pre-record OCR gate clean")
+    return restore
+
+
+def phone_privacy_restore(dev, restore: dict) -> None:
+    dev.adb_soft("shell", "settings", "put", "global", "zen_mode", restore.get("zen_mode", "0"))
+    pc = restore.get("policy_control") or "null"
+    dev.adb_soft("shell", "settings", "put", "global", "policy_control", pc)
+    dev.adb_soft("shell", "settings", "put", "global", "stay_on_while_plugged_in",
+                 (restore.get("stay_on") or "0").strip())
+
+
+def run_setup(dev, spec: dict) -> None:
+    for s in spec.get("setup") or []:
+        step, args = s["step"], s.get("args") or {}
+        log(f"setup: {step} {args or ''}")
+        if step == "kill_all_apps":
+            dev.adb_soft("shell", "am", "kill-all")
+        elif step == "wake_unlock":
+            dev.adb_soft("shell", "input", "keyevent", "KEYCODE_WAKEUP")
+            time.sleep(0.5)
+            dev.adb_soft("shell", "input", "keyevent", "82")
+        elif step == "launch_app":
+            dev.adb("shell", "monkey", "-p", args["package"],
+                    "-c", "android.intent.category.LAUNCHER", "1")
+            time.sleep(float(args.get("settle_s", 2)))
+        elif step == "clear_app":
+            dev.adb_soft("shell", "pm", "clear", args["package"])
+        elif step == "install_apk":
+            dev.adb_show("install", "-r", str(REPO_ROOT / args["path"]))
+        elif step == "shell":
+            dev.adb_soft("shell", *shlex.split(args["cmd"]))
+        elif step == "airplane_mode_on":
+            # USB adb (and thus the on-device daemon over `adb forward`) is
+            # unaffected by airplane mode, so we can still drive the phone.
+            dev.adb_soft("shell", "cmd", "connectivity", "airplane-mode", "enable")
+            time.sleep(1.5)
+
+
+class PhoneRecorder:
+    """Host-side screen capture via scrcpy (--no-control, so the driving agent
+    keeps input). Unlike device `screenrecord` this has NO 180s cap and doesn't
+    die from the agent's concurrent adb during a long harvest — a single
+    continuous clip. scrcpy records VFR, so we normalize to CFR on stop."""
+
+    def __init__(self, serial: str, limit_s: float, size: str | None):
+        self.serial = serial
+        self.size = size                       # optional max dimension (e.g. "1080")
+        self.proc: subprocess.Popen | None = None
+        self.raw = Path(tempfile.mktemp(suffix="_scrcpy.mp4"))
+        self.started_at = 0.0
+
+    def start(self) -> None:
+        cmd = ["scrcpy", "-s", self.serial, "--no-display", "--no-control",
+               "--record", str(self.raw)]
+        if self.size:
+            cmd += ["--max-size", self.size.split("x")[0]]
+        self.proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL,
+                                     stderr=subprocess.DEVNULL)
+        self.started_at = time.monotonic()
+        time.sleep(2.0)  # scrcpy pushes its server + connects before frames roll
+
+    def stop_and_pull(self, dest: Path) -> None:
+        # SIGINT lets scrcpy finalize the mp4 cleanly.
+        if self.proc and self.proc.poll() is None:
+            self.proc.send_signal(signal.SIGINT)
+            try:
+                self.proc.wait(timeout=20)
+            except subprocess.TimeoutExpired:
+                self.proc.kill()
+        time.sleep(1.0)
+        if not self.raw.exists() or self.raw.stat().st_size < 1024:
+            die("scrcpy produced no phone recording")
+        # scrcpy writes variable-frame-rate; re-encode to CFR so the composite's
+        # trim/setpts and the dedup pass behave predictably.
+        run(["ffmpeg", "-y", "-i", str(self.raw), "-vf", f"fps={FPS}",
+             "-c:v", "libx264", "-preset", "veryfast", "-pix_fmt", "yuv420p",
+             str(dest)], "normalize phone recording to CFR", heavy=True)
+        self.raw.unlink(missing_ok=True)
+
+
+# ── Inner mode: executes the timeline inside the asciinema pty ────────────────
+
+def type_and_run(cmd: str, env: dict, exec_cmd: str | None = None) -> None:
+    prompt = "\x1b[1;32mghost@demo\x1b[0m \x1b[1;34m~\x1b[0m $ "
+    sys.stdout.write(prompt)
+    sys.stdout.flush()
+    for ch in cmd:
+        sys.stdout.write(ch)
+        sys.stdout.flush()
+        time.sleep(TYPE_DELAY_S)
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+    subprocess.run(exec_cmd or cmd, shell=True, env=env, cwd=str(REPO_ROOT))
+
+
+def run_inner(plan_path: Path) -> int:
+    """Runs INSIDE `asciinema rec -c ...`: replays the timeline in real time.
+    Terminal actions render into the recording; phone actions drive the device
+    silently so both recordings stay in sync."""
+    plan = json.loads(Path(plan_path).read_text())
+    spec, serial = plan["spec"], plan.get("serial")
+    dev = None
+    if serial:
+        from gitd.bots.common.adb import Device
+        dev = Device(serial)
+    env = scrubbed_env(dict(os.environ))
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    if serial:
+        env["ANDROID_SERIAL"] = serial
+    # iOS support is feature-gated (default off since PR #33); demos that
+    # exercise it need the opt-in flag inside the recorded shell.
+    if spec.get("device") in ("ios", "both"):
+        env["GITD_ENABLE_IOS"] = "1"
+    # spec-declared extras (validated: no secret-shaped names/values)
+    env.update({k: str(v) for k, v in (spec.get("env") or {}).items()})
+
+    t0 = time.monotonic()
+    for step in spec["timeline"]:
+        target = float(step["t"])
+        lag = target - (time.monotonic() - t0)
+        if lag > 0:
+            time.sleep(lag)
+        action, args = step["action"], step.get("args") or {}
+        if action == "terminal_type":
+            # exec_cmd: run this instead of the displayed cmd (e.g. hide a
+            # demo-only pacing pipe from the typed one-liner)
+            type_and_run(args["cmd"], env, exec_cmd=args.get("exec_cmd"))
+        elif action == "terminal_exec":
+            # run without typing the command — the command draws its own
+            # terminal visuals (e.g. the Claude Code TUI driver)
+            subprocess.run(args["cmd"], shell=True, env=env, cwd=str(REPO_ROOT))
+        elif action in ("wait_for_phone", "phone_screenshot_pause", "sleep"):
+            time.sleep(float(args["seconds"]))
+        elif action == "phone_tap":
+            dev.tap(args["x"], args["y"], delay=float(args.get("delay", 0.6)))
+        elif action == "phone_swipe":
+            dev.swipe(args["x1"], args["y1"], args["x2"], args["y2"],
+                      ms=int(args.get("ms", 500)))
+        elif action == "phone_key":
+            dev.adb("shell", "input", "keyevent", str(args["key"]))
+    time.sleep(2.0)  # trailing air so the last output breathes
+    Path(plan["done_marker"]).write_text("ok")
+    return 0
+
+
+# ── Post-processing ───────────────────────────────────────────────────────────
+
+def ocr_png(png: Path) -> str:
+    r = subprocess.run(["tesseract", str(png), "stdout"], capture_output=True, text=True)
+    return r.stdout or ""
+
+
+def render_terminal(cast: Path, out_mp4: Path, workdir: Path) -> None:
+    theme = json.loads((BRAND_DIR / "asciinema-ghost.json").read_text())
+    gif = workdir / "terminal.gif"
+    # agg >= 1.9 renders Noto Color Emoji (CBDT bitmap) in color; 1.4.x leaves
+    # emoji as blank gaps regardless of renderer/font flags
+    agg_bin = shutil.which("agg-1.9") or "agg"
+    # the font stack lacks U+276F (Claude Code's ❯ input prompt) and renders
+    # it as mojibake — substitute a plain '>' before rendering (visual only)
+    glyphfix = workdir / (cast.stem + "_glyphfix.cast")
+    txt = cast.read_text()
+    # casts may store specials as literal UTF-8 OR as \uXXXX JSON escapes —
+    # substitute BOTH forms (missing either resurfaces the mojibake)
+    for lit, esc, repl in ((chr(0x276F), r"\\u276[fF]", ">"),
+                           (chr(0x00A0), r"\\u00[aA]0", " ")):
+        txt = txt.replace(lit, repl)
+        txt = re.sub(esc, repl, txt)
+    txt = re.sub(r"[\u2800-\u28ff]", "·", txt)
+    txt = re.sub(r"\\u28[0-9a-fA-F]{2}", "·", txt)
+    glyphfix.write_text(txt)
+    cast = glyphfix
+    run([agg_bin,
+         "--theme", theme["agg"]["theme_arg"],
+         "--font-dir", str(BRAND_DIR / "fonts"),
+         "--font-dir", "/usr/share/fonts/truetype/noto",
+         "--font-family",
+         theme.get("font_family", "JetBrains Mono") + ",Noto Color Emoji",
+         "--font-size", str(theme.get("font_size", 16)),
+         "--line-height", str(theme.get("line_height", 1.4)),
+         "--fps-cap", str(FPS),
+         # never compress idle time — the terminal must stay in real time
+         # or it desyncs from the phone recording
+         "--idle-time-limit", "600",
+         str(cast), str(gif)], "agg render", heavy=True)
+    run(["ffmpeg", "-y", "-i", str(gif),
+         "-vf", f"fps={FPS},scale=trunc(iw/2)*2:trunc(ih/2)*2,format=yuv420p",
+         "-c:v", "libx264", "-crf", "18",
+         str(out_mp4)], "gif→mp4", heavy=True)
+
+
+def ass_time(s: float) -> str:
+    cs = int(round(s * 100))
+    return f"{cs//360000}:{cs//6000%60:02d}:{cs//100%60:02d}.{cs%100:02d}"
+
+
+def build_captions(spec: dict, path: Path) -> None:
+    """ASS subtitles from timeline captions, bottom-center, Ghost palette."""
+    # phone_only puts a centered phone mid-canvas, so captions live in the LEFT
+    # whitespace column (Alignment=4 middle-left, margins clear the bezel);
+    # every other layout uses the C-prime top-left editorial headline.
+    if spec.get("layout") == "phone_only":
+        style = "Style: Ghost,Outfit,50,&H00E9EDE8,&H00FFFFFF,&H00000000,&H00000000,700,0,0,0,100,100,0,0,1,0,0,4,60,1290,0,1"
+    else:
+        style = "Style: Ghost,Outfit,54,&H00E9EDE8,&H00FFFFFF,&H00000000,&H00000000,700,0,0,0,100,100,0,0,1,0,0,7,42,40,88,1"
+    header = f"""[Script Info]
+ScriptType: v4.00+
+PlayResX: {CANVAS_W}
+PlayResY: {CANVAS_H}
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+{style}
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+"""
+    captioned = [s for s in spec["timeline"] if s.get("caption")]
+    end_all = timeline_end(spec)
+    lines = []
+    # Optional persistent brand tagline: one Dialogue HELD for the whole demo
+    # (fade-in only, no 6s beat cap), same two-tone split. Skips the per-beat
+    # loop. Absence of `headline` leaves every existing demo's behavior intact.
+    headline = spec.get("headline")
+    if headline:
+        text = headline.replace("\n", " ").strip()
+        parts = text.rstrip(".").split(". ")
+        head, tail = ((". ".join(parts[:-1]) + ". ", parts[-1] + ".")
+                      if len(parts) > 1 else (text, ""))
+        size_tag = r"{\fs44}" if len(text) > 44 else ""
+        two_tone = head + (r"{\c&HA0E500&}" + tail if tail else "")
+        lines.append(
+            f"Dialogue: 0,{ass_time(0)},{ass_time(end_all)},Ghost,,0,0,0,,"
+            r"{\fad(300,0)}" + size_tag + two_tone)
+        path.write_text(header + "\n".join(lines) + "\n")
+        return
+    for i, s in enumerate(captioned):
+        start = float(s["t"])
+        end = float(captioned[i + 1]["t"]) if i + 1 < len(captioned) else min(start + 5, end_all)
+        end = min(end, start + 6)
+        text = s["caption"].replace("\n", " ").strip()
+        # C-prime-4 editorial headline: two-tone — last sentence in Ghost
+        # green (ASS colors are BGR: &HA0E500& == #00e5a0). Long copy drops
+        # to 44px so it clears the window top (y=208).
+        parts = text.rstrip(".").split(". ")
+        if len(parts) > 1:
+            head, tail = ". ".join(parts[:-1]) + ". ", parts[-1] + "."
+        else:
+            head, tail = text, ""
+        size_tag = r"{\fs44}" if len(text) > 44 else ""
+        two_tone = head + (r"{\c&HA0E500&}" + tail if tail else "")
+        lines.append(
+            f"Dialogue: 0,{ass_time(start)},{ass_time(end)},Ghost,,0,0,0,,"
+            r"{\fad(200,200)}" + size_tag + two_tone)
+    path.write_text(header + "\n".join(lines) + "\n")
+
+
+def composite(spec: dict, workdir: Path, term_mp4: Path, phone_mp4: Path,
+              phone_offset_s: float, out_webm: Path) -> None:
+    """One-shot filter graph: intro card + [terminal | framed phone + captions]
+    + outro card → 720p VP9 WebM."""
+    demo = spec["demo"]
+    frames = json.loads((BRAND_DIR / "frames.json").read_text())
+    device_frame = "iphone15pro" if spec.get("device") == "ios" else "pixel8"
+    fr = frames[device_frame]
+    frame_png = BRAND_DIR / f"frame-{device_frame}.png"
+    rx, ry, rw, rh = fr["screen_rect"]
+    rx += FRAME_X_OFFSET
+    content_s = timeline_end(spec)
+    # Optional post-intro time-lapse: play the recorded content N× faster (the
+    # intro/outro cards stay real-time). content_speedup: 7 turns a ~7min harvest
+    # into ~1min. setpts divides timestamps; captions/fades scale with it.
+    speedup = float(spec.get("content_speedup", 1) or 1)
+    # content_dedup: drop near-static frames (mpdecimate) so 10-20s stretches where
+    # nothing moves collapse to nothing, THEN re-index the survivors to a continuous
+    # stream — combined with content_speedup this turns dead air into a tight cut.
+    # Value: True for defaults, or an mpdecimate arg string ("hi=..:lo=..:frac=..").
+    dedup = spec.get("content_dedup")
+    dedup_f = ""
+    if dedup:
+        dedup_f = ("mpdecimate" + (f"={dedup}" if isinstance(dedup, str) else "")
+                   + f",setpts=N/{FPS}/TB,")
+    pts = "PTS-STARTPTS" if speedup == 1 else f"(PTS-STARTPTS)/{speedup}"
+    # tail_hold_s: freeze the LAST content frame (the SQL stats payoff) for N sec so
+    # it's readable even when the harvest before it is heavily sped up / deduped.
+    tail_hold = float(spec.get("tail_hold_s", 0) or 0)
+    tail_f = f"tpad=stop_mode=clone:stop_duration={tail_hold}," if tail_hold else ""
+    captions = workdir / "captions.ass"
+    build_captions(spec, captions)
+
+    # Rounded-corner mask for the phone video. Overlaying the phone as a SQUARE
+    # rect bleeds past the bezel's rounded screen cutout — invisible on pixel8
+    # (screen_radius 56) but obvious on iphone15pro (100). Mask the phone to the
+    # frame's screen_radius so its corners match the bezel hole (CKL bug). The
+    # phone chain becomes: scale → alphamerge(mask) → overlay; harmless on any
+    # frame, essential on high-radius ones.
+    radius = int(fr.get("screen_radius", 0))
+    phone_mask = workdir / "phone_mask.png"
+    if radius > 0:
+        from PIL import Image, ImageDraw
+        _m = Image.new("L", (rw, rh), 0)
+        ImageDraw.Draw(_m).rounded_rectangle([0, 0, rw - 1, rh - 1],
+                                             radius=radius, fill=255)
+        _m.save(phone_mask)
+
+    def _round(phone_label: str, mask_idx: int) -> str:
+        """Filter snippet: apply the rounded mask to a scaled phone stream."""
+        if radius <= 0:
+            return f"{phone_label}null[phone];"
+        return (f"{phone_label}format=rgba[ph0];"
+                f"[{mask_idx}:v]format=gray[phmask];"
+                f"[ph0][phmask]alphamerge[phone];")
+
+    if spec.get("layout") == "phone_only":
+        # On-device / airplane-mode demos: the phone is the star and there is
+        # NO terminal pane (a PC terminal would contradict "nothing leaves the
+        # device"). Centered framed phone over the C-prime bg + mascot, captions
+        # bottom-center. Phone sits at the frame png's native (centered) x —
+        # FRAME_X_OFFSET is NOT applied — since nothing competes for the canvas.
+        po_rx, po_ry, po_rw, po_rh = fr["screen_rect"]  # native, un-offset
+        po_bg = BRAND_DIR / "cprime-bg.png"
+        po_mascot = BRAND_DIR / "cprime-mascot.png"
+        po_intro = BRAND_DIR / f"intro-{demo}.png"
+        po_outro = BRAND_DIR / "outro.png"
+        fc = (
+            f"color=c=0x{BG_HEX}:s={CANVAS_W}x{CANVAS_H}:d={content_s}:r={FPS}[bgc];"
+            f"[3:v]format=rgba[bgp];[bgc][bgp]overlay=0:0[bg];"
+            f"[4:v]format=rgba[mascot];[bg][mascot]overlay=0:0[m0];"
+            # fps=30 (CFR) BEFORE trim: adb screenrecord is sparse VFR (a static
+            # screen emits no frames), so normalize first or the overlay timing
+            # drifts and playback stutters.
+            f"[2:v]fps={FPS},trim=start={max(phone_offset_s, 0)},setpts=PTS-STARTPTS,"
+            f"scale={po_rw}:{po_rh},setsar=1[phscaled];"
+            + _round("[phscaled]", 6) +
+            f"[m0][phone]overlay={po_rx}:{po_ry}[c1];"
+            f"[5:v]format=rgba[framepng];"
+            f"[c1][framepng]overlay=0:0:format=auto[c2];"
+            f"[c2]subtitles='{captions}':fontsdir='{BRAND_DIR / 'fonts'}',"
+            f"trim=duration={content_s},{dedup_f}setpts={pts},fps={FPS},"
+            f"{tail_f}format=yuv420p[content];"
+            f"[0:v]scale={CANVAS_W}:{CANVAS_H},fps={FPS},format=yuv420p[intro];"
+            f"[1:v]scale={CANVAS_W}:{CANVAS_H},fps={FPS},format=yuv420p[outro];"
+            f"[intro][content][outro]concat=n=3:v=1:a=0,scale=1920:1080[out]"
+        )
+        inputs = [
+            "-loop", "1", "-t", str(INTRO_S), "-i", str(po_intro),   # [0]
+            "-loop", "1", "-t", str(OUTRO_S), "-i", str(po_outro),   # [1]
+            "-i", str(phone_mp4),                                     # [2]
+            "-i", str(po_bg),                                         # [3]
+            "-i", str(po_mascot),                                     # [4]
+            "-i", str(frame_png),                                     # [5]
+        ]
+        if radius > 0:
+            inputs += ["-loop", "1", "-t", str(content_s), "-i", str(phone_mask)]  # [6]
+        run(["ffmpeg", "-y", *inputs, "-filter_complex", fc, "-map", "[out]",
+             "-c:v", "libvpx-vp9", "-crf", "32", "-b:v", "0",
+             "-deadline", "good", "-cpu-used", "2", "-row-mt", "1", "-an",
+             str(out_webm)], "phone-only composite render", heavy=True)
+        return
+
+    intro = BRAND_DIR / f"intro-{demo}.png"
+    # Motion layouts open with an animated intro (design-review's mp4 whose
+    # final frame is pixel-matched to the code pane at the seam) instead of the
+    # 1s static card. Input [0] becomes a real video decode of its natural
+    # length; the concat is unchanged.
+    intro_motion = BRAND_DIR / f"intro-{demo}-motion.mp4"
+    use_motion_intro = spec.get("layout") == "three_window" and intro_motion.exists()
+    outro = BRAND_DIR / "outro.png"
+    three_pane = spec.get("layout") == "three_window"
+    # Motion (three_pane) uses a per-demo background with kicker + headline +
+    # mascot BAKED in (bg-<demo>.png), so there is NO separate mascot overlay
+    # and NO ASS caption headline; the standard layout uses cprime-bg + a
+    # peeking mascot overlay + captions. bg falls back to cprime-bg if absent.
+    demo_bg = BRAND_DIR / f"bg-{demo}.png"
+    bgpng = demo_bg if (three_pane and demo_bg.exists()) else BRAND_DIR / "cprime-bg.png"
+    mascot_l = BRAND_DIR / "cprime-mascot.png"  # standard layout: peeks from behind window
+    # 3-pane motion layout (spec: layout: three_window): short terminal window
+    # (term_rows) fades in as it "pops" at the seam, code pane overlaid below,
+    # framed phone SLIDES in from off-canvas right.
+    #
+    # The code pane is LIVE-RENDERED from code_pane_source every record, so it can
+    # never drift out of sync with the code it mirrors (a baked asset once shipped
+    # a stale OpenRouter version of the script long after the code had moved on).
+    # If no code_pane_source is given, fall back to a baked code_pane_asset.
+    code_pane_path = None
+    if three_pane:
+        src = spec.get("code_pane_source")
+        if src:
+            code_pane_path = workdir / "codepane.png"
+            run([sys.executable,
+                 str(Path(__file__).parent / "showcase" / "render_codepane.py"),
+                 str(REPO_ROOT / src), str(code_pane_path),
+                 f"--title={Path(src).name}"], "live-render code pane")
+        else:
+            code_pane_path = BRAND_DIR / spec.get("code_pane_asset",
+                                                  f"codepane-{demo}-v3.png")
+    code_pane = code_pane_path  # truthy iff 3-pane (drives chrome + input [8])
+    chrome = BRAND_DIR / (
+        "terminal-frame-macos-small.png" if code_pane else "terminal-frame-macos.png")
+
+    # Phone entrance (motion only): quint-ease slide from +503px (off-canvas
+    # right) into rest, at content t≈0.8..1.5s = absolute 8.6..9.3s (seam=7.8).
+    # D is added to BOTH the phone screen and the bezel x so they move together.
+    # Phone normally slides in at the seam; but when the intro already shows the
+    # phone on the side (phone_in_intro), keep it static ("0" offset) so it
+    # doesn't jump. Non-3-pane layouts don't add a slide term at all.
+    slide = (r"503*pow(1-clip((t-0.8)/0.7\,0\,1)\,5)"
+             if three_pane and not spec.get("phone_in_intro")
+             else ("0" if three_pane else ""))
+    phone_x = f"{rx}+{slide}" if three_pane else str(rx)
+    frame_x = f"{FRAME_X_OFFSET}+{slide}" if three_pane else str(FRAME_X_OFFSET)
+    mask_idx = 9 if code_pane else 8  # rounded phone-mask input (appended last)
+
+    fc = (
+        # content background (kicker/headline/mascot or glow baked in the png)
+        f"color=c=0x{BG_HEX}:s={CANVAS_W}x{CANVAS_H}:d={content_s}:r={FPS}[bgc];"
+        f"[5:v]format=rgba[bgp];"
+        f"[bgc][bgp]overlay=0:0[bg];"
+        # mascot overlay only for standard layout (baked into bg for motion)
+        + (f"[bg]null[m0];" if three_pane else
+           f"[7:v]format=rgba[mascot];[bg][mascot]overlay=0:0[m0];")
+        # chrome UNDER the terminal; motion fades the whole window in at the seam
+        + (f"[6:v]format=rgba,fade=t=in:st=0:d=0.25:alpha=1[chrome];" if three_pane else
+           f"[6:v]format=rgba[chrome];")
+        + f"[m0][chrome]overlay=0:0[c0];"
+        + (f"[2:v]format=rgba,fade=t=in:st=0:d=0.25:alpha=1[term];" if three_pane else
+           f"[2:v]null[term];")  # native render — zero rescale
+        + f"[c0][term]overlay={TERM_X}:{TERM_Y}[c1];"
+        f"[3:v]trim=start={max(phone_offset_s, 0)},setpts=PTS-STARTPTS,"
+        f"scale={rw}:{rh},setsar=1[phscaled];"
+        + _round("[phscaled]", mask_idx) +
+        f"[c1][phone]overlay=x='{phone_x}':y={ry}[c2];"
+        f"[4:v]format=rgba[framepng];"
+        f"[c2][framepng]overlay=x='{frame_x}':y=0:format=auto[c3];"
+        # code pane (3-pane only): full-canvas overlay above the phone/frame
+        + (f"[8:v]format=rgba[codepane];"
+           f"[c3][codepane]overlay=0:0[c4];" if code_pane else
+           f"[c3]null[c4];")
+        # captions only for standard layout (headline baked into motion bg)
+        + (f"[c4]trim=duration={content_s},{dedup_f}setpts={pts},fps={FPS},"
+           f"{tail_f}format=yuv420p[content];" if three_pane else
+           f"[c4]subtitles='{captions}':fontsdir='{BRAND_DIR / 'fonts'}',"
+           f"trim=duration={content_s},{dedup_f}setpts={pts},fps={FPS},"
+           f"{tail_f}format=yuv420p[content];")
+        # cards
+        + f"[0:v]scale={CANVAS_W}:{CANVAS_H},fps={FPS},format=yuv420p[intro];"
+        f"[1:v]scale={CANVAS_W}:{CANVAS_H},fps={FPS},format=yuv420p[outro];"
+        f"[intro][content][outro]concat=n=3:v=1:a=0,"
+        f"scale=1920:1080[out]"
+    )
+    inputs = [
+        *(["-i", str(intro_motion)] if use_motion_intro
+          else ["-loop", "1", "-t", str(INTRO_S), "-i", str(intro)]),
+        "-loop", "1", "-t", str(OUTRO_S), "-i", str(outro),
+        "-i", str(term_mp4),
+        "-i", str(phone_mp4),
+        "-i", str(frame_png),
+        "-i", str(bgpng),
+        # chrome is a STILL frame but gets a fade=t=in filter; without -loop it is
+        # a single frame that the fade collapses to alpha 0 (invisible whole video).
+        # Loop it across the content so the fade-in actually renders.
+        "-loop", "1", "-t", str(content_s), "-i", str(chrome),
+        "-i", str(mascot_l),
+    ]
+    if code_pane:
+        inputs += ["-i", str(code_pane_path)]  # input [8] (live-rendered or baked)
+    if radius > 0:
+        inputs += ["-loop", "1", "-t", str(content_s), "-i", str(phone_mask)]  # [8]/[9]
+    run(["ffmpeg", "-y", *inputs,
+         "-filter_complex", fc, "-map", "[out]",
+         "-c:v", "libvpx-vp9", "-crf", "32", "-b:v", "0",
+         "-deadline", "good", "-cpu-used", "2", "-row-mt", "1", "-an",
+         str(out_webm)], "composite render", heavy=True)
+
+
+def ocr_gate(webm: Path, workdir: Path, patterns) -> list[str]:
+    """Extract up to 30 frames at 2s intervals, OCR each, scan against the
+    forbidden lists. Returns list of human-readable violations (empty = pass)."""
+    frames_dir = workdir / "ocr_frames"
+    frames_dir.mkdir(exist_ok=True)
+    run(["ffmpeg", "-y", "-i", str(webm), "-vf", "fps=1/2", "-frames:v", "30",
+         str(frames_dir / "f%03d.png")], "OCR frame extraction", heavy=True)
+    frames = sorted(frames_dir.glob("f*.png"))
+    if not frames:
+        # fail closed: a gate that scanned nothing must never read as "clean"
+        # (corrupt-but-exit-0 webm, sub-2s video, bad -vf all land here)
+        die(f"OCR gate extracted 0 frames from {webm} — refusing to pass an "
+            f"unscanned video")
+    violations = []
+    for png in frames:
+        text = ocr_png(png)
+        (png.with_suffix(".txt")).write_text(text)
+        for src, m in scan_text(text, patterns):
+            ts = (int(png.stem[1:]) - 1) * 2
+            violations.append(f"{png.name} (~t={ts}s): pattern {src!r} matched {m[:3]}…")
+    return violations
+
+
+def write_snippet(spec: dict, path: Path) -> None:
+    cmds = [s["args"]["cmd"] for s in spec["timeline"] if s["action"] == "terminal_type"]
+    body = "\n".join(cmds)
+    path.write_text(
+        f"# {spec['title']} — commands from this demo\n"
+        f"# {spec['outro']['cta_link']}\n\n{body}\n")
+
+
+# ── Modes ─────────────────────────────────────────────────────────────────────
+
+def do_list() -> int:
+    copy = load_copy()
+    for demo_id in sorted(copy, key=lambda d: copy[d].get("sizzle_order") or 99):
+        has_spec = (SHOWCASE_DIR / demo_id / "spec.yaml").exists()
+        has_webm = (SHOWCASE_DIR / demo_id / "demo.webm").exists()
+        flags = ("spec " if has_spec else "     ") + ("webm" if has_webm else "")
+        print(f"  {demo_id:24s} {flags}")
+    return 0
+
+
+def do_dry_run(demo: str) -> int:
+    spec = load_spec(demo)
+    errs = validate_spec(spec)
+    missing = check_tools(need_ocr=False)
+    if missing:
+        log(f"note: tools missing on this host (fine for dry-run): {', '.join(missing)}")
+    if errs:
+        for e in errs:
+            print(f"  ✗ {e}")
+        die(f"spec for '{demo}' has {len(errs)} problem(s)")
+    n_term = sum(1 for s in spec["timeline"] if s["action"] == "terminal_type")
+    n_phone = sum(1 for s in spec["timeline"] if s["action"].startswith("phone"))
+    log(f"✓ '{demo}' valid — {len(spec['timeline'])} steps "
+        f"({n_term} terminal, {n_phone} phone), ~{timeline_end(spec):.0f}s content, "
+        f"highlight {spec['highlight_window']['start_s']}–{spec['highlight_window']['end_s']}s")
+    return 0
+
+
+def do_record(demo: str, serial: str | None, skip_phone_prep: bool,
+              keep_workdir: bool, no_local_patterns: bool = False) -> int:
+    spec = load_spec(demo)
+    errs = validate_spec(spec)
+    if errs:
+        for e in errs:
+            print(f"  ✗ {e}")
+        die("spec invalid — fix before recording (or run --dry-run)")
+    missing = check_tools()
+    if missing:
+        die(f"missing tools: {', '.join(missing)} — the privacy gate requires all of them")
+    if spec["device"] == "ios":
+        die("ios recording is manual for now: point QuickTime (New Movie Recording) "
+            "at the iPhone, then composite by hand. Android automation only.")
+
+    patterns = load_forbidden()
+    if not (Path(__file__).parent / "privacy" / "FORBIDDEN.local.txt").exists():
+        if no_local_patterns:
+            log("WARNING: running without FORBIDDEN.local.txt (--no-local-patterns) — "
+                "personal identifiers are NOT enforced. Never ship this recording.")
+        else:
+            die("scripts/privacy/FORBIDDEN.local.txt missing — the personal identifier "
+                "list is not set up (see RECORDING_CHECKLIST.md §3). If you really "
+                "want to record without it, pass --no-local-patterns.")
+
+    workdir = REPO_ROOT / ".recordings" / demo
+    if workdir.exists():
+        shutil.rmtree(workdir)
+    workdir.mkdir(parents=True)
+    log(f"workdir {workdir}")
+    if spec.get("platform_notes"):
+        log(f"platform notes: {spec['platform_notes']}")
+
+    dev = get_device(serial)
+    restore = {}
+    rec = None
+    try:
+        if skip_phone_prep:
+            log("phone prep SKIPPED (--skip-phone-prep) — dev runs only, never ship this")
+        else:
+            restore = phone_privacy_prep(dev, workdir, patterns)
+        run_setup(dev, spec)
+
+        content_s = timeline_end(spec)
+        rec = PhoneRecorder(dev.serial, content_s + 10, spec.get("record_size"))
+        log(f"recording ~{content_s:.0f}s of content on {dev.serial}")
+        rec.start()
+
+        plan = {"spec": spec, "serial": dev.serial,
+                "done_marker": str(workdir / "inner_done")}
+        plan_path = workdir / "plan.json"
+        plan_path.write_text(json.dumps(plan))
+
+        cast = workdir / "terminal.cast"
+        phone_offset = time.monotonic() - rec.started_at
+        # per-demo terminal height (motion 3-pane demos record a short window,
+        # e.g. LINES=14); defaults to the global TERM_ROWS
+        term_rows = int(spec.get(
+            "term_rows", 14 if spec.get("layout") == "three_window" else TERM_ROWS))
+        env = dict(os.environ)
+        env.update({"COLUMNS": str(TERM_COLS), "LINES": str(term_rows),
+                    "PYTHONUNBUFFERED": "1"})
+        inner_cmd = f"{shlex.quote(sys.executable)} {shlex.quote(str(Path(__file__).resolve()))} --_inner {shlex.quote(str(plan_path))}"
+        r = subprocess.run(
+            ["asciinema", "rec", "--overwrite", "--cols", str(TERM_COLS),
+             "--rows", str(term_rows), "-c", inner_cmd, str(cast)],
+            env=env)
+        if r.returncode != 0 or not (workdir / "inner_done").exists():
+            die("timeline execution failed (see output above)")
+
+        phone_mp4 = workdir / "phone.mp4"
+        rec.stop_and_pull(phone_mp4)
+        rec = None
+    finally:
+        if rec and rec.proc:
+            rec.proc.kill()
+        if restore:
+            phone_privacy_restore(dev, restore)
+
+    # ── post-process ──
+    host = socket.gethostname()
+    user = os.environ.get("USER", "")
+    extra = [(dev.serial, "<ANDROID_DEVICE>")]
+    # Every OTHER attached serial can leak too (e.g. `gitd doctor` lists them)
+    out = subprocess.run(["adb", "devices"], capture_output=True, text=True).stdout
+    others = [l.split()[0] for l in out.splitlines()[1:]
+              if l.strip().endswith("device") and l.split()[0] != dev.serial]
+    extra += [(s, f"<ANDROID_DEVICE_{i+2}>") for i, s in enumerate(others)]
+    if host:
+        extra.append((host, "ghost-dev-linux"))
+    if user and user != "ghost":
+        extra.append((f"/home/{user}", "~"))
+        extra.append((f"{user}@", "ghost@"))
+
+    cast_scrubbed = workdir / "terminal_scrubbed.cast"
+    scrub_cast(workdir / "terminal.cast", cast_scrubbed, extra=extra,
+               cols=TERM_COLS, rows=int(spec.get(
+                   "term_rows", 14 if spec.get("layout") == "three_window" else TERM_ROWS)))
+    hits = scan_text(cast_scrubbed.read_text(), patterns)
+    if hits:
+        for src, m in hits:
+            log(f"  FORBIDDEN in scrubbed terminal cast: {src!r} matched {m[:3]}…")
+        die("terminal recording still contains forbidden content after scrubbing — "
+            "extend scrub.py substitutions or fix the demo commands")
+
+    log("rendering terminal (agg)")
+    term_mp4 = workdir / "terminal.mp4"
+    render_terminal(cast_scrubbed, term_mp4, workdir)
+
+    log("compositing final video (ffmpeg)")
+    out_webm = workdir / "demo.webm"
+    composite(spec, workdir, term_mp4, workdir / "phone.mp4",
+              phone_offset_s=phone_offset, out_webm=out_webm)
+
+    log("privacy OCR gate: extracting frames + tesseract scan")
+    violations = ocr_gate(out_webm, workdir, patterns)
+    if violations:
+        for v in violations:
+            log(f"  FORBIDDEN {v}")
+        die(f"OCR gate FAILED ({len(violations)} hit(s)) — output stays quarantined in "
+            f"{workdir}, nothing was copied to site/public/. Inspect the frames, fix "
+            f"the leak, re-record.")
+    log("privacy OCR gate: clean")
+
+    out_dir = SHOWCASE_DIR / demo
+    out_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(out_webm, out_dir / "demo.webm")
+    hw = spec.get("highlight_window") or {}
+    # Skip past the intro before grabbing the poster. Motion layouts open with
+    # an animated intro whose real length (≈7.8s) replaces the 1s static card.
+    intro_motion = BRAND_DIR / f"intro-{demo}-motion.mp4"
+    intro_dur = INTRO_S
+    if spec.get("layout") == "three_window" and intro_motion.exists():
+        probe = subprocess.run(
+            ["ffprobe", "-v", "error", "-show_entries", "format=duration",
+             "-of", "default=nw=1:nk=1", str(intro_motion)],
+            capture_output=True, text=True)
+        intro_dur = float(probe.stdout.strip() or INTRO_S)
+    poster_ss = intro_dur + float(hw.get("start_s", 2)) + 1.0
+    run(["ffmpeg", "-y", "-ss", str(poster_ss), "-i", str(out_dir / "demo.webm"),
+         "-frames:v", "1", str(out_dir / "poster.png")], "poster extraction")
+    write_snippet(spec, out_dir / "snippet.py")
+
+    size_mb = (out_dir / "demo.webm").stat().st_size / 1e6
+    log(f"DONE → {out_dir / 'demo.webm'} ({size_mb:.1f} MB), poster.png, snippet.py")
+    if not keep_workdir:
+        shutil.rmtree(workdir)
+    return 0
+
+
+def do_compose(demo: str, phone_video: str, terminal_cast: str | None,
+               phone_offset: float, keep_workdir: bool,
+               no_local_patterns: bool = False) -> int:
+    """Compose a demo from EXTERNAL sources — no ADB recording. Takes a phone
+    video from ANY source (iOS WDA/Tailscale MJPEG, QuickTime, or a plain mp4)
+    plus an optional terminal.cast, and reuses the standard render→composite→
+    OCR-gate→deploy post-process. This is how iOS demos ship (ADB can't capture
+    an iPhone); device:ios in the spec already selects the iphone15pro bezel."""
+    spec = load_spec(demo)
+    errs = validate_spec(spec)
+    if errs:
+        for e in errs:
+            print(f"  ✗ {e}")
+        die("spec invalid — fix before composing (or run --dry-run)")
+    missing = [t for t in ("agg", "ffmpeg", "tesseract") if not shutil.which(t)]
+    if missing:
+        die(f"missing tools: {', '.join(missing)} — compose needs the render + gate toolchain")
+    patterns = load_forbidden()
+    if not (Path(__file__).parent / "privacy" / "FORBIDDEN.local.txt").exists() \
+            and not no_local_patterns:
+        die("scripts/privacy/FORBIDDEN.local.txt missing (see RECORDING_CHECKLIST.md §3) "
+            "— or pass --no-local-patterns.")
+
+    layout = spec.get("layout")
+    if layout != "phone_only" and not terminal_cast:
+        die(f"layout '{layout}' needs a terminal — pass --terminal-cast (only phone_only omits it)")
+    pv = Path(phone_video)
+    if not pv.exists():
+        die(f"--phone-video not found: {pv}")
+
+    demo_v = spec["demo"]
+    workdir = REPO_ROOT / ".recordings" / demo_v
+    if workdir.exists():
+        shutil.rmtree(workdir)
+    workdir.mkdir(parents=True)
+    log(f"compose workdir {workdir} (external sources; no ADB)")
+
+    # Normalize the external phone video to CFR (MJPEG / WDA / QuickTime streams
+    # are often VFR — a static screen emits sparse frames → overlay timing drifts).
+    phone_mp4 = workdir / "phone.mp4"
+    run(["ffmpeg", "-y", "-i", str(pv), "-r", str(FPS), "-an",
+         "-pix_fmt", "yuv420p", str(phone_mp4)], "normalize phone video", heavy=True)
+
+    host = socket.gethostname()
+    user = os.environ.get("USER", "")
+    extra: list[tuple[str, str]] = []
+    if host:
+        extra.append((host, "ghost-dev-linux"))
+    if user and user != "ghost":
+        extra.append((f"/home/{user}", "~"))
+        extra.append((f"{user}@", "ghost@"))
+
+    term_mp4 = None
+    if terminal_cast:
+        tc = Path(terminal_cast)
+        if not tc.exists():
+            die(f"--terminal-cast not found: {tc}")
+        shutil.copy2(tc, workdir / "terminal.cast")
+        cast_scrubbed = workdir / "terminal_scrubbed.cast"
+        rows = int(spec.get("term_rows",
+                            14 if layout == "three_window" else TERM_ROWS))
+        scrub_cast(workdir / "terminal.cast", cast_scrubbed, extra=extra,
+                   cols=TERM_COLS, rows=rows)
+        hits = scan_text(cast_scrubbed.read_text(), patterns)
+        if hits:
+            for src, m in hits:
+                log(f"  FORBIDDEN in scrubbed terminal cast: {src!r} matched {m[:3]}…")
+            die("terminal cast still contains forbidden content after scrubbing "
+                "(UDID/keys/hostnames?) — clean the source cast and retry")
+        log("rendering terminal (agg)")
+        term_mp4 = workdir / "terminal.mp4"
+        render_terminal(cast_scrubbed, term_mp4, workdir)
+
+    log("compositing final video (ffmpeg)")
+    out_webm = workdir / "demo.webm"
+    composite(spec, workdir, term_mp4, phone_mp4,
+              phone_offset_s=phone_offset, out_webm=out_webm)
+
+    log("privacy OCR gate: extracting frames + tesseract scan")
+    violations = ocr_gate(out_webm, workdir, patterns)
+    if violations:
+        for v in violations:
+            log(f"  FORBIDDEN {v}")
+        die(f"OCR gate FAILED ({len(violations)} hit(s)) — output quarantined in "
+            f"{workdir}, nothing copied to site/public/. Inspect + fix the leak.")
+    log("privacy OCR gate: clean")
+
+    out_dir = SHOWCASE_DIR / demo_v
+    out_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(out_webm, out_dir / "demo.webm")
+    hw = spec.get("highlight_window") or {}
+    poster_ss = INTRO_S + float(hw.get("start_s", 2)) + 1.0
+    run(["ffmpeg", "-y", "-ss", str(poster_ss), "-i", str(out_dir / "demo.webm"),
+         "-frames:v", "1", str(out_dir / "poster.png")], "poster extraction")
+    write_snippet(spec, out_dir / "snippet.py")
+    size_mb = (out_dir / "demo.webm").stat().st_size / 1e6
+    log(f"DONE → {out_dir / 'demo.webm'} ({size_mb:.1f} MB), poster.png, snippet.py")
+    if not keep_workdir:
+        shutil.rmtree(workdir)
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Ghost showcase demo recorder")
+    ap.add_argument("--demo", help="demo id (must exist in copy.yaml + have spec.yaml)")
+    ap.add_argument("--serial", help="android device serial (else ANDROID_SERIAL / sole device)")
+    ap.add_argument("--dry-run", action="store_true", help="validate spec + assets, don't record")
+    ap.add_argument("--list", action="store_true", help="list demos and their asset status")
+    ap.add_argument("--skip-phone-prep", action="store_true",
+                    help="DEV ONLY: skip DND/notification/OCR pre-checks")
+    ap.add_argument("--keep-workdir", action="store_true", help="keep .recordings/<demo> for debugging")
+    ap.add_argument("--no-local-patterns", action="store_true",
+                    help="DEV ONLY: allow recording without FORBIDDEN.local.txt "
+                         "(personal identifiers unenforced — never ship the result)")
+    ap.add_argument("--compose", action="store_true",
+                    help="compose from EXTERNAL sources (no ADB record; e.g. iOS)")
+    ap.add_argument("--phone-video",
+                    help="external phone video for --compose (iOS WDA/Tailscale MJPEG / mp4)")
+    ap.add_argument("--terminal-cast",
+                    help="terminal.cast to render for --compose (omit only for phone_only)")
+    ap.add_argument("--phone-offset", type=float, default=0.0,
+                    help="seconds trimmed off the phone video start (manual sync for --compose)")
+    ap.add_argument("--_inner", metavar="PLAN", help=argparse.SUPPRESS)
+    args = ap.parse_args()
+
+    if args._inner:
+        return run_inner(Path(args._inner))
+    if args.list:
+        return do_list()
+    if not args.demo:
+        ap.error("--demo is required (or --list)")
+    if args.dry_run:
+        return do_dry_run(args.demo)
+    if args.compose:
+        if not args.phone_video:
+            die("--compose needs --phone-video (and --demo)")
+        return do_compose(args.demo, args.phone_video, args.terminal_cast,
+                          args.phone_offset, args.keep_workdir, args.no_local_patterns)
+    return do_record(args.demo, args.serial, args.skip_phone_prep, args.keep_workdir,
+                     args.no_local_patterns)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/record_showcase_reel.py
+++ b/scripts/record_showcase_reel.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""record_showcase_reel.py — auto-stitch the showcase sizzle reel.
+
+Reads every demo's recording spec (site/public/showcase/<demo>/spec.yaml),
+takes each demo's highlight_window clip out of its rendered demo.webm,
+orders the clips by copy.yaml's sizzle_order, joins them with a 200ms
+crossfade, and writes site/public/showcase/hero-reel.webm.
+
+Runs the same privacy OCR gate as record_demo.py before writing the output —
+the reel is built from already-gated footage, but defense-in-depth is cheap.
+
+Usage:
+    python3 scripts/record_showcase_reel.py             # stitch all available
+    python3 scripts/record_showcase_reel.py --dry-run   # report what would stitch
+    python3 scripts/record_showcase_reel.py --demos a b # explicit subset/order
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from privacy.scrub import load_forbidden  # noqa: E402
+import record_demo  # noqa: E402  (shares INTRO_S, ocr_gate, run, log/die)
+
+XFADE_S = 0.2
+FPS = 30
+OUT_W, OUT_H = 1280, 720
+
+
+def collect(showcase_dir: Path, only: list[str] | None) -> list[dict]:
+    """All demos that have both a spec.yaml and a rendered demo.webm,
+    ordered by copy.yaml sizzle_order (or the explicit --demos order)."""
+    copy = yaml.safe_load((showcase_dir / "copy.yaml").read_text())
+    order = {d["id"]: d.get("sizzle_order") or 99 for d in copy.get("demos", [])}
+
+    clips = []
+    for spec_path in sorted(showcase_dir.glob("*/spec.yaml")):
+        demo = spec_path.parent.name
+        if only and demo not in only:
+            continue
+        spec = yaml.safe_load(spec_path.read_text())
+        webm = spec_path.parent / "demo.webm"
+        hw = spec.get("highlight_window") or {}
+        if not webm.exists():
+            record_demo.log(f"skip {demo}: no demo.webm yet")
+            continue
+        if not {"start_s", "end_s"} <= hw.keys():
+            record_demo.log(f"skip {demo}: spec has no highlight_window")
+            continue
+        clips.append({
+            "demo": demo,
+            "webm": webm,
+            # highlight_window is in timeline seconds; the rendered file has a
+            # 1s intro card in front of the content
+            "start": float(hw["start_s"]) + record_demo.INTRO_S,
+            "dur": float(hw["end_s"]) - float(hw["start_s"]),
+            "order": order.get(demo, 99),
+        })
+    if only:
+        clips.sort(key=lambda c: only.index(c["demo"]))
+    else:
+        clips.sort(key=lambda c: c["order"])
+    return clips
+
+
+def stitch(clips: list[dict], out: Path, workdir: Path) -> None:
+    """Trim each highlight clip, then chain xfade transitions."""
+    inputs, fc = [], []
+    for i, c in enumerate(clips):
+        inputs += ["-ss", str(c["start"]), "-t", str(c["dur"]), "-i", str(c["webm"])]
+        fc.append(f"[{i}:v]scale={OUT_W}:{OUT_H},fps={FPS},format=yuv420p,"
+                  f"setpts=PTS-STARTPTS[v{i}];")
+
+    if len(clips) == 1:
+        fc.append("[v0]copy[out]")
+    else:
+        prev = "v0"
+        offset = clips[0]["dur"] - XFADE_S
+        for i in range(1, len(clips)):
+            label = "out" if i == len(clips) - 1 else f"x{i}"
+            fc.append(f"[{prev}][v{i}]xfade=transition=fade:duration={XFADE_S}:"
+                      f"offset={offset:.3f}[{label}];")
+            prev = label
+            offset += clips[i]["dur"] - XFADE_S
+        fc[-1] = fc[-1].rstrip(";")
+
+    record_demo.run(
+        ["ffmpeg", "-y", *inputs, "-filter_complex", "".join(fc), "-map", "[out]",
+         "-c:v", "libvpx-vp9", "-crf", "40", "-b:v", "0",
+         "-deadline", "good", "-cpu-used", "2", "-row-mt", "1", "-an", str(out)],
+        "reel stitch", heavy=True)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Stitch the showcase sizzle reel")
+    ap.add_argument("--demos", nargs="+", help="explicit demo ids (and order); default: all with sizzle_order")
+    ap.add_argument("--dry-run", action="store_true", help="report clips without rendering")
+    ap.add_argument("--showcase-dir", type=Path, default=record_demo.SHOWCASE_DIR,
+                    help=argparse.SUPPRESS)  # test hook
+    ap.add_argument("--out", type=Path, help="output path (default <showcase>/hero-reel.webm)")
+    args = ap.parse_args()
+
+    clips = collect(args.showcase_dir, args.demos)
+    if not clips:
+        record_demo.die("no stitchable demos (need spec.yaml + demo.webm + highlight_window)")
+    total = sum(c["dur"] for c in clips) - XFADE_S * (len(clips) - 1)
+    for c in clips:
+        record_demo.log(f"clip {c['order']:>2}. {c['demo']:24s} "
+                        f"{c['dur']:.1f}s @ {c['start']:.1f}s of {c['webm'].name}")
+    record_demo.log(f"reel: {len(clips)} clips, ~{total:.1f}s with {XFADE_S}s crossfades")
+    if args.dry_run:
+        return 0
+
+    out = args.out or (args.showcase_dir / "hero-reel.webm")
+    workdir = REPO_ROOT / ".recordings" / "_reel"
+    if workdir.exists():
+        shutil.rmtree(workdir)
+    workdir.mkdir(parents=True)
+    tmp = workdir / "hero-reel.webm"
+    stitch(clips, tmp, workdir)
+
+    if shutil.which("tesseract"):
+        record_demo.log("privacy OCR gate on stitched reel")
+        violations = record_demo.ocr_gate(tmp, workdir, load_forbidden())
+        if violations:
+            for v in violations:
+                record_demo.log(f"  FORBIDDEN {v}")
+            record_demo.die(f"OCR gate FAILED — reel stays quarantined in {workdir}")
+    else:
+        record_demo.die("tesseract missing — the reel cannot ship ungated")
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(tmp, out)
+    shutil.rmtree(workdir)
+    record_demo.log(f"DONE → {out} ({out.stat().st_size / 1e6:.1f} MB)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# release.sh — cut a new release from private-mirror/main.
+#
+# Does: version bump, CHANGELOG stamp (move [Unreleased] → dated section,
+# update compare links), commit, push to private-mirror/main, create a
+# clean release PR on public repo (rebuilt on top of public/main to avoid
+# history-divergence conflicts).
+#
+# Usage:
+#   ./scripts/release.sh 1.3.0
+#
+# After merge of the public PR, tag on public main:
+#   git tag v1.3.0 && git push public v1.3.0
+# → triggers publish.yml → PyPI + GitHub Release + archive sync (all automated)
+set -euo pipefail
+
+NEW_VERSION="${1:-}"
+if [[ -z "$NEW_VERSION" ]]; then
+  echo "Usage: $0 <version>   e.g.  $0 1.3.0" >&2
+  exit 1
+fi
+
+if ! [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Error: version must match X.Y.Z (got '$NEW_VERSION')" >&2
+  exit 1
+fi
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$BRANCH" != "main" ]]; then
+  echo "Error: must be on main (currently on $BRANCH)" >&2
+  exit 1
+fi
+
+if ! git diff-index --quiet HEAD --; then
+  echo "Error: working tree not clean" >&2
+  exit 1
+fi
+
+# Ensure public remote exists
+if ! git remote get-url public >/dev/null 2>&1; then
+  git remote add public https://github.com/ghost-in-the-droid/android-agent.git
+fi
+
+echo "→ Pulling latest main"
+git pull --ff-only origin main
+git fetch public main
+
+CURRENT_VERSION=$(grep '^version = ' pyproject.toml | sed -E 's/^version = "(.+)"/\1/')
+TODAY=$(date +%Y-%m-%d)
+
+echo "→ Bumping $CURRENT_VERSION → $NEW_VERSION"
+sed -i.bak "s/^version = \"$CURRENT_VERSION\"/version = \"$NEW_VERSION\"/" pyproject.toml
+rm pyproject.toml.bak
+
+echo "→ Stamping CHANGELOG.md"
+python3 - "$NEW_VERSION" "$CURRENT_VERSION" "$TODAY" <<'PY'
+import re, sys
+new, old, today = sys.argv[1], sys.argv[2], sys.argv[3]
+with open("CHANGELOG.md") as f:
+    c = f.read()
+
+# Insert dated section below [Unreleased]
+c = c.replace(
+    "## [Unreleased]\n",
+    f"## [Unreleased]\n\n## [{new}] — {today}\n",
+    1,
+)
+
+# Update [Unreleased] compare link (was v{old}...HEAD, now v{new}...HEAD)
+c = re.sub(
+    r"^\[Unreleased\]:.*$",
+    f"[Unreleased]: https://github.com/ghost-in-the-droid/android-agent/compare/v{new}...HEAD",
+    c,
+    flags=re.MULTILINE,
+)
+
+# Add the new version's compare link just under [Unreleased]
+new_link = f"[{new}]: https://github.com/ghost-in-the-droid/android-agent/compare/v{old}...v{new}"
+c = re.sub(
+    r"^(\[Unreleased\]:.*\n)",
+    rf"\1{new_link}\n",
+    c,
+    count=1,
+    flags=re.MULTILINE,
+)
+
+with open("CHANGELOG.md", "w") as f:
+    f.write(c)
+PY
+
+echo "→ Committing version bump on private-mirror/main"
+git add pyproject.toml CHANGELOG.md
+git commit -m "Release v$NEW_VERSION"
+git push origin main
+
+# Build clean release branch on top of public/main
+echo "→ Creating release/v$NEW_VERSION on public from public/main"
+RELEASE_BRANCH="release/v$NEW_VERSION"
+git checkout -B "$RELEASE_BRANCH" public/main
+
+# Determine the commit on private-mirror that the previous tag was cut from
+# by looking for the most recent "Release v" commit before this one.
+LAST_RELEASE_COMMIT=$(git log main --grep="^Release v" --format="%H" | sed -n '2p')
+if [[ -z "$LAST_RELEASE_COMMIT" ]]; then
+  echo "Error: couldn't find previous 'Release v' commit on main" >&2
+  exit 1
+fi
+
+echo "→ Applying cumulative diff from $LAST_RELEASE_COMMIT..main onto public/main"
+git diff "$LAST_RELEASE_COMMIT..main" | git apply --3way --index || {
+  echo "→ 3-way apply had issues, trying direct apply"
+  git diff "$LAST_RELEASE_COMMIT..main" | git apply --index
+}
+
+git commit -m "Release v$NEW_VERSION"
+git push public "$RELEASE_BRANCH"
+
+# Extract the [new version] section from CHANGELOG for PR body
+PR_BODY=$(python3 - "$NEW_VERSION" <<'PY'
+import re, sys
+new = sys.argv[1]
+with open("CHANGELOG.md") as f:
+    c = f.read()
+m = re.search(rf"## \[{re.escape(new)}\].*?(?=\n## |\Z)", c, re.DOTALL)
+if m:
+    body = m.group(0)
+else:
+    body = f"Release v{new}"
+print(body)
+PY
+)
+
+echo "→ Opening PR on public repo"
+gh pr create \
+  --repo ghost-in-the-droid/android-agent \
+  --base main --head "$RELEASE_BRANCH" \
+  --title "Release v$NEW_VERSION" \
+  --body "$PR_BODY
+
+---
+
+After CI green + merge: tag \`v$NEW_VERSION\` on public main to trigger PyPI publish + GitHub Release + archive sync."
+
+# Restore private-mirror working copy
+git checkout main
+
+echo ""
+echo "✓ v$NEW_VERSION release PR opened on public repo"
+echo ""
+echo "Next steps (after CI green):"
+echo "  1. Review/merge the public PR"
+echo "  2. Tag on public main:"
+echo "       git fetch public && git checkout public/main"
+echo "       git tag v$NEW_VERSION && git push public v$NEW_VERSION"
+echo "  3. Workflows handle the rest: PyPI, GitHub Release, archive sync"

--- a/scripts/showcase/claude_tui_driver.py
+++ b/scripts/showcase/claude_tui_driver.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Record a real Claude Code TUI session driving a task, cleanly.
+
+Architecture (avoids the nested-PTY width corruption): pexpect spawns
+`asciinema rec --window-size CxR` which runs the real `claude` TUI *directly*
+(prompt passed as a positional arg so it auto-runs). Because claude renders into
+asciinema's single PTY at the forced size, there's no width mismatch. pexpect
+watches the output and, once the agent goes idle, sends the exit keystrokes to
+claude so asciinema finalizes the cast.
+
+TMUX is stripped from the child env (else claude prints tmux hints), and TERM is
+forced to xterm-256color for clean rendering.
+
+Usage:
+    python claude_tui_driver.py --prompt '<task>' --mcp-config <cfg> \
+        --cast out.cast [--cols 100] [--rows 30] [--env KEY=VAL ...]
+"""
+import argparse
+import os
+import shlex
+import sys
+import time
+
+import pexpect
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--prompt", required=True)
+    ap.add_argument("--mcp-config", required=True)
+    ap.add_argument("--cast", required=True)
+    ap.add_argument("--cols", type=int, default=100)
+    ap.add_argument("--rows", type=int, default=30)
+    ap.add_argument("--claude", default="claude")
+    ap.add_argument("--idle-done", type=float, default=8.0,
+                    help="seconds of no output (after work began) = finished")
+    ap.add_argument("--min-run", type=float, default=14.0)
+    ap.add_argument("--max-run", type=float, default=240.0)
+    ap.add_argument("--env", action="append", default=[],
+                    help="KEY=VAL injected into the claude/MCP env (repeatable)")
+    args = ap.parse_args()
+
+    # Env for the inner claude process: no TMUX, clean TERM, iOS gate on.
+    inner_env = {
+        "TERM": "xterm-256color",
+        "GITD_ENABLE_IOS": "1",
+        "COLUMNS": str(args.cols),
+        "LINES": str(args.rows),
+    }
+    for kv in args.env:
+        k, _, v = kv.partition("=")
+        inner_env[k] = v
+    env_prefix = "env -u TMUX " + " ".join(
+        f"{k}={shlex.quote(v)}" for k, v in inner_env.items()
+    )
+
+    inner = (
+        f"{env_prefix} {args.claude} --mcp-config {shlex.quote(args.mcp_config)} "
+        f"--strict-mcp-config --dangerously-skip-permissions "
+        f"{shlex.quote(args.prompt)}"
+    )
+    rec = (
+        f"asciinema rec --overwrite --window-size {args.cols}x{args.rows} "
+        f"{shlex.quote(args.cast)} -c {shlex.quote(inner)}"
+    )
+
+    spawn_env = dict(os.environ)
+    spawn_env.pop("TMUX", None)
+    spawn_env["TERM"] = "xterm-256color"
+    child = pexpect.spawn(
+        "/bin/bash", ["-lc", rec], env=spawn_env, encoding="utf-8",
+        dimensions=(args.rows, args.cols), timeout=args.max_run,
+    )
+    child.logfile_read = sys.stdout
+
+    start = time.time()
+    last_output = time.time()
+    saw_work = False
+    while time.time() - start < args.max_run:
+        try:
+            chunk = child.read_nonblocking(size=4096, timeout=1.0)
+            if chunk:
+                last_output = time.time()
+                if len(chunk.strip()) > 2:
+                    saw_work = True
+        except pexpect.TIMEOUT:
+            pass
+        except pexpect.EOF:
+            break
+        idle = time.time() - last_output
+        if saw_work and idle >= args.idle_done and time.time() - start > args.min_run:
+            break
+
+    # Exit the claude TUI so asciinema finalizes the cast.
+    time.sleep(1.2)
+    for keys in ("\x1b", "\x03", "\x03"):   # esc, then Ctrl-C twice
+        try:
+            child.send(keys)
+            time.sleep(0.4)
+        except Exception:
+            break
+    try:
+        child.expect(pexpect.EOF, timeout=10)
+    except Exception:
+        child.close(force=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/showcase/generate_brand_assets.py
+++ b/scripts/showcase/generate_brand_assets.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Generate Ghost Showcase brand assets — intro/outro cards, device frames.
+
+Source of truth for site/public/showcase/_brand/. Regenerate after palette
+or feature-list changes:
+
+    python3 scripts/showcase/generate_brand_assets.py
+
+Consumed by the showcase pipeline (record_demo.py): intro/outro cards are
+1920x1080 stills prepended/appended to each demo; device frames are
+transparent overlays composited above the screen recording (screen
+coordinates in frames.json).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import yaml
+from PIL import Image, ImageDraw, ImageFilter, ImageFont
+
+REPO = Path(__file__).resolve().parents[2]
+BRAND = REPO / "site" / "public" / "showcase" / "_brand"
+FONTS = BRAND / "fonts"
+MASCOT = REPO / "site" / "public" / "mascot"
+
+W, H = 1920, 1080
+
+# Palette — keep in sync with site/src/styles/custom.css
+ACCENT = "#00e5a0"
+ACCENT_HIGH = "#6efcd0"
+ACCENT_LOW = "#052e1e"
+GRAY_1 = "#e8ede9"
+GRAY_3 = "#8a9a8d"
+GRAY_5 = "#2a3a2d"
+GRAY_7 = "#0d130e"
+BG_DEEP = "#070b08"
+
+# Demo slugs + titles come from marketing's copy.yaml (single source of truth).
+COPY_YAML = REPO / "site" / "public" / "showcase" / "copy.yaml"
+
+
+def load_demos() -> dict[str, str]:
+    data = yaml.safe_load(COPY_YAML.read_text())
+    return {d["id"]: d["title"] for d in data["demos"]}
+
+
+def font(path: Path, size: int, weight: int) -> ImageFont.FreeTypeFont:
+    f = ImageFont.truetype(str(path), size)
+    f.set_variation_by_axes([weight])
+    return f
+
+
+def outfit(size: int, weight: int = 400) -> ImageFont.FreeTypeFont:
+    return font(FONTS / "Outfit[wght].ttf", size, weight)
+
+
+def mono(size: int, weight: int = 400) -> ImageFont.FreeTypeFont:
+    return font(FONTS / "JetBrainsMono[wght].ttf", size, weight)
+
+
+def hex_rgb(h: str) -> tuple[int, int, int]:
+    h = h.lstrip("#")
+    return tuple(int(h[i : i + 2], 16) for i in (0, 2, 4))
+
+
+def brand_background() -> Image.Image:
+    """Dark green vertical gradient with a soft accent glow, matching the site."""
+    top, bottom = hex_rgb(GRAY_7), hex_rgb(BG_DEEP)
+    grad = Image.linear_gradient("L").resize((W, H))
+    bg = Image.composite(Image.new("RGB", (W, H), bottom), Image.new("RGB", (W, H), top), grad)
+
+    glow = Image.new("L", (W, H), 0)
+    d = ImageDraw.Draw(glow)
+    d.ellipse([W * 0.55, H * 0.75, W * 1.35, H * 1.6], fill=26)
+    glow = glow.filter(ImageFilter.GaussianBlur(160))
+    bg = Image.composite(Image.new("RGB", (W, H), hex_rgb(ACCENT)), bg, glow)
+
+    d = ImageDraw.Draw(bg)
+    d.line([(0, H - 4), (W, H - 4)], fill=hex_rgb(ACCENT_LOW), width=4)
+    return bg
+
+
+def draw_lockup(img: Image.Image) -> None:
+    """Mascot + wordmark, top-left."""
+    d = ImageDraw.Draw(img)
+    mascot = Image.open(MASCOT / "09-base-ghost.png").convert("RGBA")
+    mascot.thumbnail((64, 64), Image.LANCZOS)
+    img.paste(mascot, (72, 60), mascot)
+    d.text((152, 74), "Ghost in the Droid", font=outfit(34, 600), fill=hex_rgb(GRAY_1))
+
+
+def draw_version_stamp(img: Image.Image, version: str) -> None:
+    d = ImageDraw.Draw(img)
+    label = f"v{version}"
+    f = mono(28, 500)
+    tw = d.textlength(label, font=f)
+    x, y = W - 72 - tw, H - 72
+    d.ellipse([x - 26, y + 10, x - 12, y + 24], fill=hex_rgb(ACCENT))
+    d.text((x, y), label, font=f, fill=hex_rgb(GRAY_3))
+
+
+def intro_card(slug: str, name: str, version: str) -> Image.Image:
+    img = brand_background()
+    draw_lockup(img)
+    draw_version_stamp(img, version)
+    d = ImageDraw.Draw(img)
+
+    kicker = "F E A T U R E"
+    fk = mono(30, 500)
+    d.text(((W - d.textlength(kicker, font=fk)) / 2, 402), kicker, font=fk, fill=hex_rgb(ACCENT))
+
+    size = 118
+    ft = outfit(size, 800)
+    while d.textlength(name, font=ft) > 1680 and size > 56:
+        size -= 6
+        ft = outfit(size, 800)
+    tw = d.textlength(name, font=ft)
+    d.text(((W - tw) / 2, 462 + (118 - size) * 0.55), name, font=ft, fill=hex_rgb(GRAY_1))
+
+    bar_w = 180
+    d.rounded_rectangle(
+        [(W - bar_w) / 2, 640, (W + bar_w) / 2, 648], radius=4, fill=hex_rgb(ACCENT)
+    )
+    return img
+
+
+def outro_card(version: str, cta: str) -> Image.Image:
+    img = brand_background()
+    draw_version_stamp(img, version)
+    d = ImageDraw.Draw(img)
+
+    mascot = Image.open(MASCOT / "43-wave.png").convert("RGBA")
+    mascot.thumbnail((150, 150), Image.LANCZOS)
+    img.paste(mascot, ((W - mascot.width) // 2, 280), mascot)
+
+    ft = outfit(96, 800)
+    site_txt = "ghostinthedroid.com"
+    tw = d.textlength(site_txt, font=ft)
+    d.text(((W - tw) / 2, 460), site_txt, font=ft, fill=hex_rgb(GRAY_1))
+
+    fc = mono(38, 500)
+    chip_text = f"$ {cta}"
+    ctw = d.textlength(chip_text, font=fc)
+    pad_x, pad_y = 44, 26
+    cx0 = (W - ctw) / 2 - pad_x
+    cy0 = 632
+    d.rounded_rectangle(
+        [cx0, cy0, cx0 + ctw + 2 * pad_x, cy0 + 38 + 2 * pad_y],
+        radius=16,
+        fill=hex_rgb("#101710"),
+        outline=hex_rgb(GRAY_5),
+        width=2,
+    )
+    d.text((cx0 + pad_x, cy0 + pad_y), "$ ", font=fc, fill=hex_rgb(ACCENT))
+    d.text(
+        (cx0 + pad_x + d.textlength("$ ", font=fc), cy0 + pad_y),
+        cta,
+        font=fc,
+        fill=hex_rgb(ACCENT_HIGH),
+    )
+    return img
+
+
+def _punch_transparent(img: Image.Image, box: list[float], radius: int) -> None:
+    """Make a rounded-rect region fully transparent (the screen window)."""
+    mask = Image.new("L", img.size, 0)
+    ImageDraw.Draw(mask).rounded_rectangle(box, radius=radius, fill=255)
+    px = img.load()
+    mpx = mask.load()
+    x0, y0, x1, y1 = (int(v) for v in box)
+    for y in range(max(0, y0), min(img.height, y1 + 1)):
+        for x in range(max(0, x0), min(img.width, x1 + 1)):
+            if mpx[x, y]:
+                px[x, y] = (0, 0, 0, 0)
+
+
+def device_frame(
+    screen_w_px: int,
+    screen_h_px: int,
+    bezel: int,
+    body_radius: int,
+    screen_radius: int,
+    edge_color: str,
+    body_color: str,
+    camera: str,
+) -> tuple[Image.Image, dict]:
+    """Draw a minimalist device frame centered on a transparent 1920x1080 canvas."""
+    target_h = 940
+    scr_w = round(target_h * screen_w_px / screen_h_px)
+    scr_h = target_h
+    body_w, body_h = scr_w + 2 * bezel, scr_h + 2 * bezel
+    bx0, by0 = (W - body_w) // 2, (H - body_h) // 2
+    sx0, sy0 = bx0 + bezel, by0 + bezel
+
+    img = Image.new("RGBA", (W, H), (0, 0, 0, 0))
+    d = ImageDraw.Draw(img)
+
+    d.rounded_rectangle(
+        [bx0 - 3, by0 - 3, bx0 + body_w + 3, by0 + body_h + 3],
+        radius=body_radius + 3,
+        fill=hex_rgb(edge_color) + (255,),
+    )
+    d.rounded_rectangle(
+        [bx0, by0, bx0 + body_w, by0 + body_h],
+        radius=body_radius,
+        fill=hex_rgb(body_color) + (255,),
+    )
+
+    # side buttons (right edge)
+    btn = hex_rgb(edge_color) + (255,)
+    d.rounded_rectangle([bx0 + body_w, by0 + 180, bx0 + body_w + 6, by0 + 260], radius=3, fill=btn)
+    d.rounded_rectangle([bx0 + body_w, by0 + 290, bx0 + body_w + 6, by0 + 420], radius=3, fill=btn)
+
+    _punch_transparent(img, [sx0, sy0, sx0 + scr_w, sy0 + scr_h], screen_radius)
+
+    # camera cutouts sit above the video, so draw them opaque after the punch
+    d = ImageDraw.Draw(img)
+    cam = (5, 6, 7, 255)
+    if camera == "punch-hole":
+        cx, cy, r = sx0 + scr_w / 2, sy0 + 42, 13
+        d.ellipse([cx - r, cy - r, cx + r, cy + r], fill=cam)
+    elif camera == "dynamic-island":
+        iw, ih = 128, 36
+        ix, iy = sx0 + (scr_w - iw) / 2, sy0 + 22
+        d.rounded_rectangle([ix, iy, ix + iw, iy + ih], radius=ih / 2, fill=cam)
+
+    spec = {
+        "canvas": [W, H],
+        "screen_rect": [sx0, sy0, scr_w, scr_h],
+        "screen_radius": screen_radius,
+        "source_resolution": [screen_w_px, screen_h_px],
+    }
+    return img, spec
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--version", default="1.3.0")
+    ap.add_argument("--cta", default="pip install ghost-in-the-droid")
+    args = ap.parse_args()
+
+    BRAND.mkdir(parents=True, exist_ok=True)
+
+    demos = load_demos()
+    for old in BRAND.glob("intro-*.png"):
+        old.unlink()
+    for slug, name in demos.items():
+        intro_card(slug, name, args.version).save(BRAND / f"intro-{slug}.png")
+    outro_card(args.version, args.cta).save(BRAND / "outro.png")
+    print(f"cards: {len(demos)} intros + outro (slugs from {COPY_YAML.name})")
+
+    frames = {}
+    img, spec = device_frame(
+        1080, 2400, bezel=16, body_radius=72, screen_radius=56,
+        edge_color="#3a3f46", body_color="#14161a", camera="punch-hole",
+    )
+    img.save(BRAND / "frame-pixel8.png")
+    frames["pixel8"] = spec
+
+    img, spec = device_frame(
+        1179, 2556, bezel=14, body_radius=112, screen_radius=100,
+        edge_color="#4a4a4f", body_color="#1c1c1e", camera="dynamic-island",
+    )
+    img.save(BRAND / "frame-iphone15pro.png")
+    frames["iphone15pro"] = spec
+
+    (BRAND / "frames.json").write_text(json.dumps(frames, indent=2) + "\n")
+    print("frames: pixel8 + iphone15pro (+ frames.json)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/showcase/generate_placeholders.sh
+++ b/scripts/showcase/generate_placeholders.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Placeholder demo assets for the showcase frontend (task #783), so /showcase
+# renders before the record_demo.py pipeline (task #782) produces real demos.
+# Each real demo overwrites its placeholder in place — same paths, same names.
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+BRAND_FONT="site/public/showcase/_brand/fonts/Outfit[wght].ttf"
+BG="#070b08"
+
+make_demo() {
+  local slug="$1" title="$2"
+  local dir="site/public/showcase/$slug"
+  mkdir -p "$dir"
+  ffmpeg -y -loglevel error \
+    -f lavfi -i "color=c=${BG}:s=1280x720:d=6" \
+    -vf "drawtext=fontfile='${BRAND_FONT}':text='${title}':fontcolor=0xe8ede9:fontsize=64:x=(w-text_w)/2:y=(h-text_h)/2-40, \
+         drawtext=fontfile='${BRAND_FONT}':text='placeholder — real demo ships with the showcase pipeline':fontcolor=0x8a9a8d:fontsize=28:x=(w-text_w)/2:y=(h)/2+40, \
+         drawbox=x=(iw-180)/2:y=ih-120:w=180:h=6:color=0x00e5a0:t=fill" \
+    -c:v libvpx-vp9 -b:v 0 -crf 40 -an "$dir/demo.webm"
+  ffmpeg -y -loglevel error -i "$dir/demo.webm" -frames:v 1 "$dir/poster.png"
+}
+
+make_demo on-device-gemma "On-Device Gemma"
+make_demo mcp-claude-code "Claude Code → Your Phone"
+make_demo ios "iPhone Support"
+
+# Hero reel placeholder
+ffmpeg -y -loglevel error \
+  -f lavfi -i "color=c=${BG}:s=1920x1080:d=8" \
+  -vf "drawtext=fontfile='${BRAND_FONT}':text='Ghost in the Droid':fontcolor=0xe8ede9:fontsize=110:x=(w-text_w)/2:y=(h-text_h)/2-60, \
+       drawtext=fontfile='${BRAND_FONT}':text='hero reel placeholder':fontcolor=0x8a9a8d:fontsize=36:x=(w-text_w)/2:y=(h)/2+60" \
+  -c:v libvpx-vp9 -b:v 0 -crf 42 -an site/public/showcase/hero-reel.webm
+ffmpeg -y -loglevel error -i site/public/showcase/hero-reel.webm -frames:v 1 site/public/showcase/hero-poster.png
+
+echo "placeholders written"

--- a/scripts/showcase/langchain_script.py
+++ b/scripts/showcase/langchain_script.py
@@ -1,0 +1,56 @@
+"""LangChain × Ghost — subreddit harvester. Claude Code (your own subscription,
+no cloud API key) drives the phone through LangChain tools and writes to SQLite."""
+import json, os, re, sqlite3, sys, warnings
+warnings.filterwarnings("ignore")
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from integrations.langchain import ghost_langchain_tools
+from langchain_claude_code import ChatClaudeCode
+
+DB, DEVICE = Path(__file__).with_name("posts.db"), os.environ.get("GHOST_DEVICE") or os.environ["ANDROID_SERIAL"]
+SEED = ["LocalLLaMA", "MachineLearning", "singularity", "OpenAI", "StableDiffusion"]
+
+
+def main():
+    subreddit = next_pending()
+    if not subreddit:
+        print("all subreddits profiled"); return
+    print(f"harvesting r/{subreddit} …")
+    llm   = ChatClaudeCode(model="sonnet", permission_mode="bypassPermissions",
+                           disallowed_tools=["Bash", "WebFetch", "WebSearch"])  # phone only, no shortcuts
+    tools = ghost_langchain_tools(DEVICE)          # 53 phone tools, as an in-process MCP
+    task  = (f"Force-stop and reopen the Reddit app fresh, then navigate to r/{subreddit}. "
+             f"Read the title, upvotes and comment count of the first 2 posts. Reply with "
+             f"ONLY a JSON array in a ```json fenced block.")
+    posts = parse(llm.bind_tools(tools).invoke(task).content)   # Claude Code drives the phone
+    save(subreddit, posts)
+    print(f"✓ r/{subreddit}: {len(posts)} posts → {DB.name}")
+
+
+# --- plumbing ---------------------------------------------------------------
+def next_pending():
+    row = _db().execute("SELECT subreddit FROM subs WHERE status='pending' LIMIT 1").fetchone()
+    return row[0] if row else None
+
+def save(subreddit, posts):
+    conn = _db()
+    conn.executemany("INSERT INTO posts VALUES (?,?,?,?)",
+                     [(subreddit, p.get("title"), p.get("upvotes"), p.get("comments")) for p in posts])
+    conn.execute("UPDATE subs SET status='done' WHERE subreddit=?", (subreddit,))
+    conn.commit()
+
+def parse(out):
+    for cand in (out.split("```json")[-1].split("```")[0].strip(), out.strip()):
+        try:    return json.loads(cand)
+        except: pass
+    m = re.search(r"\[.*\]", out, re.DOTALL)   # any JSON array anywhere
+    return json.loads(m.group(0)) if m else []
+
+def _db():
+    conn = sqlite3.connect(DB)
+    conn.execute("CREATE TABLE IF NOT EXISTS subs(subreddit PRIMARY KEY, status)")
+    conn.execute("CREATE TABLE IF NOT EXISTS posts(subreddit, title, upvotes, comments)")
+    conn.executemany("INSERT OR IGNORE INTO subs VALUES (?,'pending')", [(s,) for s in SEED])
+    conn.commit(); return conn
+
+if __name__ == "__main__": main()

--- a/scripts/showcase/recompose.py
+++ b/scripts/showcase/recompose.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Re-composite a demo from its kept workdir (.recordings/<demo>) WITHOUT
+re-recording — for iterating on composite / asset tweaks on already-captured
+footage. Reuses record_demo.composite() + the OCR gate + publish tail.
+
+    python3 scripts/showcase/recompose.py <demo> [phone_offset] [--publish]
+
+Default phone_offset 1.5 matches the recorder's ~1.5s screenrecord warmup.
+Without --publish the result stays in the workdir (safe for iteration).
+"""
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # scripts/
+import record_demo as R  # noqa: E402
+
+
+def main() -> None:
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    demo = args[0] if args else "langchain"
+    phone_offset = float(args[1]) if len(args) > 1 else 1.5
+    publish = "--publish" in sys.argv
+
+    workdir = R.REPO_ROOT / ".recordings" / demo
+    if not (workdir / "plan.json").exists():
+        R.die(f"no kept workdir at {workdir} (record with --keep-workdir first)")
+    # Use the CURRENT spec.yaml (not plan.json's snapshot) so composite/spec edits
+    # — content_speedup, phone_in_intro, layout tweaks — take effect on recompose.
+    spec = R.load_spec(demo)
+    patterns = R.load_forbidden()
+    term_mp4 = workdir / "terminal.mp4"
+    out_webm = workdir / "demo.webm"
+
+    print(f"[recompose] {demo} phone_offset={phone_offset} publish={publish}")
+    R.composite(spec, workdir, term_mp4, workdir / "phone.mp4",
+                phone_offset_s=phone_offset, out_webm=out_webm)
+
+    viol = R.ocr_gate(out_webm, workdir, patterns)
+    if viol:
+        for v in viol:
+            print(f"[recompose] FORBIDDEN {v}")
+        R.die(f"OCR gate FAILED ({len(viol)} hit) — not publishing")
+    print("[recompose] OCR gate clean")
+
+    size_mb = out_webm.stat().st_size / 1e6
+    if not publish:
+        print(f"[recompose] workdir only → {out_webm} ({size_mb:.1f} MB). "
+              f"Add --publish to copy into site/public/.")
+        return
+
+    out_dir = R.SHOWCASE_DIR / demo
+    out_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(out_webm, out_dir / "demo.webm")
+    intro_motion = R.BRAND_DIR / f"intro-{demo}-motion.mp4"
+    intro_dur = R.INTRO_S
+    if spec.get("layout") == "three_window" and intro_motion.exists():
+        p = subprocess.run(
+            ["ffprobe", "-v", "error", "-show_entries", "format=duration",
+             "-of", "default=nw=1:nk=1", str(intro_motion)],
+            capture_output=True, text=True)
+        intro_dur = float(p.stdout.strip() or R.INTRO_S)
+    hw = spec.get("highlight_window") or {}
+    poster_ss = intro_dur + float(hw.get("start_s", 2)) + 1.0
+    subprocess.run(["ffmpeg", "-y", "-ss", str(poster_ss), "-i",
+                    str(out_dir / "demo.webm"), "-frames:v", "1",
+                    str(out_dir / "poster.png")], check=True)
+    R.write_snippet(spec, out_dir / "snippet.py")
+    print(f"[recompose] PUBLISHED → {out_dir / 'demo.webm'} ({size_mb:.1f} MB)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/showcase/record-hero.sh
+++ b/scripts/showcase/record-hero.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Record a synced "hero" demo: a real Claude Code TUI driving the iPhone over
+# wireless direct-WDA (Tailscale, no USB, no Appium), with the phone screen
+# captured in parallel and composited side-by-side.
+#
+# Usage: record-hero.sh "<natural task prompt>" [out-basename]
+set -uo pipefail
+
+PROMPT="${1:?usage: record-hero.sh \"<prompt>\" [out]}"
+OUT="${2:-hero}"
+DIR="${HERO_DIR:-/tmp/ghost-ios/hero}"
+UDID="${IOS_DEVICE_UDID:?set IOS_DEVICE_UDID to your device udid}"
+TSIP="${IOS_TS_IP:?set IOS_TS_IP to your device tailscale ip}"
+BASE="http://${TSIP}:8100"
+REPO="${GHOST_REPO:-$HOME/Agent/android-agent}"
+MCP="${HERO_MCP:-${DIR}/.mcp.json}"
+COLS="${HERO_COLS:-100}"; ROWS="${HERO_ROWS:-30}"
+mkdir -p "$DIR"
+CAST="$DIR/${OUT}.cast"; PHONE="$DIR/${OUT}-phone.mp4"
+TERM_MP4="$DIR/${OUT}-term.mp4"; GIF="$DIR/${OUT}-term.gif"
+FINAL="$DIR/${OUT}-final.mp4"; FIFO="$DIR/${OUT}.mjpeg.fifo"
+
+say(){ printf '\033[1;36m[hero]\033[0m %s\n' "$*"; }
+
+curl -sf -m3 "$BASE/status" >/dev/null 2>&1 || { say "WDA down at $BASE — bring it up first"; exit 1; }
+say "WDA up at $BASE (wireless)"
+
+# 1) capture session with the MJPEG server enabled
+SID=$(curl -sf -m5 -X POST "$BASE/session" -H 'Content-Type: application/json' \
+  -d '{"capabilities":{"alwaysMatch":{"platformName":"iOS","appium:mjpegServerPort":9100}}}' \
+  | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('sessionId') or d['value']['sessionId'])" 2>/dev/null)
+[ -n "$SID" ] || { say "could not create capture session"; exit 1; }
+curl -sf -m4 -X POST "$BASE/session/$SID/appium/settings" -H 'Content-Type: application/json' \
+  -d '{"settings":{"mjpegServerFramerate":24,"mjpegServerScreenshotQuality":45,"mjpegScalingFactor":70}}' >/dev/null 2>&1
+say "capture session ${SID:0:8} (mjpeg :9100)"
+
+# 2) keepalive so neither WDA nor the mjpeg session idles during the run
+( for i in $(seq 1 220); do curl -sf -m2 "$BASE/status" >/dev/null 2>&1
+  curl -sf -m2 "$BASE/session/$SID/window/size" >/dev/null 2>&1
+  curl -s -m1 -o /dev/null http://192.0.2.1/ 2>/dev/null; done ) & KA=$!
+
+# 3) phone capture via a fifo so we hold ffmpeg's real pid (SIGINT finalizes mp4)
+rm -f "$FIFO"; mkfifo "$FIFO"
+curl -sN "http://${TSIP}:9100" > "$FIFO" & CURL=$!
+ffmpeg -y -loglevel error -f mpjpeg -i "$FIFO" -an \
+  -vf "scale=trunc(iw/2)*2:trunc(ih/2)*2" -r 24 -c:v libx264 -pix_fmt yuv420p "$PHONE" & FF=$!
+say "phone capture -> $PHONE (ffmpeg pid $FF)"
+sleep 1.5
+
+# 4) record the Claude Code TUI (drives the phone via MCP over direct-WDA)
+say "recording TUI (drives the phone)…"
+START=$(python3 -c "import time;print(time.time())")
+"${REPO}/.venv/bin/python" "${REPO}/scripts/showcase/claude_tui_driver.py" \
+  --prompt "$PROMPT" --mcp-config "$MCP" --cast "$CAST" \
+  --cols "$COLS" --rows "$ROWS" \
+  --env IOS_WDA_DIRECT=1 --env "IOS_WDA_URL=${BASE}" >/dev/null 2>&1
+END=$(python3 -c "import time;print(time.time())")
+RUN=$(python3 -c "print(max(6,round($END-$START)+1))")
+say "TUI done — active window ~${RUN}s"
+
+# 5) stop captures (SIGINT ffmpeg directly so the mp4 finalizes)
+kill -INT "$FF" 2>/dev/null; wait "$FF" 2>/dev/null
+kill "$CURL" 2>/dev/null; kill "$KA" 2>/dev/null; rm -f "$FIFO"
+curl -s -m3 -X DELETE "$BASE/session/$SID" >/dev/null 2>&1
+say "captures stopped"
+
+# 6) render terminal cast -> mp4
+agg --theme monokai --font-size 18 --idle-time-limit 2 "$CAST" "$GIF" >/dev/null 2>&1
+ffmpeg -y -loglevel error -i "$GIF" -movflags +faststart \
+  -vf "scale=trunc(iw/2)*2:trunc(ih/2)*2" -c:v libx264 -pix_fmt yuv420p "$TERM_MP4"
+say "terminal -> $TERM_MP4 ($(ffprobe -v error -show_entries format=duration -of default=nw=1:nk=1 "$TERM_MP4" 2>/dev/null)s)"
+
+# 7) composite: phone (trimmed to active window) left, terminal right, dark canvas
+if [ -s "$PHONE" ] && [ -s "$TERM_MP4" ]; then
+  ffmpeg -y -loglevel error -i "$PHONE" -i "$TERM_MP4" -filter_complex \
+    "color=c=0x0d1117:s=1920x1080:d=${RUN}[bg];
+     [0:v]trim=0:${RUN},setpts=PTS-STARTPTS,scale=-2:1000[ph];
+     [1:v]setpts=PTS-STARTPTS,scale=1200:-2[tm];
+     [bg][ph]overlay=90:(H-h)/2[a];
+     [a][tm]overlay=610:(H-h)/2:shortest=1[v]" \
+    -map "[v]" -r 24 -c:v libx264 -pix_fmt yuv420p -movflags +faststart "$FINAL"
+  say "FINAL -> $FINAL"; ls -l "$FINAL"
+else
+  say "phone/term video missing — phone=$(stat -f%z "$PHONE" 2>/dev/null||echo 0)B term=$(stat -f%z "$TERM_MP4" 2>/dev/null||echo 0)B"
+fi

--- a/scripts/showcase/render_codepane.py
+++ b/scripts/showcase/render_codepane.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Live-render the showcase code pane from source.
+
+Draws the ``def main()`` segment of a Python file as a macOS-style terminal
+window PNG, so the code pane in a demo can never drift out of sync with the
+script it is supposed to mirror (the old baked asset silently shipped an
+OpenRouter version of the code long after the script had moved on).
+
+Usage:  render_codepane.py <source.py> <out.png> [--title NAME]
+Geometry + palette match codepane-langchain-v3.png so the compositor is unchanged.
+"""
+import sys
+from pathlib import Path
+
+from PIL import Image, ImageDraw, ImageFilter, ImageFont
+from pygments import lex
+from pygments.lexers import PythonLexer
+from pygments.token import Comment, Keyword, Name, Number, String
+
+REPO = Path(__file__).resolve().parents[2]
+FONT_PATH = REPO / "site/public/showcase/_brand/fonts/JetBrainsMono[wght].ttf"
+
+# Ghost-brand palette, sampled straight from the shipped assets.
+BG      = (13, 19, 14)      # window / code background
+TITLE   = (26, 33, 27)      # title bar
+TEXT    = (216, 216, 216)   # default code text
+GREEN   = (0, 216, 144)     # keywords, strings, def-names (brand accent)
+COMMENT = (120, 144, 120)   # comments
+LINENO  = (96, 108, 98)     # gutter line numbers
+TITLE_FG = (150, 160, 152)  # filename in the title bar
+LIGHTS  = [(255, 95, 86), (255, 189, 46), (39, 201, 63)]  # macOS traffic lights
+
+# Full 1920x1080 canvas; window box matches codepane-langchain-v3.png exactly.
+CANVAS  = (1920, 1080)
+WIN     = (32, 742, 1392, 1041)   # x0, y0, x1, y1  — small code pane (main segment)
+FULL_WIN = (32, 175, 1392, 1041)   # tall left-column intro window (matches render_intro_motion)
+TITLE_H = 40
+RADIUS  = 14
+PAD_X   = 30      # left padding inside code area (before gutter)
+PAD_TOP = 14      # top padding inside code area
+GUTTER  = 58      # width reserved for line numbers
+
+
+def color_for(tok):
+    if tok in Comment:       return COMMENT
+    if tok in Keyword:       return GREEN
+    if tok in String:        return GREEN
+    if tok in Name.Function: return GREEN
+    if tok in Number:        return TEXT
+    return TEXT
+
+
+def extract_main(src_path):
+    """Return (lines, first_lineno) for the def main() block."""
+    lines = Path(src_path).read_text().splitlines()
+    start = next(i for i, l in enumerate(lines) if l.startswith("def main"))
+    end = start + 1
+    while end < len(lines) and not (
+        lines[end].startswith("def ") or lines[end].startswith("#")
+    ):
+        end += 1
+    seg = lines[start:end]
+    while seg and not seg[-1].strip():
+        seg.pop()
+    return seg, start + 1
+
+
+def extract_full(src_path):
+    """Return (lines, 1) for the whole file (trailing blanks trimmed)."""
+    lines = Path(src_path).read_text().splitlines()
+    while lines and not lines[-1].strip():
+        lines.pop()
+    return lines, 1
+
+
+def load_font(size):
+    f = ImageFont.truetype(str(FONT_PATH), size)
+    try:
+        f.set_variation_by_axes([460])   # medium weight for legibility
+    except Exception:
+        pass
+    return f
+
+
+def render(src_path, out_path, title="langchain_script.py", full=False):
+    seg, first_lineno = extract_full(src_path) if full else extract_main(src_path)
+    n = len(seg)
+    x0, y0, x1, y1 = FULL_WIN if full else WIN
+    win_w, win_h = x1 - x0, y1 - y0
+    code_h = win_h - TITLE_H - 2 * PAD_TOP
+
+    # Auto-fit font so all n lines fit the code area.
+    pitch = code_h / n
+    fsize = max(12, int(pitch * 0.74))
+    font = load_font(fsize)
+    ascent, descent = font.getmetrics()
+    char_w = font.getlength("M")
+
+    img = Image.new("RGBA", CANVAS, (0, 0, 0, 0))
+    d = ImageDraw.Draw(img)
+
+    # Soft drop shadow, then the window body.
+    shadow = Image.new("RGBA", CANVAS, (0, 0, 0, 0))
+    ImageDraw.Draw(shadow).rounded_rectangle(
+        [x0, y0 + 10, x1, y1 + 14], RADIUS, fill=(0, 0, 0, 120))
+    img.alpha_composite(shadow.filter(ImageFilter.GaussianBlur(12)))
+
+    d.rounded_rectangle([x0, y0, x1, y1], RADIUS, fill=BG + (255,))
+    # Title bar (rounded top, square bottom via a covering rect).
+    d.rounded_rectangle([x0, y0, x1, y0 + TITLE_H], RADIUS, fill=TITLE + (255,))
+    d.rectangle([x0, y0 + TITLE_H - RADIUS, x1, y0 + TITLE_H], fill=TITLE + (255,))
+
+    # Traffic lights.
+    cy = y0 + TITLE_H // 2
+    for i, col in enumerate(LIGHTS):
+        cx = x0 + 22 + i * 26
+        d.ellipse([cx - 7, cy - 7, cx + 7, cy + 7], fill=col + (255,))
+
+    # Centered filename.
+    tfont = load_font(19)
+    tw = tfont.getlength(title)
+    d.text(((x0 + x1) / 2 - tw / 2, cy - 11), title, font=tfont, fill=TITLE_FG + (255,))
+
+    # Code, line by line, syntax highlighted.
+    code_x = x0 + PAD_X + GUTTER
+    y = y0 + TITLE_H + PAD_TOP
+    for idx, line in enumerate(seg):
+        ln = str(first_lineno + idx)
+        lnw = font.getlength(ln)
+        d.text((x0 + PAD_X + GUTTER - 14 - lnw, y), ln, font=font, fill=LINENO + (255,))
+        x = code_x
+        for tok, val in lex(line + "\n", PythonLexer()):
+            val = val.rstrip("\n")
+            if not val:
+                continue
+            d.text((x, y), val, font=font, fill=color_for(tok) + (255,))
+            x += font.getlength(val)
+        y += pitch
+
+    img.save(out_path)
+    print(f"[render_codepane] {out_path} — {n} lines (L{first_lineno}-"
+          f"{first_lineno + n - 1}), font {fsize}px")
+
+
+if __name__ == "__main__":
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    title = next((a.split("=", 1)[1] for a in sys.argv[1:]
+                  if a.startswith("--title=")), "langchain_script.py")
+    full = "--full" in sys.argv
+    render(args[0], args[1], title, full=full)

--- a/scripts/showcase/render_intro_motion.py
+++ b/scripts/showcase/render_intro_motion.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Build the three_window intro-motion mp4 from live sources.
+
+Reproduces the original opener: the full-script code window holds, then shrinks
+and settles into the small code-pane slot while the header / headline / mascot
+fade in — ending exactly on the content layout so the concat seam is invisible.
+
+Sources (all live, so it never goes stale):
+  intro_full  : full script drawn at FULL_WIN   (render_codepane.py --full)
+  codepane    : main() segment drawn at WIN      (record's live codepane.png)
+  bg-<demo>   : header + headline + mascot        (baked brand bg)
+
+Usage: render_intro_motion.py <demo> <intro_full.png> <codepane.png> <out.mp4>
+"""
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from PIL import Image
+
+REPO = Path(__file__).resolve().parents[2]
+BRAND = REPO / "site" / "public" / "showcase" / "_brand"
+
+CANVAS = (1920, 1080)
+FPS = 30
+DUR = 4.8                          # 3s hold + ~1.8s shrink (recorder syncs to this)
+N = round(FPS * DUR)
+BG = (7, 10, 8)                    # BG_HEX 070a08
+# Startup: the code window is FULL HEIGHT but only the left column wide, so the
+# phone sits on the side and all code stays visible. It then shrinks (top edge
+# down) into the small code-pane slot as the terminal takes the top.
+FULL_WIN = (32, 175, 1392, 1041)   # tall left-column intro window
+WIN = (32, 742, 1392, 1041)        # code-pane slot in the content layout
+
+FADE_IN = 0.8                      # window fades up over the first 0.8s
+SHRINK_START = 3.0                 # hold the code for 3s, then shrink
+XFADE_AT = 0.30                    # begin full->main crossfade at 30% of the shrink
+
+
+def lerp(a, b, t):
+    return a + (b - a) * t
+
+
+def ease_out(t):
+    return 1 - (1 - t) ** 3
+
+
+def fade_alpha(img, a):
+    if a >= 1.0:
+        return img
+    out = img.copy()
+    out.putalpha(img.getchannel("A").point(lambda v: int(v * a)))
+    return out
+
+
+def main():
+    demo, full_path, pane_path, out_path = sys.argv[1:5]
+    # optional 5th arg: a pre-composited phone plate (phone + bezel) shown on the
+    # side from the start, so the seam into the (static) content phone is invisible
+    plate_path = sys.argv[5] if len(sys.argv) > 5 else None
+    full = Image.open(full_path).convert("RGBA")
+    pane = Image.open(pane_path).convert("RGBA")
+    header = Image.open(BRAND / f"bg-{demo}.png").convert("RGBA")
+    plate = Image.open(plate_path).convert("RGBA") if plate_path else None
+    full_win = full.crop(FULL_WIN)      # full-script window (with chrome)
+    pane_win = pane.crop(WIN)           # main() window (with chrome)
+
+    tmp = Path(tempfile.mkdtemp())
+    for i in range(N):
+        t = i / FPS
+        canvas = Image.new("RGBA", CANVAS, BG + (255,))
+
+        if t <= SHRINK_START:
+            prog = 0.0
+        else:
+            prog = ease_out(min(1.0, (t - SHRINK_START) / (DUR - SHRINK_START)))
+
+        # header/headline/mascot fade in as the window shrinks — composite it FIRST
+        # (it's the background), then the phone ON TOP, matching the content layer
+        # order. Otherwise the fading-in header covers the phone and it flickers
+        # away right before the content puts it back on top (the resize flicker).
+        if prog > 0:
+            canvas.alpha_composite(fade_alpha(header, prog))
+
+        # phone sits on the side for the whole intro (static), above the header
+        if plate is not None:
+            canvas.alpha_composite(plate)
+
+        # window geometry interpolates FULL_WIN -> WIN
+        x0 = lerp(FULL_WIN[0], WIN[0], prog)
+        y0 = lerp(FULL_WIN[1], WIN[1], prog)
+        x1 = lerp(FULL_WIN[2], WIN[2], prog)
+        y1 = lerp(FULL_WIN[3], WIN[3], prog)
+        w, h = max(1, int(x1 - x0)), max(1, int(y1 - y0))
+
+        win = full_win.resize((w, h))
+        if prog > XFADE_AT:                       # crossfade full script -> main()
+            xf = (prog - XFADE_AT) / (1 - XFADE_AT)
+            win = Image.blend(win, pane_win.resize((w, h)), xf)
+        if t < FADE_IN:                           # initial fade-up
+            win = fade_alpha(win, t / FADE_IN)
+
+        canvas.alpha_composite(win, (int(x0), int(y0)))
+        canvas.convert("RGB").save(tmp / f"f{i:04d}.png")
+
+    subprocess.run(
+        ["ffmpeg", "-y", "-framerate", str(FPS), "-i", str(tmp / "f%04d.png"),
+         "-t", str(DUR), "-c:v", "libx264", "-pix_fmt", "yuv420p",
+         "-movflags", "+faststart", out_path],
+        check=True, capture_output=True)
+    print(f"[render_intro_motion] {out_path} — {N} frames, "
+          f"shrink {SHRINK_START}->{DUR}s, ends on content layout")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/api/test_emulators.py
+++ b/tests/api/test_emulators.py
@@ -1,0 +1,194 @@
+"""
+Emulator API tests — Docker+KVM backend.
+
+All tests use FastAPI TestClient (no real Docker daemon needed for route shape
+tests). Tests that actually create containers are skipped unless DOCKER_EMU_TEST=1.
+"""
+
+import os
+
+import pytest
+
+
+class TestEmulatorPrerequisites:
+    def test_prerequisites_shape(self, client):
+        r = client.get("/api/emulators/prerequisites")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["backend"] == "docker"
+        assert isinstance(data["docker_available"], bool)
+        assert isinstance(data["kvm_available"], bool)
+        assert isinstance(data["adb_binary"], bool)
+
+    def test_prerequisites_has_docker_info(self, client):
+        r = client.get("/api/emulators/prerequisites")
+        data = r.json()
+        assert "image" in data
+        assert "budtmo" in data["image"]
+
+
+class TestEmulatorList:
+    def test_list_empty(self, client):
+        r = client.get("/api/emulators")
+        assert r.status_code == 200
+        assert isinstance(r.json(), list)
+
+    def test_list_running(self, client):
+        r = client.get("/api/emulators/running")
+        assert r.status_code == 200
+        assert isinstance(r.json(), list)
+
+    def test_list_system_images(self, client):
+        r = client.get("/api/emulators/system-images")
+        assert r.status_code == 200
+        assert isinstance(r.json(), list)
+
+
+class TestEmulatorCreate:
+    def test_create_missing_name(self, client):
+        r = client.post("/api/emulators", json={})
+        assert r.status_code == 422
+
+    def test_create_returns_ok_or_docker_error(self, client):
+        """Create call reaches the backend; passes if Docker is up, skips if not."""
+        import uuid
+
+        prereq = client.get("/api/emulators/prerequisites").json()
+        if not prereq.get("docker_available") or not prereq.get("kvm_available"):
+            pytest.skip("Docker emulator create requires Docker and KVM")
+
+        name = f"ci-test-{uuid.uuid4().hex[:8]}"
+        try:
+            r = client.post("/api/emulators", json={"name": name})
+            assert r.status_code in (200, 201)
+            data = r.json()
+            assert "ok" in data
+            if data["ok"]:
+                assert "serial" in data
+                assert data["serial"].startswith("localhost:")
+        finally:
+            client.delete(f"/api/emulators/{name}")
+
+
+class TestEmulatorLifecycle:
+    """Full create→boot→stop→delete cycle. Requires DOCKER_EMU_TEST=1."""
+
+    @pytest.fixture(autouse=True)
+    def require_docker_test(self):
+        if not os.environ.get("DOCKER_EMU_TEST"):
+            pytest.skip("set DOCKER_EMU_TEST=1 to run live Docker emulator tests")
+
+    def test_full_lifecycle(self, client):
+        name = "pytest-emu-lifecycle"
+
+        # Create
+        r = client.post("/api/emulators", json={"name": name, "api_level": 30})
+        assert r.status_code in (200, 201)
+        data = r.json()
+        assert data["ok"] is True, f"create failed: {data}"
+        serial = data["serial"]
+        assert serial == "localhost:5555"
+
+        # List — should appear
+        r = client.get("/api/emulators")
+        names = [e["name"] for e in r.json()]
+        assert name in names
+
+        # Boot status
+        r = client.get(f"/api/emulators/{name}/boot-status")
+        assert r.status_code == 200
+        boot = r.json()
+        assert "booted" in boot
+
+        # Stop
+        r = client.post(f"/api/emulators/{name}/stop")
+        assert r.status_code == 200
+        assert r.json()["ok"] is True
+
+        # Delete
+        r = client.delete(f"/api/emulators/{name}")
+        assert r.status_code == 200
+        assert r.json()["ok"] is True
+
+        # List — should be gone
+        r = client.get("/api/emulators")
+        names = [e["name"] for e in r.json()]
+        assert name not in names
+
+
+class TestEmulatorPool:
+    def test_pool_status(self, client):
+        r = client.get("/api/emulator-pool/status")
+        assert r.status_code == 200
+
+    def test_pool_resources(self, client):
+        r = client.get("/api/emulator-pool/resources")
+        assert r.status_code == 200
+
+
+class TestEmulatorServiceUnit:
+    """Unit tests for EmulatorManager and helpers — no HTTP, no Docker."""
+
+    def test_check_prerequisites(self):
+        from gitd.services.emulator_service import EmulatorManager
+
+        m = EmulatorManager()
+        result = m.check_prerequisites()
+        assert result["backend"] == "docker"
+        assert isinstance(result["docker_available"], bool)
+        assert isinstance(result["kvm_available"], bool)
+
+    def test_list_avds_returns_list(self):
+        from gitd.services.emulator_service import EmulatorManager
+
+        m = EmulatorManager()
+        avds = m.list_avds()
+        assert isinstance(avds, list)
+
+    def test_list_running_returns_list(self):
+        from gitd.services.emulator_service import EmulatorManager
+
+        m = EmulatorManager()
+        running = m.list_running()
+        assert isinstance(running, list)
+
+    def test_delete_nonexistent_graceful(self):
+        from gitd.services.emulator_service import EmulatorManager
+
+        m = EmulatorManager()
+        result = m.delete("does-not-exist-xyz")
+        assert "ok" in result
+        assert result["ok"] is False
+
+    def test_stop_nonexistent_graceful(self):
+        from gitd.services.emulator_service import EmulatorManager
+
+        m = EmulatorManager()
+        result = m.stop("localhost:59999")
+        assert "ok" in result
+
+    def test_emulator_config_defaults(self):
+        from gitd.services._emulator_helpers import EmulatorConfig
+
+        c = EmulatorConfig(name="test")
+        assert c.api_level == 30
+        assert c.ram_mb == 2048
+        assert c.arch in {"x86_64", "arm64-v8a"}
+
+    def test_has_docker_returns_bool(self):
+        from gitd.services._emulator_helpers import _has_docker
+
+        assert isinstance(_has_docker(), bool)
+
+    def test_has_kvm_returns_bool(self):
+        from gitd.services._emulator_helpers import _has_kvm
+
+        assert isinstance(_has_kvm(), bool)
+
+    def test_snapshot_returns_advisory(self):
+        from gitd.services.emulator_service import EmulatorManager
+
+        m = EmulatorManager()
+        result = m.snapshot_save("localhost:5555", "test-snap")
+        assert result["ok"] is False
+        assert "not supported" in result["error"].lower()

--- a/tests/api/test_explorer_ios.py
+++ b/tests/api/test_explorer_ios.py
@@ -1,0 +1,83 @@
+import json
+
+from gitd.routers import explorer as explorer_router
+
+
+class FakeProc:
+    def poll(self):
+        return None
+
+
+def test_explorer_status_reads_ios_progress_metadata(monkeypatch, tmp_path):
+    progress = {
+        "device": "ios:abc123",
+        "package": "com.google.chrome.ios",
+        "platform": "ios",
+        "output_dir": str(tmp_path),
+        "current_activity": "com.google.chrome.ios",
+        "states_found": 2,
+        "max_states": 5,
+        "transitions": 1,
+        "current_depth": 1,
+        "log_tail": ["state 2"],
+    }
+    (tmp_path / "progress.json").write_text(json.dumps(progress), encoding="utf-8")
+    monkeypatch.setattr(
+        explorer_router,
+        "_active_proc",
+        {
+            "proc": FakeProc(),
+            "pid": 1234,
+            "package": "stale.package",
+            "device": "ios:old",
+            "platform": "android",
+            "output_dir": str(tmp_path),
+            "max_states": 5,
+        },
+    )
+
+    status = explorer_router.explorer_status()
+
+    assert status["running"] is True
+    assert status["device"] == "ios:abc123"
+    assert status["package"] == "com.google.chrome.ios"
+    assert status["platform"] == "ios"
+    assert status["output_dir"] == str(tmp_path)
+    assert status["current_activity"] == "com.google.chrome.ios"
+    assert status["states_found"] == 2
+    assert status["transitions"] == 1
+    assert status["log_tail"] == ["state 2"]
+
+
+def test_explorer_runs_include_ios_platform(monkeypatch, tmp_path):
+    run_dir = tmp_path / "com.google.chrome.ios"
+    run_dir.mkdir()
+    (run_dir / "state_graph.json").write_text(
+        json.dumps(
+            {
+                "package": "com.google.chrome.ios",
+                "device": "ios:abc123",
+                "platform": "ios",
+                "total_states": 2,
+                "total_transitions": 1,
+                "max_depth": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(explorer_router, "_EXPLORER_DIR", tmp_path)
+
+    runs = explorer_router.explorer_runs()
+
+    assert runs == [
+        {
+            "name": "com.google.chrome.ios",
+            "package": "com.google.chrome.ios",
+            "states": 2,
+            "transitions": 1,
+            "max_depth": 1,
+            "platform": "ios",
+            "device": "ios:abc123",
+            "date": runs[0]["date"],
+        }
+    ]

--- a/tests/api/test_phone_app_state.py
+++ b/tests/api/test_phone_app_state.py
@@ -1,0 +1,147 @@
+import json
+
+from fastapi.testclient import TestClient
+
+from gitd.app import app
+from gitd.services.agent_tools import execute_tool, tools_for_device
+from gitd.services.tool_platforms import supports_platform, tool_platform_info
+
+
+def test_ios_app_state_normalizes_query_app_state(monkeypatch):
+    from gitd.services.device_context import app_state
+
+    class FakeIOSDevice:
+        def app_state(self, package):
+            assert package == "com.google.chrome.ios"
+            return 4
+
+    monkeypatch.setattr("gitd.services.device_context.get_device", lambda device: FakeIOSDevice())
+
+    result = app_state("ios:abc123", "com.google.chrome.ios")
+
+    assert result == {
+        "ok": True,
+        "device": "ios:abc123",
+        "platform": "ios",
+        "package": "com.google.chrome.ios",
+        "bundle_id": "com.google.chrome.ios",
+        "state": "running_foreground",
+        "raw_state": 4,
+        "installed": True,
+        "running": True,
+        "foreground": True,
+        "source": "appium_queryAppState",
+    }
+
+
+def test_android_app_state_uses_package_pid_and_foreground_window(monkeypatch):
+    from gitd.services.device_context import app_state
+
+    class FakeAndroidDevice:
+        def __init__(self, serial):
+            self.serial = serial
+
+        def adb(self, *args, timeout=30):
+            if args[:4] == ("shell", "dumpsys", "window", "windows"):
+                return "mCurrentFocus=Window{abc u0 com.example.app/.MainActivity}"
+            if args[:3] == ("shell", "pm", "path"):
+                return "package:/data/app/com.example.app/base.apk"
+            if args[:3] == ("shell", "pidof", "com.example.app"):
+                return ""
+            return ""
+
+    monkeypatch.setattr("gitd.services.device_context.Device", FakeAndroidDevice)
+
+    result = app_state("emulator-5554", "com.example.app")
+
+    assert result["platform"] == "android"
+    assert result["state"] == "running_foreground"
+    assert result["raw_state"] == 4
+    assert result["installed"] is True
+    assert result["running"] is True
+    assert result["foreground"] is True
+    assert result["current_package"] == "com.example.app"
+
+
+def test_app_state_rest_routes_use_device_context(monkeypatch):
+    calls = []
+
+    def fake_app_state(device, package):
+        calls.append((device, package))
+        return {
+            "ok": True,
+            "device": device,
+            "platform": "ios",
+            "package": package,
+            "bundle_id": package,
+            "state": "not_running",
+            "raw_state": 1,
+            "installed": True,
+            "running": False,
+            "foreground": False,
+            "source": "appium_queryAppState",
+        }
+
+    monkeypatch.setattr("gitd.services.device_context.app_state", fake_app_state)
+    client = TestClient(app)
+
+    read = client.get("/api/phone/app-state/ios:abc123", params={"package": "com.google.chrome.ios"})
+    posted = client.post(
+        "/api/phone/app-state",
+        json={"device": "ios:abc123", "package": "com.google.chrome.ios"},
+    )
+
+    assert read.status_code == 200
+    assert posted.status_code == 200
+    assert read.json()["state"] == "not_running"
+    assert posted.json()["state"] == "not_running"
+    assert calls == [
+        ("ios:abc123", "com.google.chrome.ios"),
+        ("ios:abc123", "com.google.chrome.ios"),
+    ]
+
+
+def test_app_state_rest_routes_validate_required_fields():
+    client = TestClient(app)
+
+    assert client.get("/api/phone/app-state/ios:abc123").status_code == 400
+    assert client.post("/api/phone/app-state", json={"device": "ios:abc123"}).status_code == 400
+
+
+def test_app_state_agent_and_platform_registry(monkeypatch):
+    monkeypatch.setattr(
+        "gitd.services.agent_tools.ctx.app_state",
+        lambda device, package: {
+            "ok": True,
+            "device": device,
+            "platform": "ios",
+            "package": package,
+            "state": "running_foreground",
+        },
+    )
+
+    result = json.loads(execute_tool("app_state", {"device": "ios:abc123", "package": "com.google.chrome.ios"}))
+    ios_tools = {tool["name"] for tool in tools_for_device("ios:abc123")}
+    android_tools = {tool["name"] for tool in tools_for_device("emulator-5554")}
+
+    assert result["state"] == "running_foreground"
+    assert "app_state" in ios_tools
+    assert "app_state" in android_tools
+    assert supports_platform("app_state", "ios") is True
+    assert tool_platform_info("app_state").support == "cross_platform"
+
+
+def test_tools_hub_exposes_app_state_and_paste_text():
+    client = TestClient(app)
+
+    response = client.get("/api/tools")
+
+    assert response.status_code == 200
+    categories = {category["category"]: category["tools"] for category in response.json()}
+    app_tools = {tool["name"]: tool for tool in categories["App Management"]}
+    clipboard_tools = {tool["name"]: tool for tool in categories["Clipboard & Notifications"]}
+
+    assert app_tools["app_state"]["platform_support"]["support"] == "cross_platform"
+    assert app_tools["app_state"]["platform_support"]["ios"] is True
+    assert clipboard_tools["paste_text"]["platform_support"]["support"] == "cross_platform"
+    assert clipboard_tools["paste_text"]["platform_support"]["ios"] is True

--- a/tests/api/test_phone_apps.py
+++ b/tests/api/test_phone_apps.py
@@ -1,0 +1,106 @@
+from fastapi.testclient import TestClient
+
+from gitd.app import app
+
+
+def test_ios_apps_endpoint_returns_searchable_bundle_inventory(monkeypatch):
+    calls = []
+
+    class FakeIOSDevice:
+        def list_apps(self, query="", verify=True):
+            calls.append((query, verify))
+            apps = [
+                {
+                    "name": "Chrome",
+                    "package": "com.google.chrome.ios",
+                    "bundle_id": "com.google.chrome.ios",
+                    "platform": "ios",
+                    "verified": True,
+                    "installed": True,
+                    "app_state": 1,
+                    "app_state_name": "not_running",
+                },
+                {
+                    "name": "TikTok",
+                    "package": "com.zhiliaoapp.musically",
+                    "bundle_id": "com.zhiliaoapp.musically",
+                    "platform": "ios",
+                    "verified": True,
+                    "installed": True,
+                    "app_state": 4,
+                    "app_state_name": "running_foreground",
+                },
+            ]
+            if query:
+                needle = query.lower()
+                apps = [app for app in apps if needle in app["name"].lower() or needle in app["bundle_id"].lower()]
+            return apps
+
+    monkeypatch.setattr("gitd.services.device_context.get_device", lambda device: FakeIOSDevice())
+    client = TestClient(app)
+
+    listed = client.get("/api/phone/apps/ios:abc123")
+    searched = client.get("/api/phone/apps/ios:abc123", params={"query": "chrome"})
+
+    assert listed.status_code == 200
+    assert searched.status_code == 200
+    assert listed.json()["platform"] == "ios"
+    assert listed.json()["count"] == 2
+    assert listed.json()["packages"] == ["com.google.chrome.ios", "com.zhiliaoapp.musically"]
+    assert searched.json()["count"] == 1
+    assert searched.json()["apps"][0]["bundle_id"] == "com.google.chrome.ios"
+    assert calls == [("", True), ("chrome", True)]
+
+
+def test_android_apps_endpoint_normalizes_package_names(monkeypatch):
+    class FakeAndroidDevice:
+        def __init__(self, serial):
+            self.serial = serial
+
+        def adb(self, *args, timeout=30):
+            assert args == ("shell", "pm", "list", "packages", "-3")
+            return "\n".join(
+                [
+                    "package:com.android.chrome",
+                    "package:com.example.my_app",
+                ]
+            )
+
+    monkeypatch.setattr("gitd.services.device_context.Device", FakeAndroidDevice)
+    client = TestClient(app)
+
+    response = client.get("/api/phone/apps/emulator-5554", params={"query": "chrome"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["platform"] == "android"
+    assert body["packages"] == ["com.android.chrome"]
+    assert body["apps"] == [
+        {
+            "name": "Chrome",
+            "package": "com.android.chrome",
+            "bundle_id": "",
+            "platform": "android",
+            "verified": True,
+            "installed": True,
+        }
+    ]
+
+
+def test_device_context_list_packages_uses_ios_bundle_ids(monkeypatch):
+    from gitd.services.device_context import list_packages
+
+    class FakeIOSDevice:
+        def list_apps(self, query="", verify=True):
+            return [
+                {
+                    "name": "Chrome",
+                    "package": "com.google.chrome.ios",
+                    "bundle_id": "com.google.chrome.ios",
+                    "platform": "ios",
+                }
+            ]
+
+    monkeypatch.setattr("gitd.services.device_context.get_device", lambda device: FakeIOSDevice())
+
+    assert list_packages("ios:abc123") == ["com.google.chrome.ios"]

--- a/tests/api/test_phone_clipboard_notifications.py
+++ b/tests/api/test_phone_clipboard_notifications.py
@@ -1,0 +1,122 @@
+from fastapi.testclient import TestClient
+
+from gitd.app import app
+
+
+def test_ios_clipboard_rest_routes_use_device_context(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr("gitd.services.device_context.clipboard_get", lambda device: "hello iOS")
+    monkeypatch.setattr(
+        "gitd.services.device_context.clipboard_set",
+        lambda device, text: calls.append((device, text)) or True,
+    )
+    client = TestClient(app)
+
+    read = client.get("/api/phone/clipboard/ios:abc123")
+    wrote = client.post("/api/phone/clipboard", json={"device": "ios:abc123", "text": "new text"})
+
+    assert read.status_code == 200
+    assert read.json() == {"ok": True, "device": "ios:abc123", "platform": "ios", "text": "hello iOS"}
+    assert wrote.status_code == 200
+    assert wrote.json() == {"ok": True, "device": "ios:abc123", "platform": "ios"}
+    assert calls == [("ios:abc123", "new text")]
+
+
+def test_ios_paste_text_rest_route_uses_ios_backend(monkeypatch):
+    calls = []
+
+    class FakeIOSDevice:
+        def paste_text(self, text):
+            calls.append(text)
+            return True
+
+    monkeypatch.setattr("gitd.routers.phone.get_device", lambda device: FakeIOSDevice())
+    client = TestClient(app)
+
+    response = client.post("/api/phone/paste-text", json={"device": "ios:abc123", "text": "paste me"})
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True, "device": "ios:abc123", "platform": "ios"}
+    assert calls == ["paste me"]
+
+
+def test_ios_clipboard_and_notification_errors_are_structured(monkeypatch):
+    class FailingIOSDevice:
+        def paste_text(self, *_args, **_kwargs):
+            raise RuntimeError("wda paste failed")
+
+    monkeypatch.setattr("gitd.routers.phone.get_device", lambda device: FailingIOSDevice())
+    monkeypatch.setattr(
+        "gitd.services.device_context.clipboard_get",
+        lambda device: (_ for _ in ()).throw(RuntimeError("wda clipboard get failed")),
+    )
+    monkeypatch.setattr(
+        "gitd.services.device_context.clipboard_set",
+        lambda device, text: (_ for _ in ()).throw(RuntimeError("wda clipboard set failed")),
+    )
+    monkeypatch.setattr(
+        "gitd.services.device_context.get_notifications",
+        lambda device: (_ for _ in ()).throw(RuntimeError("wda notifications list failed")),
+    )
+    monkeypatch.setattr(
+        "gitd.services.device_context.open_notifications",
+        lambda device: (_ for _ in ()).throw(RuntimeError("wda notifications open failed")),
+    )
+    monkeypatch.setattr(
+        "gitd.services.device_context.clear_notifications",
+        lambda device: (_ for _ in ()).throw(RuntimeError("wda notifications clear failed")),
+    )
+    client = TestClient(app)
+
+    cases = [
+        (client.get("/api/phone/clipboard/ios:abc123"), "wda clipboard get failed"),
+        (client.post("/api/phone/clipboard", json={"device": "ios:abc123", "text": "new text"}), "wda clipboard set failed"),
+        (client.post("/api/phone/paste-text", json={"device": "ios:abc123", "text": "paste me"}), "wda paste failed"),
+        (client.get("/api/phone/notifications/ios:abc123"), "wda notifications list failed"),
+        (client.post("/api/phone/notifications/open", json={"device": "ios:abc123"}), "wda notifications open failed"),
+        (client.post("/api/phone/notifications/clear", json={"device": "ios:abc123"}), "wda notifications clear failed"),
+    ]
+
+    for response, error in cases:
+        assert response.status_code == 200
+        assert response.json() == {
+            "ok": False,
+            "device": "ios:abc123",
+            "platform": "ios",
+            "error": error,
+        }
+
+
+def test_ios_notifications_rest_routes_use_device_context(monkeypatch):
+    monkeypatch.setattr(
+        "gitd.services.device_context.get_notifications",
+        lambda device: [{"title": "Slack", "text": "New message", "platform": "ios"}],
+    )
+    monkeypatch.setattr("gitd.services.device_context.open_notifications", lambda device: True)
+    monkeypatch.setattr("gitd.services.device_context.clear_notifications", lambda device: True)
+    client = TestClient(app)
+
+    listed = client.get("/api/phone/notifications/ios:abc123")
+    opened = client.post("/api/phone/notifications/open", json={"device": "ios:abc123"})
+    cleared = client.post("/api/phone/notifications/clear", json={"device": "ios:abc123"})
+
+    assert listed.status_code == 200
+    assert listed.json() == {
+        "ok": True,
+        "device": "ios:abc123",
+        "platform": "ios",
+        "notifications": [{"title": "Slack", "text": "New message", "platform": "ios"}],
+        "count": 1,
+    }
+    assert opened.json() == {"ok": True, "device": "ios:abc123", "platform": "ios"}
+    assert cleared.json() == {"ok": True, "device": "ios:abc123", "platform": "ios"}
+
+
+def test_clipboard_and_notification_mutations_require_device():
+    client = TestClient(app)
+
+    assert client.post("/api/phone/clipboard", json={"text": "x"}).status_code == 400
+    assert client.post("/api/phone/paste-text", json={"text": "x"}).status_code == 400
+    assert client.post("/api/phone/notifications/open", json={}).status_code == 400
+    assert client.post("/api/phone/notifications/clear", json={}).status_code == 400

--- a/tests/api/test_phone_controls.py
+++ b/tests/api/test_phone_controls.py
@@ -1,0 +1,162 @@
+from fastapi.testclient import TestClient
+
+from gitd.app import app
+
+
+class FakeIOSControlDevice:
+    def __init__(self):
+        self.calls = []
+
+    def tap(self, x, y, *args, **kwargs):
+        self.calls.append(("tap", x, y, kwargs))
+
+    def swipe(self, x1, y1, x2, y2, *args, **kwargs):
+        self.calls.append(("swipe", x1, y1, x2, y2, kwargs))
+
+    def type_text(self, text):
+        self.calls.append(("type_text", text))
+
+    def back(self, delay=0):
+        self.calls.append(("back", delay))
+
+    def press_key(self, key):
+        self.calls.append(("press_key", key))
+
+    def launch_app(self, bundle_id):
+        self.calls.append(("launch_app", bundle_id))
+
+    def terminate_app(self, bundle_id):
+        self.calls.append(("terminate_app", bundle_id))
+
+
+def test_ios_control_routes_return_platform_metadata(monkeypatch):
+    fake = FakeIOSControlDevice()
+    monkeypatch.setattr("gitd.routers.phone.get_device", lambda device: fake)
+    client = TestClient(app)
+
+    responses = [
+        client.post("/api/phone/input", json={"device": "ios:abc123", "action": "tap", "x": 11, "y": 22}),
+        client.post("/api/phone/input", json={"device": "ios:abc123", "action": "keyevent", "key": "ENTER"}),
+        client.post("/api/phone/tap", json={"device": "ios:abc123", "x": 33, "y": 44}),
+        client.post("/api/phone/type", json={"device": "ios:abc123", "text": "hello"}),
+        client.post("/api/phone/back", json={"device": "ios:abc123"}),
+        client.post("/api/phone/key", json={"device": "ios:abc123", "key": "HOME"}),
+        client.post("/api/phone/force-stop", json={"device": "ios:abc123", "package": "com.google.chrome.ios"}),
+        client.post("/api/phone/swipe", json={"device": "ios:abc123", "x1": 1, "y1": 2, "x2": 3, "y2": 4}),
+    ]
+    launch = client.post("/api/phone/launch", json={"device": "ios:abc123", "package": "com.google.chrome.ios"})
+
+    for response in responses:
+        assert response.status_code == 200
+        assert response.json()["ok"] is True
+        assert response.json()["device"] == "ios:abc123"
+        assert response.json()["platform"] == "ios"
+    assert launch.status_code == 200
+    assert launch.json()["ok"] is True
+    assert launch.json()["platform"] == "ios"
+    assert launch.json()["package"] == "com.google.chrome.ios"
+    assert launch.json()["bundle_id"] == "com.google.chrome.ios"
+
+    assert fake.calls == [
+        ("tap", 11, 22, {}),
+        ("press_key", "ENTER"),
+        ("tap", 33, 44, {}),
+        ("type_text", "hello"),
+        ("back", 0.3),
+        ("press_key", "HOME"),
+        ("terminate_app", "com.google.chrome.ios"),
+        ("swipe", 1, 2, 3, 4, {}),
+        ("launch_app", "com.google.chrome.ios"),
+    ]
+
+
+def test_ios_input_errors_include_platform_metadata(monkeypatch):
+    fake = FakeIOSControlDevice()
+
+    def fail_press_key(key):
+        raise RuntimeError(f"iOS key '{key}' is not supported through WDA")
+
+    fake.press_key = fail_press_key
+    monkeypatch.setattr("gitd.routers.phone.get_device", lambda device: fake)
+    client = TestClient(app)
+
+    missing_key = client.post("/api/phone/input", json={"device": "ios:abc123", "action": "keyevent"})
+    unsupported_key = client.post(
+        "/api/phone/input",
+        json={"device": "ios:abc123", "action": "keyevent", "key": "VOLUME_UP"},
+    )
+
+    assert missing_key.status_code == 200
+    assert missing_key.json() == {
+        "ok": False,
+        "device": "ios:abc123",
+        "platform": "ios",
+        "error": "key or keycode required",
+    }
+    assert unsupported_key.status_code == 200
+    assert unsupported_key.json()["ok"] is False
+    assert unsupported_key.json()["device"] == "ios:abc123"
+    assert unsupported_key.json()["platform"] == "ios"
+    assert unsupported_key.json()["error"] == "iOS key 'VOLUME_UP' is not supported through WDA"
+
+
+def test_ios_direct_control_errors_are_structured(monkeypatch):
+    class FailingIOSDevice:
+        def tap(self, *_args, **_kwargs):
+            raise RuntimeError("wda tap failed")
+
+        def type_text(self, *_args, **_kwargs):
+            raise RuntimeError("wda type failed")
+
+        def back(self, *_args, **_kwargs):
+            raise RuntimeError("wda back failed")
+
+        def press_key(self, *_args, **_kwargs):
+            raise RuntimeError("wda key failed")
+
+        def launch_app(self, *_args, **_kwargs):
+            raise RuntimeError("wda launch failed")
+
+        def terminate_app(self, *_args, **_kwargs):
+            raise RuntimeError("wda terminate failed")
+
+        def swipe(self, *_args, **_kwargs):
+            raise RuntimeError("wda swipe failed")
+
+    monkeypatch.setattr("gitd.routers.phone.get_device", lambda device: FailingIOSDevice())
+    client = TestClient(app)
+
+    cases = [
+        (client.post("/api/phone/tap", json={"device": "ios:abc123", "x": 1, "y": 2}), "wda tap failed"),
+        (client.post("/api/phone/type", json={"device": "ios:abc123", "text": "hello"}), "wda type failed"),
+        (client.post("/api/phone/back", json={"device": "ios:abc123"}), "wda back failed"),
+        (client.post("/api/phone/key", json={"device": "ios:abc123", "key": "HOME"}), "wda key failed"),
+        (
+            client.post("/api/phone/launch", json={"device": "ios:abc123", "package": "com.google.chrome.ios"}),
+            "wda launch failed",
+        ),
+        (
+            client.post("/api/phone/force-stop", json={"device": "ios:abc123", "package": "com.google.chrome.ios"}),
+            "wda terminate failed",
+        ),
+        (
+            client.post("/api/phone/swipe", json={"device": "ios:abc123", "x1": 1, "y1": 2, "x2": 3, "y2": 4}),
+            "wda swipe failed",
+        ),
+    ]
+
+    for response, error in cases:
+        assert response.status_code == 200
+        assert response.json() == {
+            "ok": False,
+            "device": "ios:abc123",
+            "platform": "ios",
+            "error": error,
+        }
+
+
+def test_launch_route_requires_package(client):
+    response = client.post("/api/phone/launch", json={"device": "ios:abc123"})
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "package required"

--- a/tests/api/test_phone_elements.py
+++ b/tests/api/test_phone_elements.py
@@ -1,0 +1,54 @@
+from fastapi.testclient import TestClient
+
+from gitd.app import app
+
+
+def test_ios_elements_endpoint_includes_screen_size(monkeypatch):
+    class FakeIOSDevice:
+        def get_screen_size(self):
+            return (393, 852)
+
+    monkeypatch.setattr(
+        "gitd.services.device_context.get_interactive_elements",
+        lambda device: [
+            {
+                "idx": 0,
+                "text": "Search",
+                "bounds": {"x1": 10, "y1": 20, "x2": 200, "y2": 64},
+                "center": {"x": 105, "y": 42},
+            }
+        ],
+    )
+    monkeypatch.setattr("gitd.routers.phone.get_device", lambda device: FakeIOSDevice())
+    client = TestClient(app)
+
+    response = client.get("/api/phone/elements/ios:abc123")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["platform"] == "ios"
+    assert body["screen_size"] == {"width": 393, "height": 852}
+    assert body["count"] == 1
+    assert body["elements"][0]["text"] == "Search"
+
+
+def test_android_elements_endpoint_includes_screen_size(monkeypatch):
+    class FakeAndroidDevice:
+        def __init__(self, serial):
+            self.serial = serial
+
+        def adb(self, *args, timeout=30):
+            assert args == ("shell", "wm", "size")
+            return "Physical size: 1080x2400"
+
+    monkeypatch.setattr("gitd.services.device_context.get_interactive_elements", lambda device: [])
+    monkeypatch.setattr("gitd.bots.common.adb.Device", FakeAndroidDevice)
+    client = TestClient(app)
+
+    response = client.get("/api/phone/elements/emulator-5554")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["platform"] == "android"
+    assert body["screen_size"] == {"width": 1080, "height": 2400}
+    assert body["count"] == 0

--- a/tests/api/test_phone_health_ios.py
+++ b/tests/api/test_phone_health_ios.py
@@ -1,0 +1,100 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("issue", "state"),
+    [
+        ("check_ios_device_config", "configured_unreachable"),
+        ("unlock_and_trust_device", "locked"),
+        ("fix_wda_signing", "wda_signing_failed"),
+    ],
+)
+def test_ios_health_fix_returns_manual_recovery_for_recommended_codes(client, issue, state):
+    response = client.post("/api/phone/health/ios:abc123/fix", json={"issue": issue})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is False
+    assert body["platform"] == "ios"
+    assert body["issue"] == issue
+    assert body["manual_action_required"] is True
+    assert body["recovery"]["state"] == state
+    assert body["recovery"]["code"] == issue
+    assert body["recovery"]["steps"]
+
+
+def test_ios_health_fix_resets_appium_session(client, monkeypatch):
+    calls = []
+
+    class FakeIOSDevice:
+        def reset_session(self):
+            calls.append("reset")
+
+    monkeypatch.setattr("gitd.services.device_context.get_device", lambda device: FakeIOSDevice())
+
+    response = client.post("/api/phone/health/ios:abc123/fix", json={"issue": "reset_session"})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "ok": True,
+        "platform": "ios",
+        "issue": "reset_session",
+        "message": "iOS Appium session reset",
+    }
+    assert calls == ["reset"]
+
+
+def test_ios_health_fix_starts_local_appium(client, monkeypatch):
+    calls = []
+
+    class FakeIOSDevice:
+        def start_appium_server(self):
+            calls.append("start")
+            return {
+                "ok": True,
+                "platform": "ios",
+                "issue": "start_appium",
+                "pid": 2468,
+                "appium_url": "http://127.0.0.1:4723",
+            }
+
+    monkeypatch.setattr("gitd.services.device_context.get_device", lambda device: FakeIOSDevice())
+
+    response = client.post("/api/phone/health/ios:abc123/fix", json={"issue": "start_appium"})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "ok": True,
+        "platform": "ios",
+        "issue": "start_appium",
+        "pid": 2468,
+        "appium_url": "http://127.0.0.1:4723",
+    }
+    assert calls == ["start"]
+
+
+def test_ios_health_fix_restarts_remote_xpc_tunnel(client, monkeypatch):
+    calls = []
+
+    class FakeIOSDevice:
+        def restart_remote_xpc_tunnel(self):
+            calls.append("restart")
+            return {
+                "ok": True,
+                "platform": "ios",
+                "issue": "restart_remote_xpc_tunnel",
+                "pid": 1234,
+            }
+
+    monkeypatch.setattr("gitd.services.device_context.get_device", lambda device: FakeIOSDevice())
+
+    response = client.post("/api/phone/health/ios:abc123/fix", json={"issue": "restart_remote_xpc_tunnel"})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "ok": True,
+        "platform": "ios",
+        "issue": "restart_remote_xpc_tunnel",
+        "pid": 1234,
+    }
+    assert calls == ["restart"]

--- a/tests/api/test_phone_platform_metadata.py
+++ b/tests/api/test_phone_platform_metadata.py
@@ -1,0 +1,101 @@
+import json
+
+from fastapi.testclient import TestClient
+
+from gitd.app import app
+
+
+class FakeTreeDevice:
+    def dump_xml(self):
+        return """
+        <hierarchy>
+          <node class="XCUIElementTypeApplication" bounds="[0,0][393,852]">
+            <node class="XCUIElementTypeTextField" text="Search" clickable="true" bounds="[10,20][300,64]" />
+          </node>
+        </hierarchy>
+        """
+
+
+def test_phone_context_routes_include_device_and_platform(monkeypatch):
+    from gitd.services import device_context
+
+    monkeypatch.setattr(
+        device_context,
+        "screenshot",
+        lambda device: {"device": device, "platform": "ios", "image": "image", "width": 393, "height": 852},
+    )
+    monkeypatch.setattr(device_context, "get_device", lambda device: FakeTreeDevice())
+    monkeypatch.setattr(device_context, "ocr_screen", lambda device: [{"text": "Search", "x": 10, "y": 20}])
+    client = TestClient(app)
+
+    screenshot = client.get("/api/phone/screenshot/ios:abc123")
+    xml = client.get("/api/phone/xml/ios:abc123")
+    tree = client.get("/api/phone/screen-tree/ios:abc123")
+    ocr = client.get("/api/phone/ocr/ios:abc123")
+
+    for response in (screenshot, xml, tree, ocr):
+        assert response.status_code == 200
+        body = response.json()
+        assert body["device"] == "ios:abc123"
+        assert body["platform"] == "ios"
+
+    assert screenshot.json()["width"] == 393
+    assert "Search" in xml.json()["xml"]
+    assert "Search" in tree.json()["tree"]
+    assert ocr.json()["texts"][0]["text"] == "Search"
+
+
+def test_device_context_classify_and_fingerprint_include_platform(monkeypatch):
+    from gitd.services import device_context
+
+    monkeypatch.setattr(
+        device_context,
+        "get_phone_state",
+        lambda device: {
+            "packageName": "com.google.chrome.ios",
+            "activityName": "com.google.chrome.ios",
+            "currentApp": "Chrome",
+            "keyboardVisible": True,
+        },
+    )
+    monkeypatch.setattr(device_context, "get_device", lambda device: FakeTreeDevice())
+    monkeypatch.setattr(
+        device_context,
+        "get_interactive_elements",
+        lambda device: [{"class": "TextField", "resource_id": "Search"}],
+    )
+
+    classified = device_context.classify_screen("ios:abc123")
+    fingerprint = device_context.fingerprint_screen("ios:abc123")
+    validated = device_context.validate_fingerprint("ios:abc123", {"package": "com.google.chrome.ios"})
+
+    assert classified["device"] == "ios:abc123"
+    assert classified["platform"] == "ios"
+    assert classified["screen_type"] == "search"
+    assert fingerprint["device"] == "ios:abc123"
+    assert fingerprint["platform"] == "ios"
+    assert validated["device"] == "ios:abc123"
+    assert validated["platform"] == "ios"
+    assert validated["valid"] is True
+
+
+def test_agent_screenshot_tools_preserve_platform_metadata(monkeypatch):
+    from gitd.services.agent_tools import execute_tool
+
+    monkeypatch.setattr(
+        "gitd.services.agent_tools.ctx.screenshot",
+        lambda device: {
+            "device": device,
+            "platform": "ios",
+            "image": "a" * 200,
+            "width": 393,
+            "height": 852,
+        },
+    )
+
+    payload = json.loads(execute_tool("screenshot", {"device": "ios:abc123"}))
+
+    assert payload["device"] == "ios:abc123"
+    assert payload["platform"] == "ios"
+    assert payload["width"] == 393
+    assert payload["image"].endswith("...(truncated)")

--- a/tests/api/test_phone_recording.py
+++ b/tests/api/test_phone_recording.py
@@ -1,0 +1,223 @@
+import json
+
+from fastapi.testclient import TestClient
+
+from gitd.app import app
+from gitd.services.agent_tools import execute_tool, tools_for_device
+from gitd.services.tool_platforms import supports_platform, tool_platform_info
+
+
+class FakeProc:
+    def __init__(self):
+        self.terminated = False
+        self.signals = []
+        self.killed = False
+        self.returncode = None
+
+    def poll(self):
+        return self.returncode
+
+    def terminate(self):
+        self.terminated = True
+        self.returncode = 0
+
+    def send_signal(self, sig):
+        self.signals.append(sig)
+        self.returncode = 0
+
+    def wait(self, timeout=None):
+        self.returncode = 0
+        return 0
+
+    def kill(self):
+        self.killed = True
+        self.returncode = -9
+
+
+def test_ios_phone_recording_uses_wda_mjpeg_and_ffmpeg(tmp_path, monkeypatch):
+    from gitd.services import phone_recording
+
+    calls = []
+    proc = FakeProc()
+
+    class FakeIOSDevice:
+        mjpeg_url = "http://127.0.0.1:9100"
+
+    monkeypatch.setattr(phone_recording, "RECORDINGS_DIR", tmp_path)
+    monkeypatch.setattr(phone_recording, "get_device", lambda device: FakeIOSDevice())
+    phone_recording._active.clear()
+
+    def fake_popen(cmd, stdout=None, stderr=None):
+        calls.append(cmd)
+        return proc
+
+    monkeypatch.setattr(phone_recording.subprocess, "Popen", fake_popen)
+
+    started = phone_recording.start_recording("ios:abc123", filename="ios-smoke.mp4")
+    assert started["ok"] is True
+    assert started["platform"] == "ios"
+    assert started["mode"] == "wda-mjpeg"
+    assert started["filename"] == "ios-smoke.mp4"
+    assert calls == [
+        [
+            "ffmpeg",
+            "-y",
+            "-loglevel",
+            "error",
+            "-f",
+            "mjpeg",
+            "-i",
+            "http://127.0.0.1:9100",
+            "-an",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            str(tmp_path / "ios-smoke.mp4"),
+        ]
+    ]
+
+    (tmp_path / "ios-smoke.mp4").write_bytes(b"mp4")
+    stopped = phone_recording.stop_recording("ios:abc123")
+
+    assert proc.terminated is True
+    assert stopped["ok"] is True
+    assert stopped["saved"] is True
+    assert stopped["url"] == "/api/phone/recording/ios-smoke.mp4"
+    assert phone_recording.recording_status("ios:abc123")["running"] is False
+
+
+def test_android_phone_recording_uses_adb_screenrecord_and_pull(tmp_path, monkeypatch):
+    from gitd.services import phone_recording
+
+    popen_calls = []
+    run_calls = []
+    proc = FakeProc()
+
+    monkeypatch.setattr(phone_recording, "RECORDINGS_DIR", tmp_path)
+    phone_recording._active.clear()
+
+    def fake_popen(cmd, stdout=None, stderr=None):
+        popen_calls.append(cmd)
+        return proc
+
+    def fake_run(cmd, timeout=None, check=False, capture_output=False):
+        run_calls.append(cmd)
+        if "pull" in cmd:
+            (tmp_path / "android-smoke.mp4").write_bytes(b"mp4")
+
+        class Result:
+            returncode = 0
+
+        return Result()
+
+    monkeypatch.setattr(phone_recording.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(phone_recording.subprocess, "run", fake_run)
+
+    started = phone_recording.start_recording("emulator-5554", filename="android-smoke.mp4")
+    stopped = phone_recording.stop_recording("emulator-5554")
+
+    assert started["platform"] == "android"
+    assert started["mode"] == "adb-screenrecord"
+    assert popen_calls[0][:5] == ["adb", "-s", "emulator-5554", "shell", "screenrecord"]
+    assert proc.signals
+    assert any("pull" in call for call in run_calls)
+    assert stopped["ok"] is True
+    assert stopped["url"] == "/api/phone/recording/android-smoke.mp4"
+
+
+def test_recording_rest_routes_use_service(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(
+        "gitd.services.phone_recording.start_recording",
+        lambda device, filename="": calls.append(("start", device, filename))
+        or {"ok": True, "device": device, "filename": filename, "running": True},
+    )
+    monkeypatch.setattr(
+        "gitd.services.phone_recording.stop_recording",
+        lambda device: calls.append(("stop", device))
+        or {"ok": True, "device": device, "filename": "rec.mp4", "saved": True},
+    )
+    monkeypatch.setattr(
+        "gitd.services.phone_recording.recording_status",
+        lambda device: {"ok": True, "device": device, "running": False},
+    )
+    monkeypatch.setattr(
+        "gitd.services.phone_recording.list_recordings",
+        lambda: [{"name": "rec.mp4", "url": "/api/phone/recording/rec.mp4"}],
+    )
+
+    client = TestClient(app)
+
+    started = client.post("/api/phone/recording/start", json={"device": "ios:abc123", "filename": "rec.mp4"})
+    stopped = client.post("/api/phone/recording/stop", json={"device": "ios:abc123"})
+    status = client.get("/api/phone/recording/status/ios:abc123")
+    listed = client.get("/api/phone/recordings")
+
+    assert started.status_code == 200
+    assert stopped.status_code == 200
+    assert status.json()["running"] is False
+    assert listed.json()["recordings"][0]["name"] == "rec.mp4"
+    assert calls == [("start", "ios:abc123", "rec.mp4"), ("stop", "ios:abc123")]
+
+
+def test_phone_recordings_list_includes_ios_metadata(tmp_path, monkeypatch):
+    from gitd.services import phone_recording
+
+    recording = tmp_path / "ios_abc123_20260608_123456.mp4"
+    recording.write_bytes(b"mp4")
+    monkeypatch.setattr(phone_recording, "RECORDINGS_DIR", tmp_path)
+
+    listed = phone_recording.list_recordings()
+
+    assert listed == [
+        {
+            "name": "ios_abc123_20260608_123456.mp4",
+            "size_bytes": 3,
+            "size_mb": 0.0,
+            "date": listed[0]["date"],
+            "url": "/api/phone/recording/ios_abc123_20260608_123456.mp4",
+            "device_ref": "ios:abc123",
+            "platform": "ios",
+        }
+    ]
+
+
+def test_phone_recordings_list_keeps_custom_filename_metadata_empty(tmp_path, monkeypatch):
+    from gitd.services import phone_recording
+
+    recording = tmp_path / "agent-rec.mp4"
+    recording.write_bytes(b"mp4")
+    monkeypatch.setattr(phone_recording, "RECORDINGS_DIR", tmp_path)
+
+    listed = phone_recording.list_recordings()
+
+    assert listed[0]["name"] == "agent-rec.mp4"
+    assert listed[0]["device_ref"] == ""
+    assert listed[0]["platform"] == ""
+
+
+def test_recording_agent_tools_and_platform_registry(monkeypatch):
+    monkeypatch.setattr(
+        "gitd.services.phone_recording.start_recording",
+        lambda device, filename="": {"ok": True, "device": device, "platform": "ios", "filename": filename},
+    )
+    monkeypatch.setattr(
+        "gitd.services.phone_recording.recording_status",
+        lambda device: {"ok": True, "device": device, "platform": "ios", "running": True},
+    )
+
+    started = json.loads(
+        execute_tool("start_screen_recording", {"device": "ios:abc123", "filename": "agent-rec.mp4"})
+    )
+    status = json.loads(execute_tool("screen_recording_status", {"device": "ios:abc123"}))
+    ios_tools = {tool["name"] for tool in tools_for_device("ios:abc123")}
+
+    assert started["filename"] == "agent-rec.mp4"
+    assert status["running"] is True
+    assert "start_screen_recording" in ios_tools
+    assert "stop_screen_recording" in ios_tools
+    assert "screen_recording_status" in ios_tools
+    assert supports_platform("start_screen_recording", "ios") is True
+    assert tool_platform_info("start_screen_recording").support == "cross_platform"

--- a/tests/api/test_smoke.py
+++ b/tests/api/test_smoke.py
@@ -7,6 +7,15 @@ class TestHealth:
         assert r.status_code == 200
         assert r.json()["server"] == "fastapi"
 
+    def test_openapi_metadata_is_ios_aware(self, client):
+        r = client.get("/openapi.json")
+        assert r.status_code == 200
+        schema = r.json()
+        assert "iOS Appium/WDA" in schema["info"]["description"]
+        tags = {tag["name"]: tag["description"] for tag in schema["tags"]}
+        assert tags["phone"] == "Android/iOS device control, tap, swipe, screenshots"
+        assert "iOS WDA MJPEG" in tags["streaming"]
+
 
 class TestFeatures:
     def test_features(self, client):
@@ -74,6 +83,42 @@ class TestPhone:
         assert r.status_code == 200
         assert "devices" in r.json()
 
+    def test_devices_deep_probe_query_reaches_ios_listing(self, client, monkeypatch):
+        calls = []
+
+        monkeypatch.setattr("gitd.routers.phone._try_wifi_reconnect", lambda db: None)
+        monkeypatch.setattr("gitd.routers.phone.subprocess.check_output", lambda *args, **kwargs: b"List of devices attached\n")
+
+        def fake_ios_devices(deep_probe=False):
+            calls.append(deep_probe)
+            return [{"serial": "ios:abc123", "model": "iPhone", "connection": "appium-wda", "platform": "ios"}]
+
+        monkeypatch.setattr("gitd.routers.phone.list_configured_ios_devices", fake_ios_devices)
+
+        r = client.get("/api/phone/devices?probe=deep")
+
+        assert r.status_code == 200
+        assert calls == [True]
+        assert r.json()["devices"][0]["serial"] == "ios:abc123"
+
+    def test_android_device_rows_include_platform(self, client, monkeypatch):
+        monkeypatch.setattr("gitd.routers.phone._try_wifi_reconnect", lambda db: None)
+        monkeypatch.setattr(
+            "gitd.routers.phone.subprocess.check_output",
+            lambda *args, **kwargs: (
+                b"List of devices attached\n"
+                b"emulator-5554 device product:sdk model:Pixel_8 device:emu transport_id:1\n"
+            ),
+        )
+        monkeypatch.setattr("gitd.routers.phone.list_configured_ios_devices", lambda deep_probe=False: [])
+
+        r = client.get("/api/phone/devices")
+
+        assert r.status_code == 200
+        device = r.json()["devices"][0]
+        assert device["serial"] == "emulator-5554"
+        assert device["platform"] == "android"
+
 
 class TestSkills:
     def test_list(self, client):
@@ -85,4 +130,18 @@ class TestSkills:
 class TestCreator:
     def test_ollama_models(self, client):
         r = client.get("/api/creator/ollama-models")
-        assert r.status_code in (200, 500)
+        # The endpoint catches a missing Ollama and returns 200 with an empty
+        # list, so it should ALWAYS be 200 with a well-formed shape — asserting
+        # "200 or 500" passed even when the endpoint was broken.
+        assert r.status_code == 200
+        body = r.json()
+        assert isinstance(body.get("models"), list)
+
+    def test_openapi_metadata_is_ios_aware(self, client):
+        r = client.get("/openapi.json")
+        assert r.status_code == 200
+        schema = r.json()
+        assert "iOS Appium/WDA" in schema["info"]["description"]
+        tags = {tag["name"]: tag["description"] for tag in schema["tags"]}
+        assert tags["phone"] == "Android/iOS device control, tap, swipe, screenshots"
+        assert "iOS WDA MJPEG" in tags["streaming"]

--- a/tests/api/test_streaming.py
+++ b/tests/api/test_streaming.py
@@ -1,0 +1,189 @@
+import asyncio
+import base64
+
+from gitd.routers.streaming import (
+    _webrtc_signal_sync,
+    phone_stream,
+    phone_stream_info,
+    webrtc_poll_signals,
+    webrtc_signals_stream,
+    webrtc_ws_poll,
+    webrtc_ws_send,
+)
+
+
+class FakeIOSStreamDevice:
+    mjpeg_url = "http://127.0.0.1:9123"
+    mjpeg_settings = {
+        "mjpegServerFramerate": 12,
+        "mjpegScalingFactor": 60.0,
+        "mjpegServerScreenshotQuality": 45,
+    }
+
+
+def test_ios_stream_headers_expose_effective_wda_mjpeg_mode(monkeypatch):
+    monkeypatch.setattr("gitd.routers.streaming.get_device", lambda device: FakeIOSStreamDevice())
+
+    response = phone_stream(device="ios:abc123", fps=99, mode="mjpeg")
+
+    assert response.headers["x-phone-platform"] == "ios"
+    assert response.headers["x-phone-stream-mode"] == "wda-mjpeg"
+    assert response.headers["x-phone-stream-fallback-mode"] == "screenshot-polling"
+    assert response.headers["x-phone-health-url"] == "/api/phone/health/ios:abc123"
+    assert response.headers["x-phone-health-fix-url"] == "/api/phone/health/ios:abc123/fix"
+    assert response.headers["x-phone-mjpeg-url"] == "http://127.0.0.1:9123"
+    assert "boundary=BoundaryString" in response.headers["content-type"]
+    assert response.headers["x-phone-mjpeg-settings"] == (
+        '{"mjpegScalingFactor": 60.0, "mjpegServerFramerate": 12, "mjpegServerScreenshotQuality": 45}'
+    )
+
+
+def test_ios_wda_stream_fallback_frames_use_declared_boundary(monkeypatch):
+    monkeypatch.setattr("gitd.routers.streaming.get_device", lambda device: FakeIOSStreamDevice())
+    monkeypatch.setattr(
+        "gitd.routers.streaming.urllib.request.urlopen",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("mjpeg down")),
+    )
+    monkeypatch.setattr(
+        "gitd.services.device_context.screenshot",
+        lambda *_args, **_kwargs: {"image": base64.b64encode(b"jpeg").decode("ascii")},
+    )
+
+    response = phone_stream(device="ios:abc123", fps=5, mode="mjpeg")
+    chunk = asyncio.run(anext(response.body_iterator))
+
+    assert "boundary=BoundaryString" in response.headers["content-type"]
+    assert chunk.startswith(b"--BoundaryString\r\nContent-Type: image/jpeg\r\n\r\njpeg\r\n")
+
+
+def test_ios_stream_info_exposes_wda_mjpeg_and_recovery_metadata(monkeypatch):
+    monkeypatch.setattr("gitd.routers.streaming.get_device", lambda device: FakeIOSStreamDevice())
+
+    response = phone_stream_info(device="ios:abc123", fps=99, mode="mjpeg")
+
+    assert response == {
+        "ok": True,
+        "device": "ios:abc123",
+        "platform": "ios",
+        "requested_mode": "mjpeg",
+        "effective_mode": "wda-mjpeg",
+        "recommended_mode": "wda-mjpeg",
+        "fallback_mode": "screenshot-polling",
+        "stream_url": "/api/phone/stream?device=ios%3Aabc123&fps=10&mode=wda-mjpeg",
+        "mjpeg_url": "http://127.0.0.1:9123",
+        "mjpeg_settings": {
+            "mjpegServerFramerate": 12,
+            "mjpegScalingFactor": 60.0,
+            "mjpegServerScreenshotQuality": 45,
+        },
+        "fps": 10,
+        "quality": 8,
+        "portal_supported": False,
+        "webrtc_supported": False,
+        "control_supported": True,
+        "unsupported_actions": ["portal", "webrtc", "wireless_adb", "overlay"],
+        "recovery": {
+            "health_endpoint": "/api/phone/health/ios:abc123",
+            "fix_endpoint": "/api/phone/health/ios:abc123/fix",
+            "fix_tool": "fix_device_health",
+            "common_fixes": ["start_appium", "reset_session", "restart_remote_xpc_tunnel"],
+        },
+    }
+
+
+def test_ios_stream_headers_expose_screenshot_polling_fallback_mode(monkeypatch):
+    monkeypatch.setattr("gitd.routers.streaming.get_device", lambda device: FakeIOSStreamDevice())
+
+    response = phone_stream(device="ios:abc123", fps=5, mode="screencap")
+
+    assert response.headers["x-phone-platform"] == "ios"
+    assert response.headers["x-phone-stream-mode"] == "screenshot-polling"
+    assert "boundary=frame" in response.headers["content-type"]
+
+
+def test_android_stream_info_exposes_portal_and_screencap_modes():
+    response = phone_stream_info(device="emulator-5554", fps=5, mode="h264")
+
+    assert response == {
+        "ok": True,
+        "device": "emulator-5554",
+        "platform": "android",
+        "requested_mode": "h264",
+        "effective_mode": "h264",
+        "recommended_mode": "portal",
+        "fallback_mode": "screencap",
+        "stream_url": "/api/phone/stream?device=emulator-5554&fps=5&mode=h264",
+        "fps": 5,
+        "quality": 8,
+        "portal_supported": True,
+        "webrtc_supported": True,
+        "control_supported": True,
+        "unsupported_actions": [],
+        "recovery": {
+            "health_endpoint": "/api/phone/health/emulator-5554",
+            "fix_endpoint": "/api/phone/health/emulator-5554/fix",
+            "fix_tool": "fix_device_health",
+        },
+    }
+
+
+def test_android_stream_headers_expose_effective_mode():
+    response = phone_stream(device="emulator-5554", fps=5, mode="h264")
+
+    assert response.headers["x-phone-platform"] == "android"
+    assert response.headers["x-phone-stream-mode"] == "h264"
+    assert response.headers["x-phone-health-url"] == "/api/phone/health/emulator-5554"
+    assert response.headers["x-phone-health-fix-url"] == "/api/phone/health/emulator-5554/fix"
+
+
+def test_ios_webrtc_signal_returns_wda_stream_fallback():
+    response = _webrtc_signal_sync({"device": "ios:abc123", "method": "stream/start", "params": {}})
+
+    assert response["ok"] is False
+    assert response["platform"] == "ios"
+    assert "WebRTC" in response["error"]
+    assert response["stream_fallback"]["recommended_mode"] == "wda-mjpeg"
+    assert response["stream_fallback"]["fallback_mode"] == "screenshot-polling"
+    assert response["stream_fallback"]["stream_url"] == "/api/phone/stream?device=ios%3Aabc123&fps=10&mode=wda-mjpeg"
+    assert response["stream_fallback"]["url"] == response["stream_fallback"]["stream_url"]
+    assert response["recovery"]["health_endpoint"] == "/api/phone/health/ios:abc123"
+    assert response["recovery"]["fix_endpoint"] == "/api/phone/health/ios:abc123/fix"
+    assert response["recovery"]["fix_tool"] == "fix_device_health"
+    assert "restart_remote_xpc_tunnel" in response["recovery"]["common_fixes"]
+
+
+def test_ios_webrtc_poll_signals_returns_wda_stream_fallback():
+    response = webrtc_poll_signals("ios:abc123")
+
+    assert response["ok"] is False
+    assert response["platform"] == "ios"
+    assert "WebRTC signal polling" in response["error"]
+    assert response["stream_fallback"]["recommended_mode"] == "wda-mjpeg"
+    assert response["recovery"]["health_endpoint"] == "/api/phone/health/ios:abc123"
+
+
+def test_ios_webrtc_signals_stream_returns_wda_stream_fallback():
+    response = asyncio.run(webrtc_signals_stream("ios:abc123"))
+
+    assert response["ok"] is False
+    assert response["platform"] == "ios"
+    assert "WebRTC signal stream" in response["error"]
+    assert response["stream_fallback"]["fallback_mode"] == "screenshot-polling"
+
+
+def test_ios_webrtc_ws_send_returns_wda_stream_fallback():
+    response = webrtc_ws_send({"device": "ios:abc123", "message": {"type": "ping"}})
+
+    assert response["ok"] is False
+    assert response["platform"] == "ios"
+    assert "Portal WebSocket" in response["error"]
+    assert response["stream_fallback"]["fallback_mode"] == "screenshot-polling"
+
+
+def test_ios_webrtc_ws_poll_returns_wda_stream_fallback():
+    response = webrtc_ws_poll({"device": "ios:abc123"})
+
+    assert response["ok"] is False
+    assert response["platform"] == "ios"
+    assert "Portal WebSocket polling" in response["error"]
+    assert response["stream_fallback"]["endpoint"] == "/api/phone/stream"

--- a/tests/api/test_streaming_viewers.py
+++ b/tests/api/test_streaming_viewers.py
@@ -1,0 +1,71 @@
+from fastapi.testclient import TestClient
+
+from gitd.app import app
+
+
+def test_ios_webrtc_viewer_renders_wda_mjpeg_image_without_adb(monkeypatch):
+    def fail_adb(*args, **kwargs):
+        raise AssertionError("iOS viewer should not run adb forwarding")
+
+    monkeypatch.setattr("gitd.routers.streaming_viewers.subprocess.run", fail_adb)
+
+    response = TestClient(app).get("/api/phone/webrtc-viewer?device=ios:abc123")
+
+    assert response.status_code == 200
+    body = response.text
+    assert 'src="/api/phone/stream?device=ios%3Aabc123&amp;fps=10&amp;mode=wda-mjpeg"' in body
+    assert "<img" in body
+    assert "ios" in body
+    assert "wda-mjpeg" in body
+    assert "<video" not in body
+
+
+def test_ios_webrtc_multi_viewer_renders_wda_mjpeg_image_without_adb(monkeypatch):
+    def fail_adb(*args, **kwargs):
+        raise AssertionError("iOS multi-viewer should not run adb forwarding")
+
+    monkeypatch.setattr("gitd.routers.streaming_viewers.subprocess.run", fail_adb)
+
+    response = TestClient(app).get("/api/phone/webrtc-multi?device=ios:abc123")
+
+    assert response.status_code == 200
+    body = response.text
+    assert '"platform": "ios"' in body
+    assert '"mode": "wda-mjpeg"' in body
+    assert '"streamUrl": "/api/phone/stream?device=ios%3Aabc123&fps=10&mode=wda-mjpeg"' in body
+    assert "d.platform === 'ios'" in body
+
+
+def test_mixed_webrtc_multi_viewer_only_sets_up_android_adb(monkeypatch):
+    adb_devices = []
+    adb_forwards = []
+
+    class FakeAdbDevice:
+        def __init__(self, serial):
+            adb_devices.append(serial)
+
+        def _ensure_portal_forward(self):
+            return 18000
+
+    def fake_run(cmd, capture_output=False, timeout=None):
+        adb_forwards.append(cmd)
+
+        class Result:
+            returncode = 0
+
+        return Result()
+
+    monkeypatch.setattr("gitd.bots.common.adb.Device", FakeAdbDevice)
+    monkeypatch.setattr("gitd.routers.streaming_viewers.subprocess.run", fake_run)
+
+    response = TestClient(app).get("/api/phone/webrtc-multi?device=ios:abc123&device=emulator-5554")
+
+    assert response.status_code == 200
+    assert adb_devices == ["emulator-5554"]
+    assert len(adb_forwards) == 1
+    assert adb_forwards[0][:3] == ["adb", "-s", "emulator-5554"]
+    body = response.text
+    assert '"serial": "ios:abc123"' in body
+    assert '"platform": "ios"' in body
+    assert '"serial": "emulator-5554"' in body
+    assert '"platform": "android"' in body

--- a/tests/api/test_tools_hub.py
+++ b/tests/api/test_tools_hub.py
@@ -1,0 +1,173 @@
+def test_tools_hub_exposes_platform_support(client):
+    response = client.get("/api/tools")
+    assert response.status_code == 200
+
+    categories = response.json()
+    web = next(category for category in categories if category["category"] == "Web")
+    screen = next(category for category in categories if category["category"] == "Screen Reading")
+    input_tools = next(category for category in categories if category["category"] == "Input")
+    app_management = next(category for category in categories if category["category"] == "App Management")
+    clipboard = next(category for category in categories if category["category"] == "Clipboard & Notifications")
+    skills = next(category for category in categories if category["category"] == "Skills")
+    marketing = next(category for category in categories if category["category"] == "Marketing")
+    crm = next(category for category in categories if category["category"] == "CRM")
+    device_tools = next(category for category in categories if category["category"] == "Device")
+    open_url = next(tool for tool in web["tools"] if tool["name"] == "open_url")
+    current_url = next(tool for tool in web["tools"] if tool["name"] == "get_current_url")
+    read_news = next(tool for tool in web["tools"] if tool["name"] == "read_news")
+    device_health = next(tool for tool in screen["tools"] if tool["name"] == "device_health")
+    fix_device_health = next(tool for tool in screen["tools"] if tool["name"] == "fix_device_health")
+    start_recording = next(tool for tool in screen["tools"] if tool["name"] == "start_screen_recording")
+    stream_info = next(tool for tool in screen["tools"] if tool["name"] == "get_stream_info")
+    type_unicode = next(tool for tool in input_tools["tools"] if tool["name"] == "type_unicode")
+    press_back = next(tool for tool in input_tools["tools"] if tool["name"] == "press_back")
+    press_home = next(tool for tool in input_tools["tools"] if tool["name"] == "press_home")
+    app_state = next(tool for tool in app_management["tools"] if tool["name"] == "app_state")
+    explore_app = next(tool for tool in app_management["tools"] if tool["name"] == "explore_app")
+    paste_text = next(tool for tool in clipboard["tools"] if tool["name"] == "paste_text")
+    open_notifications = next(tool for tool in clipboard["tools"] if tool["name"] == "open_notifications")
+    run_workflow = next(tool for tool in skills["tools"] if tool["name"] == "run_workflow")
+    run_action = next(tool for tool in skills["tools"] if tool["name"] == "run_action")
+    create_skill = next(tool for tool in skills["tools"] if tool["name"] == "create_skill")
+    lookup_lead = next(tool for tool in marketing["tools"] if tool["name"] == "lookup_lead")
+    list_unread_leads = next(tool for tool in marketing["tools"] if tool["name"] == "list_unread_leads")
+    crm_lookup_contact = next(tool for tool in crm["tools"] if tool["name"] == "crm_lookup_contact")
+    crm_list_unread_messages = next(tool for tool in crm["tools"] if tool["name"] == "crm_list_unread_messages")
+    list_devices = next(tool for tool in device_tools["tools"] if tool["name"] == "list_devices")
+    toggle_overlay = next(tool for tool in device_tools["tools"] if tool["name"] == "toggle_overlay")
+    create_skill_params = {param["name"]: param for param in create_skill["params"]}
+
+    assert open_url["platform_support"]["support"] == "cross_platform"
+    assert open_url["platform_support"]["ios"] is True
+    assert current_url["platform_support"]["support"] == "ios_supported"
+    assert current_url["platform_support"]["android"] is False
+    assert read_news["platform_support"]["support"] == "ios_supported"
+    assert read_news["platform_support"]["ios"] is True
+    assert device_health["platform_support"]["support"] == "cross_platform"
+    assert fix_device_health["platform_support"]["support"] == "cross_platform"
+    assert fix_device_health["platform_support"]["ios"] is True
+    assert start_recording["platform_support"]["support"] == "cross_platform"
+    assert start_recording["platform_support"]["ios"] is True
+    assert stream_info["platform_support"]["support"] == "cross_platform"
+    assert stream_info["platform_support"]["ios"] is True
+    assert type_unicode["platform_support"]["support"] == "cross_platform"
+    assert type_unicode["platform_support"]["ios"] is True
+    assert press_back["platform_support"]["support"] == "cross_platform"
+    assert press_back["platform_support"]["ios"] is True
+    assert press_home["platform_support"]["support"] == "cross_platform"
+    assert press_home["platform_support"]["ios"] is True
+    assert app_state["platform_support"]["support"] == "cross_platform"
+    assert app_state["platform_support"]["ios"] is True
+    assert explore_app["platform_support"]["support"] == "cross_platform"
+    assert explore_app["platform_support"]["ios"] is True
+    assert paste_text["platform_support"]["support"] == "cross_platform"
+    assert paste_text["platform_support"]["ios"] is True
+    assert open_notifications["platform_support"]["support"] == "cross_platform"
+    assert open_notifications["platform_support"]["ios"] is True
+    assert "Notification Center" in open_notifications["description"]
+    assert run_workflow["platform_support"]["support"] == "cross_platform"
+    assert run_workflow["platform_support"]["ios"] is True
+    assert run_action["platform_support"]["support"] == "cross_platform"
+    assert run_action["platform_support"]["ios"] is True
+    assert create_skill["platform_support"]["support"] == "cross_platform"
+    assert create_skill["platform_support"]["ios"] is True
+    assert create_skill_params["steps"]["type"] == "array"
+    assert "Recorded step list" in create_skill_params["steps"]["description"]
+    assert create_skill_params["elements_ios"]["type"] == ["object", "array"]
+    assert create_skill_params["elements_ios"]["items"] == {"type": "object"}
+    assert create_skill_params["elements_android"]["type"] == ["object", "array"]
+    assert create_skill_params["platforms"]["items"] == {"type": "string"}
+    assert lookup_lead["platform_support"]["support"] == "cross_platform"
+    assert lookup_lead["platform_support"]["ios"] is True
+    assert list_unread_leads["platform_support"]["support"] == "cross_platform"
+    assert list_unread_leads["platform_support"]["ios"] is True
+    assert crm_lookup_contact["platform_support"]["support"] == "cross_platform"
+    assert crm_lookup_contact["platform_support"]["ios"] is True
+    assert crm_list_unread_messages["platform_support"]["support"] == "cross_platform"
+    assert crm_list_unread_messages["platform_support"]["ios"] is True
+    assert list_devices["platform_support"]["support"] == "cross_platform"
+    assert list_devices["platform_support"]["ios"] is True
+    assert toggle_overlay["platform_support"]["support"] == "android_only"
+    assert toggle_overlay["platform_support"]["ios"] is False
+    assert "Android-only" in toggle_overlay["description"]
+
+
+def test_tools_platforms_endpoint(client):
+    response = client.get("/api/tools/platforms")
+    assert response.status_code == 200
+    body = response.json()
+
+    supports = {tool["name"]: tool for tool in body["tools"]}
+
+    assert supports["shell"]["support"] == "android_only"
+    assert supports["clipboard_get"]["support"] == "cross_platform"
+    assert supports["clipboard_get"]["ios"] is True
+    assert supports["app_state"]["support"] == "cross_platform"
+    assert supports["app_state"]["ios"] is True
+    assert supports["start_screen_recording"]["support"] == "cross_platform"
+    assert supports["start_screen_recording"]["ios"] is True
+    assert supports["fix_device_health"]["support"] == "cross_platform"
+    assert supports["fix_device_health"]["ios"] is True
+    assert supports["extract_articles"]["support"] == "cross_platform"
+    assert set(body["categories"]) == {"cross_platform", "android_only", "ios_supported", "ios_planned"}
+
+
+def test_tools_test_endpoint_rejects_unsupported_platform_combo(client):
+    android_news = client.post(
+        "/api/tools/test",
+        json={"name": "read_news", "args": {"device": "emulator-5554", "url": "https://text.npr.org/"}},
+    )
+    ios_shell = client.post(
+        "/api/tools/test",
+        json={"name": "shell", "args": {"device": "ios:abc123", "command": "ls"}},
+    )
+    unknown_ios = client.post(
+        "/api/tools/test",
+        json={"name": "definitely_not_a_tool", "args": {"device": "ios:abc123"}},
+    )
+
+    assert android_news.status_code == 200
+    assert android_news.json()["ok"] is False
+    assert android_news.json()["platform"] == "android"
+    assert android_news.json()["support"] == "ios_supported"
+    assert "implemented only for iOS" in android_news.json()["error"]
+
+    assert ios_shell.status_code == 200
+    assert ios_shell.json()["ok"] is False
+    assert ios_shell.json()["platform"] == "ios"
+    assert ios_shell.json()["support"] == "android_only"
+    assert "Android-only" in ios_shell.json()["error"]
+
+    assert unknown_ios.status_code == 200
+    assert unknown_ios.json()["ok"] is False
+    assert unknown_ios.json()["error"] == "unknown_tool"
+    assert unknown_ios.json()["tool"] == "definitely_not_a_tool"
+    assert "support" not in unknown_ios.json()
+
+
+def test_ios_packages_endpoint_returns_verified_bundle_inventory(client, monkeypatch):
+    class FakeIOSDevice:
+        def list_apps(self, query="", verify=True):
+            assert query == ""
+            assert verify is True
+            return [
+                {
+                    "name": "Chrome",
+                    "package": "com.google.chrome.ios",
+                    "bundle_id": "com.google.chrome.ios",
+                    "platform": "ios",
+                    "verified": True,
+                    "installed": True,
+                }
+            ]
+
+    monkeypatch.setattr("gitd.services.device_context.get_device", lambda device: FakeIOSDevice())
+
+    response = client.get("/api/phone/packages/ios:abc123")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["platform"] == "ios"
+    assert body["packages"] == ["com.google.chrome.ios"]
+    assert body["apps"][0]["bundle_id"] == "com.google.chrome.ios"
+    assert "configured/common" in body["note"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,10 +4,63 @@ Shared test fixtures.
 Device tests require a connected Android phone (set DEVICE env var).
 API tests use FastAPI TestClient (no phone needed).
 """
+
+import hashlib
 import os
+import tempfile
 from pathlib import Path
 
 import pytest
+
+# ── Test DB isolation (must run at conftest import, before any gitd import) ───
+# gitd.models.base builds its SQLAlchemy engine bound to settings.db_path AT
+# IMPORT TIME, and `settings` is created the first time gitd.config is imported.
+# So the ONLY place we can redirect the DB is here, at conftest import — pytest
+# loads conftest before collecting/importing any test module that pulls in gitd.
+# Without this, trace tests (which insert and DELETE trace rows) run against the
+# real data/gitd.db and wipe live rows. This module does NOT import gitd, so the
+# env var is set first.
+# ── iOS feature gate ──────────────────────────────────────────────────────────
+# iOS support ships gate-OFF by default; the test suite exercises the full iOS
+# surface, so enable it here. Gate-off behavior has its own dedicated tests
+# (tests/test_ios_feature_gate.py) that monkeypatch the gate closed.
+os.environ.setdefault("GITD_ENABLE_IOS", "1")
+
+if "DB_PATH" not in os.environ:
+    # Per-worktree DB path. A fixed /tmp/gitd_pytest.db is shared by every
+    # checkout, so pytest running concurrently in two per-agent worktrees would
+    # race on the same file (one session's clean-slate unlink + create clobbers
+    # the other → intermittent "no such table"/locked failures). Keying the path
+    # to this worktree's root makes each checkout use its own DB; re-runs in the
+    # same worktree still reuse one stable, debuggable path.
+    _wt_key = hashlib.md5(str(Path(__file__).resolve().parent.parent).encode()).hexdigest()[:8]
+    _TEST_DB = Path(tempfile.gettempdir()) / f"gitd_pytest_{_wt_key}.db"
+    # Start each test session from a clean slate (drop WAL/SHM sidecars too).
+    for _suffix in ("", "-wal", "-shm"):
+        Path(str(_TEST_DB) + _suffix).unlink(missing_ok=True)
+    os.environ["DB_PATH"] = str(_TEST_DB)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _verify_db_isolated():
+    """Fail loudly if the app DB wasn't redirected to the throwaway test DB.
+
+    If anything imported gitd before this conftest set DB_PATH, the module-level
+    engine would still point at the real dev DB and the trace tests would wipe
+    it. This guard turns that silent data-loss into an immediate, obvious error.
+    """
+    from gitd.models.base import engine
+
+    engine_url = str(engine.url)
+    db_path = os.environ.get("DB_PATH", "")
+    real_db = "data/gitd.db"  # the production default in gitd/config.py
+    assert db_path and db_path in engine_url and real_db not in engine_url, (
+        f"Test DB isolation failed: engine is bound to {engine_url!r} (DB_PATH="
+        f"{db_path!r}), expected a throwaway temp DB and definitely NOT {real_db}. "
+        "Something imported gitd before conftest set DB_PATH — do NOT run this "
+        "suite, it would touch the real dev DB."
+    )
+    yield
 
 
 @pytest.fixture(scope="session")
@@ -19,3 +72,21 @@ def dev():
     if not serial:
         pytest.skip("DEVICE env var not set — skipping device tests")
     return Device(serial)
+
+
+@pytest.fixture(scope="session")
+def client():
+    """FastAPI test client — no real server needed.
+
+    Lives here (the top-level conftest) rather than tests/api/conftest.py so it
+    resolves reliably: when a run mixes ``tests/`` and ``tests/api/`` files (the CI
+    ios-parity job), a subdir conftest that only defines this fixture was not
+    getting collected, causing 'fixture client not found' setup errors. gitd is
+    imported inside the fixture (not at module import) to preserve DB isolation.
+    """
+    from fastapi.testclient import TestClient
+
+    from gitd.app import app
+
+    with TestClient(app) as c:
+        yield c

--- a/tests/test_a11y_diff.py
+++ b/tests/test_a11y_diff.py
@@ -1,0 +1,144 @@
+"""Tests for differential a11y state (#6) — the pure diff + execute_tool wiring."""
+
+import pytest
+
+from gitd.services import agent_tools
+from gitd.services.a11y_diff import diff_elements, element_key, element_label
+
+
+def _el(idx, text="", cls="Button", cx=100, cy=200, desc=""):
+    return {
+        "idx": idx,
+        "text": text,
+        "content_desc": desc,
+        "resource_id": "",
+        "class": cls,
+        "bounds": {"x1": cx - 10, "y1": cy - 10, "x2": cx + 10, "y2": cy + 10},
+        "center": {"x": cx, "y": cy},
+        "clickable": True,
+        "scrollable": False,
+    }
+
+
+# ── pure function ────────────────────────────────────────────────────────────
+
+
+def test_no_prev_returns_empty():
+    assert diff_elements(None, [_el(0, "A")]) == ""
+    assert diff_elements([], [_el(0, "A")]) == ""
+
+
+def test_identical_states_report_no_change():
+    a = [_el(0, "Send"), _el(1, "Cancel")]
+    b = [_el(0, "Send"), _el(1, "Cancel")]
+    assert diff_elements(a, b) == "A11y diff: no change."
+
+
+def test_added_element():
+    prev = [_el(0, "Send")]
+    curr = [_el(0, "Send"), _el(1, "Undo", cx=300)]
+    out = diff_elements(prev, curr)
+    assert "+ 'Undo' (Button)" in out
+    assert "since last action" in out
+    assert "- '" not in out  # nothing removed
+
+
+def test_removed_element():
+    prev = [_el(0, "Send"), _el(1, "Draft", cx=300)]
+    curr = [_el(0, "Send")]
+    out = diff_elements(prev, curr)
+    assert "- 'Draft' (Button)" in out
+    assert "+ '" not in out
+
+
+def test_key_is_robust_to_small_coordinate_jitter():
+    # same element, center shifted by a few px → same coarse key → no change
+    prev = [_el(0, "Ok", cx=100, cy=200)]
+    curr = [_el(0, "Ok", cx=108, cy=205)]
+    assert element_key(prev[0]) == element_key(curr[0])
+    assert diff_elements(prev, curr) == "A11y diff: no change."
+
+
+def test_large_move_counts_as_change():
+    prev = [_el(0, "Ok", cx=100, cy=200)]
+    curr = [_el(0, "Ok", cx=100, cy=900)]
+    out = diff_elements(prev, curr)
+    assert "+ 'Ok'" in out and "- 'Ok'" in out
+
+
+def test_label_falls_back_to_content_desc():
+    assert element_label(_el(0, text="", desc="More options")) == "More options"
+    assert element_label(_el(0, text="Reply", desc="ignored")) == "Reply"
+
+
+def test_added_list_is_capped_with_overflow_count():
+    prev = [_el(0, "keep")]
+    curr = [_el(0, "keep")] + [_el(i, f"new{i}", cx=100 + i * 50) for i in range(1, 10)]
+    out = diff_elements(prev, curr)
+    assert "…3 more new" in out  # 9 new, 6 listed, 3 collapsed
+    assert out.count("  + '") == 6
+
+
+# ── execute_tool integration ─────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def wired(monkeypatch):
+    """Stub the device layer so execute_tool runs without a real phone."""
+    agent_tools._LAST_ELEMENTS.clear()
+    monkeypatch.setattr(agent_tools, "_execute_tool_inner", lambda name, args: f"ok:{name}")
+    monkeypatch.setattr(agent_tools.ctx, "get_screen_tree", lambda d: '[0] Button "x" [] [0,0][1,1]')
+    monkeypatch.setattr("time.sleep", lambda _s: None)
+
+    state = {"elems": [_el(0, "Send")]}
+    monkeypatch.setattr(agent_tools.ctx, "get_interactive_elements", lambda d: state["elems"])
+    return state
+
+
+def test_first_ui_action_appends_no_diff(wired):
+    out = agent_tools.execute_tool("tap", {"device": "d", "x": 1, "y": 2})
+    assert "A11y diff" not in out  # nothing cached yet to diff against
+    assert agent_tools._LAST_ELEMENTS["d"] == wired["elems"]  # but state is now cached
+
+
+def test_second_ui_action_appends_the_diff(wired):
+    agent_tools.execute_tool("tap", {"device": "d", "x": 1, "y": 2})  # primes cache
+    wired["elems"] = [_el(0, "Send"), _el(1, "Sent ✓", cx=400)]
+    out = agent_tools.execute_tool("tap", {"device": "d", "x": 1, "y": 2})
+    assert "A11y diff (since last action)" in out
+    assert "+ 'Sent ✓'" in out
+
+
+def test_no_change_is_suppressed(wired):
+    agent_tools.execute_tool("tap", {"device": "d", "x": 1, "y": 2})
+    out = agent_tools.execute_tool("tap", {"device": "d", "x": 1, "y": 2})  # same elems
+    assert "no change" not in out
+    assert "A11y diff" not in out
+
+
+def test_kill_switch_disables_diff(wired, monkeypatch):
+    from gitd.config import settings
+
+    monkeypatch.setattr(settings, "a11y_diff_enabled", False)
+    agent_tools.execute_tool("tap", {"device": "d", "x": 1, "y": 2})
+    wired["elems"] = [_el(0, "Send"), _el(1, "New", cx=400)]
+    out = agent_tools.execute_tool("tap", {"device": "d", "x": 1, "y": 2})
+    assert "A11y diff" not in out
+
+
+def test_read_only_tool_does_not_update_cache(wired):
+    # screenshot is not a _UI_ACTION_TOOL → no diff, no cache write
+    agent_tools.execute_tool("screenshot", {"device": "d"})
+    assert "d" not in agent_tools._LAST_ELEMENTS
+
+
+def test_diff_failure_is_fail_open(wired, monkeypatch):
+    agent_tools.execute_tool("tap", {"device": "d", "x": 1, "y": 2})  # prime
+
+    def boom(_d):
+        raise RuntimeError("uiautomator dump failed")
+
+    monkeypatch.setattr(agent_tools.ctx, "get_interactive_elements", boom)
+    # must still return the normal result, no exception
+    out = agent_tools.execute_tool("tap", {"device": "d", "x": 1, "y": 2})
+    assert out.startswith("ok:tap")

--- a/tests/test_account_health_ios.py
+++ b/tests/test_account_health_ios.py
@@ -1,0 +1,225 @@
+from fastapi.testclient import TestClient
+
+from gitd.app import app
+from gitd.db import get_connection
+from gitd.services import account_health
+
+
+class FakeIOSAccountDevice:
+    def __init__(self, text: str = "Profile\n@ghost\nFollowers\n@backup"):
+        self.text = text
+        self.launched = []
+
+    def launch_app(self, bundle_id):
+        self.launched.append(bundle_id)
+
+    def extract_visible_text(self, max_lines=120):
+        return self.text
+
+
+def test_ios_account_health_detects_visible_handle_without_premium_probe(monkeypatch):
+    def fail_premium_probe():
+        raise AssertionError("premium probe should not run for iOS account health")
+
+    account_health._cache.clear()
+    monkeypatch.setattr(account_health, "_premium_available", fail_premium_probe)
+    monkeypatch.setattr(account_health, "get_device", lambda device: FakeIOSAccountDevice())
+    monkeypatch.setattr(account_health.time, "sleep", lambda *_args, **_kwargs: None)
+
+    result = account_health.device_account_health("ios:abc123", fresh=True)
+
+    assert result["ok"] is True
+    assert result["device"] == "ios:abc123"
+    assert result["platform"] == "ios"
+    assert result["error"] is None
+    assert result["active"] == "ghost"
+    assert result["logged_in"] == ["ghost", "backup"]
+    assert result["cached"] is False
+    assert result["detection"]["method"] == "wda_visible_text"
+    assert result["detection"]["bundle_id"] == "com.zhiliaoapp.musically"
+
+
+def test_ios_account_health_reports_undetected_handle(monkeypatch):
+    account_health._cache.clear()
+    monkeypatch.setattr(account_health, "get_device", lambda device: FakeIOSAccountDevice("Profile\nNo videos yet"))
+    monkeypatch.setattr(account_health.time, "sleep", lambda *_args, **_kwargs: None)
+
+    result = account_health.device_account_health("ios:nohandle", fresh=True)
+
+    assert result["ok"] is False
+    assert result["platform"] == "ios"
+    assert result["error"] == "no visible TikTok account handle detected"
+    assert result["logged_in"] == []
+
+
+def test_ios_account_switch_succeeds_when_target_already_active(monkeypatch):
+    account_health._cache.clear()
+    monkeypatch.setattr(account_health, "get_device", lambda device: FakeIOSAccountDevice())
+    monkeypatch.setattr(account_health.time, "sleep", lambda *_args, **_kwargs: None)
+
+    switch = account_health.switch_active_account("ios:abc123", "@ghost")
+
+    assert switch["ok"] is True
+    assert switch["platform"] == "ios"
+    assert switch["error"] is None
+    assert switch["active"] == "ghost"
+    assert switch["target"] == "ghost"
+    assert switch["logged_in"] == ["ghost", "backup"]
+    assert switch["switched"] is False
+    assert switch["message"] == "target TikTok account is already active on iOS"
+
+
+def test_ios_account_switch_returns_context_when_switch_needed(monkeypatch):
+    account_health._cache.clear()
+    monkeypatch.setattr(account_health, "get_device", lambda device: FakeIOSAccountDevice())
+    monkeypatch.setattr(account_health.time, "sleep", lambda *_args, **_kwargs: None)
+
+    switch = account_health.switch_active_account("ios:abc123", "@backup")
+
+    assert switch["ok"] is False
+    assert switch["platform"] == "ios"
+    assert switch["error"] == "unsupported_platform"
+    assert switch["active"] == "ghost"
+    assert switch["target"] == "backup"
+    assert switch["logged_in"] == ["ghost", "backup"]
+    assert switch["health_ok"] is True
+    assert switch["health_error"] is None
+
+
+def test_ios_account_switch_returns_health_error_when_undetectable(monkeypatch):
+    account_health._cache.clear()
+    monkeypatch.setattr(account_health, "get_device", lambda device: FakeIOSAccountDevice("Profile\nNo videos yet"))
+    monkeypatch.setattr(account_health.time, "sleep", lambda *_args, **_kwargs: None)
+
+    switch = account_health.switch_active_account("ios:nohandle", "@ghost")
+
+    assert switch["ok"] is False
+    assert switch["platform"] == "ios"
+    assert switch["error"] == "unsupported_platform"
+    assert switch["active"] is None
+    assert switch["target"] == "ghost"
+    assert switch["logged_in"] == []
+    assert switch["health_ok"] is False
+    assert switch["health_error"] == "no visible TikTok account handle detected"
+
+
+def test_ios_account_sync_writes_detected_handles(tmp_path, monkeypatch):
+    db_path = tmp_path / "gitd.db"
+    account_health._cache.clear()
+    monkeypatch.setattr("gitd.db.DEFAULT_DB", db_path)
+    monkeypatch.setattr(account_health, "get_device", lambda device: FakeIOSAccountDevice())
+    monkeypatch.setattr(account_health.time, "sleep", lambda *_args, **_kwargs: None)
+
+    sync = account_health.sync_tiktok_accounts_table("ios:abc123")
+
+    assert sync["ok"] is True
+    assert sync["platform"] == "ios"
+    assert sync["added"] == ["ghost", "backup"]
+    assert sync["updated"] == []
+    assert sync["active"] == "ghost"
+    assert sync["error"] is None
+
+    conn = get_connection(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT handle, phone_serial, is_active FROM tiktok_accounts ORDER BY handle"
+        ).fetchall()
+    finally:
+        conn.close()
+    assert [dict(row) for row in rows] == [
+        {"handle": "backup", "phone_serial": "ios:abc123", "is_active": 1},
+        {"handle": "ghost", "phone_serial": "ios:abc123", "is_active": 1},
+    ]
+
+
+def test_ios_account_sync_reports_detection_failure(tmp_path, monkeypatch):
+    account_health._cache.clear()
+    monkeypatch.setattr("gitd.db.DEFAULT_DB", tmp_path / "gitd.db")
+    monkeypatch.setattr(account_health, "get_device", lambda device: FakeIOSAccountDevice("Profile\nNo videos yet"))
+    monkeypatch.setattr(account_health.time, "sleep", lambda *_args, **_kwargs: None)
+
+    sync = account_health.sync_tiktok_accounts_table("ios:nohandle")
+
+    assert sync["ok"] is False
+    assert sync["platform"] == "ios"
+    assert sync["error"] == "no visible TikTok account handle detected"
+    assert sync["added"] == []
+    assert sync["updated"] == []
+    assert sync["active"] is None
+
+
+def test_account_health_all_includes_ios_configured_refs(monkeypatch):
+    account_health._cache.clear()
+    monkeypatch.setattr("gitd.bots.common.adb.list_connected", lambda: ["emulator-5554"])
+    monkeypatch.setattr("gitd.bots.common.device.ios_refs_from_host", lambda: ["ios:abc123"])
+    monkeypatch.setattr(account_health, "_premium_available", lambda: False)
+    monkeypatch.setattr(account_health, "get_device", lambda device: FakeIOSAccountDevice())
+    monkeypatch.setattr(account_health.time, "sleep", lambda *_args, **_kwargs: None)
+
+    results = account_health.all_devices_health()
+
+    by_device = {item["device"]: item for item in results}
+    assert set(by_device) == {"emulator-5554", "ios:abc123"}
+    assert by_device["emulator-5554"]["platform"] == "android"
+    assert by_device["emulator-5554"]["error"] == "premium not installed"
+    assert by_device["ios:abc123"]["platform"] == "ios"
+    assert by_device["ios:abc123"]["ok"] is True
+    assert by_device["ios:abc123"]["active"] == "ghost"
+
+
+def test_expected_account_matches_uses_ios_visible_handle(monkeypatch):
+    account_health._cache.clear()
+    monkeypatch.setattr(account_health, "get_device", lambda device: FakeIOSAccountDevice("Profile\n@ghost"))
+    monkeypatch.setattr(account_health.time, "sleep", lambda *_args, **_kwargs: None)
+
+    match = account_health.expected_account_matches("ios:abc123", "@ghost")
+    mismatch = account_health.expected_account_matches("ios:abc123", "@other")
+
+    assert match == {"ok": True, "reason": None, "active": "ghost", "expected": "ghost"}
+    assert mismatch == {
+        "ok": False,
+        "reason": "wrong active account: have @ghost, expected @other",
+        "active": "ghost",
+        "expected": "other",
+    }
+
+
+def test_expected_account_matches_allows_ios_when_undetectable(monkeypatch):
+    account_health._cache.clear()
+    monkeypatch.setattr(account_health, "get_device", lambda device: FakeIOSAccountDevice("Profile\nNo videos yet"))
+    monkeypatch.setattr(account_health.time, "sleep", lambda *_args, **_kwargs: None)
+
+    result = account_health.expected_account_matches("ios:nohandle", "@ghost")
+
+    assert result == {
+        "ok": True,
+        "reason": "undetectable: no visible TikTok account handle detected",
+        "active": None,
+        "expected": "ghost",
+    }
+
+
+def test_scheduler_account_health_routes_return_ios_detection(tmp_path, monkeypatch):
+    account_health._cache.clear()
+    monkeypatch.setattr("gitd.db.DEFAULT_DB", tmp_path / "gitd.db")
+    monkeypatch.setattr(account_health, "get_device", lambda device: FakeIOSAccountDevice())
+    monkeypatch.setattr(account_health.time, "sleep", lambda *_args, **_kwargs: None)
+    client = TestClient(app)
+
+    health = client.get("/api/scheduler/account-health/ios:abc123")
+    switch = client.post("/api/scheduler/account-switch/ios:abc123", json={"handle": "@ghost"})
+    sync = client.post("/api/scheduler/account-sync/ios:abc123")
+
+    assert health.status_code == 200
+    assert health.json()["ok"] is True
+    assert health.json()["platform"] == "ios"
+    assert health.json()["active"] == "ghost"
+    assert switch.status_code == 200
+    assert switch.json()["ok"] is True
+    assert switch.json()["error"] is None
+    assert switch.json()["platform"] == "ios"
+    assert switch.json()["active"] == "ghost"
+    assert sync.status_code == 200
+    assert sync.json()["ok"] is True
+    assert sync.json()["platform"] == "ios"
+    assert sync.json()["added"] == ["ghost", "backup"]

--- a/tests/test_adb.py
+++ b/tests/test_adb.py
@@ -1,0 +1,106 @@
+"""Tests for the Device.adb error contract (bots/common/adb.py).
+
+The core guarantee under test: a failed adb call raises ADBError instead of
+silently returning "" (the old phantom-success bug that every tool inherited).
+The happy path (exit 0) is unchanged — it still returns stripped stdout — and
+adb_soft() is the escape hatch for callers that tolerate a nonzero exit.
+"""
+
+import shutil
+import subprocess
+
+import pytest
+
+from gitd.bots.common.adb import ADBError, ADBResult, Device
+
+
+class _FakeCompleted:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_adb_success_returns_stripped_stdout(monkeypatch):
+    """Exit 0 → stripped stdout, contract unchanged from before the fix."""
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: _FakeCompleted(0, "  hello\n", "")
+    )
+    assert Device("serial").adb("shell", "echo", "hello") == "hello"
+
+
+def test_adb_nonzero_raises_adberror(monkeypatch):
+    """Nonzero exit → ADBError carrying the exit code and stderr message."""
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **k: _FakeCompleted(1, "", "error: device 'x' not found"),
+    )
+    with pytest.raises(ADBError) as exc:
+        Device("x").adb("shell", "echo", "hi")
+    assert exc.value.returncode == 1
+    assert "not found" in str(exc.value)
+
+
+def test_adberror_is_runtimeerror(monkeypatch):
+    """ADBError must subclass RuntimeError so existing `except Exception` /
+    `except RuntimeError` call sites keep degrading gracefully."""
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: _FakeCompleted(1, "", "boom")
+    )
+    with pytest.raises(RuntimeError):
+        Device("x").adb("shell", "whatever")
+
+
+def test_adb_missing_binary_raises_adberror(monkeypatch):
+    """adb not on PATH → ADBError(127), never a silent empty string."""
+
+    def _raise(*a, **k):
+        raise FileNotFoundError("adb")
+
+    monkeypatch.setattr(subprocess, "run", _raise)
+    with pytest.raises(ADBError) as exc:
+        Device("x").adb("devices")
+    assert exc.value.returncode == 127
+
+
+def test_adb_timeout_raises_adberror(monkeypatch):
+    """A timeout is a hard failure → ADBError, not a swallowed TimeoutExpired."""
+
+    def _raise(*a, **k):
+        raise subprocess.TimeoutExpired(cmd="adb", timeout=1)
+
+    monkeypatch.setattr(subprocess, "run", _raise)
+    with pytest.raises(ADBError):
+        Device("x").adb("shell", "sleep", "5", timeout=1)
+
+
+def test_adb_soft_does_not_raise_on_nonzero(monkeypatch):
+    """adb_soft returns the result on a nonzero exit instead of raising."""
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: _FakeCompleted(1, "out", "err")
+    )
+    res = Device("x").adb_soft("shell", "cmd", "clipboard", "get-text")
+    assert isinstance(res, ADBResult)
+    assert res.returncode == 1
+    assert res.stdout == "out"
+    assert res.stderr == "err"
+    assert res.ok is False
+
+
+def test_adb_soft_ok_property(monkeypatch):
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: _FakeCompleted(0, "x", "")
+    )
+    assert Device("x").adb_soft("shell", "true").ok is True
+
+
+@pytest.mark.skipif(shutil.which("adb") is None, reason="adb not installed")
+def test_adb_real_bad_serial_raises():
+    """End-to-end: a bogus serial against real adb raises ADBError.
+
+    This is the acceptance test from the task — a failing adb command
+    (unknown device) must raise with a meaningful message, not return "".
+    """
+    with pytest.raises(ADBError):
+        Device("no-such-device-serial-xyz").adb("shell", "echo", "hi", timeout=5)

--- a/tests/test_adb_shell_injection.py
+++ b/tests/test_adb_shell_injection.py
@@ -1,0 +1,83 @@
+"""Device-shell command-injection guards for the adb `input` boundary.
+
+`adb shell <argv>` re-parses its arguments through the *device* shell, so any
+agent/attacker-controlled value sent to `input keyevent` / `input text` (e.g. a
+prompt-injected web page the agent transcribes) could otherwise break out and run
+arbitrary device commands (reboot, pm uninstall, settings, wipe). These verify
+the two shared guards neutralize that.
+"""
+
+import shlex
+
+import pytest
+
+from gitd.bots.common.adb import ascii_typeable, input_text_arg, normalize_keycode
+
+
+# ── normalize_keycode (press_key vector) ─────────────────────────────────────
+
+def test_normalize_keycode_adds_prefix_and_accepts_valid():
+    assert normalize_keycode("HOME") == "KEYCODE_HOME"
+    assert normalize_keycode("KEYCODE_BACK") == "KEYCODE_BACK"
+    assert normalize_keycode("KEYCODE_DPAD_DOWN") == "KEYCODE_DPAD_DOWN"
+    assert normalize_keycode("VOLUME_UP") == "KEYCODE_VOLUME_UP"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "KEYCODE_HOME; reboot",
+        "HOME; reboot",
+        "KEYCODE_HOME && pm uninstall com.foo",
+        "KEYCODE_HOME | sh",
+        "KEYCODE_HOME $(reboot)",
+        "KEYCODE_HOME `reboot`",
+        "KEYCODE_HOME\nreboot",
+        "KEYCODE_HOME ; wipe",
+        "home",           # lowercase — not a real keycode
+        "KEYCODE_",        # empty body
+        "",
+    ],
+)
+def test_normalize_keycode_rejects_injection_and_junk(payload):
+    with pytest.raises(ValueError):
+        normalize_keycode(payload)
+
+
+# ── input_text_arg (type_text vector) ────────────────────────────────────────
+
+def _device_argv(text: str) -> list[str]:
+    """What the *device* shell parses from `input text <arg>` — the whole command
+    line is re-split by sh on the device, so this mirrors the real boundary."""
+    return shlex.split("input text " + input_text_arg(ascii_typeable(text)))
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "; reboot",
+        "＃reboot",                     # fullwidth — folds toward ascii
+        "；reboot",                     # fullwidth semicolon → ascii ';'
+        "rm -rf /; reboot",
+        "a && pm clear com.foo",
+        "x | sh",
+        "$(reboot)",
+        "`reboot`",
+        "a > /sdcard/x",
+        "a\nreboot",
+        "it's a \"test\"",             # embedded quotes
+    ],
+)
+def test_input_text_never_breaks_out_of_the_device_shell(payload):
+    # The device shell must see exactly `input`, `text`, and ONE more token —
+    # never a second command. (3 tokens total; the payload is the single arg.)
+    argv = _device_argv(payload)
+    assert argv[:2] == ["input", "text"]
+    assert len(argv) == 3, f"payload broke into extra device-shell tokens: {argv}"
+
+
+def test_input_text_preserves_normal_text():
+    # plain ascii with spaces: %s-encoded, no quoting needed, types verbatim
+    assert input_text_arg("hello world") == "hello%sworld"
+    # the fullwidth-semicolon attack folds to a literal ';' that types as text
+    assert shlex.split("input text " + input_text_arg(ascii_typeable("；reboot")))[2] == ";reboot"

--- a/tests/test_agent_chat_claude_code_ios.py
+++ b/tests/test_agent_chat_claude_code_ios.py
@@ -1,0 +1,27 @@
+import inspect
+
+from gitd.services import agent_chat_claude_code
+
+
+def test_claude_code_auto_tts_skips_ios(monkeypatch):
+    started = []
+
+    class FakeThread:
+        def __init__(self, *args, **kwargs):
+            started.append((args, kwargs))
+
+        def start(self):
+            started.append("started")
+
+    monkeypatch.setattr(agent_chat_claude_code.threading, "Thread", FakeThread)
+
+    agent_chat_claude_code._tts_speak_bg("ios:abc123", "hello")
+
+    assert started == []
+
+
+def test_claude_code_remote_docs_are_platform_routed():
+    doc = inspect.getdoc(agent_chat_claude_code._chat_claude_code_remote)
+
+    assert "Android through ADB or iOS through Appium/WebDriverAgent" in doc
+    assert "via ADB (USB or wireless)" not in doc

--- a/tests/test_agent_chat_openrouter.py
+++ b/tests/test_agent_chat_openrouter.py
@@ -1,0 +1,95 @@
+"""Regression tests for the OpenRouter provider loop fixes.
+
+Two bugs found by ghost-video-editor while running the ghost CLI:
+  1. creds read only os.environ, ignoring settings.openrouter_api_key.
+  2. single-shot: executed tool_calls but never fed results back → any real task
+     died after one round.
+"""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from gitd.services import agent_chat
+
+
+def _msg(content=None, tool_calls=None):
+    return SimpleNamespace(content=content, tool_calls=tool_calls)
+
+
+def _resp(message):
+    return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+
+def _tool_call(cid, name, args):
+    return SimpleNamespace(id=cid, function=SimpleNamespace(name=name, arguments=json.dumps(args)))
+
+
+@pytest.fixture()
+def stub_env(monkeypatch):
+    """Neutralize device/screen/tool calls so only the loop logic is exercised."""
+    monkeypatch.setattr(agent_chat, "get_screen_tree", lambda d: "")
+    monkeypatch.setattr(agent_chat, "openai_tools_for_device", lambda d: [])
+    monkeypatch.setattr(agent_chat, "system_prompt_for_device", lambda d: "sys")
+    monkeypatch.setattr(agent_chat, "execute_tool", lambda name, args: f"ran {name}")
+
+
+def _install_fake_openai(monkeypatch, responses, recorder=None):
+    """Patch openai.OpenAI so create() returns queued responses in order."""
+    seq = iter(responses)
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            if recorder is not None:
+                recorder.update(kwargs)
+            self.chat = SimpleNamespace(completions=SimpleNamespace(create=lambda **kw: next(seq)))
+
+    import openai
+
+    monkeypatch.setattr(openai, "OpenAI", FakeClient)
+
+
+def test_openrouter_multiturn_feeds_tool_results_back(stub_env, monkeypatch):
+    # turn 1: model asks for a tool; turn 2: model answers with no tool → loop ends
+    responses = [
+        _resp(_msg(content=None, tool_calls=[_tool_call("c1", "tap", {"x": 1, "y": 2})])),
+        _resp(_msg(content="all done", tool_calls=None)),
+    ]
+    _install_fake_openai(monkeypatch, responses)
+    session = agent_chat.create_session(device="dev", provider="openrouter", model="anthropic/claude-sonnet-4")
+
+    events = list(agent_chat._chat_openrouter(session, "do the thing"))
+    types = [e["type"] for e in events]
+
+    assert "tool_call" in types  # the tap was issued
+    assert "tool_result" in types  # its result surfaced (was missing when single-shot)
+    # the "all done" text is the 2nd model turn — it only happens if the loop
+    # continued AFTER executing the tool (the single-shot bug ended before it).
+    assert any(e["type"] == "text" and e["content"] == "all done" for e in events)
+    assert types[-1] == "done"
+
+
+def test_openrouter_stops_at_max_turns(stub_env, monkeypatch):
+    # model never stops asking for tools → loop must terminate at MAX_TURNS, not hang
+    always_tool = _resp(_msg(content=None, tool_calls=[_tool_call("c", "tap", {})]))
+    _install_fake_openai(monkeypatch, [always_tool] * (agent_chat.MAX_TURNS + 5))
+    session = agent_chat.create_session(device="dev", provider="openrouter", model="m")
+
+    events = list(agent_chat._chat_openrouter(session, "loop"))
+    tool_calls = sum(1 for e in events if e["type"] == "tool_call")
+    assert tool_calls == agent_chat.MAX_TURNS  # bounded, not infinite
+    assert events[-1]["type"] == "done"
+
+
+def test_openrouter_creds_fall_back_to_settings(stub_env, monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    from gitd.config import settings
+
+    monkeypatch.setattr(settings, "openrouter_api_key", "sk-from-config", raising=False)
+    recorder: dict = {}
+    _install_fake_openai(monkeypatch, [_resp(_msg(content="hi", tool_calls=None))], recorder=recorder)
+
+    session = agent_chat.create_session(device="dev", provider="openrouter", model="m")
+    list(agent_chat._chat_openrouter(session, "hello"))
+    assert recorder.get("api_key") == "sk-from-config"  # used config key, not empty env

--- a/tests/test_agent_chat_routing.py
+++ b/tests/test_agent_chat_routing.py
@@ -1,0 +1,41 @@
+"""Tests for chat_turn provider dispatch.
+
+Guards the provider-routing table in chat_turn — in particular that the
+`claude-code` provider still delegates to the live `chat_claude_code`
+(in agent_chat_claude_code.py) after the dead in-module `_chat_claude_code`
+duplicate was removed.
+"""
+
+import gitd.services.agent_chat as agent_chat
+import gitd.services.agent_chat_claude_code as cc
+from gitd.services.agent_chat import ChatSession, chat_turn
+
+
+def test_dead_chat_claude_code_removed():
+    """The ~180-LOC dead duplicate must stay gone — chat_turn never used it."""
+    assert not hasattr(agent_chat, "_chat_claude_code")
+
+
+def test_chat_turn_routes_claude_code_to_live_module(monkeypatch):
+    """provider='claude-code' delegates to agent_chat_claude_code.chat_claude_code."""
+    calls = {}
+
+    def fake_chat_claude_code(session, message):
+        calls["session"] = session
+        calls["message"] = message
+        yield {"type": "text", "content": "routed"}
+
+    # chat_turn imports the symbol at call time, so patch it on the module.
+    monkeypatch.setattr(cc, "chat_claude_code", fake_chat_claude_code)
+
+    session = ChatSession(id="t1", device="emulator-5554", provider="claude-code")
+    events = list(chat_turn(session, "hello"))
+
+    assert calls["message"] == "hello"
+    assert {"type": "text", "content": "routed"} in events
+
+
+def test_chat_turn_unknown_provider_yields_error():
+    session = ChatSession(id="t2", device="emulator-5554", provider="bogus-provider")
+    events = list(chat_turn(session, "hi"))
+    assert events == [{"type": "error", "content": "Unknown provider: bogus-provider"}]

--- a/tests/test_anthropic_tool_errors.py
+++ b/tests/test_anthropic_tool_errors.py
@@ -1,0 +1,76 @@
+"""Regression test for the Anthropic provider's tool-error handling.
+
+Once Device.adb raises ADBError on a failed adb call, a tool invocation
+(tap/swipe/launch_app) against an offline/unauthorized device raises. Every
+provider loop must turn that into a tool_result the model can react to — NOT
+let it propagate uncaught and break the SSE stream. _chat_anthropic is the
+default provider and was the one loop that did not wrap execute_tool.
+"""
+
+import pytest
+
+anthropic = pytest.importorskip("anthropic")
+
+from gitd.services import agent_chat  # noqa: E402
+from gitd.services.agent_chat import ChatSession, _chat_anthropic  # noqa: E402
+
+
+class _Block:
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+
+class _Resp:
+    def __init__(self, content):
+        self.content = content
+
+
+def test_anthropic_tool_error_yields_result_not_raise(monkeypatch):
+    # Turn 1: model asks to tap. Turn 2: plain text → ends the loop.
+    responses = iter(
+        [
+            _Resp([_Block(type="tool_use", name="tap", input={"x": 1, "y": 2}, id="tu_1")]),
+            _Resp([_Block(type="text", text="done")]),
+        ]
+    )
+
+    class _FakeMessages:
+        def create(self, **kwargs):
+            return next(responses)
+
+    class _FakeClient:
+        def __init__(self, *a, **k):
+            self.messages = _FakeMessages()
+
+    monkeypatch.setattr(anthropic, "Anthropic", _FakeClient)
+
+    # Simulate an offline-device failure surfacing from execute_tool (ADBError
+    # is a RuntimeError subclass; any Exception must be caught the same way).
+    def _boom(name, args):
+        raise RuntimeError("adb shell input tap failed (exit 1): device 'x' not found")
+
+    monkeypatch.setattr(agent_chat, "execute_tool", _boom)
+
+    session = ChatSession(id="s1", device="offline-serial", provider="anthropic", model="claude-sonnet-4-20250514")
+    session.auto_screenshot = False  # skip device I/O in _build_vision_content
+
+    # The whole point: draining the generator must NOT raise.
+    events = list(_chat_anthropic(session, "tap the button"))
+
+    tool_results = [e for e in events if e.get("type") == "tool_result"]
+    assert tool_results, "expected a tool_result event even when the tool failed"
+    assert "Tool error" in tool_results[0]["result"]
+    assert "device 'x' not found" in tool_results[0]["result"]
+
+    # Protocol stays valid: the assistant tool_use turn must be followed by a
+    # user turn carrying a matching tool_result for tool_use_id tu_1.
+    tool_result_turns = [
+        m
+        for m in session.api_messages
+        if m["role"] == "user"
+        and isinstance(m["content"], list)
+        and any(isinstance(b, dict) and b.get("type") == "tool_result" for b in m["content"])
+    ]
+    assert tool_result_turns, "a tool_result must be sent back for the tool_use"
+    ids = [b["tool_use_id"] for m in tool_result_turns for b in m["content"] if b.get("type") == "tool_result"]
+    assert "tu_1" in ids

--- a/tests/test_ascii_typeable.py
+++ b/tests/test_ascii_typeable.py
@@ -1,0 +1,43 @@
+"""Tests for ascii_typeable — the adb `input text` transliteration guard."""
+
+import pytest
+
+from gitd.bots.common.adb import ascii_typeable
+
+
+def test_plain_ascii_unchanged():
+    assert ascii_typeable("hello world") == "hello world"
+    assert ascii_typeable("Search #cats 123!") == "Search #cats 123!"
+    assert ascii_typeable("") == ""
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("Sauté", "Saute"),
+        ("café", "cafe"),
+        ("naïve résumé", "naive resume"),
+        ("Zürich", "Zurich"),
+        ("piñata", "pinata"),
+        ("Málaga", "Malaga"),
+    ],
+)
+def test_accents_decomposed_to_base_letter(raw, expected):
+    assert ascii_typeable(raw) == expected
+
+
+def test_result_is_always_ascii():
+    for s in ["Sauté", "日本語", "😀 emoji", "Ω mix café"]:
+        assert ascii_typeable(s).isascii()
+
+
+def test_untypeable_glyphs_dropped_not_erroring():
+    # CJK / emoji have no ASCII base form → dropped (type_unicode is the path
+    # for those); the guard must never raise, just return what it can.
+    assert ascii_typeable("日本語") == ""
+    assert ascii_typeable("café 😀") == "cafe "
+
+
+def test_ascii_fast_path_is_identity():
+    s = "already ascii, no change"
+    assert ascii_typeable(s) is s  # isascii() short-circuit returns the same object

--- a/tests/test_base_skill_ios_actions.py
+++ b/tests/test_base_skill_ios_actions.py
@@ -1,0 +1,98 @@
+from pathlib import Path
+
+from gitd.skills._base.actions.core import LaunchApp, PressHome, SwipeDirection, TakeScreenshot, TypeText
+
+
+class FakeIOSDevice:
+    serial = "ios:abc123"
+
+    def __init__(self):
+        self.calls = []
+
+    def adb(self, *args, **kwargs):
+        raise AssertionError(f"iOS base action should not call adb: {args}")
+
+    def type_text(self, text):
+        self.calls.append(("type_text", text))
+
+    def launch_app(self, bundle_id):
+        self.calls.append(("launch_app", bundle_id))
+
+    def app_state(self, bundle_id):
+        self.calls.append(("app_state", bundle_id))
+        return 4
+
+    def press_key(self, key):
+        self.calls.append(("press_key", key))
+
+    def get_screen_size(self):
+        self.calls.append(("get_screen_size",))
+        return (393, 852)
+
+    def swipe(self, x1, y1, x2, y2):
+        self.calls.append(("swipe", x1, y1, x2, y2))
+
+    def take_screenshot(self):
+        self.calls.append(("take_screenshot",))
+        return b"ios-png"
+
+
+def test_base_type_text_uses_ios_text_entry(monkeypatch):
+    monkeypatch.setattr("gitd.skills._base.actions.core.time.sleep", lambda *_args, **_kwargs: None)
+    dev = FakeIOSDevice()
+
+    result = TypeText(dev, {}, text="hello iOS").execute()
+
+    assert result.success is True
+    assert result.data == {"text": "hello iOS"}
+    assert dev.calls == [("type_text", "hello iOS")]
+
+
+def test_base_launch_app_uses_ios_bundle_and_query_state(monkeypatch):
+    monkeypatch.setattr("gitd.skills._base.actions.core.time.sleep", lambda *_args, **_kwargs: None)
+    dev = FakeIOSDevice()
+    action = LaunchApp(dev, {}, package="com.google.chrome.ios")
+
+    result = action.execute()
+
+    assert result.success is True
+    assert result.data == {"bundle_id": "com.google.chrome.ios"}
+    assert action.postcondition() is True
+    assert dev.calls == [
+        ("launch_app", "com.google.chrome.ios"),
+        ("app_state", "com.google.chrome.ios"),
+    ]
+
+
+def test_base_press_home_uses_ios_home_button(monkeypatch):
+    monkeypatch.setattr("gitd.skills._base.actions.core.time.sleep", lambda *_args, **_kwargs: None)
+    dev = FakeIOSDevice()
+
+    result = PressHome(dev, {}).execute()
+
+    assert result.success is True
+    assert dev.calls == [("press_key", "HOME")]
+
+
+def test_base_swipe_direction_uses_ios_screen_size():
+    dev = FakeIOSDevice()
+
+    result = SwipeDirection(dev, {}, direction="up", distance=100).execute()
+
+    assert result.success is True
+    assert dev.calls == [
+        ("get_screen_size",),
+        ("swipe", 196, 426, 196, 326),
+    ]
+
+
+def test_base_take_screenshot_uses_ios_screenshot_bytes(tmp_path):
+    dev = FakeIOSDevice()
+    output = tmp_path / "shot.png"
+
+    result = TakeScreenshot(dev, {}, output_path=str(output)).execute()
+
+    assert result.success is True
+    assert result.data == {"path": str(output)}
+    assert Path(output).read_bytes() == b"ios-png"
+    assert dev.calls == [("take_screenshot",)]

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -2,6 +2,11 @@
 
 from gitd.benchmarks.base import Task, TaskResult, load_tasks_from_dir
 from gitd.benchmarks.ghost_bench.tasks import TASK_DATA_DIR, get_task, list_task_ids, load_tasks
+import pytest
+from fastapi.testclient import TestClient
+
+from gitd.app import app
+from gitd.benchmarks.ghost_bench import evaluators
 
 
 def test_load_tasks():
@@ -43,6 +48,13 @@ def test_task_max_steps():
     assert task.max_steps == 15
 
 
+def test_tasks_default_to_android_platform():
+    task = Task(id="Sample", goal="Do a thing.", app="com.example", category="settings")
+    assert task.supported_platforms() == ["android"]
+    assert task.supports_platform("android")
+    assert not task.supports_platform("ios")
+
+
 def test_task_result_defaults():
     result = TaskResult(task_id="test", goal="test goal", model="m", device="d")
     assert result.score == 0.0
@@ -59,3 +71,52 @@ def test_all_tasks_have_eval():
     for task in load_tasks():
         assert task.eval, f"Task {task.id} missing eval"
         assert task.eval.get("cmd"), f"Task {task.id} eval missing cmd"
+        assert task.supported_platforms() == ["android"]
+
+
+def test_benchmark_tasks_api_exposes_platform_metadata():
+    response = TestClient(app).get("/api/benchmarks/tasks")
+    assert response.status_code == 200
+    data = response.json()
+    assert data
+    first = data[0]
+    assert first["platforms"] == ["android"]
+    assert first["supports_android"] is True
+    assert first["supports_ios"] is False
+
+
+def test_benchmark_run_rejects_ios_for_android_only_tasks():
+    response = TestClient(app).post(
+        "/api/benchmarks/runs",
+        json={
+            "suite": "ghost_bench",
+            "tasks": ["SystemWifiTurnOn"],
+            "provider": "ollama",
+            "model": "gemma3:4b",
+            "device": "ios:abc123",
+        },
+    )
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert detail["error"] == "unsupported_platform"
+    assert detail["platform"] == "ios"
+    assert detail["device"] == "ios:abc123"
+    assert detail["unsupported_tasks"] == ["SystemWifiTurnOn"]
+
+
+def test_ghost_bench_evaluators_reject_ios_before_adb(monkeypatch):
+    def fail_subprocess(*args, **kwargs):
+        raise AssertionError("subprocess.run should not be called for iOS refs")
+
+    monkeypatch.setattr(evaluators.subprocess, "run", fail_subprocess)
+    task = Task(
+        id="Sample",
+        goal="Do a thing.",
+        app="com.android.settings",
+        category="settings",
+        init={"cmd": "svc wifi disable"},
+    )
+
+    with pytest.raises(RuntimeError, match="Android-only.*iOS"):
+        evaluators.initialize_task(task, "ios:abc123")

--- a/tests/test_browser_news.py
+++ b/tests/test_browser_news.py
@@ -1,0 +1,1222 @@
+import json
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gitd.app import app
+from gitd.bots.common.ios import IOSDevice
+from gitd.services.agent_tools import execute_tool
+from gitd.services.browser import (
+    browser_back,
+    extract_articles,
+    extract_visible_text,
+    get_current_url,
+    open_url,
+    read_news,
+    wait_for_text,
+)
+
+
+class FakeNewsIOSDevice:
+    serial = "ios:abc123"
+    bundle_id = "com.google.chrome.ios"
+
+    def __init__(self):
+        self.current_url = ""
+        self.launched = []
+        self.opened_urls = []
+        self.back_count = 0
+
+    def launch_app(self, bundle_id):
+        self.launched.append(bundle_id)
+
+    def open_url(self, url, delay=2.0):
+        self.current_url = url
+        self.opened_urls.append(url)
+        return {"ok": True, "expected_url": url, "url": url, "state": "url_matched", "method": "fake"}
+
+    def get_current_url(self):
+        return self.current_url
+
+    def extract_articles(self, max_items=5):
+        return [
+            {
+                "title": "First major story from the test fixture",
+                "url": "https://text.npr.org/article/1",
+                "bounds": {"x1": 10, "y1": 20, "x2": 350, "y2": 60},
+                "center": {"x": 180, "y": 40},
+                "class": "a",
+                "provenance": "web_context",
+            },
+            {
+                "title": "Second major story from the test fixture",
+                "url": "https://text.npr.org/article/2",
+                "bounds": {"x1": 10, "y1": 80, "x2": 350, "y2": 120},
+                "center": {"x": 180, "y": 100},
+                "class": "a",
+                "provenance": "web_context",
+            },
+        ][:max_items]
+
+    def extract_visible_text(self, max_lines=200, include_controls=False):
+        if self.current_url.endswith("/article/1"):
+            return "First article title\nFirst article body line.\nFirst article body line."
+        if self.current_url.endswith("/article/2"):
+            return "Second article title\nSecond article body line."
+        return "NPR text home\nFirst major story from the test fixture\nSecond major story from the test fixture"
+
+    def take_screenshot(self):
+        return b"fake-png"
+
+    def tap(self, x, y, delay=0.6):
+        self.current_url = "ocr_article"
+
+    def browser_back(self, delay=1.0):
+        self.back_count += 1
+        self.current_url = "https://text.npr.org/"
+
+
+def test_read_news_opens_headlines_and_extracts_article_snippets(monkeypatch, tmp_path):
+    fake = FakeNewsIOSDevice()
+    monkeypatch.setattr("gitd.services.browser.get_device", lambda device: fake)
+    monkeypatch.setattr("gitd.services.browser.time.sleep", lambda *_args, **_kwargs: None)
+
+    result = read_news(
+        "ios:abc123",
+        "text.npr.org",
+        max_headlines=2,
+        max_articles=2,
+        save_screenshots=True,
+        out_dir=str(tmp_path),
+    )
+
+    assert result["ok"] is True
+    assert result["url"] == "https://text.npr.org"
+    assert fake.launched == ["com.google.chrome.ios"]
+    assert fake.opened_urls == ["https://text.npr.org", "https://text.npr.org/article/1", "https://text.npr.org/article/2"]
+    assert fake.back_count == 2
+    assert result["navigation"]["state"] == "url_matched"
+    assert result["extraction"]["headlines"] == {
+        "requested": 2,
+        "target": 2,
+        "returned": 2,
+        "ready": True,
+        "attempts": 1,
+        "source": "web_context",
+    }
+    assert result["extraction"]["front_page_text"]["ready"] is True
+    assert result["extraction"]["front_page_text"]["source"] == "native_or_web"
+    assert [item["title"] for item in result["headlines"]] == [
+        "First major story from the test fixture",
+        "Second major story from the test fixture",
+    ]
+    assert result["articles"][0]["navigation"]["url"] == "https://text.npr.org/article/1"
+    assert result["articles"][0]["page_title"] == "First article title"
+    assert result["articles"][0]["body_snippet"] == "First article title\nFirst article body line."
+    assert result["articles"][0]["headline_provenance"] == "web_context"
+    assert result["extraction"]["articles"][0]["open_method"] == "url"
+    assert result["extraction"]["articles"][0]["text"]["returned_lines"] == 3
+    assert result["extraction"]["articles"][0]["text"]["body_ready"] is True
+    assert result["articles"][1]["opened"] is True
+    assert result["completion"] == {
+        "requested_headlines": 2,
+        "headlines_found": 2,
+        "headline_target_met": True,
+        "requested_articles": 2,
+        "articles_opened": 2,
+        "articles_with_body": 2,
+        "article_target_met": True,
+        "workflow_complete": True,
+    }
+    assert (tmp_path / "front_page.png").read_bytes() == b"fake-png"
+    assert (tmp_path / "article_1.png").read_bytes() == b"fake-png"
+
+
+def test_read_news_retries_until_headlines_and_article_text_are_ready(monkeypatch):
+    class DelayedNewsDevice(FakeNewsIOSDevice):
+        def __init__(self):
+            super().__init__()
+            self.article_extraction_calls = 0
+            self.text_calls: dict[str, int] = {}
+
+        def extract_articles(self, max_items=5):
+            self.article_extraction_calls += 1
+            if self.article_extraction_calls == 1:
+                return []
+            return super().extract_articles(max_items=max_items)
+
+        def extract_visible_text(self, max_lines=200, include_controls=False):
+            calls = self.text_calls.get(self.current_url, 0)
+            self.text_calls[self.current_url] = calls + 1
+            if self.current_url.endswith("/article/1") and calls == 0:
+                return ""
+            return super().extract_visible_text(max_lines=max_lines, include_controls=include_controls)
+
+    fake = DelayedNewsDevice()
+    monkeypatch.setattr("gitd.services.browser.get_device", lambda device: fake)
+    monkeypatch.setattr("gitd.services.browser.time.sleep", lambda *_args, **_kwargs: None)
+
+    result = read_news("ios:abc123", "https://text.npr.org/", max_headlines=1, max_articles=1, wait_s=1)
+
+    assert result["ok"] is True
+    assert fake.article_extraction_calls == 2
+    assert fake.text_calls["https://text.npr.org/article/1"] == 2
+    assert result["extraction"]["headlines"]["attempts"] == 2
+    assert result["extraction"]["articles"][0]["text"]["attempts"] == 2
+    assert result["articles"][0]["body_snippet"] == "First article title\nFirst article body line."
+
+
+def test_read_news_waits_for_requested_headline_count(monkeypatch):
+    class PartialHeadlineDevice(FakeNewsIOSDevice):
+        def __init__(self):
+            super().__init__()
+            self.article_extraction_calls = 0
+
+        def extract_articles(self, max_items=5):
+            self.article_extraction_calls += 1
+            articles = super().extract_articles(max_items=max_items)
+            if self.article_extraction_calls == 1:
+                return articles[:1]
+            return articles
+
+    fake = PartialHeadlineDevice()
+    monkeypatch.setattr("gitd.services.browser.get_device", lambda device: fake)
+    monkeypatch.setattr("gitd.services.browser.time.sleep", lambda *_args, **_kwargs: None)
+
+    result = read_news("ios:abc123", "https://text.npr.org/", max_headlines=2, max_articles=0, wait_s=1)
+
+    assert result["ok"] is True
+    assert fake.article_extraction_calls == 2
+    assert [item["title"] for item in result["headlines"]] == [
+        "First major story from the test fixture",
+        "Second major story from the test fixture",
+    ]
+
+
+def test_read_news_requires_requested_headline_count_for_success(monkeypatch):
+    class SparseHeadlineDevice(FakeNewsIOSDevice):
+        def extract_articles(self, max_items=5):
+            return super().extract_articles(max_items=max_items)[:1]
+
+    fake = SparseHeadlineDevice()
+    monkeypatch.setattr("gitd.services.browser.get_device", lambda device: fake)
+    monkeypatch.setattr("gitd.services.browser.time.sleep", lambda *_args, **_kwargs: None)
+
+    result = read_news("ios:abc123", "https://text.npr.org/", max_headlines=2, max_articles=0, wait_s=0)
+
+    assert result["ok"] is False
+    assert result["completion"] == {
+        "requested_headlines": 2,
+        "headlines_found": 1,
+        "headline_target_met": False,
+        "requested_articles": 0,
+        "articles_opened": 0,
+        "articles_with_body": 0,
+        "article_target_met": True,
+        "workflow_complete": False,
+    }
+    assert result["errors"][-1]["stage"] == "success_criteria"
+
+
+def test_read_news_waits_for_article_body_beyond_title(monkeypatch):
+    class TitleOnlyArticleDevice(FakeNewsIOSDevice):
+        def __init__(self):
+            super().__init__()
+            self.text_calls: dict[str, int] = {}
+
+        def extract_visible_text(self, max_lines=200, include_controls=False):
+            calls = self.text_calls.get(self.current_url, 0)
+            self.text_calls[self.current_url] = calls + 1
+            if self.current_url.endswith("/article/1") and calls == 0:
+                return "First article title"
+            return super().extract_visible_text(max_lines=max_lines, include_controls=include_controls)
+
+    fake = TitleOnlyArticleDevice()
+    monkeypatch.setattr("gitd.services.browser.get_device", lambda device: fake)
+    monkeypatch.setattr("gitd.services.browser.time.sleep", lambda *_args, **_kwargs: None)
+
+    result = read_news("ios:abc123", "https://text.npr.org/", max_headlines=1, max_articles=1, wait_s=1)
+
+    assert result["ok"] is True
+    assert fake.text_calls["https://text.npr.org/article/1"] == 2
+    assert result["articles"][0]["body_snippet"] == "First article title\nFirst article body line."
+    assert result["extraction"]["articles"][0]["text"]["body_ready"] is True
+
+
+def test_read_news_waits_past_toolbar_only_article_text(monkeypatch):
+    class ToolbarOnlyArticleDevice(FakeNewsIOSDevice):
+        def __init__(self):
+            super().__init__()
+            self.text_calls: dict[str, int] = {}
+
+        def extract_visible_text(self, max_lines=200, include_controls=False):
+            calls = self.text_calls.get(self.current_url, 0)
+            self.text_calls[self.current_url] = calls + 1
+            if self.current_url.endswith("/article/1") and calls == 0:
+                return "First major story from the test fixture\nMenu\nShare\nAdvertisement"
+            return super().extract_visible_text(max_lines=max_lines, include_controls=include_controls)
+
+    fake = ToolbarOnlyArticleDevice()
+    monkeypatch.setattr("gitd.services.browser.get_device", lambda device: fake)
+    monkeypatch.setattr("gitd.services.browser.time.sleep", lambda *_args, **_kwargs: None)
+
+    result = read_news("ios:abc123", "https://text.npr.org/", max_headlines=1, max_articles=1, wait_s=1)
+
+    assert result["ok"] is True
+    assert fake.text_calls["https://text.npr.org/article/1"] == 2
+    assert result["extraction"]["articles"][0]["text"]["attempts"] == 2
+    assert result["extraction"]["articles"][0]["text"]["body_ready"] is True
+    assert result["articles"][0]["body_snippet"] == "First article title\nFirst article body line."
+
+
+def test_read_news_does_not_count_toolbar_only_article_text_as_body(monkeypatch):
+    class ToolbarOnlyArticleDevice(FakeNewsIOSDevice):
+        def extract_visible_text(self, max_lines=200, include_controls=False):
+            if self.current_url.endswith("/article/1"):
+                return "First major story from the test fixture\nMenu\nShare\nAdvertisement"
+            return super().extract_visible_text(max_lines=max_lines, include_controls=include_controls)
+
+    fake = ToolbarOnlyArticleDevice()
+    monkeypatch.setattr("gitd.services.browser.get_device", lambda device: fake)
+    monkeypatch.setattr("gitd.services.browser.time.sleep", lambda *_args, **_kwargs: None)
+
+    result = read_news("ios:abc123", "https://text.npr.org/", max_headlines=1, max_articles=1, wait_s=0)
+
+    assert result["ok"] is False
+    assert result["completion"]["articles_with_body"] == 0
+    assert result["extraction"]["articles"][0]["text"]["body_ready"] is False
+    assert result["errors"][-1]["stage"] == "success_criteria"
+
+
+def test_read_news_falls_back_to_tapping_headline_when_url_navigation_fails(monkeypatch):
+    class UrlFallbackDevice(FakeNewsIOSDevice):
+        def __init__(self):
+            super().__init__()
+            self.taps = []
+
+        def open_url(self, url, delay=2.0):
+            self.opened_urls.append(url)
+            if url.endswith("/article/1"):
+                return {
+                    "ok": False,
+                    "expected_url": url,
+                    "url": "https://text.npr.org/",
+                    "state": "timeout",
+                    "error": "URL navigation was not verified",
+                }
+            self.current_url = url
+            return {"ok": True, "expected_url": url, "url": url, "state": "url_matched", "method": "fake"}
+
+        def tap(self, x, y, delay=0.6):
+            self.taps.append((x, y))
+            self.current_url = "https://text.npr.org/article/1"
+
+    fake = UrlFallbackDevice()
+    monkeypatch.setattr("gitd.services.browser.get_device", lambda device: fake)
+    monkeypatch.setattr("gitd.services.browser.time.sleep", lambda *_args, **_kwargs: None)
+
+    result = read_news("ios:abc123", "https://text.npr.org/", max_headlines=1, max_articles=1, wait_s=0)
+
+    assert result["ok"] is True
+    assert fake.opened_urls == ["https://text.npr.org/", "https://text.npr.org/article/1"]
+    assert fake.taps == [(180, 40)]
+    assert result["articles"][0]["open_method"] == "center"
+    assert result["articles"][0]["navigation"]["fallback_from"] == "url"
+    assert result["articles"][0]["navigation"]["fallback_errors"][0]["navigation"]["state"] == "timeout"
+    assert result["articles"][0]["body_snippet"] == "First article title\nFirst article body line."
+
+
+def test_read_news_does_not_treat_failed_url_navigation_as_open_article(monkeypatch):
+    class FailedUrlNoGeometryDevice(FakeNewsIOSDevice):
+        def extract_articles(self, max_items=5):
+            return [
+                {
+                    "title": "First major story from the test fixture",
+                    "url": "https://text.npr.org/article/1",
+                    "class": "a",
+                    "provenance": "web_context",
+                }
+            ][:max_items]
+
+        def open_url(self, url, delay=2.0):
+            self.opened_urls.append(url)
+            if url.endswith("/article/1"):
+                return {
+                    "ok": False,
+                    "expected_url": url,
+                    "url": "https://text.npr.org/",
+                    "state": "timeout",
+                    "error": "URL navigation was not verified",
+                }
+            self.current_url = url
+            return {"ok": True, "expected_url": url, "url": url, "state": "url_matched", "method": "fake"}
+
+        def extract_visible_text(self, max_lines=200, include_controls=False):
+            return (
+                "NPR text home\n"
+                "This front page teaser is long enough that it would look like body text "
+                "if the failed article navigation were incorrectly treated as opened."
+            )
+
+    fake = FailedUrlNoGeometryDevice()
+    monkeypatch.setattr("gitd.services.browser.get_device", lambda device: fake)
+    monkeypatch.setattr("gitd.services.browser.time.sleep", lambda *_args, **_kwargs: None)
+
+    result = read_news("ios:abc123", "https://text.npr.org/", max_headlines=1, max_articles=1, wait_s=0)
+
+    assert result["ok"] is False
+    assert fake.opened_urls == ["https://text.npr.org/", "https://text.npr.org/article/1"]
+    assert fake.back_count == 0
+    assert result["articles"][0]["opened"] is False
+    assert "article URL navigation failed" in result["articles"][0]["error"]
+    assert result["completion"]["articles_opened"] == 0
+    assert result["completion"]["articles_with_body"] == 0
+    assert result["errors"][-1]["stage"] == "success_criteria"
+
+
+def test_read_news_does_not_treat_non_navigating_tap_as_open_article(monkeypatch):
+    class NonNavigatingTapDevice(FakeNewsIOSDevice):
+        def __init__(self):
+            super().__init__()
+            self.taps = []
+
+        def extract_articles(self, max_items=5):
+            return [
+                {
+                    "title": "First major story from the test fixture",
+                    "url": "",
+                    "bounds": {"x1": 10, "y1": 20, "x2": 350, "y2": 60},
+                    "center": {"x": 180, "y": 40},
+                    "class": "h2",
+                    "provenance": "web_context",
+                }
+            ][:max_items]
+
+        def tap(self, x, y, delay=0.6):
+            self.taps.append((x, y))
+
+        def extract_visible_text(self, max_lines=200, include_controls=False):
+            return (
+                "NPR text home\n"
+                "First major story from the test fixture\n"
+                "This front page teaser is long enough that it would look like body text "
+                "if a non-navigating tap were incorrectly counted as an opened article."
+            )
+
+    fake = NonNavigatingTapDevice()
+    monkeypatch.setattr("gitd.services.browser.get_device", lambda device: fake)
+    monkeypatch.setattr("gitd.services.browser.time.sleep", lambda *_args, **_kwargs: None)
+
+    result = read_news("ios:abc123", "https://text.npr.org/", max_headlines=1, max_articles=1, wait_s=0)
+
+    assert result["ok"] is False
+    assert fake.taps == [(180, 40)]
+    assert fake.back_count == 0
+    assert result["articles"][0]["opened"] is False
+    assert result["articles"][0]["error"] == "article navigation stayed on the front page"
+    assert result["completion"]["articles_opened"] == 0
+    assert result["completion"]["articles_with_body"] == 0
+    assert result["errors"][-1]["stage"] == "success_criteria"
+
+
+def test_read_news_accepts_same_host_ios_toolbar_url_when_article_text_confirms_open(monkeypatch):
+    class SameToolbarUrlArticleDevice(FakeNewsIOSDevice):
+        def __init__(self):
+            super().__init__()
+            self.article_opened = False
+
+        def get_current_url(self):
+            return "text.npr.org"
+
+        def extract_articles(self, max_items=5):
+            return [
+                {
+                    "title": "First major story from the test fixture",
+                    "url": "",
+                    "bounds": {"x1": 10, "y1": 20, "x2": 350, "y2": 60},
+                    "center": {"x": 180, "y": 40},
+                    "class": "XCUIElementTypeLink",
+                    "provenance": "native",
+                }
+            ][:max_items]
+
+        def tap(self, x, y, delay=0.6):
+            self.article_opened = True
+
+        def extract_visible_text(self, max_lines=200, include_controls=False):
+            if self.article_opened:
+                return (
+                    "NPR\n>\nPolitics\n"
+                    "First major story from the test fixture\n"
+                    "By The Associated Press\n"
+                    "Sunday, June 7, 2026 - 7:07 PM EDT\n"
+                    "This article body line is long enough to confirm that a real article page opened."
+                )
+            return "NPR text home\nFirst major story from the test fixture"
+
+    fake = SameToolbarUrlArticleDevice()
+    monkeypatch.setattr("gitd.services.browser.get_device", lambda device: fake)
+    monkeypatch.setattr("gitd.services.browser.time.sleep", lambda *_args, **_kwargs: None)
+
+    result = read_news("ios:abc123", "https://text.npr.org/", max_headlines=1, max_articles=1, wait_s=0)
+
+    assert result["ok"] is True
+    assert result["articles"][0]["opened"] is True
+    assert result["articles"][0]["url_verification"] == "same_host_article_text"
+    assert result["completion"]["articles_with_body"] == 1
+
+
+def test_read_news_marks_article_body_extraction_failure_as_partial(monkeypatch):
+    class TitleOnlyArticleDevice(FakeNewsIOSDevice):
+        def extract_visible_text(self, max_lines=200, include_controls=False):
+            if self.current_url.endswith("/article/1"):
+                return "First article title"
+            return super().extract_visible_text(max_lines=max_lines, include_controls=include_controls)
+
+    fake = TitleOnlyArticleDevice()
+    monkeypatch.setattr("gitd.services.browser.get_device", lambda device: fake)
+    monkeypatch.setattr("gitd.services.browser.time.sleep", lambda *_args, **_kwargs: None)
+
+    result = read_news("ios:abc123", "https://text.npr.org/", max_headlines=1, max_articles=1, wait_s=0)
+
+    assert result["ok"] is False
+    assert result["headlines"][0]["title"] == "First major story from the test fixture"
+    assert result["articles"][0]["opened"] is True
+    assert result["articles"][0]["body_snippet"] == "First article title"
+    assert result["completion"] == {
+        "requested_headlines": 1,
+        "headlines_found": 1,
+        "headline_target_met": True,
+        "requested_articles": 1,
+        "articles_opened": 1,
+        "articles_with_body": 0,
+        "article_target_met": False,
+        "workflow_complete": False,
+    }
+    assert result["errors"][-1]["stage"] == "success_criteria"
+
+
+def test_read_news_accepts_single_meaningful_article_paragraph(monkeypatch):
+    class SingleParagraphArticleDevice(FakeNewsIOSDevice):
+        def extract_visible_text(self, max_lines=200, include_controls=False):
+            if self.current_url.endswith("/article/1"):
+                return (
+                    "This single paragraph has enough substance to be treated as article body text even "
+                    "when iOS WebView extraction does not expose a separate title node."
+                )
+            return super().extract_visible_text(max_lines=max_lines, include_controls=include_controls)
+
+    fake = SingleParagraphArticleDevice()
+    monkeypatch.setattr("gitd.services.browser.get_device", lambda device: fake)
+    monkeypatch.setattr("gitd.services.browser.time.sleep", lambda *_args, **_kwargs: None)
+
+    result = read_news("ios:abc123", "https://text.npr.org/", max_headlines=1, max_articles=1, wait_s=0)
+
+    assert result["ok"] is True
+    assert result["completion"]["articles_with_body"] == 1
+    assert result["completion"]["workflow_complete"] is True
+    assert "single paragraph has enough substance" in result["articles"][0]["body_snippet"]
+
+
+def test_ios_extract_visible_text_falls_back_to_ocr(monkeypatch):
+    class EmptyTextDevice(FakeNewsIOSDevice):
+        def extract_visible_text(self, max_lines=200, include_controls=False):
+            return ""
+
+    monkeypatch.setattr("gitd.services.browser.get_device", lambda device: EmptyTextDevice())
+    monkeypatch.setattr(
+        "gitd.services.device_context.ocr_screen",
+        lambda device: [
+            {"text": "OCR headline line", "conf": 0.91, "x": 10, "y": 40, "w": 200, "h": 24},
+            {"text": "OCR body line", "conf": 0.87, "x": 10, "y": 80, "w": 180, "h": 24},
+        ],
+    )
+
+    result = extract_visible_text("ios:abc123", max_lines=5)
+
+    assert result["source"] == "ocr"
+    assert result["lines"] == ["OCR headline line", "OCR body line"]
+
+
+def test_ios_extract_visible_text_reports_web_context_body_source(monkeypatch):
+    class BodyTextOnlyDevice(FakeNewsIOSDevice):
+        def visible_text_entries(self, include_controls=False, max_entries=300):
+            assert include_controls is False
+            return [
+                {
+                    "text": "Article body exposed by WebView document.body",
+                    "provenance": "web_context_body",
+                }
+            ]
+
+        def extract_visible_text(self, max_lines=200, include_controls=False):
+            raise AssertionError("visible_text_entries should provide source-aware text first")
+
+    monkeypatch.setattr("gitd.services.browser.get_device", lambda device: BodyTextOnlyDevice())
+
+    result = extract_visible_text("ios:abc123", max_lines=5)
+
+    assert result["source"] == "web_context_body"
+    assert result["lines"] == ["Article body exposed by WebView document.body"]
+
+
+def test_ios_extract_articles_falls_back_to_ocr(monkeypatch):
+    class EmptyArticleDevice(FakeNewsIOSDevice):
+        def extract_articles(self, max_items=5):
+            return []
+
+    monkeypatch.setattr("gitd.services.browser.get_device", lambda device: EmptyArticleDevice())
+    monkeypatch.setattr(
+        "gitd.services.device_context.ocr_screen",
+        lambda device: [
+            {"text": "World leaders meet for climate talks today", "conf": 0.91, "x": 10, "y": 40, "w": 300, "h": 24},
+            {"text": "Menu", "conf": 0.94, "x": 10, "y": 10, "w": 80, "h": 20},
+        ],
+    )
+
+    result = extract_articles("ios:abc123", max_items=3)
+
+    assert result["source"] == "ocr"
+    assert result["articles"] == [
+        {
+            "title": "World leaders meet for climate talks today",
+            "url": "",
+            "bounds": {"x1": 10, "y1": 40, "x2": 310, "y2": 64},
+            "center": {"x": 160, "y": 52},
+            "class": "ocr",
+            "provenance": "ocr",
+            "confidence": 0.91,
+        }
+    ]
+
+
+def test_ios_extract_articles_deduplicates_candidates_and_prefers_url(monkeypatch):
+    class DuplicateArticleDevice(FakeNewsIOSDevice):
+        def __init__(self):
+            super().__init__()
+            self.requested_items = []
+
+        def extract_articles(self, max_items=5):
+            self.requested_items.append(max_items)
+            return [
+                {
+                    "title": "First major story from the test fixture",
+                    "url": "",
+                    "bounds": {"x1": 10, "y1": 20, "x2": 350, "y2": 60},
+                    "center": {"x": 180, "y": 40},
+                    "class": "StaticText",
+                    "provenance": "native",
+                },
+                {
+                    "title": "First major story from the test fixture",
+                    "url": "https://text.npr.org/article/1",
+                    "bounds": {"x1": 10, "y1": 80, "x2": 350, "y2": 120},
+                    "center": {"x": 180, "y": 100},
+                    "class": "a",
+                    "provenance": "web_context",
+                },
+                {
+                    "title": "First major story duplicate from URL",
+                    "url": "https://text.npr.org/article/1/",
+                    "bounds": {"x1": 10, "y1": 140, "x2": 350, "y2": 180},
+                    "center": {"x": 180, "y": 160},
+                    "class": "a",
+                    "provenance": "web_context",
+                },
+                {
+                    "title": "Second major story from the test fixture",
+                    "url": "https://text.npr.org/article/2",
+                    "bounds": {"x1": 10, "y1": 200, "x2": 350, "y2": 240},
+                    "center": {"x": 180, "y": 220},
+                    "class": "a",
+                    "provenance": "web_context",
+                },
+            ][:max_items]
+
+    fake = DuplicateArticleDevice()
+    monkeypatch.setattr("gitd.services.browser.get_device", lambda device: fake)
+
+    result = extract_articles("ios:abc123", max_items=3)
+
+    assert fake.requested_items == [6]
+    assert [item["url"] for item in result["articles"]] == [
+        "https://text.npr.org/article/1",
+        "https://text.npr.org/article/2",
+    ]
+    assert result["articles"][0]["provenance"] == "web_context"
+
+
+def test_read_news_waits_for_distinct_headlines_not_duplicate_nodes(monkeypatch):
+    class DuplicateHeadlineDevice(FakeNewsIOSDevice):
+        def __init__(self):
+            super().__init__()
+            self.article_extraction_calls = 0
+
+        def extract_articles(self, max_items=5):
+            self.article_extraction_calls += 1
+            duplicate = [
+                {
+                    "title": "First major story from the test fixture",
+                    "url": "",
+                    "bounds": {"x1": 10, "y1": 20, "x2": 350, "y2": 60},
+                    "center": {"x": 180, "y": 40},
+                    "class": "StaticText",
+                    "provenance": "native",
+                },
+                {
+                    "title": "First major story from the test fixture",
+                    "url": "https://text.npr.org/article/1",
+                    "bounds": {"x1": 10, "y1": 80, "x2": 350, "y2": 120},
+                    "center": {"x": 180, "y": 100},
+                    "class": "a",
+                    "provenance": "web_context",
+                },
+            ]
+            if self.article_extraction_calls == 1:
+                return duplicate[:max_items]
+            return [
+                *duplicate,
+                {
+                    "title": "Second major story from the test fixture",
+                    "url": "https://text.npr.org/article/2",
+                    "bounds": {"x1": 10, "y1": 140, "x2": 350, "y2": 180},
+                    "center": {"x": 180, "y": 160},
+                    "class": "a",
+                    "provenance": "web_context",
+                },
+            ][:max_items]
+
+    fake = DuplicateHeadlineDevice()
+    monkeypatch.setattr("gitd.services.browser.get_device", lambda device: fake)
+    monkeypatch.setattr("gitd.services.browser.time.sleep", lambda *_args, **_kwargs: None)
+
+    result = read_news("ios:abc123", "https://text.npr.org/", max_headlines=2, max_articles=0, wait_s=1)
+
+    assert result["ok"] is True
+    assert fake.article_extraction_calls == 2
+    assert [item["url"] for item in result["headlines"]] == [
+        "https://text.npr.org/article/1",
+        "https://text.npr.org/article/2",
+    ]
+
+
+def test_read_news_can_complete_with_ocr_only_extraction(monkeypatch):
+    class OcrOnlyDevice(FakeNewsIOSDevice):
+        def __init__(self):
+            super().__init__()
+            self.taps = []
+
+        def extract_articles(self, max_items=5):
+            return []
+
+        def extract_visible_text(self, max_lines=200, include_controls=False):
+            return ""
+
+        def tap(self, x, y, delay=0.6):
+            self.taps.append((x, y))
+            self.current_url = "ocr_article"
+
+    fake = OcrOnlyDevice()
+
+    def fake_ocr(device):
+        if fake.current_url == "ocr_article":
+            return [
+                {"text": "World leaders meet for climate talks today", "conf": 0.91, "x": 10, "y": 40, "w": 300, "h": 24},
+                {"text": "The first paragraph appears in OCR.", "conf": 0.86, "x": 10, "y": 80, "w": 330, "h": 24},
+            ]
+        return [
+            {"text": "World leaders meet for climate talks today", "conf": 0.91, "x": 10, "y": 120, "w": 300, "h": 24}
+        ]
+
+    monkeypatch.setattr("gitd.services.browser.get_device", lambda device: fake)
+    monkeypatch.setattr("gitd.services.device_context.ocr_screen", fake_ocr)
+    monkeypatch.setattr("gitd.services.browser.time.sleep", lambda *_args, **_kwargs: None)
+
+    result = read_news("ios:abc123", "https://text.npr.org/", max_headlines=1, max_articles=1, wait_s=0)
+
+    assert result["ok"] is True
+    assert result["headlines"][0]["provenance"] == "ocr"
+    assert result["extraction"]["headlines"]["source"] == "ocr"
+    assert fake.taps == [(160, 132)]
+    assert result["articles"][0]["open_method"] == "center"
+    assert result["extraction"]["articles"][0]["text"]["source"] == "ocr"
+    assert result["articles"][0]["body_snippet"] == (
+        "World leaders meet for climate talks today\nThe first paragraph appears in OCR."
+    )
+
+
+def test_read_news_android_returns_explicit_unsupported():
+    result = read_news("emulator-5554", "https://text.npr.org/")
+
+    assert result["ok"] is False
+    assert result["platform"] == "android"
+    assert "currently implemented for iOS" in result["error"]
+
+
+def test_ios_open_url_service_returns_navigation_evidence(monkeypatch):
+    fake = FakeNewsIOSDevice()
+    monkeypatch.setattr("gitd.services.browser.get_device", lambda device: fake)
+
+    result = open_url("ios:abc123", "text.npr.org", bundle_id="com.google.chrome.ios")
+
+    assert result == {
+        "ok": True,
+        "platform": "ios",
+        "url": "https://text.npr.org",
+        "navigation": {
+            "ok": True,
+            "expected_url": "https://text.npr.org",
+            "url": "https://text.npr.org",
+            "state": "url_matched",
+            "method": "fake",
+        },
+    }
+    assert fake.bundle_id == "com.google.chrome.ios"
+
+
+def test_ios_open_url_service_uses_target_app_switch(monkeypatch):
+    class TargetSwitchDevice(FakeNewsIOSDevice):
+        def __init__(self):
+            super().__init__()
+            self.target_switches = []
+
+        def set_target_app(self, *, bundle_id=None, browser_name=None):
+            self.target_switches.append({"bundle_id": bundle_id, "browser_name": browser_name})
+            if bundle_id:
+                self.bundle_id = bundle_id
+
+    fake = TargetSwitchDevice()
+    monkeypatch.setattr("gitd.services.browser.get_device", lambda device: fake)
+
+    result = open_url("ios:abc123", "text.npr.org", bundle_id="com.google.chrome.ios")
+
+    assert result["ok"] is True
+    assert fake.target_switches == [{"bundle_id": "com.google.chrome.ios", "browser_name": None}]
+    assert fake.bundle_id == "com.google.chrome.ios"
+
+
+def test_ios_open_url_preserves_navigation_when_current_url_probe_fails(monkeypatch):
+    class NoCurrentUrlDevice(FakeNewsIOSDevice):
+        def get_current_url(self):
+            raise RuntimeError("web context not attached")
+
+    fake = NoCurrentUrlDevice()
+    monkeypatch.setattr("gitd.services.browser.get_device", lambda device: fake)
+
+    result = open_url("ios:abc123", "text.npr.org", bundle_id="com.google.chrome.ios")
+
+    assert result["ok"] is True
+    assert result["platform"] == "ios"
+    assert result["url"] == "https://text.npr.org"
+    assert result["navigation"]["state"] == "url_matched"
+    assert result["current_url_error"] == "web context not attached"
+
+
+def test_ios_open_url_returns_structured_error_when_navigation_fails(monkeypatch):
+    class FailingOpenDevice(FakeNewsIOSDevice):
+        def open_url(self, url, delay=2.0):
+            raise RuntimeError("wda navigation failed")
+
+    monkeypatch.setattr("gitd.services.browser.get_device", lambda device: FailingOpenDevice())
+
+    result = open_url("ios:abc123", "text.npr.org", bundle_id="com.google.chrome.ios")
+
+    assert result == {
+        "ok": False,
+        "platform": "ios",
+        "device": "ios:abc123",
+        "operation": "open_url",
+        "error": "wda navigation failed",
+        "url": "https://text.npr.org",
+    }
+
+
+def test_ios_browser_back_returns_structured_error(monkeypatch):
+    class FailingBackDevice(FakeNewsIOSDevice):
+        def browser_back(self, delay=1.0):
+            raise RuntimeError("wda back failed")
+
+    monkeypatch.setattr("gitd.services.browser.get_device", lambda device: FailingBackDevice())
+
+    result = browser_back("ios:abc123")
+
+    assert result == {
+        "ok": False,
+        "platform": "ios",
+        "device": "ios:abc123",
+        "operation": "browser_back",
+        "error": "wda back failed",
+    }
+
+
+def test_ios_get_current_url_returns_structured_error(monkeypatch):
+    class NoCurrentUrlDevice(FakeNewsIOSDevice):
+        def get_current_url(self):
+            raise RuntimeError("web context not attached")
+
+    monkeypatch.setattr("gitd.services.browser.get_device", lambda device: NoCurrentUrlDevice())
+
+    result = get_current_url("ios:abc123")
+
+    assert result == {
+        "ok": False,
+        "platform": "ios",
+        "url": "",
+        "error": "web context not attached",
+    }
+
+
+def test_ios_get_current_url_reports_setup_failure(monkeypatch):
+    monkeypatch.setattr(
+        "gitd.services.browser.get_device",
+        lambda device: (_ for _ in ()).throw(RuntimeError("appium unavailable")),
+    )
+
+    result = get_current_url("ios:abc123")
+
+    assert result == {
+        "ok": False,
+        "platform": "ios",
+        "device": "ios:abc123",
+        "operation": "get_current_url",
+        "error": "appium unavailable",
+        "url": "",
+    }
+
+
+def test_ios_get_current_url_returns_url_when_exposed(monkeypatch):
+    fake = FakeNewsIOSDevice()
+    fake.current_url = "https://text.npr.org/"
+    monkeypatch.setattr("gitd.services.browser.get_device", lambda device: fake)
+
+    result = get_current_url("ios:abc123")
+
+    assert result == {"ok": True, "platform": "ios", "url": "https://text.npr.org/"}
+
+
+def test_ios_get_current_url_reports_empty_context_as_unavailable(monkeypatch):
+    monkeypatch.setattr("gitd.services.browser.get_device", lambda device: FakeNewsIOSDevice())
+
+    result = get_current_url("ios:abc123")
+
+    assert result == {
+        "ok": False,
+        "platform": "ios",
+        "url": "",
+        "error": "Current URL is not exposed by the active iOS browser context",
+    }
+
+
+def test_android_wait_for_text_retries_until_match(monkeypatch):
+    calls = []
+
+    def fake_find(device, text):
+        calls.append((device, text))
+        if len(calls) < 3:
+            return None
+        return {"text": "Loaded headline", "x": 20, "y": 40, "w": 100, "h": 20, "method": "xml"}
+
+    monkeypatch.setattr("gitd.services.device_context.find_on_screen", fake_find)
+    monkeypatch.setattr("gitd.services.browser.time.sleep", lambda *_args, **_kwargs: None)
+
+    result = wait_for_text("emulator-5554", "headline", timeout=1)
+
+    assert result["ok"] is True
+    assert result["platform"] == "android"
+    assert result["found"] is True
+    assert result["attempts"] == 3
+    assert result["match"]["text"] == "Loaded headline"
+    assert calls == [
+        ("emulator-5554", "headline"),
+        ("emulator-5554", "headline"),
+        ("emulator-5554", "headline"),
+    ]
+
+
+def test_android_wait_for_text_returns_structured_timeout(monkeypatch):
+    monkeypatch.setattr("gitd.services.device_context.find_on_screen", lambda device, text: None)
+
+    result = wait_for_text("emulator-5554", "missing text", timeout=0)
+
+    assert result == {
+        "ok": False,
+        "platform": "android",
+        "text": "missing text",
+        "found": False,
+        "match": None,
+        "attempts": 1,
+        "timeout": 0.0,
+    }
+
+
+def test_ios_wait_for_text_returns_structured_timeout(monkeypatch):
+    class TimeoutIOSDevice(FakeNewsIOSDevice):
+        def wait_for_text(self, text, timeout=12):
+            raise TimeoutError(f"Timed out waiting for {text}")
+
+    fake = TimeoutIOSDevice()
+    monkeypatch.setattr("gitd.services.browser.get_device", lambda device: fake)
+
+    result = wait_for_text("ios:abc123", "missing text", timeout=0)
+
+    assert result["ok"] is False
+    assert result["platform"] == "ios"
+    assert result["found"] is False
+    assert result["visible_text"].startswith("NPR text home")
+    assert "Timed out waiting" in result["error"]
+
+
+def test_ios_wait_for_text_reports_setup_failure(monkeypatch):
+    monkeypatch.setattr(
+        "gitd.services.browser.get_device",
+        lambda device: (_ for _ in ()).throw(RuntimeError("appium unavailable")),
+    )
+
+    result = wait_for_text("ios:abc123", "headline", timeout=0)
+
+    assert result == {
+        "ok": False,
+        "platform": "ios",
+        "device": "ios:abc123",
+        "operation": "wait_for_text",
+        "error": "appium unavailable",
+        "text": "headline",
+        "found": False,
+        "visible_text": "",
+    }
+
+
+def test_ios_extract_visible_text_uses_ocr_after_native_failure(monkeypatch):
+    class FailingTextDevice(FakeNewsIOSDevice):
+        def extract_visible_text(self, max_lines=200, include_controls=False):
+            raise RuntimeError("native text failed")
+
+    monkeypatch.setattr("gitd.services.browser.get_device", lambda device: FailingTextDevice())
+    monkeypatch.setattr(
+        "gitd.services.device_context.ocr_screen",
+        lambda device: [
+            {"text": "OCR headline one", "conf": 0.9, "x": 10, "y": 20, "w": 100, "h": 20},
+            {"text": "OCR body line", "conf": 0.8, "x": 10, "y": 60, "w": 100, "h": 20},
+        ],
+    )
+
+    result = extract_visible_text("ios:abc123", max_lines=5)
+
+    assert result["ok"] is True
+    assert result["platform"] == "ios"
+    assert result["source"] == "ocr"
+    assert result["extraction_error"] == "native text failed"
+    assert result["lines"] == ["OCR headline one", "OCR body line"]
+
+
+def test_ios_extract_visible_text_reports_failure_when_all_sources_fail(monkeypatch):
+    class FailingTextDevice(FakeNewsIOSDevice):
+        def extract_visible_text(self, max_lines=200, include_controls=False):
+            raise RuntimeError("native text failed")
+
+    monkeypatch.setattr("gitd.services.browser.get_device", lambda device: FailingTextDevice())
+    monkeypatch.setattr("gitd.services.device_context.ocr_screen", lambda device: [])
+
+    result = extract_visible_text("ios:abc123", max_lines=5)
+
+    assert result == {
+        "ok": False,
+        "platform": "ios",
+        "device": "ios:abc123",
+        "operation": "extract_visible_text",
+        "error": "native text failed",
+        "text": "",
+        "lines": [],
+        "source": "native_or_web",
+    }
+
+
+def test_ios_extract_articles_uses_ocr_after_native_failure(monkeypatch):
+    class FailingArticleDevice(FakeNewsIOSDevice):
+        def extract_articles(self, max_items=5):
+            raise RuntimeError("native articles failed")
+
+    monkeypatch.setattr("gitd.services.browser.get_device", lambda device: FailingArticleDevice())
+    monkeypatch.setattr(
+        "gitd.services.device_context.ocr_screen",
+        lambda device: [
+            {
+                "text": "World leaders meet for climate talks today",
+                "conf": 0.91,
+                "x": 10,
+                "y": 40,
+                "w": 300,
+                "h": 24,
+            }
+        ],
+    )
+
+    result = extract_articles("ios:abc123", max_items=3)
+
+    assert result["ok"] is True
+    assert result["platform"] == "ios"
+    assert result["source"] == "ocr"
+    assert result["extraction_error"] == "native articles failed"
+    assert result["articles"][0]["title"] == "World leaders meet for climate talks today"
+
+
+def test_read_news_reports_ios_setup_failure(monkeypatch):
+    monkeypatch.setattr(
+        "gitd.services.browser.get_device",
+        lambda device: (_ for _ in ()).throw(RuntimeError("appium unavailable")),
+    )
+
+    result = read_news("ios:abc123", "text.npr.org", max_headlines=1, max_articles=1, wait_s=0)
+
+    assert result["ok"] is False
+    assert result["platform"] == "ios"
+    assert result["device"] == "ios:abc123"
+    assert result["url"] == "https://text.npr.org"
+    assert result["error"] == "appium unavailable"
+    assert result["errors"] == [{"stage": "workflow", "error": "appium unavailable"}]
+
+
+def test_read_news_rest_route_uses_browser_service(monkeypatch):
+    def fake_read_news(device, url, **kwargs):
+        return {"ok": True, "device": device, "url": url, "kwargs": kwargs, "headlines": []}
+
+    monkeypatch.setattr("gitd.services.browser.read_news", fake_read_news)
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/phone/browser/read-news",
+        json={"device": "ios:abc123", "url": "https://text.npr.org/", "max_headlines": 4, "max_articles": 2},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is True
+    assert body["device"] == "ios:abc123"
+    assert body["kwargs"]["max_headlines"] == 4
+    assert body["kwargs"]["max_articles"] == 2
+
+
+def test_browser_rest_routes_reject_unsupported_platform():
+    client = TestClient(app)
+
+    current_url = client.get("/api/phone/browser/current-url/emulator-5554")
+    news = client.post(
+        "/api/phone/browser/read-news",
+        json={"device": "emulator-5554", "url": "https://text.npr.org/"},
+    )
+
+    assert current_url.status_code == 200
+    assert current_url.json()["ok"] is False
+    assert current_url.json()["platform"] == "android"
+    assert current_url.json()["support"] == "ios_supported"
+
+    assert news.status_code == 200
+    assert news.json()["ok"] is False
+    assert news.json()["platform"] == "android"
+    assert news.json()["support"] == "ios_supported"
+    assert "implemented only for iOS" in news.json()["error"]
+
+
+def test_read_news_agent_tool_dispatches_to_browser_service(monkeypatch):
+    def fake_read_news(device, url, **kwargs):
+        return {"ok": True, "device": device, "url": url, "kwargs": kwargs, "headlines": [{"title": "One"}]}
+
+    monkeypatch.setattr("gitd.services.browser.read_news", fake_read_news)
+
+    result = json.loads(
+        execute_tool(
+            "read_news",
+            {
+                "device": "ios:abc123",
+                "url": "https://text.npr.org/",
+                "max_headlines": 1,
+                "max_articles": 1,
+                "wait_s": 0,
+            },
+        )
+    )
+
+    assert result["ok"] is True
+    assert result["kwargs"]["max_headlines"] == 1
+    assert result["kwargs"]["max_articles"] == 1
+
+
+def test_mcp_web_search_forwards_ios_bundle_override(monkeypatch):
+    from gitd import mcp_server
+
+    def fake_web_search(device, query, **kwargs):
+        return {"ok": True, "device": device, "query": query, "kwargs": kwargs}
+
+    monkeypatch.setattr("gitd.services.browser.web_search", fake_web_search)
+
+    result = json.loads(
+        mcp_server.web_search(
+            "ios:abc123",
+            "latest robotics news",
+            engine="ddg",
+            bundle_id="com.google.chrome.ios",
+        )
+    )
+
+    assert result["ok"] is True
+    assert result["device"] == "ios:abc123"
+    assert result["query"] == "latest robotics news"
+    assert result["kwargs"] == {"engine": "ddg", "bundle_id": "com.google.chrome.ios"}
+
+
+def test_mcp_ios_only_browser_tools_reject_android_device():
+    from gitd import mcp_server
+
+    current_url = mcp_server.get_current_url("emulator-5554")
+    news = mcp_server.read_news("emulator-5554", "https://text.npr.org/")
+
+    assert current_url == "ERROR: get_current_url is currently implemented only for iOS"
+    assert news == "ERROR: read_news is currently implemented only for iOS"
+
+
+def test_ios_wait_for_text_checks_webview_text_before_native_xml(monkeypatch):
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+    calls = []
+
+    def fake_extract_visible_text(max_lines=300):
+        calls.append(max_lines)
+        return "Article body from web context"
+
+    monkeypatch.setattr(dev, "extract_visible_text", fake_extract_visible_text)
+
+    assert dev.wait_for_text("web context", timeout=0.01, interval=0.01) == "Article body from web context"
+    assert calls == [300]
+
+
+@pytest.mark.skipif(
+    not (
+        os.getenv("IOS_LIVE_NEWS_TEST")
+        and os.getenv("IOS_APPIUM_URL")
+        and os.getenv("IOS_DEVICE_UDID")
+    ),
+    reason="set IOS_LIVE_NEWS_TEST=1, IOS_APPIUM_URL, and IOS_DEVICE_UDID to run live iOS Chrome news test",
+)
+def test_live_ios_chrome_news_workflow():
+    from gitd.services.device_context import device_health
+
+    device = f"ios:{os.environ['IOS_DEVICE_UDID']}"
+    health = device_health(device)
+    assert health["connection"]["status"] == "available", health
+
+    result = read_news(
+        device,
+        os.getenv("IOS_LIVE_NEWS_URL", "https://text.npr.org/"),
+        max_headlines=int(os.getenv("IOS_LIVE_NEWS_HEADLINES", "2")),
+        max_articles=int(os.getenv("IOS_LIVE_NEWS_ARTICLES", "1")),
+        bundle_id=os.getenv("IOS_BUNDLE_ID", "com.google.chrome.ios"),
+        wait_s=float(os.getenv("IOS_LIVE_NEWS_WAIT", "2.0")),
+        save_screenshots=False,
+    )
+
+    assert result["ok"] is True, result
+    assert len(result["headlines"]) >= 1
+    assert result["headlines"][0].get("title")
+    if result["articles"]:
+        assert result["articles"][0].get("opened") is True
+        assert result["articles"][0].get("body_snippet")

--- a/tests/test_chain_action.py
+++ b/tests/test_chain_action.py
@@ -1,0 +1,162 @@
+"""Tests for the `chain` action — batched sub-actions with a settle between."""
+
+import pytest
+
+from gitd.services import agent_tools
+from gitd.services.agent_tools import EXEC_CAPABLE_TOOLS, SAFE_DEVICE_TOOLS, execute_tool
+
+
+@pytest.fixture()
+def record_dispatch(monkeypatch):
+    """Capture every _execute_tool_inner sub-call and stub them out."""
+    calls = []
+
+    real_inner = agent_tools._execute_tool_inner
+
+    def fake_inner(name, args):
+        # chain itself must still go through the real dispatch → _execute_chain
+        if name == "chain":
+            return real_inner(name, args)
+        calls.append((name, dict(args)))
+        return f"ran {name}"
+
+    monkeypatch.setattr(agent_tools, "_execute_tool_inner", fake_inner)
+    # no real sleeps
+    monkeypatch.setattr("time.sleep", lambda _s: None)
+    return calls
+
+
+def test_chain_runs_sub_actions_in_order(record_dispatch):
+    out = execute_tool(
+        "chain",
+        {
+            "device": "emulator-5554",
+            "actions": [
+                {"tool": "tap_element", "args": {"idx": 3}},
+                {"tool": "type_text", "args": {"text": "hello"}},
+                {"tool": "tap_element", "args": {"idx": 7}},
+            ],
+        },
+    )
+    assert [c[0] for c in record_dispatch] == ["tap_element", "type_text", "tap_element"]
+    # device propagated into every sub-action
+    assert all(c[1].get("device") == "emulator-5554" for c in record_dispatch)
+    assert out.startswith("chain[3/3]:")
+
+
+def test_chain_rejects_exec_tool_before_running_anything(record_dispatch):
+    out = execute_tool(
+        "chain",
+        {
+            "device": "d",
+            "actions": [
+                {"tool": "tap", "args": {"x": 1, "y": 2}},
+                {"tool": "shell", "args": {"command": "rm -rf /"}},  # not allowed
+            ],
+        },
+    )
+    assert "not allowed inside a chain" in out
+    assert record_dispatch == []  # fail-closed: nothing ran, incl. the benign first step
+
+
+def test_chain_refuses_to_nest(record_dispatch):
+    out = execute_tool(
+        "chain",
+        {"device": "d", "actions": [{"tool": "chain", "args": {"actions": []}}]},
+    )
+    assert "may not nest another chain" in out
+    assert record_dispatch == []
+
+
+def test_chain_rejects_oversized_batch(record_dispatch):
+    out = execute_tool(
+        "chain",
+        {"device": "d", "actions": [{"tool": "tap", "args": {"x": 0, "y": 0}}] * 20},
+    )
+    assert "too many actions" in out
+    assert record_dispatch == []
+
+
+def test_chain_empty_or_bad_shape(record_dispatch):
+    assert "non-empty list" in execute_tool("chain", {"device": "d", "actions": []})
+    assert "non-empty list" in execute_tool("chain", {"device": "d"})
+    assert "'tool' field" in execute_tool("chain", {"device": "d", "actions": [{"args": {}}]})
+
+
+def test_chain_aborts_remaining_on_hard_failure(monkeypatch):
+    calls = []
+
+    def fake_inner(name, args):
+        if name == "chain":
+            return agent_tools._execute_chain(args.get("device", ""), args)
+        calls.append(name)
+        if name == "type_text":
+            raise RuntimeError("focus lost")
+        return f"ran {name}"
+
+    monkeypatch.setattr(agent_tools, "_execute_tool_inner", fake_inner)
+    monkeypatch.setattr("time.sleep", lambda _s: None)
+
+    out = agent_tools._execute_chain(
+        "d",
+        {
+            "actions": [
+                {"tool": "tap", "args": {}},
+                {"tool": "type_text", "args": {}},
+                {"tool": "tap_element", "args": {}},  # should NOT run
+            ]
+        },
+    )
+    assert calls == ["tap", "type_text"]  # third never ran
+    assert "err:focus lost" in out
+    assert out.startswith("chain[2/3]:")
+
+
+def test_chain_soft_continues_on_error_string_return(monkeypatch):
+    """A sub-action that RETURNS an error string (not raises) must not abort.
+
+    iOS `speak_text` on stock (un-patched) WDA no-ops and returns an
+    ``ERROR: ...`` string rather than raising — a chain that announces status
+    should log it and keep going, not fail the whole flow. Only a raised
+    exception is a hard failure (see test_chain_aborts_remaining_on_hard_failure).
+    """
+    calls = []
+
+    def fake_inner(name, args):
+        if name == "chain":
+            return agent_tools._execute_chain(args.get("device", ""), args)
+        calls.append(name)
+        if name == "speak_text":
+            return "ERROR: speak_text requires the GhostAgent-patched WDA /wda/speak route"
+        return f"ran {name}"
+
+    monkeypatch.setattr(agent_tools, "_execute_tool_inner", fake_inner)
+    monkeypatch.setattr("time.sleep", lambda _s: None)
+
+    out = agent_tools._execute_chain(
+        "d",
+        {
+            "actions": [
+                {"tool": "tap", "args": {}},
+                {"tool": "speak_text", "args": {"text": "done"}},  # soft-fails on iOS
+                {"tool": "tap_element", "args": {"idx": 1}},  # MUST still run
+            ]
+        },
+    )
+    assert calls == ["tap", "speak_text", "tap_element"]  # all three ran
+    assert out.startswith("chain[3/3]:")
+    assert "ERROR: speak_text" in out
+
+
+def test_chain_is_exec_capable_not_safe():
+    # chain is a meta-executor: must be denied from run_flow / framework adapters
+    # (fail-closed) exactly like the other exec vectors.
+    assert "chain" in EXEC_CAPABLE_TOOLS
+    assert "chain" not in SAFE_DEVICE_TOOLS
+
+
+def test_chain_not_reachable_via_run_flow():
+    """run_flow gates on SAFE_DEVICE_TOOLS; chain must not be in it."""
+    from gitd.mcp_server import FLOW_ALLOWED_TOOLS
+
+    assert "chain" not in FLOW_ALLOWED_TOOLS

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -1,0 +1,104 @@
+"""Tests for the `android-agent doctor` / `up` CLI commands."""
+
+import types
+
+import gitd.cli as cli
+
+
+def _by_name(checks, name):
+    return next(c for c in checks if c["name"] == name)
+
+
+def test_doctor_flags_missing_adb(monkeypatch):
+    monkeypatch.setattr(cli.shutil, "which", lambda name: None)  # nothing on PATH
+    monkeypatch.setattr(cli, "_port_in_use", lambda *a, **k: False)
+    checks = cli.collect_doctor_checks()
+
+    adb = _by_name(checks, "adb on PATH")
+    assert adb["status"] == "fail"
+    assert "PATH" in adb["hint"]
+    # with no adb, the devices probe is skipped entirely (no traceback)
+    assert not any(c["name"] == "adb devices" for c in checks)
+
+
+def test_doctor_ok_with_devices(monkeypatch):
+    monkeypatch.setattr(cli.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr("gitd.bots.common.adb.list_connected", lambda: ["emulator-5554"])
+    monkeypatch.setattr(cli, "_port_in_use", lambda *a, **k: False)
+    checks = cli.collect_doctor_checks()
+
+    assert _by_name(checks, "adb on PATH")["status"] == "ok"
+    assert _by_name(checks, "adb devices")["status"] == "ok"
+    assert "emulator-5554" in _by_name(checks, "adb devices")["detail"]
+
+
+def test_doctor_warns_when_no_devices(monkeypatch):
+    monkeypatch.setattr(cli.shutil, "which", lambda name: f"/usr/bin/{name}" if name == "adb" else None)
+    monkeypatch.setattr("gitd.bots.common.adb.list_connected", lambda: [])
+    monkeypatch.setattr(cli, "_port_in_use", lambda *a, **k: False)
+    checks = cli.collect_doctor_checks()
+
+    dev = _by_name(checks, "adb devices")
+    assert dev["status"] == "warn"
+    assert dev["hint"]
+
+
+def test_doctor_warns_when_port_in_use(monkeypatch):
+    monkeypatch.setattr(cli.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr("gitd.bots.common.adb.list_connected", lambda: [])
+    monkeypatch.setattr(cli, "_port_in_use", lambda *a, **k: True)
+    checks = cli.collect_doctor_checks()
+
+    port_check = next(c for c in checks if c["name"].startswith("server port"))
+    assert port_check["status"] == "warn"
+    assert "in use" in port_check["detail"]
+
+
+def test_cmd_doctor_exit_code_fails_on_missing_adb(monkeypatch, capsys):
+    monkeypatch.setattr(cli.shutil, "which", lambda name: None)
+    monkeypatch.setattr(cli, "_port_in_use", lambda *a, **k: False)
+    rc = cli.cmd_doctor(None)
+    assert rc == 1
+    assert "must be fixed" in capsys.readouterr().out
+
+
+def test_cmd_doctor_exit_zero_when_only_warnings(monkeypatch, capsys):
+    monkeypatch.setattr(cli.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr("gitd.bots.common.adb.list_connected", lambda: [])  # 0 devices → warn
+    monkeypatch.setattr(cli, "_port_in_use", lambda *a, **k: False)
+    rc = cli.cmd_doctor(None)
+    assert rc == 0
+
+
+def test_cmd_up_honors_host_port_overrides(monkeypatch):
+    import uvicorn
+
+    captured = {}
+    monkeypatch.setattr(uvicorn, "run", lambda app, host, port: captured.update(host=host, port=port))
+
+    rc = cli.cmd_up(types.SimpleNamespace(host="1.2.3.4", port=9999))
+    assert rc == 0
+    assert captured == {"host": "1.2.3.4", "port": 9999}
+
+
+def test_cmd_up_defaults_to_localhost(monkeypatch):
+    """No --host → bind localhost only; the phone-controlling server must not be
+    exposed to the LAN by default."""
+    import uvicorn
+
+    captured = {}
+    monkeypatch.setattr(uvicorn, "run", lambda app, host, port: captured.update(host=host, port=port))
+
+    cli.cmd_up(types.SimpleNamespace(host=None, port=None))
+    assert captured["host"] == "127.0.0.1"
+
+
+def test_cmd_up_lan_exposure_is_opt_in(monkeypatch):
+    """--host 0.0.0.0 is honored (explicit LAN opt-in)."""
+    import uvicorn
+
+    captured = {}
+    monkeypatch.setattr(uvicorn, "run", lambda app, host, port: captured.update(host=host, port=port))
+
+    cli.cmd_up(types.SimpleNamespace(host="0.0.0.0", port=None))
+    assert captured["host"] == "0.0.0.0"

--- a/tests/test_cli_login.py
+++ b/tests/test_cli_login.py
@@ -1,0 +1,162 @@
+"""Tests for `android-agent login` (Claude subscription sign-in, no API key)."""
+
+import json
+import types
+
+import gitd.cli as cli
+
+
+def _write_creds(home, payload):
+    d = home / ".claude"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / ".credentials.json").write_text(json.dumps(payload))
+
+
+# ── _claude_auth_state (offline, never reads token values) ───────────────────
+
+
+def test_auth_state_not_installed(monkeypatch):
+    monkeypatch.setattr(cli.shutil, "which", lambda n: None)
+    assert cli._claude_auth_state() == "not_installed"
+
+
+def test_auth_state_logged_out(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli.shutil, "which", lambda n: "/usr/bin/claude")
+    monkeypatch.setattr(cli.Path, "home", lambda: tmp_path)  # no creds file
+    monkeypatch.setattr(cli, "_claude_status_logged_in", lambda: False)  # CLI says not signed in
+    assert cli._claude_auth_state() == "logged_out"
+
+
+def test_auth_state_logged_in_fast_path_skips_status_probe(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli.shutil, "which", lambda n: "/usr/bin/claude")
+    monkeypatch.setattr(cli.Path, "home", lambda: tmp_path)
+    _write_creds(tmp_path, {"claudeAiOauth": {"accessToken": "SECRET-should-not-be-read"}})
+
+    def _boom():
+        raise AssertionError("status probe must not run when the creds file exists")
+
+    monkeypatch.setattr(cli, "_claude_status_logged_in", _boom)
+    assert cli._claude_auth_state() == "logged_in"
+
+
+def test_auth_state_logged_in_via_status_when_file_absent(monkeypatch, tmp_path):
+    """macOS Keychain case: no creds file, but the CLI reports signed in."""
+    monkeypatch.setattr(cli.shutil, "which", lambda n: "/usr/bin/claude")
+    monkeypatch.setattr(cli.Path, "home", lambda: tmp_path)  # no creds file
+    monkeypatch.setattr(cli, "_claude_status_logged_in", lambda: True)
+    assert cli._claude_auth_state() == "logged_in"
+
+
+def test_claude_status_parses_loggedIn_json(monkeypatch):
+    monkeypatch.setattr(
+        cli.subprocess,
+        "run",
+        lambda *a, **k: types.SimpleNamespace(returncode=0, stdout='{"loggedIn": true}', stderr=""),
+    )
+    assert cli._claude_status_logged_in() is True
+    monkeypatch.setattr(
+        cli.subprocess,
+        "run",
+        lambda *a, **k: types.SimpleNamespace(returncode=0, stdout='{"loggedIn": false}', stderr=""),
+    )
+    assert cli._claude_status_logged_in() is False
+
+
+def test_claude_status_falls_back_to_exit_code(monkeypatch):
+    # non-JSON output → use the exit code
+    monkeypatch.setattr(
+        cli.subprocess, "run", lambda *a, **k: types.SimpleNamespace(returncode=0, stdout="Signed in", stderr="")
+    )
+    assert cli._claude_status_logged_in() is True
+
+
+def test_claude_status_handles_failure(monkeypatch):
+    def _raise(*a, **k):
+        raise FileNotFoundError("claude")
+
+    monkeypatch.setattr(cli.subprocess, "run", _raise)
+    assert cli._claude_status_logged_in() is False
+
+
+# ── cmd_login ────────────────────────────────────────────────────────────────
+
+
+def test_login_not_installed_guides_and_fails(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "_claude_auth_state", lambda: "not_installed")
+    rc = cli.cmd_login(types.SimpleNamespace(relogin=False))
+    assert rc == 1
+    assert "not installed" in capsys.readouterr().out.lower()
+
+
+def test_login_already_signed_in_records_default(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "_claude_auth_state", lambda: "logged_in")
+    recorded = {}
+    monkeypatch.setattr(cli, "_record_default_provider", lambda p: recorded.update(p=p))
+    rc = cli.cmd_login(types.SimpleNamespace(relogin=False))
+    assert rc == 0
+    assert recorded["p"] == "claude-code"
+    assert "signed in" in capsys.readouterr().out.lower()
+
+
+def test_login_delegates_to_claude_auth_login_when_logged_out(monkeypatch):
+    states = iter(["logged_out", "logged_in"])  # before login, then after
+    monkeypatch.setattr(cli, "_claude_auth_state", lambda: next(states))
+    ran = {}
+    monkeypatch.setattr(
+        cli.subprocess, "run", lambda cmd, **k: ran.update(cmd=cmd) or types.SimpleNamespace(returncode=0)
+    )
+    monkeypatch.setattr(cli, "_record_default_provider", lambda p: None)
+    rc = cli.cmd_login(types.SimpleNamespace(relogin=False))
+    assert rc == 0
+    assert ran["cmd"] == ["claude", "auth", "login"]  # delegates to the sanctioned flow
+
+
+def test_login_aborts_if_claude_login_fails(monkeypatch):
+    monkeypatch.setattr(cli, "_claude_auth_state", lambda: "logged_out")
+    monkeypatch.setattr(cli.subprocess, "run", lambda cmd, **k: types.SimpleNamespace(returncode=1))
+    rc = cli.cmd_login(types.SimpleNamespace(relogin=False))
+    assert rc == 1
+
+
+def test_record_default_provider_upserts_env(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    cli._record_default_provider("claude-code")
+    assert "DEFAULT_PROVIDER=claude-code" in (tmp_path / ".env").read_text()
+
+    # upsert (not duplicate) when the key already exists, preserving other lines
+    (tmp_path / ".env").write_text("FOO=bar\nDEFAULT_PROVIDER=old\n")
+    cli._record_default_provider("claude-code")
+    env = (tmp_path / ".env").read_text()
+    assert env.count("DEFAULT_PROVIDER=") == 1
+    assert "DEFAULT_PROVIDER=claude-code" in env and "FOO=bar" in env
+
+
+# ── doctor subscription check + create_session default ───────────────────────
+
+
+def test_doctor_subscription_ok_when_signed_in(monkeypatch):
+    monkeypatch.setattr(cli.shutil, "which", lambda n: f"/usr/bin/{n}")
+    monkeypatch.setattr(cli, "_claude_auth_state", lambda: "logged_in")
+    monkeypatch.setattr(cli, "_port_in_use", lambda *a, **k: False)
+    monkeypatch.setattr("gitd.bots.common.adb.list_connected", lambda: [])
+    sub = next(c for c in cli.collect_doctor_checks() if c["name"] == "Claude subscription")
+    assert sub["status"] == "ok"
+
+
+def test_doctor_subscription_warns_when_signed_out(monkeypatch):
+    monkeypatch.setattr(cli.shutil, "which", lambda n: f"/usr/bin/{n}")
+    monkeypatch.setattr(cli, "_claude_auth_state", lambda: "logged_out")
+    monkeypatch.setattr(cli, "_port_in_use", lambda *a, **k: False)
+    monkeypatch.setattr("gitd.bots.common.adb.list_connected", lambda: [])
+    sub = next(c for c in cli.collect_doctor_checks() if c["name"] == "Claude subscription")
+    assert sub["status"] == "warn"
+    assert "login" in sub["hint"]
+
+
+def test_create_session_honors_default_provider(monkeypatch):
+    from gitd.config import settings
+    from gitd.services import agent_chat
+
+    monkeypatch.setattr(settings, "default_provider", "claude-code")
+    assert agent_chat.create_session(device="d").provider == "claude-code"  # no provider → default
+    assert agent_chat.create_session(device="d", provider="ollama").provider == "ollama"  # explicit wins

--- a/tests/test_cli_tool_emojis.py
+++ b/tests/test_cli_tool_emojis.py
@@ -1,0 +1,27 @@
+"""Per-tool emoji rendering for the ghost CLI tool-call line."""
+
+from gitd.ghostcli.run import _tool_emoji
+
+
+def test_common_tools_have_distinct_emojis():
+    assert _tool_emoji("tap") == "👆"
+    assert _tool_emoji("type_text") == "⌨️"
+    assert _tool_emoji("swipe") == "📜"
+    assert _tool_emoji("launch_app") == "🚀"
+    assert _tool_emoji("screenshot") == "📸"
+    assert _tool_emoji("press_key") == "🎹"
+    assert _tool_emoji("wait") == "⏳"
+    assert _tool_emoji("shell") == "⚙️"
+    assert _tool_emoji("open_url") == "🌐"
+    assert _tool_emoji("get_screen_tree") == "🌲"
+
+
+def test_unmapped_tool_falls_back_to_toolbox():
+    assert _tool_emoji("some_future_tool") == "🧰"
+    assert _tool_emoji("") == "🧰"
+
+
+def test_tap_and_type_are_visually_different():
+    # the whole point: the demo must not render a flat wall of identical glyphs
+    assert _tool_emoji("tap") != _tool_emoji("type_text")
+    assert _tool_emoji("screenshot") != _tool_emoji("launch_app")

--- a/tests/test_crash_tools.py
+++ b/tests/test_crash_tools.py
@@ -1,0 +1,109 @@
+"""Tests for the crash-report MCP tools (_parse_crashes / list_crashes / get_crash).
+
+The parser is exercised against captured logcat crash-buffer text — no device.
+"""
+
+import json
+import types
+
+import pytest
+
+import gitd.mcp_server as mcp_server
+from gitd.mcp_server import _parse_crashes, get_crash, list_crashes
+
+_SAMPLE = """--------- beginning of crash
+06-24 02:45:49.127 21001 21001 E AndroidRuntime: FATAL EXCEPTION: main
+06-24 02:45:49.127 21001 21001 E AndroidRuntime: Process: com.example.app, PID: 21001
+06-24 02:45:49.127 21001 21001 E AndroidRuntime: java.lang.RuntimeException: Unable to start activity
+06-24 02:45:49.127 21001 21001 E AndroidRuntime: \tat android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3782)
+06-24 03:00:00.000 1500 1600 E ActivityManager: ANR in com.other.app (com.other/.MainActivity)
+06-24 04:10:10.000 999 999 E AndroidRuntime: FATAL EXCEPTION: worker
+06-24 04:10:10.000 999 999 E AndroidRuntime: Process: com.late.crash, PID: 999
+06-24 04:10:10.000 999 999 E AndroidRuntime: java.lang.NullPointerException: boom
+06-24 04:10:10.000 999 999 E AndroidRuntime: \tat com.late.Thing.run(Thing.java:1)
+"""
+
+
+def test_parse_java_crash_extracts_process_and_summary():
+    crashes = _parse_crashes(_SAMPLE)
+    java = [c for c in crashes if c["type"] == "java"]
+    assert len(java) == 2
+    first = next(c for c in java if c["process"] == "com.example.app")
+    assert first["timestamp"] == "06-24 02:45:49.127"
+    assert "RuntimeException" in first["summary"]
+    assert "performLaunchActivity" in first["raw"]  # full stack retained
+
+
+def test_parse_anr():
+    anr = [c for c in _parse_crashes(_SAMPLE) if c["type"] == "anr"]
+    assert len(anr) == 1
+    assert anr[0]["process"] == "com.other.app"
+
+
+def test_most_recent_first():
+    crashes = _parse_crashes(_SAMPLE)
+    # the 04:10 NullPointer crash is latest in the log → first in the result
+    assert crashes[0]["process"] == "com.late.crash"
+
+
+def test_parse_empty_is_empty():
+    assert _parse_crashes("") == []
+    assert _parse_crashes("06-24 nothing interesting here\n") == []
+
+
+def test_list_crashes_shape_and_package_filter(monkeypatch):
+    monkeypatch.setattr(mcp_server, "_run_logcat_crash", lambda device, timeout=10: _SAMPLE)
+    body = json.loads(list_crashes("SER1"))
+    assert body["count"] == 3
+    assert {c["type"] for c in body["crashes"]} == {"java", "anr"}
+
+    filtered = json.loads(list_crashes("SER1", package="com.example"))
+    assert filtered["count"] == 1
+    assert filtered["crashes"][0]["process"] == "com.example.app"
+
+
+def test_get_crash_returns_most_recent_full_stack(monkeypatch):
+    monkeypatch.setattr(mcp_server, "_run_logcat_crash", lambda device, timeout=10: _SAMPLE)
+    out = get_crash("SER1")
+    assert "com.late.crash" in out and "NullPointerException" in out
+
+    scoped = get_crash("SER1", package="com.example.app")
+    assert "RuntimeException" in scoped and "performLaunchActivity" in scoped
+
+
+def test_get_crash_no_crashes(monkeypatch):
+    monkeypatch.setattr(mcp_server, "_run_logcat_crash", lambda device, timeout=10: "")
+    assert "No crashes found" in get_crash("SER1")
+
+
+# ── #675: adb failure must surface, not read as "no crashes" ─────────────────
+
+
+def _fake_run(returncode, stdout="", stderr=""):
+    return lambda *a, **k: types.SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def test_run_logcat_crash_raises_on_nonzero(monkeypatch):
+    monkeypatch.setattr(mcp_server.subprocess, "run", _fake_run(1, "", "error: device offline"))
+    with pytest.raises(RuntimeError, match="offline"):
+        mcp_server._run_logcat_crash("SER1")
+
+
+def test_offline_device_surfaces_error_not_phantom_no_crashes(monkeypatch):
+    # nonzero exit + empty stdout used to parse to zero crashes → "app is fine".
+    monkeypatch.setattr(mcp_server.subprocess, "run", _fake_run(1, "", "device offline"))
+    body = json.loads(list_crashes("SER1"))
+    assert "error" in body and body.get("count") != 0
+    assert get_crash("SER1").startswith("Error")
+
+
+# ── #675: ANRs come from the events buffer (am_anr), not the crash buffer ─────
+
+_ANR_EVENT = "06-24 05:00:00.000 1500 1600 I am_anr  : [0,21001,com.anr.app,952647748,Input dispatching timed out]"
+
+
+def test_parse_am_anr_event():
+    anr = [c for c in _parse_crashes(_ANR_EVENT) if c["type"] == "anr"]
+    assert len(anr) == 1
+    assert anr[0]["process"] == "com.anr.app"
+    assert "timed out" in anr[0]["summary"]

--- a/tests/test_creator_ios.py
+++ b/tests/test_creator_ios.py
@@ -1,0 +1,101 @@
+import json
+
+import yaml
+
+from gitd.routers import creator
+from gitd.routers import skills as skills_router
+
+
+def test_creator_prompt_uses_ios_appium_language(monkeypatch):
+    monkeypatch.setattr(
+        "gitd.services.device_context.get_phone_state",
+        lambda _device: {"currentApp": "Chrome", "bundleId": "com.google.chrome.ios"},
+    )
+
+    prompt = creator._build_creator_system_prompt(
+        {
+            "backend": "openrouter",
+            "context": {
+                "device": "ios:abc123",
+                "elements": [
+                    {
+                        "idx": 0,
+                        "text": "Search or type URL",
+                        "class": "XCUIElementTypeTextField",
+                        "bounds": {"x1": 10, "y1": 20, "x2": 300, "y2": 60},
+                    }
+                ],
+            },
+        }
+    )
+
+    assert "controls iOS devices through Appium XCUITest and WebDriverAgent" in prompt
+    assert "launch(bundle_id)" in prompt
+    assert 'platforms: ["ios"]' in prompt
+    assert "Do NOT use ADB shell" in prompt
+    assert "Current app: Chrome (com.google.chrome.ios)" in prompt
+    assert "XCUIElementTypeTextField" in prompt
+
+
+def test_creator_prompt_keeps_android_adb_language(monkeypatch):
+    monkeypatch.setattr(
+        "gitd.services.device_context.get_phone_state",
+        lambda _device: {"currentApp": "TikTok", "packageName": "com.zhiliaoapp.musically"},
+    )
+
+    prompt = creator._build_creator_system_prompt(
+        {"backend": "openrouter", "context": {"device": "emulator-5554"}}
+    )
+
+    assert "controls Android devices via ADB" in prompt
+    assert "launch(package)" in prompt
+    assert "Appium XCUITest" not in prompt
+    assert "Current app: TikTok (com.zhiliaoapp.musically)" in prompt
+
+
+def test_create_from_recording_writes_ios_skill_metadata(tmp_path, monkeypatch):
+    monkeypatch.setattr(skills_router, "_SKILLS_DIR", tmp_path)
+
+    result = skills_router.api_skills_create_from_recording(
+        {
+            "name": "ios_creator_demo",
+            "steps": [{"action": "launch", "package": "com.google.chrome.ios"}],
+            "platforms": ["ios"],
+            "app_package": "",
+            "android_package": "",
+            "ios_bundle_id": "com.google.chrome.ios",
+            "elements_ios": [{"text": "Search", "class": "XCUIElementTypeTextField"}],
+        }
+    )
+
+    skill_dir = tmp_path / "ios_creator_demo"
+    meta = yaml.safe_load((skill_dir / "skill.yaml").read_text())
+
+    assert result["ok"] is True
+    assert meta["platforms"] == ["ios"]
+    assert meta["app_package"] == ""
+    assert meta["android_package"] == ""
+    assert meta["ios_bundle_id"] == "com.google.chrome.ios"
+    assert json.loads((skill_dir / "workflows" / "recorded.json").read_text())[0]["package"] == "com.google.chrome.ios"
+    assert yaml.safe_load((skill_dir / "elements_ios.yaml").read_text())[0]["text"] == "Search"
+
+
+def test_create_from_recording_treats_ios_app_package_as_bundle_id(tmp_path, monkeypatch):
+    monkeypatch.setattr(skills_router, "_SKILLS_DIR", tmp_path)
+
+    result = skills_router.api_skills_create_from_recording(
+        {
+            "name": "ios_bundle_in_app_package",
+            "steps": [{"action": "launch", "package": "com.google.chrome.ios"}],
+            "platforms": ["ios"],
+            "app_package": "com.google.chrome.ios",
+        }
+    )
+
+    meta = yaml.safe_load((tmp_path / "ios_bundle_in_app_package" / "skill.yaml").read_text())
+
+    assert result["ok"] is True
+    assert meta["platforms"] == ["ios"]
+    assert meta["app_package"] == ""
+    assert meta["android_package"] == ""
+    assert meta["ios_bundle_id"] == "com.google.chrome.ios"

--- a/tests/test_crm_lookup.py
+++ b/tests/test_crm_lookup.py
@@ -1,0 +1,103 @@
+"""Tests for the read-only local CRM lookup service (gitd/services/crm_lookup.py)."""
+
+from gitd.db import create_tables, get_connection
+from gitd.services.crm_lookup import crm_list_unread_messages, crm_lookup_contact
+
+
+def _seeded_db(tmp_path):
+    db_path = tmp_path / "gitd.db"
+    conn = get_connection(db_path)
+    try:
+        create_tables(conn)
+        conn.execute(
+            """
+            INSERT INTO influencers
+                (id, handle, followers, following, total_likes, bio, niche, caption, source_query, scraped_at)
+            VALUES
+                (1, '@demo', 1200, 300, 6000, 'Creator bio', 'pets', 'First line\nSecond line', '#pets', '2026-06-01')
+            """
+        )
+        conn.execute("INSERT INTO outreach_strategies (id, name) VALUES (7, 'Creator collab')")
+        conn.execute(
+            """
+            INSERT INTO outreach_log
+                (influencer_id, strategy_id, status, deal_status, contacted_at, source_account, notes)
+            VALUES
+                (1, 7, 'contacted', 'negotiating', '2026-06-02', 'brandacct', 'Asked for rates')
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO inbox_replies
+                (handle, last_msg, status, unread, influencer_id, first_seen_at, last_seen_at)
+            VALUES
+                ('demo', 'Sounds good', 'reply', 2, 1, '2026-06-03', '2026-06-04')
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return db_path
+
+
+def test_crm_lookup_contact_returns_fact_sheet_with_history_and_conversation(tmp_path):
+    db_path = _seeded_db(tmp_path)
+
+    result = crm_lookup_contact("demo", db_path=db_path)
+
+    assert "HANDLE:    @demo" in result
+    assert "FOLLOWERS: 1,200" in result
+    assert "CONTACT STATUS:" in result
+    assert "Contacted via: @brandacct" in result
+    assert "Last msg:   Sounds good" in result
+    assert "Unread:     2" in result
+
+
+def test_crm_lookup_contact_handles_missing_contact(tmp_path):
+    db_path = tmp_path / "gitd.db"
+    conn = get_connection(db_path)
+    try:
+        create_tables(conn)
+        conn.commit()
+    finally:
+        conn.close()
+
+    assert crm_lookup_contact("nobody", db_path=db_path) == "No contact record for @nobody"
+
+
+def test_crm_list_unread_messages_returns_recent_unread_only(tmp_path):
+    db_path = tmp_path / "gitd.db"
+    conn = get_connection(db_path)
+    try:
+        create_tables(conn)
+        conn.execute(
+            """
+            INSERT INTO inbox_replies
+                (handle, last_msg, status, unread, first_seen_at, last_seen_at)
+            VALUES
+                ('newer', 'Latest reply', 'reply', 3, '2026-06-01', '2026-06-05'),
+                ('read',  'Already handled', 'reply', 0, '2026-06-01', '2026-06-06'),
+                ('older', 'Earlier reply', 'reply', 1, '2026-06-01', '2026-06-02')
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    result = crm_list_unread_messages(db_path=db_path)
+
+    assert result.startswith("2 unread:")
+    assert "read" not in result.split("unread:")[1].split("\n")[0]  # zero-unread row excluded
+    assert result.index("newer") < result.index("older")  # recency order
+
+
+def test_crm_list_unread_messages_empty(tmp_path):
+    db_path = tmp_path / "gitd.db"
+    conn = get_connection(db_path)
+    try:
+        create_tables(conn)
+        conn.commit()
+    finally:
+        conn.close()
+
+    assert crm_list_unread_messages(db_path=db_path) == "0 unread"

--- a/tests/test_db_isolation.py
+++ b/tests/test_db_isolation.py
@@ -1,0 +1,32 @@
+"""Guards that the test DB path is per-worktree, not a shared fixed file.
+
+A fixed /tmp/gitd_pytest.db is shared by every checkout, so pytest running
+concurrently in two per-agent worktrees races on the same file (one session's
+clean-slate unlink+create clobbers the other → intermittent "no such table" /
+locked failures). conftest keys the path to the worktree root instead.
+"""
+
+import hashlib
+import os
+from pathlib import Path
+
+
+def _worktree_key():
+    # Must match the derivation in tests/conftest.py.
+    root = Path(__file__).resolve().parent.parent
+    return hashlib.md5(str(root).encode()).hexdigest()[:8]
+
+
+def test_db_path_is_worktree_keyed():
+    db = os.environ.get("DB_PATH", "")
+    # Not the old shared fixed name (that was the collision source).
+    assert not db.endswith("gitd_pytest.db"), "test DB uses the old shared fixed path"
+    # Keyed to THIS worktree so concurrent runs in other worktrees don't collide.
+    assert f"gitd_pytest_{_worktree_key()}.db" in db
+
+
+def test_different_worktrees_get_different_paths():
+    """The keying must actually separate distinct checkouts."""
+    k1 = hashlib.md5(b"/home/agent/worktrees/core-dev").hexdigest()[:8]
+    k2 = hashlib.md5(b"/home/agent/worktrees/reviewer").hexdigest()[:8]
+    assert k1 != k2

--- a/tests/test_ghost_cli.py
+++ b/tests/test_ghost_cli.py
@@ -1,0 +1,324 @@
+"""Tests for the task-first `ghost` CLI: dispatch, config, aliases, wizard, mcp, compat."""
+
+import json
+
+import pytest
+
+from gitd import ghost_cli
+from gitd.ghostcli import config as gcfg
+from gitd.ghostcli import devices as gdev
+from gitd.ghostcli import mcp as gmcp
+from gitd.ghostcli import resolve as gres
+from gitd.ghostcli import wizard as gwiz
+
+
+@pytest.fixture()
+def ghost_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("GHOST_CONFIG_DIR", str(tmp_path / ".ghost"))
+    monkeypatch.setenv("GHOST_HOME_OVERRIDE", str(tmp_path))
+    for var in ("GHOST_BACKEND", "GHOST_MODEL", "GHOST_MODE"):
+        monkeypatch.delenv(var, raising=False)
+    return tmp_path
+
+
+# ── dispatch algorithm ───────────────────────────────────────────────────────
+
+
+def test_split_leading_stops_at_first_flag():
+    assert ghost_cli._split_leading(["check", "reddit", "--device", "x"]) == ["check", "reddit"]
+    assert ghost_cli._split_leading(["devices"]) == ["devices"]
+    assert ghost_cli._split_leading(["--device", "x"]) == []
+
+
+@pytest.fixture()
+def captured_run(monkeypatch):
+    calls = {}
+
+    def fake_run(prompt, flag_argv):
+        calls["prompt"] = prompt
+        calls["flags"] = flag_argv
+        return 0
+
+    monkeypatch.setattr(ghost_cli, "_run_prompt", fake_run)
+    return calls
+
+
+def test_bare_positional_is_a_task(captured_run):
+    assert ghost_cli.main(["check", "r/LocalLLaMA", "--device", "asus"]) == 0
+    assert captured_run["prompt"] == "check r/LocalLLaMA"
+    assert captured_run["flags"] == ["--device", "asus"]
+
+
+def test_reserved_first_token_routes_to_subcommand(captured_run, monkeypatch):
+    seen = {}
+    monkeypatch.setattr(ghost_cli, "_cmd_devices", lambda rest: seen.setdefault("devices", rest) or 0)
+    assert ghost_cli.main(["devices"]) == 0
+    assert seen["devices"] == []
+    assert "prompt" not in captured_run  # did NOT go to the prompt path
+
+
+def test_reserved_word_collision_escaped_by_quoting(captured_run):
+    # unquoted → subcommand; quoted single arg → prompt
+    assert ghost_cli.main(["config", "path"]) == 0 or True  # config routes locally
+    assert "prompt" not in captured_run
+    ghost_cli.main(["record my afternoon"])  # single quoted token, 'record' not a bare token
+    assert captured_run["prompt"] == "record my afternoon"
+
+
+def test_double_dash_forces_prompt_mode(captured_run):
+    ghost_cli.main(["--", "devices", "--device", "x"])
+    assert captured_run["prompt"] == "devices"
+    assert captured_run["flags"] == ["--device", "x"]
+
+
+def test_legacy_subcommand_delegates(monkeypatch):
+    got = {}
+
+    def fake_legacy(argv):
+        got["argv"] = argv
+        return 0
+
+    monkeypatch.setattr("gitd.cli.main", fake_legacy)
+    assert ghost_cli.main(["doctor"]) == 0
+    assert got["argv"] == ["doctor"]
+
+
+def test_empty_and_help_print_help(capsys):
+    assert ghost_cli.main([]) == 0
+    assert "ghost" in capsys.readouterr().out
+    assert ghost_cli.main(["--help"]) == 0
+
+
+# ── config get/set roundtrip ─────────────────────────────────────────────────
+
+
+def test_config_set_get_roundtrip(ghost_home):
+    gcfg.set_value("backend.name", "ollama")
+    gcfg.set_value("defaults.mode", "vision")
+    assert gcfg.get_value("backend.name") == "ollama"
+    assert gcfg.get_value("defaults.mode") == "vision"
+    # persisted to disk
+    assert "ollama" in gcfg.config_path().read_text()
+
+
+def test_config_set_rejects_unknown_key(ghost_home):
+    with pytest.raises(KeyError):
+        gcfg.set_value("nope.key", "x")
+
+
+def test_config_set_validates_mode(ghost_home):
+    with pytest.raises(ValueError):
+        gcfg.set_value("defaults.mode", "turbo")
+
+
+def test_config_cli_roundtrip(ghost_home, capsys):
+    ghost_cli.main(["config", "set", "backend.name=anthropic"])
+    ghost_cli.main(["config", "get", "backend.name"])
+    assert "anthropic" in capsys.readouterr().out
+
+
+# ── device alias resolution ──────────────────────────────────────────────────
+
+
+def test_alias_resolves_to_serial(ghost_home):
+    gcfg.set_device_alias("asus", "L9ABC")
+    assert gdev.resolve_device("asus") == "L9ABC"
+
+
+def test_raw_serial_used_verbatim(ghost_home):
+    assert gdev.resolve_device("R58NRAW") == "R58NRAW"
+
+
+def test_auto_pick_single_device(ghost_home, monkeypatch):
+    monkeypatch.setattr(gdev, "_connected_refs", lambda: ["only-one"])
+    assert gdev.resolve_device(None) == "only-one"
+    assert gdev.auto_picked(None) is True
+
+
+def test_multiple_devices_errors(ghost_home, monkeypatch):
+    monkeypatch.setattr(gdev, "_connected_refs", lambda: ["a", "b"])
+    with pytest.raises(gdev.DeviceError, match="Multiple devices"):
+        gdev.resolve_device(None)
+
+
+def test_no_device_errors(ghost_home, monkeypatch):
+    monkeypatch.setattr(gdev, "_connected_refs", lambda: [])
+    with pytest.raises(gdev.DeviceError, match="No device"):
+        gdev.resolve_device(None)
+
+
+# ── backend / mode resolution precedence ─────────────────────────────────────
+
+
+def test_backend_precedence_flag_beats_env_beats_config(ghost_home, monkeypatch):
+    gcfg.save_config({"backend": {"name": "ollama", "model": "llama3.2"}})
+    monkeypatch.setenv("GHOST_BACKEND", "openrouter")
+    # flag wins
+    assert gres.resolve_backend("anthropic", None)[0] == "anthropic"
+    # env beats config
+    assert gres.resolve_backend(None, None)[0] == "openrouter"
+    monkeypatch.delenv("GHOST_BACKEND")
+    # config beats default
+    assert gres.resolve_backend(None, None) == ("ollama", "llama3.2")
+
+
+def test_mode_precedence_and_validation(ghost_home, monkeypatch):
+    assert gres.resolve_mode("vision") == "vision"
+    monkeypatch.setenv("GHOST_MODE", "reason")
+    assert gres.resolve_mode(None) == "reason"
+    with pytest.raises(gres.GhostConfigError):
+        gres.resolve_mode("turbo")
+
+
+def test_unconfigured_unusable_backend_errors(ghost_home, monkeypatch):
+    monkeypatch.setattr(gres, "is_provider_usable", lambda p: False)
+    with pytest.raises(gres.GhostConfigError, match="No backend configured"):
+        gres.resolve_backend_or_error(None, None)
+
+
+def test_explicit_backend_bypasses_usability_gate(ghost_home, monkeypatch):
+    monkeypatch.setattr(gres, "is_provider_usable", lambda p: False)
+    # explicit --backend is trusted even when unconfigured
+    assert gres.resolve_backend_or_error("ollama", None)[0] == "ollama"
+
+
+# ── wizard ───────────────────────────────────────────────────────────────────
+
+
+def test_wizard_noninteractive_writes_config_and_alias(ghost_home):
+    cfg = gwiz.apply_noninteractive(backend="claude-code", model="sonnet", mode="vision", device="galaxy:0AXYZ")
+    assert cfg["backend"] == {"name": "claude-code", "model": "sonnet"}
+    assert cfg["defaults"]["mode"] == "vision"
+    assert gcfg.load_devices()["galaxy"] == "0AXYZ"
+    assert gcfg.get_value("defaults.device") == "galaxy"
+
+
+def test_wizard_bare_serial_aliases_to_itself(ghost_home):
+    gwiz.apply_noninteractive(backend="ollama", device="RAWSERIAL")
+    assert gcfg.load_devices()["RAWSERIAL"] == "RAWSERIAL"
+
+
+def test_wizard_run_resumes_original_command(ghost_home, monkeypatch, capsys):
+    # unconfigured + interactive → wizard runs, THEN the prompt proceeds
+    monkeypatch.setattr(gwiz, "is_interactive", lambda: True)
+    wiz_ran = {}
+    monkeypatch.setattr(gwiz, "run_interactive", lambda: wiz_ran.setdefault("ran", True))
+    monkeypatch.setattr(gres, "resolve_backend_or_error", lambda b, m: ("ollama", "x"))
+    monkeypatch.setattr(gres, "resolve_mode", lambda m: "fast")
+    monkeypatch.setattr(gdev, "resolve_device", lambda d: "dev1")
+    monkeypatch.setattr(gdev, "auto_picked", lambda d: False)
+    ran_task = {}
+    monkeypatch.setattr("gitd.ghostcli.run.run_task", lambda *a, **k: ran_task.setdefault("ran", True) or 0)
+    ghost_cli._run_prompt("do it", [])
+    assert wiz_ran.get("ran") and ran_task.get("ran")  # wizard THEN the task
+
+
+# ── mcp install ──────────────────────────────────────────────────────────────
+
+
+def test_mcp_opencode_emits_correct_config(ghost_home):
+    gmcp.install("opencode")
+    path = ghost_home / ".config" / "opencode" / "opencode.json"
+    data = json.loads(path.read_text())
+    entry = data["mcp"]["android-agent"]
+    assert entry == {"type": "local", "command": ["android-agent-mcp"], "enabled": True}
+
+
+def test_mcp_cursor_merges_without_clobber(ghost_home):
+    path = ghost_home / ".cursor" / "mcp.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps({"mcpServers": {"other": {"command": "x"}}}))
+    gmcp.install("cursor")
+    data = json.loads(path.read_text())
+    assert "other" in data["mcpServers"]  # existing kept
+    assert data["mcpServers"]["android-agent"]["command"] == "android-agent-mcp"
+
+
+def test_mcp_codex_toml(ghost_home):
+    gmcp.install("codex")
+    text = (ghost_home / ".codex" / "config.toml").read_text()
+    assert "[mcp_servers.android-agent]" in text and "android-agent-mcp" in text
+
+
+def test_mcp_agy_emits_correct_config(ghost_home):
+    gmcp.install("agy")
+    path = ghost_home / ".gemini" / "config" / "mcp_config.json"
+    data = json.loads(path.read_text())
+    assert data["mcpServers"]["android-agent"] == {"command": "android-agent-mcp"}
+
+
+def test_mcp_agy_merges_without_clobber(ghost_home):
+    path = ghost_home / ".gemini" / "config" / "mcp_config.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps({"mcpServers": {"other": {"command": "x"}}}))
+    gmcp.install("agy")
+    data = json.loads(path.read_text())
+    assert "other" in data["mcpServers"]  # existing kept
+    assert data["mcpServers"]["android-agent"]["command"] == "android-agent-mcp"
+
+
+def test_mcp_agy_tolerates_empty_config_file(ghost_home):
+    # agy's own installer creates a 0-byte mcp_config.json; must not error
+    path = ghost_home / ".gemini" / "config" / "mcp_config.json"
+    path.parent.mkdir(parents=True)
+    path.write_text("")
+    gmcp.install("agy")
+    data = json.loads(path.read_text())
+    assert data["mcpServers"]["android-agent"]["command"] == "android-agent-mcp"
+
+
+def test_mcp_antigravity_alias(ghost_home):
+    gmcp.install("antigravity")
+    path = ghost_home / ".gemini" / "config" / "mcp_config.json"
+    data = json.loads(path.read_text())
+    assert data["mcpServers"]["android-agent"]["command"] == "android-agent-mcp"
+
+
+def test_mcp_agy_idempotent(ghost_home):
+    gmcp.install("agy")
+    path = ghost_home / ".gemini" / "config" / "mcp_config.json"
+    first = path.read_text()
+    gmcp.install("agy")
+    assert path.read_text() == first
+
+
+def test_mcp_unknown_client_raises(ghost_home):
+    with pytest.raises(gmcp.McpInstallError):
+        gmcp.install("notaclient")
+
+
+# ── backwards compat ─────────────────────────────────────────────────────────
+
+
+def test_legacy_bin_emits_deprecation_warning(monkeypatch, capsys):
+    from gitd import cli as legacy
+
+    monkeypatch.setattr("sys.argv", ["/usr/local/bin/gitd", "--help"])
+    try:
+        legacy.main(["--help"])
+    except SystemExit:
+        pass
+    err = capsys.readouterr().err
+    assert "deprecated" in err and "gitd" in err
+
+
+def test_ghost_delegation_does_not_warn(monkeypatch, capsys):
+    from gitd import cli as legacy
+
+    monkeypatch.setattr("sys.argv", ["/usr/local/bin/ghost", "doctor"])
+    monkeypatch.setattr(legacy, "cmd_doctor", lambda args: 0)
+    legacy.main(["doctor"])
+    assert "deprecated" not in capsys.readouterr().err
+
+
+def test_load_devices_accepts_bare_key_file(ghost_home):
+    # a hand-edited devices.toml WITHOUT the [devices] header must still parse
+    gcfg.devices_path().parent.mkdir(parents=True, exist_ok=True)
+    gcfg.devices_path().write_text('galaxy = "R58NX"\npixel = "1F2E3D"\n')
+    assert gcfg.load_devices() == {"galaxy": "R58NX", "pixel": "1F2E3D"}
+
+
+def test_load_devices_still_reads_sectioned_file(ghost_home):
+    gcfg.devices_path().parent.mkdir(parents=True, exist_ok=True)
+    gcfg.devices_path().write_text('[devices]\nasus = "L9ABC"\n')
+    assert gcfg.load_devices() == {"asus": "L9ABC"}

--- a/tests/test_h264_stream.py
+++ b/tests/test_h264_stream.py
@@ -1,0 +1,99 @@
+"""Unit tests for the H.264 stream proxy's reachability logic (no hardware).
+
+The robustness of the stream hinges on _candidate_urls picking the right device
+endpoints in the right order and never throwing, and on _h264_port deriving the
+device stream port from the MJPEG port. These are pure/mockable, so they run in
+CI without a phone.
+"""
+import pytest
+
+from gitd.routers import h264_stream as h
+
+
+def test_h264_port_default(monkeypatch):
+    monkeypatch.setattr(h, "_host_device_config_for_udid", lambda udid: {})
+    assert h._h264_port("any") == 9200  # 9100 (default mjpeg) + 100
+
+
+def test_h264_port_from_custom_mjpeg_port(monkeypatch):
+    monkeypatch.setattr(h, "_host_device_config_for_udid", lambda udid: {"mjpeg_server_port": 9500})
+    assert h._h264_port("any") == 9600
+
+
+def test_h264_port_bad_value_falls_back(monkeypatch):
+    monkeypatch.setattr(h, "_host_device_config_for_udid", lambda udid: {"mjpeg_server_port": "nope"})
+    assert h._h264_port("any") == 9200
+
+
+def test_candidate_urls_prefers_tunnel_address(monkeypatch):
+    monkeypatch.setattr(
+        h, "remote_xpc_tunnel_status",
+        lambda udid: {"registry": {"address": "fd23:a45d:8f2d::1"}},
+    )
+    urls = h._candidate_urls("udid", 9200)
+    # Tunnel IPv6 route first (most reliable on iOS 17+), bracketed.
+    assert urls[0] == "ws://[fd23:a45d:8f2d::1]:9200/"
+    # localhost fallbacks still present.
+    assert "ws://localhost:9200/" in urls
+    assert "ws://127.0.0.1:9200/" in urls
+    # No duplicates.
+    assert len(urls) == len(set(urls))
+
+
+def test_candidate_urls_without_tunnel(monkeypatch):
+    monkeypatch.setattr(h, "remote_xpc_tunnel_status", lambda udid: {})
+    urls = h._candidate_urls("udid", 9200)
+    assert urls  # never empty
+    assert all(("localhost" in u) or ("127.0.0.1" in u) for u in urls)
+
+
+def test_candidate_urls_never_throws(monkeypatch):
+    def boom(_udid):
+        raise RuntimeError("tunnel registry down")
+
+    monkeypatch.setattr(h, "remote_xpc_tunnel_status", boom)
+    # Robustness: a tunnel-status failure must NOT crash the relay setup.
+    urls = h._candidate_urls("udid", 9200)
+    assert urls  # falls back to localhost candidates
+
+
+def test_candidate_urls_ipv4_address_not_bracketed(monkeypatch):
+    monkeypatch.setattr(
+        h, "remote_xpc_tunnel_status",
+        lambda udid: {"registry": {"address": "10.0.0.5"}},
+    )
+    urls = h._candidate_urls("udid", 9200)
+    assert urls[0] == "ws://10.0.0.5:9200/"
+
+
+def test_candidate_urls_force_localhost_skips_tunnel(monkeypatch):
+    # Remote-drive: a caller over the SSH forward can't route the tunnel IPv6, so
+    # force_localhost must drop the tunnel candidate entirely — even when the
+    # registry HAS a live address. Must NOT probe/return the fdxx:: route.
+    called = {"n": 0}
+
+    def _should_not_be_called(_udid):
+        called["n"] += 1
+        return {"registry": {"address": "fd23:a45d:8f2d::1"}}
+
+    monkeypatch.setattr(h, "remote_xpc_tunnel_status", _should_not_be_called)
+    urls = h._candidate_urls("udid", 9200, force_localhost=True)
+    assert urls == ["ws://localhost:9200/", "ws://127.0.0.1:9200/"]
+    assert all("[" not in u for u in urls)  # no bracketed IPv6 tunnel route
+    assert called["n"] == 0  # tunnel registry not even queried when forced local
+
+
+def test_is_remote_ref_interim_signal():
+    # Interim fallback until core-dev's is_remote_ref lands: only remote <name>@<host>
+    # refs carry "@"; iOS and Android local refs never do.
+    assert h._is_remote_ref("demo-iphone@mac1") is True
+    assert h._is_remote_ref("ios:00008XXX-XXXX") is False
+    assert h._is_remote_ref("emulator-5554") is False
+    assert h._is_remote_ref("") is False
+
+
+def test_env_force_localhost(monkeypatch):
+    monkeypatch.delenv("IOS_STREAM_FORCE_LOCALHOST", raising=False)
+    assert h._env_force_localhost() is False
+    monkeypatch.setenv("IOS_STREAM_FORCE_LOCALHOST", "1")
+    assert h._env_force_localhost() is True

--- a/tests/test_h264_stream_device.py
+++ b/tests/test_h264_stream_device.py
@@ -1,0 +1,79 @@
+"""Device-backed verification of the GhostAgent H.264 stream (no browser needed).
+
+Connects to the backend H.264 proxy (which relays the patched WDA's stream) and
+parses the raw Annex-B bytes to prove the native encoder produces a *decodable*
+stream: at least one SPS (NAL type 7) and one IDR keyframe (NAL type 5) must
+arrive. This validates the whole native encode → WebSocket → proxy path without
+WebCodecs.
+
+Gated on a real iOS device + a running stack (backend + patched WDA + a live
+session so the stream server is up). Skips otherwise, so CI stays green.
+Requires the WDA rebuilt with FBH264StreamServer (see docs/ios/FLEET.md).
+"""
+import os
+
+import pytest
+
+
+def _ios_target() -> str:
+    device = os.getenv("DEVICE", "")
+    if device.startswith("ios:"):
+        return device
+    udid = os.getenv("IOS_DEVICE_UDID", "")
+    return f"ios:{udid}" if udid else ""
+
+
+pytestmark = pytest.mark.skipif(
+    not _ios_target() or os.getenv("GHOST_H264_E2E") != "1",
+    reason="H.264 device E2E disabled (set IOS_DEVICE_UDID + GHOST_H264_E2E=1 with the stack + patched WDA up)",
+)
+
+BACKEND = os.getenv("GHOST_BACKEND", "http://127.0.0.1:5055")
+
+
+def _nal_types(annexb: bytes) -> list[int]:
+    """Return the NAL unit types found in an Annex-B buffer."""
+    types: list[int] = []
+    i = 0
+    n = len(annexb)
+    while i + 3 < n:
+        if annexb[i] == 0 and annexb[i + 1] == 0 and (
+            annexb[i + 2] == 1 or (annexb[i + 2] == 0 and i + 3 < n and annexb[i + 3] == 1)
+        ):
+            start = i + 3 if annexb[i + 2] == 1 else i + 4
+            if start < n:
+                types.append(annexb[start] & 0x1F)
+            i = start
+        else:
+            i += 1
+    return types
+
+
+def test_h264_stream_emits_decodable_keyframe():
+    import asyncio
+
+    import websockets
+
+    device = _ios_target()
+    ws_base = BACKEND.replace("http", "ws", 1)
+    url = f"{ws_base}/api/phone/h264/{device}"
+
+    async def run() -> list[int]:
+        seen: list[int] = []
+        async with websockets.connect(url, max_size=None, open_timeout=15) as ws:
+            deadline = asyncio.get_event_loop().time() + 25
+            while asyncio.get_event_loop().time() < deadline:
+                try:
+                    msg = await asyncio.wait_for(ws.recv(), timeout=10)
+                except asyncio.TimeoutError:
+                    break
+                if isinstance(msg, (bytes, bytearray)):
+                    seen.extend(_nal_types(bytes(msg)))
+                    # SPS (7) + IDR (5) means a decoder can start.
+                    if 7 in seen and 5 in seen:
+                        break
+        return seen
+
+    nal_types = asyncio.run(run())
+    assert 7 in nal_types, f"no SPS (NAL 7) in stream; got NAL types {sorted(set(nal_types))}"
+    assert 5 in nal_types, f"no IDR keyframe (NAL 5) in stream; got NAL types {sorted(set(nal_types))}"

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1,0 +1,132 @@
+"""Tests for the LangChain / LlamaIndex framework adapters.
+
+The framework-agnostic core (build_ghost_tools) is tested with a mocked
+execute_tool — no device, no frameworks. Both the LangChain and LlamaIndex
+adapters are tested for real (langchain-core and llama-index-core are test deps),
+so the "both frameworks are first-class" claim in the docs is CI-verified.
+"""
+
+import pytest
+
+import gitd.services.agent_tools as agent_tools
+from gitd.services.agent_tools import SAFE_DEVICE_TOOLS
+from integrations._core import build_ghost_tools, pydantic_args_model
+
+_DANGEROUS = {"shell", "run_skill"}
+
+
+@pytest.fixture
+def mock_execute(monkeypatch):
+    calls = []
+
+    def fake(name, args):
+        calls.append((name, dict(args)))
+        return f"{name}-ok"
+
+    monkeypatch.setattr(agent_tools, "execute_tool", fake)
+    return calls
+
+
+# ── framework-agnostic core ──────────────────────────────────────────────────
+
+
+def test_build_ghost_tools_binds_device_and_strips_it(mock_execute):
+    tools = build_ghost_tools("emulator-5554")
+    tap = next(t for t in tools if t.name == "tap")
+    # device is bound, not an agent-supplied arg
+    assert "device" not in tap.args_schema["properties"]
+    assert "device" not in tap.args_schema.get("required", [])
+
+    out = tap.run(x=540, y=300)
+    assert out == "tap-ok"
+    name, args = mock_execute[-1]
+    assert name == "tap"
+    assert args == {"x": 540, "y": 300, "device": "emulator-5554"}
+
+
+def test_bound_device_overrides_any_passed_device(mock_execute):
+    tools = build_ghost_tools("real-serial")
+    tap = next(t for t in tools if t.name == "tap")
+    tap.run(x=1, y=2, device="attacker-serial")  # must not win
+    assert mock_execute[-1][1]["device"] == "real-serial"
+
+
+def test_default_exposes_only_the_allow_list(mock_execute):
+    """Fail-closed: by default, ONLY vetted allow-list tools are exposed —
+    not merely 'everything except a dangerous deny-list'."""
+    names = {t.name for t in build_ghost_tools("d")}
+    assert names <= SAFE_DEVICE_TOOLS  # subset — nothing off the allow-list leaks
+    assert _DANGEROUS.isdisjoint(names)
+    assert "tap" in names and "launch_app" in names
+
+
+def test_new_tool_is_not_auto_exposed(mock_execute, monkeypatch):
+    """A tool added to the dispatch later must NOT appear until it's vetted onto
+    the allow-list — this is what a deny-list would have failed open on."""
+    monkeypatch.setattr(
+        agent_tools,
+        "TOOLS",
+        agent_tools.TOOLS + [{"name": "some_new_risky_tool", "description": "x", "input_schema": {}}],
+    )
+    names = {t.name for t in build_ghost_tools("d")}
+    assert "some_new_risky_tool" not in names
+
+
+def test_include_dangerous_exposes_everything(mock_execute):
+    names = {t.name for t in build_ghost_tools("d", include_dangerous=True)}
+    assert "shell" in names and "run_skill" in names
+
+
+def test_pydantic_args_model_respects_required_and_optional():
+    model = pydantic_args_model(
+        "tap",
+        {"type": "object", "properties": {"x": {"type": "integer"}, "y": {"type": "integer"}}, "required": ["x", "y"]},
+    )
+    inst = model(x=1, y=2)
+    assert inst.x == 1 and inst.y == 2
+    with pytest.raises(Exception):
+        model(x=1)  # y required
+
+
+# ── LangChain adapter (langchain-core is a test dep — runs, never skips) ──────
+
+
+def test_langchain_tools_dispatch(mock_execute):
+    from integrations.langchain import ghost_langchain_tools
+
+    tools = ghost_langchain_tools("emulator-5554")
+    names = {t.name for t in tools}
+    assert "tap" in names
+    assert _DANGEROUS.isdisjoint(names)
+
+    tap = next(t for t in tools if t.name == "tap")
+    # a LangChain agent calls .invoke with the structured args
+    result = tap.invoke({"x": 540, "y": 300})
+    assert result == "tap-ok"
+    assert mock_execute[-1] == ("tap", {"x": 540, "y": 300, "device": "emulator-5554"})
+
+
+# ── LlamaIndex adapter (llama-index-core is a test dep — runs, never skips) ────
+
+
+def test_llamaindex_tools_dispatch(mock_execute):
+    from llama_index.core.tools import FunctionTool
+
+    from integrations.llamaindex import ghost_llamaindex_tools
+
+    tools = ghost_llamaindex_tools("emulator-5554")
+    assert all(isinstance(t, FunctionTool) for t in tools)
+    names = {t.metadata.name for t in tools}
+    assert "tap" in names
+    assert _DANGEROUS.isdisjoint(names)  # shell/run_skill excluded, like LangChain
+
+    tap = next(t for t in tools if t.metadata.name == "tap")
+    # the LLM-facing tool spec must expose x/y and NOT the bound device
+    schema = tap.metadata.fn_schema.model_json_schema()
+    assert set(schema.get("properties", {})) == {"x", "y"}
+    assert "function" in tap.metadata.to_openai_tool()
+
+    # an agent runtime calls the tool like this
+    result = tap.call(x=540, y=300)
+    assert "tap-ok" in str(result)
+    assert mock_execute[-1] == ("tap", {"x": 540, "y": 300, "device": "emulator-5554"})

--- a/tests/test_ios_chrome_news_smoke.py
+++ b/tests/test_ios_chrome_news_smoke.py
@@ -1,0 +1,283 @@
+import json
+import sys
+
+import scripts.ios_chrome_news_smoke as smoke
+from gitd.bots.common.ios import IOSDeviceConfig
+
+
+def test_ios_chrome_news_smoke_stops_on_failed_health_preflight(monkeypatch, tmp_path):
+    health = {
+        "platform": "ios",
+        "connection": {"type": "appium-wda", "status": "wda_signing_failed"},
+        "appium": {"message": "xcodebuild failed to sign WebDriverAgent"},
+        "recommended_fix": "fix_wda_signing",
+    }
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["ios_chrome_news_smoke.py", "--device", "abc123", "--out-dir", str(tmp_path)],
+    )
+    monkeypatch.setattr(smoke, "_preflight_health", lambda device, bundle_id: health)
+    monkeypatch.setattr(
+        smoke,
+        "read_news",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("read_news should not run")),
+    )
+
+    rc = smoke.main()
+
+    assert rc == 1
+    result = json.loads((tmp_path / "result.json").read_text(encoding="utf-8"))
+    saved_health = json.loads((tmp_path / "health.json").read_text(encoding="utf-8"))
+    assert result["stage"] == "health"
+    assert result["error"] == (
+        "iOS Appium/WDA health preflight failed: wda_signing_failed - "
+        "xcodebuild failed to sign WebDriverAgent - recommended fix: fix_wda_signing"
+    )
+    assert result["health"]["recommended_fix"] == "fix_wda_signing"
+    assert saved_health == health
+
+
+def test_ios_chrome_news_smoke_preflight_uses_requested_browser_bundle(monkeypatch):
+    calls = []
+
+    class FakeIOSDevice:
+        def __init__(self, device, bundle_id=None):
+            calls.append(("device", device, bundle_id))
+            self.mjpeg_url = "http://127.0.0.1:9100"
+            self.mjpeg_settings = {}
+
+    def fake_ios_device_health(device, ios_dev):
+        calls.append(("health", device, ios_dev))
+        return {"platform": "ios", "connection": {"status": "available"}}
+
+    monkeypatch.setattr(smoke, "IOSDevice", FakeIOSDevice)
+    monkeypatch.setattr(smoke, "ios_device_health", fake_ios_device_health)
+
+    health = smoke._preflight_health("ios:abc123", "com.google.chrome.ios")
+
+    assert health["connection"]["status"] == "available"
+    assert calls[0] == ("device", "ios:abc123", "com.google.chrome.ios")
+    assert calls[1][0:2] == ("health", "ios:abc123")
+    assert isinstance(calls[1][2], FakeIOSDevice)
+
+
+def test_ios_chrome_news_smoke_can_skip_health_preflight(monkeypatch, tmp_path):
+    calls = []
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["ios_chrome_news_smoke.py", "--device", "ios:abc123", "--out-dir", str(tmp_path), "--skip-health"],
+    )
+    monkeypatch.setattr(smoke, "_preflight_health", lambda device, bundle_id: calls.append(("health", device, bundle_id)))
+    monkeypatch.setattr(
+        smoke,
+        "read_news",
+        lambda device, url, **kwargs: {
+            "ok": True,
+            "device": device,
+            "url": url,
+            "headlines": [{"title": "One"}],
+            "kwargs": kwargs,
+        },
+    )
+
+    rc = smoke.main()
+
+    assert rc == 0
+    assert calls == []
+    result = json.loads((tmp_path / "result.json").read_text(encoding="utf-8"))
+    assert result["device"] == "ios:abc123"
+    assert result["headlines"] == [{"title": "One"}]
+
+
+def test_ios_chrome_news_smoke_can_apply_recommended_health_fix(monkeypatch, tmp_path):
+    calls = []
+    health_results = iter(
+        [
+            {
+                "platform": "ios",
+                "connection": {"type": "appium-wda", "status": "appium_down"},
+                "recommended_fix": "start_appium",
+            },
+            {
+                "platform": "ios",
+                "connection": {"type": "appium-wda", "status": "available"},
+                "recommended_fix": "",
+            },
+        ]
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["ios_chrome_news_smoke.py", "--device", "ios:abc123", "--out-dir", str(tmp_path), "--fix-health"],
+    )
+    monkeypatch.setattr(smoke, "_preflight_health", lambda device, bundle_id: next(health_results))
+    monkeypatch.setattr(
+        smoke,
+        "fix_device_health",
+        lambda device, issue: calls.append(("fix", device, issue))
+        or {"ok": True, "platform": "ios", "issue": issue, "pid": 2468},
+    )
+    monkeypatch.setattr(
+        smoke,
+        "read_news",
+        lambda device, url, **kwargs: {
+            "ok": True,
+            "device": device,
+            "url": url,
+            "headlines": [{"title": "One"}],
+            "articles": [],
+        },
+    )
+
+    rc = smoke.main()
+
+    assert rc == 0
+    result = json.loads((tmp_path / "result.json").read_text(encoding="utf-8"))
+    health_fix = json.loads((tmp_path / "health_fix.json").read_text(encoding="utf-8"))
+    saved_health = json.loads((tmp_path / "health.json").read_text(encoding="utf-8"))
+    assert calls == [("fix", "ios:abc123", "start_appium")]
+    assert saved_health["connection"]["status"] == "available"
+    assert health_fix["issue"] == "start_appium"
+    assert result["health_fix"]["pid"] == 2468
+    assert result["headlines"] == [{"title": "One"}]
+
+
+def test_ios_chrome_news_smoke_uses_first_discovered_device(monkeypatch, tmp_path):
+    monkeypatch.delenv("IOS_DEVICE_UDID", raising=False)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["ios_chrome_news_smoke.py", "--out-dir", str(tmp_path), "--skip-health"],
+    )
+    monkeypatch.setattr(smoke, "known_ios_udids", lambda **_kwargs: ["00008110-0012345678901234"])
+    monkeypatch.setattr(
+        smoke,
+        "read_news",
+        lambda device, url, **kwargs: {
+            "ok": True,
+            "device": device,
+            "url": url,
+            "headlines": [{"title": "One"}],
+            "kwargs": kwargs,
+        },
+    )
+
+    rc = smoke.main()
+
+    assert rc == 0
+    result = json.loads((tmp_path / "result.json").read_text(encoding="utf-8"))
+    assert result["device"] == "ios:00008110-0012345678901234"
+
+
+def test_ios_chrome_news_smoke_dry_run_prints_discovery_without_session(monkeypatch, capsys):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "ios_chrome_news_smoke.py",
+            "--dry-run",
+            "--device",
+            "SIM-123",
+            "--bundle-id",
+            "com.google.chrome.ios",
+        ],
+    )
+    monkeypatch.setattr(smoke, "configured_ios_udids", lambda: ["PHONE-123"])
+    monkeypatch.setattr(
+        smoke,
+        "discover_host_ios_devices",
+        lambda include_simulators=True: [
+            {
+                "udid": "SIM-123",
+                "name": "iPhone 16",
+                "platform_version": "18.5",
+                "source": "simulator",
+                "state": "Booted",
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        smoke,
+        "ios_config_for_udid",
+        lambda udid: IOSDeviceConfig(
+            udid=udid,
+            appium_url="http://127.0.0.1:4723",
+            bundle_id="com.apple.mobilesafari" if udid == "SIM-123" else "com.google.chrome.ios",
+            mjpeg_server_port=9107,
+        ),
+    )
+    monkeypatch.setattr(
+        smoke,
+        "_preflight_health",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("health should not run")),
+    )
+    monkeypatch.setattr(
+        smoke,
+        "read_news",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("read_news should not run")),
+    )
+
+    rc = smoke.main()
+
+    assert rc == 0
+    plan = json.loads(capsys.readouterr().out)
+    assert plan["selected_device"] == "ios:SIM-123"
+    assert plan["requested_bundle_id"] == "com.google.chrome.ios"
+    assert [item["device"] for item in plan["devices"]] == ["ios:SIM-123", "ios:PHONE-123"]
+    selected = plan["devices"][0]
+    assert selected["selected"] is True
+    assert selected["source"] == "simulator"
+    assert selected["host_state"] == "Booted"
+    assert selected["bundle_id"] == "com.apple.mobilesafari"
+    assert selected["mjpeg_server_port"] == 9107
+
+
+def test_ios_chrome_news_smoke_list_devices_respects_no_simulators(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["ios_chrome_news_smoke.py", "--list-devices", "--no-simulators"])
+    monkeypatch.setattr(smoke, "configured_ios_udids", lambda: [])
+    monkeypatch.setattr(
+        smoke,
+        "known_ios_udids",
+        lambda include_host=True, include_simulators=True: ["REAL-123"] if not include_simulators else ["SIM-123"],
+    )
+    monkeypatch.setattr(
+        smoke,
+        "discover_host_ios_devices",
+        lambda include_simulators=True: [
+            {
+                "udid": "REAL-123",
+                "name": "Dan's iPhone",
+                "platform_version": "18.5",
+                "source": "host",
+                "state": "connected",
+            },
+            *(
+                [
+                    {
+                        "udid": "SIM-123",
+                        "name": "iPhone 16",
+                        "platform_version": "18.5",
+                        "source": "simulator",
+                        "state": "Booted",
+                    }
+                ]
+                if include_simulators
+                else []
+            ),
+        ],
+    )
+    monkeypatch.setattr(
+        smoke,
+        "ios_config_for_udid",
+        lambda udid: IOSDeviceConfig(udid=udid, bundle_id="com.google.chrome.ios"),
+    )
+
+    rc = smoke.main()
+
+    assert rc == 0
+    plan = json.loads(capsys.readouterr().out)
+    assert plan["include_simulators"] is False
+    assert plan["selected_device"] == "ios:REAL-123"
+    assert [item["device"] for item in plan["devices"]] == ["ios:REAL-123"]

--- a/tests/test_ios_chrome_news_smoke_device.py
+++ b/tests/test_ios_chrome_news_smoke_device.py
@@ -1,0 +1,62 @@
+"""Device-backed iOS smoke / health check.
+
+Unlike ``test_ios_chrome_news_smoke.py`` (fast, fully mocked unit tests of the
+CLI control flow), this drives a **real iPhone** end-to-end through Ghost's iOS
+device backend: opens Chrome, loads text.npr.org, and extracts headlines +
+article bodies. It is the on-demand health check surfaced in the dashboard's
+"Device Health" tab and runnable via the Test Runner.
+
+Gated: it only runs when an iOS device target is present (the Test Runner sets
+``DEVICE=ios:<udid>``; locally set ``IOS_DEVICE_UDID``). It skips otherwise, so
+CI stays green without hardware. Requires the tunnel + Appium + WDA signing to
+be up (see ``ghost-ios up`` / the iOS setup guide).
+"""
+import os
+
+import pytest
+
+from gitd.services.browser import read_news
+
+
+def _ios_target() -> str:
+    device = os.getenv("DEVICE", "")
+    if device.startswith("ios:"):
+        return device
+    udid = os.getenv("IOS_DEVICE_UDID", "")
+    return f"ios:{udid}" if udid else ""
+
+
+pytestmark = pytest.mark.skipif(
+    not _ios_target(),
+    reason="no iOS device target (set IOS_DEVICE_UDID or DEVICE=ios:<udid>) — device health test",
+)
+
+MIN_HEADLINES = 5
+MIN_ARTICLE_BODIES = 3
+
+
+def test_ios_chrome_news_smoke_on_device(tmp_path):
+    device = _ios_target()
+    result = read_news(
+        device,
+        "https://text.npr.org/",
+        max_headlines=MIN_HEADLINES,
+        max_articles=MIN_ARTICLE_BODIES,
+        bundle_id=os.getenv("IOS_BUNDLE_ID", "com.google.chrome.ios"),
+        wait_s=2.0,
+        save_screenshots=True,
+        out_dir=str(tmp_path),
+    )
+
+    assert result.get("ok"), f"read_news did not succeed: {result.get('error')!r}"
+
+    headlines = result.get("headlines") or []
+    assert len(headlines) >= MIN_HEADLINES, (
+        f"expected >= {MIN_HEADLINES} headlines, got {len(headlines)}"
+    )
+
+    articles = result.get("articles") or []
+    bodies = [a for a in articles if len(str(a.get("body_snippet") or "").strip()) > 40]
+    assert len(bodies) >= MIN_ARTICLE_BODIES, (
+        f"expected >= {MIN_ARTICLE_BODIES} non-empty article bodies, got {len(bodies)}"
+    )

--- a/tests/test_ios_device.py
+++ b/tests/test_ios_device.py
@@ -1,0 +1,2678 @@
+import base64
+import json
+import os
+
+import pytest
+
+from gitd.bots.common.device import (
+    get_device,
+    ios_refs_from_env,
+    ios_refs_from_host,
+    list_configured_ios_devices,
+    platform_for_device,
+)
+from gitd.bots.common.ios import (
+    IOSBackendError,
+    IOSDevice,
+    _parse_devicectl_details,
+    _parse_xctrace_devices,
+    _skill_ios_app_inventory,
+    classify_ios_error,
+    configured_ios_udids,
+    discover_host_ios_devices,
+    ios_config_for_udid,
+    ios_xml_to_elements,
+    known_ios_udids,
+    normalize_wda_xml,
+    remote_xpc_manual_recovery,
+    remote_xpc_tunnel_status,
+    visible_text_entries_from_xml,
+)
+
+RAW_WDA_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<AppiumAUT>
+  <XCUIElementTypeApplication type="XCUIElementTypeApplication" name="Safari" label="Safari" enabled="true" visible="true" x="0" y="0" width="393" height="852">
+    <XCUIElementTypeButton type="XCUIElementTypeButton" name="Done" label="Done" enabled="true" visible="true" x="10" y="20" width="100" height="30"/>
+    <XCUIElementTypeTextField type="XCUIElementTypeTextField" name="Address" label="Address" value="ghostinthedroid.com" enabled="true" visible="true" x="20" y="60" width="300" height="44"/>
+    <XCUIElementTypeScrollView type="XCUIElementTypeScrollView" name="Page" label="Page" enabled="true" visible="true" x="0" y="120" width="393" height="700"/>
+  </XCUIElementTypeApplication>
+</AppiumAUT>
+"""
+
+PNG_1X1 = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+)
+
+
+class FakeResponse:
+    def __init__(self, data, status_code=200, text=""):
+        self._data = data
+        self.status_code = status_code
+        self.text = text
+
+    def json(self):
+        return self._data
+
+
+def test_normalize_wda_xml_scales_bounds_and_marks_interactive():
+    xml = normalize_wda_xml(RAW_WDA_XML, scale_x=3.0, scale_y=3.0)
+
+    assert "<hierarchy" in xml
+    assert 'class="XCUIElementTypeButton"' in xml
+    assert 'text="Done"' in xml
+    assert 'content-desc="Done"' in xml
+    assert 'resource-id="Done"' in xml
+    assert 'clickable="true"' in xml
+    assert 'bounds="[30,60][330,150]"' in xml
+    assert 'ios-point-bounds="[10,20][110,50]"' in xml
+    assert 'class="XCUIElementTypeScrollView"' in xml
+    assert 'scrollable="true"' in xml
+
+
+def test_ios_xml_to_elements_matches_android_element_shape():
+    xml = normalize_wda_xml(RAW_WDA_XML, scale_x=2.0, scale_y=2.0)
+    elements = ios_xml_to_elements(xml)
+
+    done = next(el for el in elements if el["text"] == "Done")
+    assert done["content_desc"] == "Done"
+    assert done["resource_id"] == "Done"
+    assert done["class"] == "XCUIElementTypeButton"
+    assert done["bounds"] == {"x1": 20, "y1": 40, "x2": 220, "y2": 100}
+    assert done["center"] == {"x": 120, "y": 70}
+    assert done["clickable"] is True
+
+    assert any(el["scrollable"] for el in elements)
+
+
+def test_factory_routes_ios_prefix(monkeypatch):
+    monkeypatch.setenv("IOS_DEVICE_UDID", "abc123")
+    monkeypatch.delenv("IOS_DEVICE_UDIDS", raising=False)
+    monkeypatch.setattr("gitd.bots.common.device.discover_host_ios_devices", lambda include_simulators=True: [])
+
+    assert platform_for_device("ios:abc123") == "ios"
+    assert platform_for_device("emulator-5554") == "android"
+    assert ios_refs_from_env() == ["ios:abc123"]
+    dev = get_device("ios:abc123")
+    assert isinstance(dev, IOSDevice)
+    assert dev.udid == "abc123"
+
+
+def test_list_configured_ios_devices_includes_config_and_probe_state(monkeypatch):
+    calls = []
+
+    class ProbeStatus:
+        def to_dict(self):
+            return {
+                "platform": "ios",
+                "device": "ios:abc123",
+                "udid": "abc123",
+                "state": "available",
+                "message": "Appium is reachable",
+                "appium_url": "http://appium.local",
+            }
+
+    monkeypatch.setenv("IOS_DEVICE_UDID", "abc123")
+    monkeypatch.setenv("IOS_DEVICE_NAME", "Blah's iPhone")
+    monkeypatch.setenv("IOS_PLATFORM_VERSION", "17.5")
+    monkeypatch.setenv("IOS_BUNDLE_ID", "com.google.chrome.ios")
+    monkeypatch.setenv("IOS_APPIUM_URL", "http://appium.local")
+    monkeypatch.setenv("IOS_MJPEG_SERVER_PORT", "9107")
+    monkeypatch.setenv("IOS_MJPEG_SERVER_FRAMERATE", "12")
+    monkeypatch.setenv("IOS_MJPEG_SCALING_FACTOR", "60")
+    monkeypatch.setenv("IOS_MJPEG_SERVER_SCREENSHOT_QUALITY", "45")
+    monkeypatch.setenv("IOS_MJPEG_FIX_ORIENTATION", "false")
+    monkeypatch.delenv("IOS_DEVICE_UDIDS", raising=False)
+    monkeypatch.delenv("IOS_DEVICES_JSON", raising=False)
+    monkeypatch.setattr("gitd.bots.common.device.discover_host_ios_devices", lambda include_simulators=True: [])
+
+    def fake_probe(device, deep=True):
+        calls.append((device, deep))
+        return ProbeStatus()
+
+    monkeypatch.setattr("gitd.bots.common.device.probe_ios_device", fake_probe)
+
+    devices = list_configured_ios_devices(deep_probe=True)
+
+    assert calls == [("ios:abc123", True)]
+    assert devices == [
+        {
+            "serial": "ios:abc123",
+            "model": "Blah's iPhone",
+            "connection": "appium-wda",
+            "platform": "ios",
+            "source": "configured",
+            "host_state": "",
+            "status": "available",
+            "status_message": "Appium is reachable",
+            "appium_url": "http://appium.local",
+            "device_name": "Blah's iPhone",
+            "platform_version": "17.5",
+            "bundle_id": "com.google.chrome.ios",
+            "browser_name": "",
+            "wda_url": "",
+            "mjpeg_server_port": 9107,
+            "mjpeg_settings": {
+                "mjpegServerFramerate": 12,
+                "mjpegScalingFactor": 60.0,
+                "mjpegServerScreenshotQuality": 45,
+                "mjpegFixOrientation": False,
+            },
+            "details": {
+                "platform": "ios",
+                "device": "ios:abc123",
+                "udid": "abc123",
+                "state": "available",
+                "message": "Appium is reachable",
+                "appium_url": "http://appium.local",
+            },
+        }
+    ]
+
+
+def test_parse_xctrace_devices_discovers_connected_ios_and_booted_simulators():
+    output = """
+== Devices ==
+Blah's MacBook Pro (15.5) (00006000-0000000000000000)
+Blah's iPhone (18.5) (00008110-0012345678901234)
+QA Phone (26.5) (00008110-0016443101D0401E)
+iPad QA (17.5) (00008101-0098765432109876)
+== Simulators ==
+iPhone 16 Pro (18.5) (11111111-2222-3333-4444-555555555555) (Booted)
+iPhone 15 (17.5) (aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee) (Shutdown)
+iPad mini (18.5) (99999999-8888-7777-6666-555555555555) (Booted)
+"""
+
+    assert _parse_xctrace_devices(output) == [
+        {
+            "udid": "00008110-0012345678901234",
+            "name": "Blah's iPhone",
+            "platform_version": "18.5",
+            "source": "host",
+            "state": "connected",
+        },
+        {
+            "udid": "00008110-0016443101D0401E",
+            "name": "QA Phone",
+            "platform_version": "26.5",
+            "source": "host",
+            "state": "connected",
+        },
+        {
+            "udid": "00008101-0098765432109876",
+            "name": "iPad QA",
+            "platform_version": "17.5",
+            "source": "host",
+            "state": "connected",
+        },
+        {
+            "udid": "11111111-2222-3333-4444-555555555555",
+            "name": "iPhone 16 Pro",
+            "platform_version": "18.5",
+            "source": "simulator",
+            "state": "Booted",
+        },
+        {
+            "udid": "99999999-8888-7777-6666-555555555555",
+            "name": "iPad mini",
+            "platform_version": "18.5",
+            "source": "simulator",
+            "state": "Booted",
+        },
+    ]
+
+    assert [item["udid"] for item in _parse_xctrace_devices(output, include_simulators=False)] == [
+        "00008110-0012345678901234",
+        "00008110-0016443101D0401E",
+        "00008101-0098765432109876",
+    ]
+
+
+def test_discover_host_ios_devices_adds_booted_simctl_simulators(monkeypatch):
+    xctrace_output = """
+== Devices ==
+QA Phone (26.5) (00008110-0016443101D0401E)
+== Simulators ==
+iPhone 15 Pro Simulator (17.5) (32918B6B-71E5-4A14-94C6-97F0B8B2DC44)
+"""
+    simctl_output = json.dumps(
+        {
+            "devices": {
+                "com.apple.CoreSimulator.SimRuntime.iOS-17-5": [
+                    {
+                        "udid": "32918B6B-71E5-4A14-94C6-97F0B8B2DC44",
+                        "name": "iPhone 15 Pro",
+                        "state": "Booted",
+                        "isAvailable": True,
+                    }
+                ]
+            }
+        }
+    )
+
+    def fake_check_output(cmd, **_kwargs):
+        if cmd[:3] == ["xcrun", "xctrace", "list"]:
+            return xctrace_output
+        if cmd[:4] == ["xcrun", "simctl", "list", "devices"]:
+            return simctl_output
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr("gitd.bots.common.ios.subprocess.check_output", fake_check_output)
+
+    assert discover_host_ios_devices() == [
+        {
+            "udid": "00008110-0016443101D0401E",
+            "name": "QA Phone",
+            "platform_version": "26.5",
+            "source": "host",
+            "state": "connected",
+        },
+        {
+            "udid": "32918B6B-71E5-4A14-94C6-97F0B8B2DC44",
+            "name": "iPhone 15 Pro",
+            "platform_version": "17.5",
+            "source": "simulator",
+            "state": "Booted",
+        },
+    ]
+
+    assert discover_host_ios_devices(include_simulators=False) == [
+        {
+            "udid": "00008110-0016443101D0401E",
+            "name": "QA Phone",
+            "platform_version": "26.5",
+            "source": "host",
+            "state": "connected",
+        }
+    ]
+
+
+def test_parse_xctrace_devices_ignores_offline_devices():
+    output = """
+== Devices ==
+Blah's MacBook Pro (15.5) (00006000-0000000000000000)
+test_owner (26.5) (00008110-0016443101D0401E)
+
+== Devices Offline ==
+iPhone von Tobias (18.5) (00008030-000134EA11C3402E)
+mad_pad (18.6.2) (00008112-000429D2362A201E)
+
+== Simulators ==
+iPhone 16 Pro (18.5) (11111111-2222-3333-4444-555555555555) (Booted)
+"""
+
+    assert _parse_xctrace_devices(output) == [
+        {
+            "udid": "00008110-0016443101D0401E",
+            "name": "test_owner",
+            "platform_version": "26.5",
+            "source": "host",
+            "state": "connected",
+        },
+        {
+            "udid": "11111111-2222-3333-4444-555555555555",
+            "name": "iPhone 16 Pro",
+            "platform_version": "18.5",
+            "source": "simulator",
+            "state": "Booted",
+        },
+    ]
+
+
+def test_parse_devicectl_details_extracts_remote_xpc_tunnel_fields():
+    output = """
+Current device information:
+• identifier: 12E9E87A-11C8-5607-B09B-B58265CE5D4E
+▿ deviceProperties:
+    • bootState: booted
+    • developerModeStatus: enabled
+    • name: test_owner
+    • osVersionNumber: 26.5
+▿ connectionProperties:
+    • pairingState: paired
+    • transportType: localNetwork
+    • tunnelTransportProtocol: tcp
+    • tunnelIPAddress: fdc0:1f0c:103c::1
+    • tunnelState: connected
+"""
+
+    assert _parse_devicectl_details(output) == {
+        "identifier": "12E9E87A-11C8-5607-B09B-B58265CE5D4E",
+        "boot_state": "booted",
+        "developer_mode": "enabled",
+        "name": "test_owner",
+        "os_version": "26.5",
+        "pairing_state": "paired",
+        "transport_type": "localNetwork",
+        "tunnel_transport_protocol": "tcp",
+        "tunnel_ip_address": "fdc0:1f0c:103c::1",
+        "tunnel_state": "connected",
+    }
+
+
+def test_remote_xpc_tunnel_status_tolerates_independent_tunnel_addresses(monkeypatch):
+    monkeypatch.delenv("IOS_REMOTE_XPC_REGISTRY_PORT", raising=False)
+    monkeypatch.delenv("IOS_REMOTE_XPC_REGISTRY_PORTS", raising=False)
+
+    def fake_request(method, url, timeout=None, **kwargs):
+        assert method == "GET"
+        assert "42314/remotexpc/tunnels/00008110-0016443101D0401E" in url
+        return FakeResponse(
+            {
+                "status": "OK",
+                "udid": "00008110-0016443101D0401E",
+                "address": "fd5d:d8f1:7a61::1",
+                "rsdPort": 63925,
+            }
+        )
+
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+    monkeypatch.setattr(
+        "gitd.bots.common.ios.devicectl_device_details",
+        lambda udid: {"tunnel_ip_address": "fdc0:1f0c:103c::1", "tunnel_state": "connected"},
+    )
+
+    status = remote_xpc_tunnel_status(
+        "00008110-0016443101D0401E",
+        platform_version="26.5",
+        host={"source": "host", "platform_version": "26.5"},
+    )
+
+    # Independent tunnels (pymobiledevice3 vs CoreDevice) with different addresses:
+    # while devicectl reports the tunnel connected, this is 'available', not stale.
+    assert status["required"] is True
+    assert status["ok"] is True
+    assert status["state"] == "available"
+    assert status["registry"]["address"] == "fd5d:d8f1:7a61::1"
+    assert status["devicectl"]["tunnel_ip_address"] == "fdc0:1f0c:103c::1"
+    assert status["registry_address"] == "fd5d:d8f1:7a61::1"
+    assert status["current_address"] == "fdc0:1f0c:103c::1"
+    assert status["devicectl_connected"] is True
+
+
+def test_remote_xpc_tunnel_status_reports_missing_registry_entry(monkeypatch):
+    monkeypatch.delenv("IOS_REMOTE_XPC_REGISTRY_PORT", raising=False)
+    monkeypatch.delenv("IOS_REMOTE_XPC_REGISTRY_PORTS", raising=False)
+
+    def fake_request(method, url, timeout=None, **kwargs):
+        return FakeResponse({"status": "NOT_FOUND"}, status_code=404)
+
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+
+    status = remote_xpc_tunnel_status(
+        "00008110-0016443101D0401E",
+        platform_version="26.5",
+        host={"source": "host", "platform_version": "26.5"},
+    )
+
+    assert status["required"] is True
+    assert status["ok"] is False
+    assert status["state"] == "missing"
+    assert status["registry"]["status_code"] == 404
+
+
+def test_remote_xpc_tunnel_status_uses_configured_registry_ports(monkeypatch):
+    urls = []
+    monkeypatch.setenv("IOS_REMOTE_XPC_REGISTRY_PORTS", "50000, 42314")
+
+    def fake_request(method, url, timeout=None, **kwargs):
+        urls.append(url)
+        if ":50000/" in url:
+            return FakeResponse({"status": "NOT_FOUND"}, status_code=404)
+        return FakeResponse(
+            {
+                "status": "OK",
+                "udid": "00008110-0016443101D0401E",
+                "address": "fdc0:1f0c:103c::1",
+            }
+        )
+
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+    monkeypatch.setattr(
+        "gitd.bots.common.ios.devicectl_device_details",
+        lambda udid: {"tunnel_ip_address": "fdc0:1f0c:103c::1", "tunnel_state": "connected"},
+    )
+
+    status = remote_xpc_tunnel_status(
+        "00008110-0016443101D0401E",
+        platform_version="26.5",
+        host={"source": "host", "platform_version": "26.5"},
+    )
+
+    assert status["ok"] is True
+    assert status["state"] == "available"
+    assert status["checked_ports"] == [50000, 42314]
+    assert status["registry"]["port"] == 42314
+    assert [":50000/" in url for url in urls] == [True, False]
+
+
+def test_remote_xpc_tunnel_status_rejects_disconnected_devicectl_tunnel(monkeypatch):
+    monkeypatch.delenv("IOS_REMOTE_XPC_REGISTRY_PORT", raising=False)
+    monkeypatch.delenv("IOS_REMOTE_XPC_REGISTRY_PORTS", raising=False)
+
+    def fake_request(method, url, timeout=None, **kwargs):
+        return FakeResponse(
+            {
+                "status": "OK",
+                "udid": "00008110-0016443101D0401E",
+                "address": "fdc0:1f0c:103c::1",
+            }
+        )
+
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+    monkeypatch.setattr(
+        "gitd.bots.common.ios.devicectl_device_details",
+        lambda udid: {"tunnel_state": "disconnected"},
+    )
+
+    status = remote_xpc_tunnel_status(
+        "00008110-0016443101D0401E",
+        platform_version="26.5",
+        host={"source": "host", "platform_version": "26.5"},
+    )
+
+    assert status["required"] is True
+    assert status["ok"] is False
+    assert status["state"] == "stale"
+    assert status["registry_address"] == "fdc0:1f0c:103c::1"
+    assert status["current_address"] == ""
+    assert status["devicectl_connected"] is False
+    assert status["stale_reason"] == "devicectl_tunnel_disconnected"
+    assert "not connected" in status["message"]
+
+
+def test_remote_xpc_tunnel_status_requires_devicectl_tunnel_address(monkeypatch):
+    monkeypatch.delenv("IOS_REMOTE_XPC_REGISTRY_PORT", raising=False)
+    monkeypatch.delenv("IOS_REMOTE_XPC_REGISTRY_PORTS", raising=False)
+
+    def fake_request(method, url, timeout=None, **kwargs):
+        return FakeResponse(
+            {
+                "status": "OK",
+                "udid": "00008110-0016443101D0401E",
+                "address": "fdc0:1f0c:103c::1",
+            }
+        )
+
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+    monkeypatch.setattr(
+        "gitd.bots.common.ios.devicectl_device_details",
+        lambda udid: {"tunnel_state": "connected"},
+    )
+
+    status = remote_xpc_tunnel_status(
+        "00008110-0016443101D0401E",
+        platform_version="26.5",
+        host={"source": "host", "platform_version": "26.5"},
+    )
+
+    assert status["required"] is True
+    assert status["ok"] is False
+    assert status["state"] == "stale"
+    assert status["registry_address"] == "fdc0:1f0c:103c::1"
+    assert status["current_address"] == ""
+    assert status["devicectl_connected"] is True
+    assert status["stale_reason"] == "devicectl_address_missing"
+    assert "no tunnel IP address" in status["message"]
+
+
+def test_remote_xpc_tunnel_status_skips_simulators(monkeypatch):
+    calls = []
+
+    def fake_request(method, url, timeout=None, **kwargs):
+        calls.append(url)
+        return FakeResponse({"status": "OK"})
+
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+
+    status = remote_xpc_tunnel_status(
+        "11111111-2222-3333-4444-555555555555",
+        platform_version="26.5",
+        host={"source": "simulator", "platform_version": "26.5"},
+    )
+
+    assert status["required"] is False
+    assert status["ok"] is True
+    assert status["state"] == "not_required"
+    assert calls == []
+
+
+def test_known_ios_udids_merges_config_and_host_discovery(monkeypatch):
+    monkeypatch.setenv("IOS_DEVICE_UDID", "abc123")
+    monkeypatch.setenv("IOS_DEVICE_UDIDS", "ios:abc123,def456")
+    monkeypatch.delenv("IOS_DEVICES_JSON", raising=False)
+    monkeypatch.setattr(
+        "gitd.bots.common.ios.discover_host_ios_devices",
+        lambda include_simulators=True: [{"udid": "def456"}, {"udid": "sim789"}],
+    )
+    monkeypatch.setattr(
+        "gitd.bots.common.device.discover_host_ios_devices",
+        lambda include_simulators=True: [{"udid": "def456"}, {"udid": "sim789"}],
+    )
+
+    assert known_ios_udids() == ["abc123", "def456", "sim789"]
+    assert ios_refs_from_host() == ["ios:abc123", "ios:def456", "ios:sim789"]
+
+
+def test_list_configured_ios_devices_includes_host_discovered_devices(monkeypatch):
+    calls = []
+    monkeypatch.delenv("IOS_DEVICE_UDID", raising=False)
+    monkeypatch.delenv("IOS_DEVICE_UDIDS", raising=False)
+    monkeypatch.delenv("IOS_DEVICES_JSON", raising=False)
+    monkeypatch.setattr(
+        "gitd.bots.common.device.discover_host_ios_devices",
+        lambda include_simulators=True: [
+            {
+                "udid": "00008110-0012345678901234",
+                "name": "Blah's iPhone",
+                "platform_version": "18.5",
+                "source": "host",
+                "state": "connected",
+            }
+        ],
+    )
+
+    def fake_probe(device, deep=True):
+        calls.append((device, deep))
+
+        class ProbeStatus:
+            def to_dict(self):
+                return {
+                    "platform": "ios",
+                    "device": device,
+                    "udid": "00008110-0012345678901234",
+                    "state": "appium_down",
+                    "message": "Appium is unreachable",
+                    "appium_url": "http://127.0.0.1:4723",
+                }
+
+        return ProbeStatus()
+
+    monkeypatch.setattr("gitd.bots.common.device.probe_ios_device", fake_probe)
+
+    devices = list_configured_ios_devices(deep_probe=False)
+
+    assert calls == [("ios:00008110-0012345678901234", False)]
+    assert devices[0]["serial"] == "ios:00008110-0012345678901234"
+    assert devices[0]["model"] == "Blah's iPhone"
+    assert devices[0]["source"] == "host"
+    assert devices[0]["host_state"] == "connected"
+    assert devices[0]["platform_version"] == "18.5"
+    assert devices[0]["status"] == "appium_down"
+
+
+def test_per_device_ios_config_from_json(monkeypatch):
+    monkeypatch.delenv("IOS_DEVICE_UDID", raising=False)
+    monkeypatch.delenv("IOS_DEVICE_UDIDS", raising=False)
+    monkeypatch.setenv(
+        "IOS_DEVICES_JSON",
+        json.dumps(
+            {
+                "abc123": {
+                    "appium_url": "http://127.0.0.1:4725",
+                    "bundle_id": "com.google.chrome.ios",
+                    "known_apps": [
+                        {"name": "Chrome", "bundle_id": "com.google.chrome.ios"},
+                        {"name": "NPR", "bundleId": "org.npr.NPR"},
+                    ],
+                    "mjpeg_server_port": 9101,
+                    "mjpeg_server_framerate": 15,
+                    "mjpeg_scaling_factor": 50,
+                    "mjpeg_server_screenshot_quality": 40,
+                    "mjpeg_fix_orientation": False,
+                    "screenshot_quality": 2,
+                    "wda_launch_timeout": 180000,
+                    "allow_provisioning_device_registration": True,
+                }
+            }
+        ),
+    )
+
+    assert configured_ios_udids() == ["abc123"]
+    cfg = ios_config_for_udid("ios:abc123")
+    assert cfg.appium_url == "http://127.0.0.1:4725"
+    assert cfg.bundle_id == "com.google.chrome.ios"
+    assert cfg.known_apps == (("Chrome", "com.google.chrome.ios"), ("NPR", "org.npr.NPR"))
+    assert cfg.mjpeg_server_port == 9101
+    assert cfg.mjpeg_settings() == {
+        "mjpegServerFramerate": 15,
+        "mjpegScalingFactor": 50.0,
+        "mjpegServerScreenshotQuality": 40,
+        "mjpegFixOrientation": False,
+    }
+    assert cfg.capabilities()["appium:mjpegServerPort"] == 9101
+    assert cfg.capabilities()["appium:screenshotQuality"] == 2
+    assert cfg.capabilities()["appium:settings[mjpegServerFramerate]"] == 15
+    assert cfg.capabilities()["appium:settings[mjpegScalingFactor]"] == 50.0
+    assert cfg.capabilities()["appium:settings[mjpegServerScreenshotQuality]"] == 40
+    assert cfg.capabilities()["appium:settings[mjpegFixOrientation]"] is False
+    assert cfg.capabilities()["appium:wdaLaunchTimeout"] == 180000
+    assert cfg.capabilities()["appium:allowProvisioningDeviceRegistration"] is True
+
+
+def test_ios_config_infers_host_name_and_platform_version(monkeypatch):
+    monkeypatch.delenv("IOS_DEVICE_NAME", raising=False)
+    monkeypatch.delenv("IOS_PLATFORM_VERSION", raising=False)
+    monkeypatch.delenv("IOS_DEVICES_JSON", raising=False)
+    monkeypatch.delenv("IOS_CONFIG_FILE", raising=False)
+    monkeypatch.setattr(
+        "gitd.bots.common.ios.discover_host_ios_devices",
+        lambda include_simulators=True: [
+            {
+                "udid": "00008110-0016443101D0401E",
+                "name": "test_owner",
+                "platform_version": "26.5",
+                "source": "host",
+                "state": "connected",
+            }
+        ],
+    )
+
+    cfg = ios_config_for_udid("ios:00008110-0016443101D0401E")
+
+    assert cfg.device_name == "test_owner"
+    assert cfg.platform_version == "26.5"
+
+
+def test_ios_config_defaults_to_chrome_browser(monkeypatch):
+    monkeypatch.delenv("IOS_BUNDLE_ID", raising=False)
+    monkeypatch.delenv("IOS_DEVICES_JSON", raising=False)
+    monkeypatch.delenv("IOS_CONFIG_FILE", raising=False)
+
+    cfg = ios_config_for_udid("ios:abc123")
+
+    assert cfg.bundle_id == "com.google.chrome.ios"
+
+
+def test_ios_mjpeg_url_uses_appium_host_and_explicit_override():
+    remote = IOSDevice("ios:abc123", appium_url="https://appium.example.test:4723")
+    remote.mjpeg_server_port = 9123
+
+    ipv6 = IOSDevice("ios:abc123", appium_url="http://[::1]:4723")
+    ipv6.mjpeg_server_port = 9124
+
+    explicit = IOSDevice("ios:abc123", appium_url="http://appium.example.test:4723")
+    explicit.mjpeg_screenshot_url = "http://wda.example.test:9100/stream"
+
+    assert IOSDevice("ios:abc123").mjpeg_url == "http://127.0.0.1:9100"
+    assert remote.mjpeg_url == "https://appium.example.test:9123"
+    assert ipv6.mjpeg_url == "http://[::1]:9124"
+    assert explicit.mjpeg_url == "http://wda.example.test:9100/stream"
+
+
+def test_ios_known_apps_env_accepts_name_to_bundle_mapping(monkeypatch):
+    monkeypatch.delenv("IOS_DEVICES_JSON", raising=False)
+    monkeypatch.setenv("IOS_KNOWN_APPS_JSON", json.dumps({"Chrome": "com.google.chrome.ios", "NPR": "org.npr.NPR"}))
+
+    cfg = ios_config_for_udid("ios:abc123")
+
+    assert cfg.known_apps == (("Chrome", "com.google.chrome.ios"), ("NPR", "org.npr.NPR"))
+
+
+def test_ios_skill_app_inventory_reads_local_ios_skill_bundle_ids():
+    bundles = {bundle_id for _name, bundle_id in _skill_ios_app_inventory()}
+
+    assert "com.google.chrome.ios" in bundles
+    assert "com.zhiliaoapp.musically" in bundles
+
+
+def test_list_apps_includes_ios_skill_bundle_candidates(monkeypatch):
+    monkeypatch.delenv("IOS_BUNDLE_ID", raising=False)
+    monkeypatch.delenv("IOS_DEVICES_JSON", raising=False)
+    monkeypatch.delenv("IOS_KNOWN_APPS_JSON", raising=False)
+    monkeypatch.setattr("gitd.bots.common.ios._skill_ios_app_inventory", lambda: (("NPR Skill", "org.npr.NPR"),))
+
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+
+    apps = dev.list_apps(query="npr", verify=False)
+
+    assert apps == [
+        {
+            "name": "NPR Skill",
+            "package": "org.npr.NPR",
+            "bundle_id": "org.npr.NPR",
+            "platform": "ios",
+            "source": "skill",
+            "verified": False,
+            "installed": None,
+        }
+    ]
+
+
+def test_list_apps_verifies_known_ios_bundles_with_appium(monkeypatch):
+    monkeypatch.delenv("IOS_BUNDLE_ID", raising=False)
+    monkeypatch.delenv("IOS_DEVICES_JSON", raising=False)
+    monkeypatch.delenv("IOS_KNOWN_APPS_JSON", raising=False)
+    calls = []
+
+    def fake_request(method, url, json=None, timeout=None):
+        calls.append({"method": method, "url": url, "json": json})
+        if url.endswith("/session/session-1/execute/sync"):
+            assert json["script"] == "mobile: queryAppState"
+            bundle_id = json["args"][0]["bundleId"]
+            state = 4 if bundle_id == "com.google.chrome.ios" else 0
+            return FakeResponse({"value": state})
+        raise AssertionError(f"unexpected request: {method} {url}")
+
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+    dev._session_id = "session-1"
+
+    chrome = dev.list_apps(query="chrome")
+    tiktok = dev.list_apps(query="tiktok")
+
+    assert chrome == [
+        {
+            "name": "Chrome",
+            "package": "com.google.chrome.ios",
+            "bundle_id": "com.google.chrome.ios",
+            "platform": "ios",
+            "source": "default",
+            "verified": True,
+            "installed": True,
+            "app_state": 4,
+            "app_state_name": "running_foreground",
+        }
+    ]
+    assert tiktok == []
+    assert len(calls) == 2
+
+
+def test_list_apps_returns_unverified_candidates_when_appium_is_unavailable(monkeypatch):
+    monkeypatch.delenv("IOS_BUNDLE_ID", raising=False)
+    monkeypatch.delenv("IOS_DEVICES_JSON", raising=False)
+    monkeypatch.delenv("IOS_KNOWN_APPS_JSON", raising=False)
+
+    def fake_request(method, url, json=None, timeout=None):
+        raise __import__("requests").ConnectionError("connection refused")
+
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+
+    apps = dev.list_apps(query="chrome")
+
+    assert apps[0]["name"] == "Chrome"
+    assert apps[0]["bundle_id"] == "com.google.chrome.ios"
+    assert apps[0]["verified"] is False
+    assert apps[0]["installed"] is None
+    assert "connection refused" in apps[0]["verification_error"]
+
+
+def test_session_creation_uses_appium_xcuitest_payload(monkeypatch):
+    IOSDevice._sessions.clear()
+    calls = []
+
+    def fake_request(method, url, json=None, timeout=None):
+        calls.append({"method": method, "url": url, "json": json, "timeout": timeout})
+        return FakeResponse({"value": {"sessionId": "session-1"}})
+
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+    monkeypatch.delenv("IOS_WDA_URL", raising=False)
+    monkeypatch.delenv("IOS_WEBDRIVERAGENT_URL", raising=False)
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local", bundle_id="com.apple.mobilesafari", timeout=1)
+
+    assert dev._ensure_session() == "session-1"
+    body = calls[0]["json"]["capabilities"]["alwaysMatch"]
+    assert calls[0]["method"] == "POST"
+    assert calls[0]["url"] == "http://appium.local/session"
+    assert body["platformName"] == "iOS"
+    assert body["appium:automationName"] == "XCUITest"
+    assert body["appium:udid"] == "abc123"
+    assert body["appium:bundleId"] == "com.apple.mobilesafari"
+
+
+def test_target_app_switch_clears_instance_session_and_browser_name(monkeypatch):
+    IOSDevice._sessions.clear()
+    calls = []
+
+    def fake_request(method, url, json=None, timeout=None):
+        calls.append({"method": method, "url": url, "json": json, "timeout": timeout})
+        return FakeResponse({"value": {"sessionId": "session-chrome"}})
+
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+    dev = IOSDevice(
+        "ios:abc123",
+        appium_url="http://appium.local",
+        bundle_id="com.apple.mobilesafari",
+        browser_name="Safari",
+        timeout=1,
+    )
+    old_config = dev._config
+    dev._session_id = "session-safari"
+    IOSDevice._sessions[old_config] = "session-safari"
+
+    dev.set_target_app(bundle_id="com.google.chrome.ios")
+
+    assert dev.bundle_id == "com.google.chrome.ios"
+    assert dev.browser_name == ""
+    assert dev._session_id is None
+    assert IOSDevice._sessions[old_config] == "session-safari"
+    assert dev._ensure_session() == "session-chrome"
+    body = calls[0]["json"]["capabilities"]["alwaysMatch"]
+    assert body["appium:bundleId"] == "com.google.chrome.ios"
+    assert "browserName" not in body
+
+
+def test_target_app_switch_reuses_cached_session_for_new_bundle(monkeypatch):
+    IOSDevice._sessions.clear()
+    validate_calls = []
+
+    def fake_request(method, url, json=None, timeout=None):
+        validate_calls.append({"method": method, "url": url, "json": json, "timeout": timeout})
+        if url.endswith("/session/session-chrome/window/rect"):
+            return FakeResponse({"value": {"width": 393, "height": 852}})
+        raise AssertionError(f"unexpected request: {method} {url}")
+
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local", bundle_id="com.apple.mobilesafari", timeout=1)
+    dev.set_target_app(bundle_id="com.google.chrome.ios")
+    IOSDevice._sessions[dev._config] = "session-chrome"
+
+    assert dev._ensure_session() == "session-chrome"
+    assert dev._session_id == "session-chrome"
+    assert validate_calls == [
+        {
+            "method": "GET",
+            "url": "http://appium.local/session/session-chrome/window/rect",
+            "json": None,
+            "timeout": 1,
+        }
+    ]
+
+
+def test_stale_appium_session_is_evicted_and_recreated(monkeypatch):
+    IOSDevice._sessions.clear()
+    calls = []
+
+    def fake_request(method, url, json=None, timeout=None):
+        calls.append({"method": method, "url": url, "json": json})
+        if url.endswith("/session/session-old/source"):
+            return FakeResponse(
+                {"value": {"error": "invalid session id", "message": "Session does not exist"}},
+                status_code=404,
+                text="invalid session id",
+            )
+        if method == "POST" and url.endswith("/session"):
+            return FakeResponse({"value": {"sessionId": "session-new"}})
+        if url.endswith("/session/session-new/source"):
+            return FakeResponse({"value": RAW_WDA_XML})
+        raise AssertionError(f"unexpected request: {method} {url}")
+
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+    dev._session_id = "session-old"
+    IOSDevice._sessions[dev._config] = "session-old"
+
+    assert dev._request("GET", "/session/session-old/source") == RAW_WDA_XML
+    assert dev._session_id == "session-new"
+    assert IOSDevice._sessions[dev._config] == "session-new"
+    assert [c["url"] for c in calls] == [
+        "http://appium.local/session/session-old/source",
+        "http://appium.local/session",
+        "http://appium.local/session/session-new/source",
+    ]
+
+
+def test_close_deletes_cached_session_even_without_instance_session(monkeypatch):
+    IOSDevice._sessions.clear()
+    calls = []
+
+    def fake_request(method, url, json=None, timeout=None):
+        calls.append({"method": method, "url": url, "json": json, "timeout": timeout})
+        if method == "DELETE" and url.endswith("/session/session-cached"):
+            return FakeResponse({"value": None})
+        raise AssertionError(f"unexpected request: {method} {url}")
+
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local", bundle_id="com.google.chrome.ios", timeout=1)
+    IOSDevice._sessions[dev._config] = "session-cached"
+
+    dev.close()
+
+    assert calls == [
+        {
+            "method": "DELETE",
+            "url": "http://appium.local/session/session-cached",
+            "json": {},
+            "timeout": 1,
+        }
+    ]
+    assert dev._session_id is None
+    assert IOSDevice._sessions.get(dev._config) is None
+
+
+def test_session_creation_includes_real_device_signing_capabilities(monkeypatch):
+    IOSDevice._sessions.clear()
+    calls = []
+
+    def fake_request(method, url, json=None, timeout=None):
+        calls.append({"method": method, "url": url, "json": json, "timeout": timeout})
+        return FakeResponse({"value": {"sessionId": "session-1"}})
+
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+    monkeypatch.setenv("IOS_XCODE_ORG_ID", "83JH73NBRY")
+    monkeypatch.setenv("IOS_XCODE_SIGNING_ID", "Apple Development")
+    monkeypatch.setenv("IOS_UPDATED_WDA_BUNDLE_ID", "com.ghostinthedroid.wda83")
+    monkeypatch.setenv("IOS_ALLOW_PROVISIONING_DEVICE_REGISTRATION", "true")
+    monkeypatch.setenv("IOS_WDA_LAUNCH_TIMEOUT", "180000")
+    monkeypatch.setenv("IOS_WDA_STARTUP_RETRIES", "1")
+    monkeypatch.setenv("IOS_WDA_STARTUP_RETRY_INTERVAL", "10000")
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local", timeout=1)
+
+    assert dev._ensure_session() == "session-1"
+    body = calls[0]["json"]["capabilities"]["alwaysMatch"]
+    assert body["appium:xcodeOrgId"] == "83JH73NBRY"
+    assert body["appium:xcodeSigningId"] == "Apple Development"
+    assert body["appium:updatedWDABundleId"] == "com.ghostinthedroid.wda83"
+    assert body["appium:allowProvisioningDeviceRegistration"] is True
+    assert body["appium:wdaLaunchTimeout"] == 180000
+    assert body["appium:wdaStartupRetries"] == 1
+    assert body["appium:wdaStartupRetryInterval"] == 10000
+
+
+def test_session_creation_uses_host_discovered_platform_version(monkeypatch):
+    IOSDevice._sessions.clear()
+    calls = []
+
+    def fake_request(method, url, json=None, timeout=None):
+        calls.append({"method": method, "url": url, "json": json, "timeout": timeout})
+        return FakeResponse({"value": {"sessionId": "session-1"}})
+
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+    monkeypatch.setattr(
+        "gitd.bots.common.ios.discover_host_ios_devices",
+        lambda include_simulators=True: [
+            {
+                "udid": "00008110-0016443101D0401E",
+                "name": "test_owner",
+                "platform_version": "26.5",
+                "source": "host",
+                "state": "connected",
+            }
+        ],
+    )
+    monkeypatch.delenv("IOS_DEVICE_NAME", raising=False)
+    monkeypatch.delenv("IOS_PLATFORM_VERSION", raising=False)
+    monkeypatch.delenv("IOS_DEVICES_JSON", raising=False)
+    monkeypatch.delenv("IOS_CONFIG_FILE", raising=False)
+    dev = IOSDevice(
+        "ios:00008110-0016443101D0401E",
+        appium_url="http://appium.local",
+        bundle_id="com.google.chrome.ios",
+        timeout=1,
+    )
+
+    assert dev._ensure_session() == "session-1"
+    body = calls[0]["json"]["capabilities"]["alwaysMatch"]
+    assert body["appium:deviceName"] == "test_owner"
+    assert body["appium:platformVersion"] == "26.5"
+
+
+def test_probe_classifies_unreachable_appium(monkeypatch):
+    def fake_request(method, url, json=None, timeout=None):
+        raise __import__("requests").ConnectionError("connection refused")
+
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+    status = IOSDevice("ios:abc123", appium_url="http://appium.local").probe(deep=True)
+
+    assert status.state == "appium_down"
+    assert "unreachable" in status.message.lower()
+
+
+def test_probe_reports_configured_unreachable_when_local_udid_not_visible(monkeypatch):
+    IOSDevice._sessions.clear()
+    calls = []
+
+    def fake_request(method, url, json=None, timeout=None):
+        calls.append(url)
+        if url.endswith("/status"):
+            return FakeResponse({"value": {"ready": True}})
+        raise AssertionError(f"unexpected request: {url}")
+
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+    monkeypatch.setattr("gitd.bots.common.ios.discover_host_ios_devices", lambda include_simulators=True: [])
+
+    status = IOSDevice("ios:00008110-0016443101D0401E", timeout=1).probe(deep=False)
+
+    assert status.state == "configured_unreachable"
+    assert "not visible" in status.message
+    assert status.checks["appium_status_code"] == 200
+    assert status.checks["host_device"] == {"visible": False, "source": "xcrun xctrace list devices"}
+    assert all(not url.endswith("/session") for url in calls)
+
+
+def test_probe_allows_remote_appium_when_udid_not_visible_locally(monkeypatch):
+    IOSDevice._sessions.clear()
+    calls = []
+
+    def fake_request(method, url, json=None, timeout=None):
+        calls.append(url)
+        if url.endswith("/status"):
+            return FakeResponse({"value": {"ready": True}})
+        raise AssertionError(f"unexpected request: {url}")
+
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+    monkeypatch.setattr("gitd.bots.common.ios.discover_host_ios_devices", lambda include_simulators=True: [])
+    monkeypatch.setattr(
+        "gitd.bots.common.ios.remote_xpc_tunnel_status",
+        lambda *args, **kwargs: {"required": False, "state": "not_required", "ok": True},
+    )
+
+    status = IOSDevice(
+        "ios:00008110-0016443101D0401E",
+        appium_url="http://appium.example.test:4723",
+        timeout=1,
+    ).probe(deep=False)
+
+    assert status.state == "available"
+    assert status.checks == {"appium_status_code": 200}
+
+
+def test_probe_fails_fast_when_required_remote_xpc_tunnel_is_stale(monkeypatch):
+    IOSDevice._sessions.clear()
+    calls = []
+    monkeypatch.delenv("IOS_REMOTE_XPC_REGISTRY_PORT", raising=False)
+    monkeypatch.delenv("IOS_REMOTE_XPC_REGISTRY_PORTS", raising=False)
+
+    def fake_request(method, url, json=None, timeout=None):
+        calls.append(url)
+        if url.endswith("/status"):
+            return FakeResponse({"value": {"ready": True}})
+        if "42314/remotexpc/tunnels/00008110-0016443101D0401E" in url:
+            return FakeResponse(
+                {
+                    "status": "OK",
+                    "udid": "00008110-0016443101D0401E",
+                    "address": "fd5d:d8f1:7a61::1",
+                }
+            )
+        raise AssertionError(f"unexpected request: {url}")
+
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+    monkeypatch.setattr(
+        "gitd.bots.common.ios.discover_host_ios_devices",
+        lambda include_simulators=True: [
+            {
+                "udid": "00008110-0016443101D0401E",
+                "name": "test_owner",
+                "platform_version": "26.5",
+                "source": "host",
+                "state": "connected",
+            }
+        ],
+    )
+    # Genuinely stale: devicectl reports the tunnel disconnected (a real staleness
+    # signal, unlike a mere address mismatch which is normal for independent tunnels).
+    monkeypatch.setattr(
+        "gitd.bots.common.ios.devicectl_device_details",
+        lambda udid: {"tunnel_ip_address": "", "tunnel_state": "disconnected"},
+    )
+    monkeypatch.delenv("IOS_DEVICE_NAME", raising=False)
+    monkeypatch.delenv("IOS_PLATFORM_VERSION", raising=False)
+    dev = IOSDevice("ios:00008110-0016443101D0401E", appium_url="http://appium.local", timeout=1)
+
+    status = dev.probe(deep=True)
+
+    assert status.state == "remote_xpc_tunnel_unavailable"
+    assert "not connected" in status.message
+    assert status.checks["remote_xpc_tunnel"]["state"] == "stale"
+    assert status.checks["remote_xpc_tunnel"]["stale_reason"] == "devicectl_tunnel_disconnected"
+    assert all(not url.endswith("/session") for url in calls)
+
+
+def test_restart_remote_xpc_tunnel_starts_new_process_after_stopping_owned_process(monkeypatch, tmp_path):
+    IOSDevice._sessions.clear()
+    kill_calls = []
+    popen_calls = []
+    status_calls = []
+    log_path = tmp_path / "tunnel.log"
+
+    class FakePopen:
+        pid = 4321
+
+        def __init__(self, command, stdin=None, stdout=None, stderr=None, start_new_session=False):
+            popen_calls.append(
+                {
+                    "command": command,
+                    "stdin": stdin,
+                    "stdout": stdout,
+                    "stderr": stderr,
+                    "start_new_session": start_new_session,
+                }
+            )
+
+    def fake_tunnel_status(*args, **kwargs):
+        status_calls.append((args, kwargs))
+        if len(status_calls) == 1:
+            return {"required": True, "state": "stale", "ok": False}
+        return {"required": True, "state": "available", "ok": True}
+
+    monkeypatch.setattr("gitd.bots.common.ios.remote_xpc_tunnel_status", fake_tunnel_status)
+    monkeypatch.setattr(
+        "gitd.bots.common.ios._remote_xpc_tunnel_processes",
+        lambda udid: [{"pid": 1234, "uid": 501, "command": "appium driver run xcuitest tunnel-creation --udid abc123"}],
+    )
+    monkeypatch.setattr("gitd.bots.common.ios.os.getuid", lambda: 501)
+    monkeypatch.setattr("gitd.bots.common.ios.os.kill", lambda pid, sig: kill_calls.append((pid, sig)))
+    monkeypatch.setattr("gitd.bots.common.ios.subprocess.Popen", FakePopen)
+    monkeypatch.setenv("IOS_REMOTE_XPC_REGISTRY_PORT", "50000")
+    monkeypatch.setenv("IOS_REMOTE_XPC_TUNNEL_LOG", str(log_path))
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+
+    result = dev.restart_remote_xpc_tunnel()
+
+    assert result["ok"] is True
+    assert result["pid"] == 4321
+    assert result["tunnel_after"]["state"] == "available"
+    assert result["attempts"] == 1
+    assert result["killed"] == [
+        {"pid": 1234, "uid": 501, "command": "appium driver run xcuitest tunnel-creation --udid abc123"}
+    ]
+    assert kill_calls == [(1234, __import__("signal").SIGTERM)]
+    assert popen_calls[0]["command"] == [
+        "appium",
+        "driver",
+        "run",
+        "xcuitest",
+        "tunnel-creation",
+        "--udid",
+        "abc123",
+        "--tunnel-registry-port",
+        "50000",
+    ]
+    assert popen_calls[0]["start_new_session"] is True
+    assert result["log_path"] == str(log_path)
+
+
+def test_restart_remote_xpc_tunnel_honors_appium_command_override(monkeypatch, tmp_path):
+    IOSDevice._sessions.clear()
+    popen_calls = []
+    log_path = tmp_path / "tunnel.log"
+
+    class FakePopen:
+        pid = 4321
+
+        def __init__(self, command, stdin=None, stdout=None, stderr=None, start_new_session=False):
+            popen_calls.append(command)
+
+    status_calls = []
+
+    def fake_tunnel_status(*args, **kwargs):
+        status_calls.append((args, kwargs))
+        if len(status_calls) == 1:
+            return {"required": True, "state": "missing", "ok": False, "checked_ports": [42314]}
+        return {"required": True, "state": "available", "ok": True}
+
+    monkeypatch.setattr("gitd.bots.common.ios.remote_xpc_tunnel_status", fake_tunnel_status)
+    monkeypatch.setattr("gitd.bots.common.ios._remote_xpc_tunnel_processes", lambda udid: [])
+    monkeypatch.setattr("gitd.bots.common.ios.subprocess.Popen", FakePopen)
+    monkeypatch.setenv("IOS_APPIUM_COMMAND", "npx appium")
+    monkeypatch.setenv("IOS_REMOTE_XPC_TUNNEL_LOG", str(log_path))
+
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+    result = dev.restart_remote_xpc_tunnel()
+
+    assert result["ok"] is True
+    assert popen_calls == [
+        ["npx", "appium", "driver", "run", "xcuitest", "tunnel-creation", "--udid", "abc123"]
+    ]
+
+
+def test_restart_remote_xpc_tunnel_reports_not_ready_after_start(monkeypatch, tmp_path):
+    IOSDevice._sessions.clear()
+    log_path = tmp_path / "tunnel.log"
+
+    class FakePopen:
+        pid = 4321
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(
+        "gitd.bots.common.ios.remote_xpc_tunnel_status",
+        lambda *args, **kwargs: {"required": True, "state": "missing", "ok": False, "checked_ports": [42314]},
+    )
+    monkeypatch.setattr("gitd.bots.common.ios._remote_xpc_tunnel_processes", lambda udid: [])
+    monkeypatch.setattr("gitd.bots.common.ios.subprocess.Popen", FakePopen)
+    monkeypatch.setenv("IOS_REMOTE_XPC_TUNNEL_START_TIMEOUT", "0")
+    monkeypatch.setenv("IOS_REMOTE_XPC_TUNNEL_LOG", str(log_path))
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+
+    result = dev.restart_remote_xpc_tunnel()
+
+    assert result["ok"] is False
+    assert result["manual_action_required"] is True
+    assert result["pid"] == 4321
+    assert result["tunnel_after"]["state"] == "missing"
+    assert result["recovery"]["code"] == "restart_remote_xpc_tunnel"
+
+
+def test_restart_remote_xpc_tunnel_returns_manual_action_for_foreign_process(monkeypatch):
+    IOSDevice._sessions.clear()
+
+    monkeypatch.setattr(
+        "gitd.bots.common.ios.remote_xpc_tunnel_status",
+        lambda *args, **kwargs: {"required": True, "state": "stale", "ok": False},
+    )
+    monkeypatch.setattr(
+        "gitd.bots.common.ios._remote_xpc_tunnel_processes",
+        lambda udid: [{"pid": 1234, "uid": 0, "command": "appium driver run xcuitest tunnel-creation --udid abc123"}],
+    )
+    monkeypatch.setattr("gitd.bots.common.ios.os.getuid", lambda: 501)
+    monkeypatch.setattr(
+        "gitd.bots.common.ios.subprocess.Popen",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("should not start process")),
+    )
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+
+    result = dev.restart_remote_xpc_tunnel()
+
+    assert result["ok"] is False
+    assert result["manual_action_required"] is True
+    assert result["processes"][0]["uid"] == 0
+    assert result["recovery"]["code"] == "restart_remote_xpc_tunnel"
+    assert result["recovery"]["auto_fixable"] is False
+    assert result["recovery"]["manual_action_required"] is True
+    assert result["recovery"]["requires_sudo"] is True
+    assert result["recovery"]["summary"] == "Stop the stale XCUITest tunnel process with sudo, then start a fresh tunnel."
+    assert "sudo appium driver run xcuitest tunnel-creation --udid abc123" in result["recovery"]["steps"][1]
+    assert result["recovery"]["kill_command"] == "sudo kill 1234"
+    assert result["recovery"]["commands"] == [
+        "sudo kill 1234",
+        "sudo appium driver run xcuitest tunnel-creation --udid abc123",
+        "curl -s http://127.0.0.1:42314/remotexpc/tunnels/abc123",
+    ]
+
+
+def test_remote_xpc_manual_recovery_honors_appium_command_override(monkeypatch):
+    monkeypatch.setenv("IOS_APPIUM_COMMAND", "npx appium")
+    monkeypatch.setattr("gitd.bots.common.ios._remote_xpc_tunnel_processes", lambda udid: [])
+
+    recovery = remote_xpc_manual_recovery("abc123")
+
+    assert recovery["start_command"] == "sudo npx appium driver run xcuitest tunnel-creation --udid abc123"
+    assert recovery["commands"][0] == "sudo npx appium driver run xcuitest tunnel-creation --udid abc123"
+    assert recovery["auto_fixable"] is True
+    assert recovery["manual_action_required"] is False
+    assert recovery["requires_sudo"] is False
+    assert recovery["summary"] == "Ghost can restart the stale XCUITest tunnel; manual commands are provided as a fallback."
+
+
+def test_ios_error_classifier_promotes_real_device_readiness_failures():
+    cases = [
+        "Unlock test_owner to Continue",
+        "Device is passcode locked",
+        "The device has not trusted this computer",
+        "Developer Mode must be enabled before running WebDriverAgent",
+        "UI Automation is not enabled for this device",
+        "Timed out waiting for the user to unlock the device",
+    ]
+
+    for message in cases:
+        state, details = classify_ios_error(RuntimeError(message))
+        assert state == "locked"
+        assert "blocked by iOS automation permissions" in details
+
+
+def test_ios_error_classifier_keeps_wda_signing_failures_actionable():
+    state, details = classify_ios_error(RuntimeError("xcodebuild failed with code 65: provisioning profile missing"))
+
+    assert state == "wda_signing_failed"
+    assert "WebDriverAgent signing" in details
+
+
+def test_ios_error_classifier_treats_wda_developer_certificate_trust_as_signing():
+    message = (
+        "WebDriverAgentRunner-Runner encountered an error: The application could not be launched because "
+        "the Developer App Certificate is not trusted. Unable to launch com.ghostinthedroid.wda83.xctrunner "
+        "because it has an invalid code signature, inadequate entitlements or its profile has not been "
+        "explicitly trusted by the user."
+    )
+
+    state, details = classify_ios_error(RuntimeError(message))
+
+    assert state == "wda_signing_failed"
+    assert "WebDriverAgent signing" in details
+
+
+def test_ios_error_classifier_treats_session_creation_read_timeout_as_wda_launch_timeout():
+    message = (
+        "Could not create Appium iOS session: HTTPConnectionPool(host='127.0.0.1', port=4723): "
+        "Read timed out. (read timeout=120.0)"
+    )
+
+    state, details = classify_ios_error(RuntimeError(message))
+
+    assert state == "wda_launch_timeout"
+    assert "WebDriverAgent session creation timed out" in details
+
+
+def test_ios_error_classifier_promotes_remote_xpc_tunnel_failures():
+    state, details = classify_ios_error(
+        RuntimeError("Could not create Appium iOS session (500): Could not find the expected device 'abc123'")
+    )
+
+    assert state == "remote_xpc_tunnel_unavailable"
+    assert "RemoteXPC tunnel" in details
+
+
+def test_ios_device_health_promotes_stable_wda_fields(monkeypatch):
+    class ProbeStatus:
+        def to_dict(self):
+            return {
+                "device": "ios:abc123",
+                "udid": "abc123",
+                "state": "available",
+                "message": "iOS Appium/WDA session is usable",
+                "appium_url": "http://appium.local",
+                "session_id": "session-1",
+                "active_app": {"name": "Chrome", "bundleId": "com.google.chrome.ios"},
+                "screen_size": {"width": 393, "height": 852},
+                "checks": {"screenshot_bytes": 68, "source_bytes": 2048},
+            }
+
+    class FakeIOSDevice:
+        def probe(self, deep=True):
+            assert deep is True
+            return ProbeStatus()
+
+        @property
+        def mjpeg_url(self):
+            return "http://appium.local/session/session-1/appium/device/screen_stream"
+
+        @property
+        def mjpeg_settings(self):
+            return {"mjpegServerFramerate": 12, "mjpegScalingFactor": 60.0}
+
+    monkeypatch.setattr("gitd.services.device_context.get_device", lambda device: FakeIOSDevice())
+
+    from gitd.services.device_context import device_health
+
+    health = device_health("ios:abc123")
+
+    assert health["platform"] == "ios"
+    assert health["connection"] == {"type": "appium-wda", "status": "available"}
+    assert health["appium"]["reachable"] is True
+    assert health["appium"]["session_id"] == "session-1"
+    assert health["wda"]["session"] == "session-1"
+    assert health["wda"]["ready"] is True
+    assert health["wda"]["screenshot_ok"] is True
+    assert health["wda"]["source_ok"] is True
+    assert health["wda"]["active_app"]["bundleId"] == "com.google.chrome.ios"
+    assert health["wda"]["mjpeg_url"].endswith("/screen_stream")
+    assert health["wda"]["mjpeg_settings"] == {"mjpegServerFramerate": 12, "mjpegScalingFactor": 60.0}
+    assert health["recommended_fix"] == ""
+    assert health["recovery"] == {"code": "", "summary": "iOS Appium/WDA session is usable.", "steps": []}
+
+
+def test_ios_device_health_includes_recovery_steps_for_remote_xpc_tunnel(monkeypatch):
+    class ProbeStatus:
+        def to_dict(self):
+            return {
+                "device": "ios:abc123",
+                "udid": "abc123",
+                "state": "remote_xpc_tunnel_unavailable",
+                "message": "RemoteXPC tunnel or usbmux device listing is unavailable",
+                "appium_url": "http://appium.local",
+                "session_id": "",
+                "active_app": None,
+                "screen_size": None,
+                "checks": {
+                    "appium_status_code": 200,
+                    "remote_xpc_tunnel": {"required": True, "state": "stale", "ok": False, "checked_ports": [42314]},
+                },
+            }
+
+    class FakeIOSDevice:
+        def probe(self, deep=True):
+            assert deep is True
+            return ProbeStatus()
+
+        @property
+        def mjpeg_url(self):
+            return "http://appium.local:9100"
+
+        @property
+        def mjpeg_settings(self):
+            return {}
+
+    monkeypatch.setattr("gitd.services.device_context.get_device", lambda device: FakeIOSDevice())
+    monkeypatch.setattr(
+        "gitd.bots.common.ios._remote_xpc_tunnel_processes",
+        lambda udid: [{"pid": 1234, "uid": 0, "command": "appium driver run xcuitest tunnel-creation --udid abc123"}],
+    )
+    monkeypatch.setattr("gitd.bots.common.ios.os.getuid", lambda: 501)
+
+    from gitd.services.device_context import device_health
+
+    health = device_health("ios:abc123")
+
+    assert health["connection"]["status"] == "remote_xpc_tunnel_unavailable"
+    assert health["appium"]["reachable"] is True
+    assert health["appium"]["status_code"] == 200
+    assert health["wda"]["ready"] is False
+    assert health["recommended_fix"] == "restart_remote_xpc_tunnel"
+    assert health["recovery"]["state"] == "remote_xpc_tunnel_unavailable"
+    assert health["recovery"]["auto_fixable"] is False
+    assert health["recovery"]["manual_action_required"] is True
+    assert health["recovery"]["requires_sudo"] is True
+    assert health["recovery"]["processes"][0]["pid"] == 1234
+    assert health["recovery"]["steps"] == [
+        "Stop the stale process ids with sudo: 1234",
+        "Run: sudo appium driver run xcuitest tunnel-creation --udid abc123",
+        "Verify: http://127.0.0.1:42314/remotexpc/tunnels/abc123",
+    ]
+    assert health["recovery"]["commands"] == [
+        "sudo kill 1234",
+        "sudo appium driver run xcuitest tunnel-creation --udid abc123",
+        "curl -s http://127.0.0.1:42314/remotexpc/tunnels/abc123",
+    ]
+    assert health["recovery"]["registry_port"] == 42314
+
+
+def test_ios_device_health_marks_local_appium_down_auto_fixable(monkeypatch):
+    class ProbeStatus:
+        def to_dict(self):
+            return {
+                "device": "ios:abc123",
+                "udid": "abc123",
+                "state": "appium_down",
+                "message": "Appium is unreachable",
+                "appium_url": "http://127.0.0.1:4723",
+                "session_id": "",
+                "checks": {"appium_status_code": None},
+            }
+
+    class FakeIOSDevice:
+        appium_url = "http://127.0.0.1:4723"
+
+        def probe(self, deep=True):
+            assert deep is True
+            return ProbeStatus()
+
+        @property
+        def mjpeg_url(self):
+            return "http://127.0.0.1:9100"
+
+        @property
+        def mjpeg_settings(self):
+            return {}
+
+    monkeypatch.setattr("gitd.services.device_context.get_device", lambda device: FakeIOSDevice())
+
+    from gitd.services.device_context import device_health
+
+    health = device_health("ios:abc123")
+
+    assert health["connection"]["status"] == "appium_down"
+    assert health["recommended_fix"] == "start_appium"
+    assert health["recovery"]["auto_fixable"] is True
+    assert health["recovery"]["manual_action_required"] is False
+    assert health["recovery"]["requires_sudo"] is False
+
+
+def test_ios_device_health_marks_remote_appium_down_manual(monkeypatch):
+    class ProbeStatus:
+        def to_dict(self):
+            return {
+                "device": "ios:abc123",
+                "udid": "abc123",
+                "state": "appium_down",
+                "message": "Appium is unreachable",
+                "appium_url": "https://appium.example.test:4723",
+                "session_id": "",
+                "checks": {"appium_status_code": None},
+            }
+
+    class FakeIOSDevice:
+        appium_url = "https://appium.example.test:4723"
+
+        def probe(self, deep=True):
+            assert deep is True
+            return ProbeStatus()
+
+        @property
+        def mjpeg_url(self):
+            return "http://127.0.0.1:9100"
+
+        @property
+        def mjpeg_settings(self):
+            return {}
+
+    monkeypatch.setattr("gitd.services.device_context.get_device", lambda device: FakeIOSDevice())
+
+    from gitd.services.device_context import device_health
+
+    health = device_health("ios:abc123")
+
+    assert health["connection"]["status"] == "appium_down"
+    assert health["recommended_fix"] == "start_appium"
+    assert health["recovery"]["auto_fixable"] is False
+    assert health["recovery"]["manual_action_required"] is True
+    assert health["recovery"]["requires_sudo"] is False
+
+
+def test_ios_device_health_includes_recovery_steps_for_wda_signing_failure(monkeypatch):
+    class ProbeStatus:
+        def to_dict(self):
+            return {
+                "device": "ios:abc123",
+                "udid": "abc123",
+                "state": "wda_signing_failed",
+                "message": "WebDriverAgent signing/provisioning failed: xcodebuild failed with code 65",
+                "appium_url": "http://appium.local",
+                "session_id": "",
+                "checks": {"appium_status_code": 200, "error": "xcodebuild failed with code 65"},
+            }
+
+    class FakeIOSDevice:
+        def probe(self, deep=True):
+            assert deep is True
+            return ProbeStatus()
+
+        @property
+        def mjpeg_url(self):
+            return "http://127.0.0.1:9100"
+
+        @property
+        def mjpeg_settings(self):
+            return {}
+
+    monkeypatch.setattr("gitd.services.device_context.get_device", lambda device: FakeIOSDevice())
+
+    from gitd.services.device_context import device_health
+
+    health = device_health("ios:abc123")
+
+    assert health["connection"]["status"] == "wda_signing_failed"
+    assert health["recommended_fix"] == "fix_wda_signing"
+    assert health["recovery"]["state"] == "wda_signing_failed"
+    assert health["recovery"]["code"] == "fix_wda_signing"
+    assert "WebDriverAgent" in health["recovery"]["summary"]
+    assert any("IOS_XCODE_ORG_ID" in step for step in health["recovery"]["steps"])
+
+
+def test_ios_device_health_includes_recovery_steps_for_wda_launch_timeout(monkeypatch):
+    class ProbeStatus:
+        def to_dict(self):
+            return {
+                "device": "ios:abc123",
+                "udid": "abc123",
+                "state": "wda_launch_timeout",
+                "message": "WebDriverAgent session creation timed out",
+                "appium_url": "http://127.0.0.1:4723",
+                "session_id": "",
+                "checks": {"appium_status_code": 200, "error": "Read timed out"},
+            }
+
+    class FakeIOSDevice:
+        appium_url = "http://127.0.0.1:4723"
+
+        def probe(self, deep=True):
+            assert deep is True
+            return ProbeStatus()
+
+        @property
+        def mjpeg_url(self):
+            return "http://127.0.0.1:9100"
+
+        @property
+        def mjpeg_settings(self):
+            return {}
+
+    monkeypatch.setattr("gitd.services.device_context.get_device", lambda device: FakeIOSDevice())
+
+    from gitd.services.device_context import device_health
+
+    health = device_health("ios:abc123")
+
+    assert health["connection"]["status"] == "wda_launch_timeout"
+    assert health["appium"]["reachable"] is True
+    assert health["recommended_fix"] == "fix_wda_launch_timeout"
+    assert health["recovery"]["state"] == "wda_launch_timeout"
+    assert any("unlocked and awake" in step for step in health["recovery"]["steps"])
+
+
+def test_fix_device_health_resets_ios_session(monkeypatch):
+    calls = []
+
+    class FakeIOSDevice:
+        def reset_session(self):
+            calls.append("reset")
+
+    monkeypatch.setattr("gitd.services.device_context.get_device", lambda device: FakeIOSDevice())
+
+    from gitd.services.device_context import fix_device_health
+
+    result = fix_device_health("ios:abc123", "reset_session")
+
+    assert result == {
+        "ok": True,
+        "platform": "ios",
+        "issue": "reset_session",
+        "message": "iOS Appium session reset",
+    }
+    assert calls == ["reset"]
+
+
+def test_ios_start_appium_server_launches_loopback_process(monkeypatch, tmp_path):
+    calls = []
+    popen_calls = []
+    log_path = tmp_path / "appium.log"
+
+    class FakePopen:
+        pid = 2468
+
+        def __init__(self, command, stdin=None, stdout=None, stderr=None, start_new_session=False):
+            popen_calls.append(
+                {
+                    "command": command,
+                    "stdin": stdin,
+                    "stdout": stdout,
+                    "stderr": stderr,
+                    "start_new_session": start_new_session,
+                }
+            )
+
+    def fake_request(method, url, json=None, timeout=None):
+        calls.append(url)
+        if len(calls) == 1:
+            raise __import__("requests").ConnectionError("connection refused")
+        return FakeResponse({"value": {"ready": True}}, status_code=200)
+
+    monkeypatch.setenv("IOS_APPIUM_LOG", str(log_path))
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+    monkeypatch.setattr("gitd.bots.common.ios.subprocess.Popen", FakePopen)
+    monkeypatch.setattr("gitd.bots.common.ios.time.sleep", lambda *_args: None)
+
+    dev = IOSDevice("ios:abc123", appium_url="http://localhost:4729")
+    result = dev.start_appium_server()
+
+    assert result["ok"] is True
+    assert result["pid"] == 2468
+    assert result["command"] == ["appium", "--address", "127.0.0.1", "--port", "4729", "--log-level", "info"]
+    assert result["log_path"] == str(log_path)
+    assert popen_calls[0]["start_new_session"] is True
+    assert calls == ["http://localhost:4729/status", "http://localhost:4729/status"]
+
+
+def test_ios_start_appium_server_honors_command_override(monkeypatch, tmp_path):
+    calls = []
+    popen_calls = []
+    log_path = tmp_path / "appium.log"
+
+    class FakePopen:
+        pid = 2468
+
+        def __init__(self, command, stdin=None, stdout=None, stderr=None, start_new_session=False):
+            popen_calls.append(command)
+
+    def fake_request(method, url, json=None, timeout=None):
+        calls.append(url)
+        if len(calls) == 1:
+            raise __import__("requests").ConnectionError("connection refused")
+        return FakeResponse({"value": {"ready": True}}, status_code=200)
+
+    monkeypatch.setenv("IOS_APPIUM_COMMAND", "npx appium")
+    monkeypatch.setenv("IOS_APPIUM_LOG", str(log_path))
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+    monkeypatch.setattr("gitd.bots.common.ios.subprocess.Popen", FakePopen)
+    monkeypatch.setattr("gitd.bots.common.ios.time.sleep", lambda *_args: None)
+
+    dev = IOSDevice("ios:abc123", appium_url="http://127.0.0.1:4729")
+    result = dev.start_appium_server()
+
+    assert result["ok"] is True
+    assert result["command"] == ["npx", "appium", "--address", "127.0.0.1", "--port", "4729", "--log-level", "info"]
+    assert popen_calls == [result["command"]]
+
+
+def test_ios_start_appium_server_rejects_invalid_command_override(monkeypatch):
+    monkeypatch.setenv("IOS_APPIUM_COMMAND", "npx 'appium")
+    monkeypatch.setattr(
+        "gitd.bots.common.ios.subprocess.Popen",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("should not start process")),
+    )
+    monkeypatch.setattr(
+        "gitd.bots.common.ios.requests.request",
+        lambda *args, **kwargs: (_ for _ in ()).throw(__import__("requests").ConnectionError("down")),
+    )
+
+    dev = IOSDevice("ios:abc123", appium_url="http://127.0.0.1:4729")
+    result = dev.start_appium_server()
+
+    assert result["ok"] is False
+    assert result["manual_action_required"] is True
+    assert result["issue"] == "start_appium"
+    assert "IOS_APPIUM_COMMAND is not parseable" in result["message"]
+
+
+def test_ios_start_appium_server_refuses_remote_url():
+    dev = IOSDevice("ios:abc123", appium_url="https://appium.example.test:4723")
+
+    result = dev.start_appium_server()
+
+    assert result["ok"] is False
+    assert result["manual_action_required"] is True
+    assert result["issue"] == "start_appium"
+    assert "not a local HTTP server" in result["message"]
+
+
+def test_fix_device_health_returns_manual_ios_recovery_for_nonlocal_fix():
+    from gitd.services.device_context import fix_device_health
+
+    result = fix_device_health("ios:abc123", "fix_wda_signing")
+
+    assert result["ok"] is False
+    assert result["platform"] == "ios"
+    assert result["issue"] == "fix_wda_signing"
+    assert result["manual_action_required"] is True
+    assert result["recovery"]["state"] == "wda_signing_failed"
+
+
+def test_visible_text_entries_filter_controls_and_offscreen_nodes():
+    raw = """<?xml version="1.0" encoding="UTF-8"?>
+<AppiumAUT>
+  <XCUIElementTypeApplication type="XCUIElementTypeApplication" name="Chrome" label="Chrome" enabled="true" visible="true" x="0" y="0" width="393" height="852">
+    <XCUIElementTypeButton type="XCUIElementTypeButton" name="Tabs" label="Tabs" enabled="true" visible="true" x="0" y="0" width="60" height="44"/>
+    <XCUIElementTypeStaticText type="XCUIElementTypeStaticText" name="World leaders meet for climate talks today" label="World leaders meet for climate talks today" enabled="true" visible="true" x="10" y="120" width="360" height="44"/>
+    <XCUIElementTypeStaticText type="XCUIElementTypeStaticText" name="Offscreen article should not appear" label="Offscreen article should not appear" enabled="true" visible="true" x="10" y="900" width="360" height="44"/>
+    <XCUIElementTypeStaticText type="XCUIElementTypeStaticText" name="Hidden article should not appear" label="Hidden article should not appear" enabled="true" visible="false" x="10" y="180" width="360" height="44"/>
+  </XCUIElementTypeApplication>
+</AppiumAUT>
+"""
+    xml = normalize_wda_xml(raw)
+
+    entries = visible_text_entries_from_xml(xml, screen_size=(393, 852))
+
+    assert [entry["text"] for entry in entries] == ["World leaders meet for climate talks today"]
+
+
+def test_web_context_entries_prefer_dom_text_and_article_urls(monkeypatch):
+    calls = []
+    snapshot = {
+        "url": "https://text.npr.org/",
+        "title": "NPR",
+        "bodyText": "Top Stories\nWorld leaders meet for climate talks today",
+        "entries": [
+            {
+                "text": "World leaders meet for climate talks today",
+                "tag": "a",
+                "href": "https://text.npr.org/article/123",
+                "bounds": {"x1": 10, "y1": 100, "x2": 350, "y2": 140},
+                "provenance": "web_context",
+            }
+        ],
+    }
+
+    def fake_request(method, url, json=None, timeout=None):
+        calls.append({"method": method, "url": url, "json": json})
+        if url.endswith("/session/session-1/contexts"):
+            return FakeResponse({"value": ["NATIVE_APP", "WEBVIEW_1"]})
+        if url.endswith("/session/session-1/context"):
+            return FakeResponse({"value": None})
+        if url.endswith("/session/session-1/execute/sync"):
+            assert "document.querySelectorAll" in json["script"]
+            return FakeResponse({"value": snapshot})
+        raise AssertionError(f"unexpected request: {method} {url}")
+
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+    dev._session_id = "session-1"
+
+    entries = dev.web_text_entries()
+    articles = dev.extract_articles(max_items=1)
+
+    assert entries[0]["text"] == "World leaders meet for climate talks today"
+    assert entries[0]["url"] == "https://text.npr.org/article/123"
+    assert entries[0]["provenance"] == "web_context"
+    assert articles == [
+        {
+            "title": "World leaders meet for climate talks today",
+            "url": "https://text.npr.org/article/123",
+            "bounds": {"x1": 10, "y1": 100, "x2": 350, "y2": 140},
+            "center": {"x": 180, "y": 120},
+            "class": "a",
+            "provenance": "web_context",
+        }
+    ]
+    context_names = [call["json"]["name"] for call in calls if call["url"].endswith("/context")]
+    assert "WEBVIEW_1" in context_names
+    assert context_names[-1] == "NATIVE_APP"
+
+
+def test_native_article_extraction_filters_browser_toolbar_controls(monkeypatch):
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+    monkeypatch.setattr(dev, "web_text_entries", lambda max_entries=300: [])
+    monkeypatch.setattr(
+        dev,
+        "native_text_entries",
+        lambda include_controls=False, max_entries=300: [
+            {
+                "text": "Search your screen with Google Lens",
+                "bounds": {"x1": 30, "y1": 153, "x2": 162, "y2": 261},
+                "center": {"x": 96, "y": 207},
+                "class": "XCUIElementTypeButton",
+                "provenance": "native",
+            },
+            {
+                "text": "text.npr.org Secure",
+                "bounds": {"x1": 30, "y1": 153, "x2": 1140, "y2": 261},
+                "center": {"x": 585, "y": 207},
+                "class": "XCUIElementTypeButton",
+                "provenance": "native",
+            },
+            {
+                "text": "NPR : National Public Radio",
+                "bounds": {"x1": 60, "y1": 498, "x2": 963, "y2": 585},
+                "center": {"x": 511, "y": 541},
+                "class": "XCUIElementTypeStaticText",
+                "provenance": "native",
+            },
+            {
+                "text": "Monday, June 8, 2026",
+                "bounds": {"x1": 60, "y1": 711, "x2": 546, "y2": 774},
+                "center": {"x": 303, "y": 742},
+                "class": "XCUIElementTypeStaticText",
+                "provenance": "native",
+            },
+            {
+                "text": "Israel and Iran exchange missile fire threatening Middle East truce",
+                "bounds": {"x1": 60, "y1": 834, "x2": 1092, "y2": 963},
+                "center": {"x": 576, "y": 898},
+                "class": "XCUIElementTypeLink",
+                "provenance": "native",
+            },
+        ],
+    )
+
+    articles = dev.extract_articles(max_items=3)
+
+    assert [article["title"] for article in articles] == [
+        "Israel and Iran exchange missile fire threatening Middle East truce"
+    ]
+
+
+def test_web_context_body_text_fallback_preserves_article_text(monkeypatch):
+    snapshot = {
+        "url": "https://text.npr.org/article/123",
+        "title": "NPR",
+        "bodyText": (
+            "World leaders meet for climate talks today. "
+            "The article body is exposed through document.body even when no DOM entries are returned."
+        ),
+        "viewport": {"width": 393, "height": 852},
+        "entries": [],
+    }
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+
+    monkeypatch.setattr(dev, "web_text_snapshot", lambda max_entries=300: snapshot)
+
+    def fail_native_text_entries(**kwargs):
+        raise AssertionError("WebView bodyText should be used before native XML fallback")
+
+    monkeypatch.setattr(dev, "native_text_entries", fail_native_text_entries)
+
+    entries = dev.visible_text_entries(max_entries=5)
+
+    assert entries == [
+        {
+            "text": snapshot["bodyText"],
+            "bounds": {"x1": 0, "y1": 0, "x2": 393, "y2": 852},
+            "center": {"x": 196, "y": 426},
+            "class": "body",
+            "resource_id": "",
+            "content_desc": "",
+            "provenance": "web_context_body",
+            "url": "https://text.npr.org/article/123",
+            "role": "document",
+        }
+    ]
+    assert dev.extract_visible_text(max_lines=1) == snapshot["bodyText"]
+
+
+def test_web_context_article_extraction_uses_headings_without_urls(monkeypatch):
+    snapshot = {
+        "url": "https://news.example/",
+        "title": "News",
+        "bodyText": "Top Stories\nWorld leaders meet for climate talks today",
+        "entries": [
+            {
+                "text": "World leaders meet for climate talks today",
+                "tag": "h2",
+                "href": "",
+                "bounds": {"x1": 10, "y1": 100, "x2": 350, "y2": 140},
+                "provenance": "web_context",
+            },
+            {
+                "text": "Short dek",
+                "tag": "p",
+                "href": "",
+                "bounds": {"x1": 10, "y1": 150, "x2": 350, "y2": 180},
+                "provenance": "web_context",
+            },
+        ],
+    }
+
+    def fake_request(method, url, json=None, timeout=None):
+        if url.endswith("/session/session-1/contexts"):
+            return FakeResponse({"value": ["NATIVE_APP", "WEBVIEW_1"]})
+        if url.endswith("/session/session-1/context"):
+            return FakeResponse({"value": None})
+        if url.endswith("/session/session-1/execute/sync"):
+            return FakeResponse({"value": snapshot})
+        raise AssertionError(f"unexpected request: {method} {url}")
+
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+    dev._session_id = "session-1"
+
+    articles = dev.extract_articles(max_items=1)
+
+    assert articles == [
+        {
+            "title": "World leaders meet for climate talks today",
+            "url": "",
+            "bounds": {"x1": 10, "y1": 100, "x2": 350, "y2": 140},
+            "center": {"x": 180, "y": 120},
+            "class": "h2",
+            "provenance": "web_context",
+        }
+    ]
+
+
+def test_web_context_article_extraction_prioritizes_content_links(monkeypatch):
+    snapshot = {
+        "url": "https://text.npr.org/",
+        "title": "NPR",
+        "bodyText": "Top Stories\nWorld leaders meet for climate talks today",
+        "entries": [
+            {
+                "text": "Sign up for NPR daily newsletter today",
+                "tag": "a",
+                "href": "https://text.npr.org/newsletter",
+                "bounds": {"x1": 10, "y1": 60, "x2": 350, "y2": 90},
+                "provenance": "web_context",
+            },
+            {
+                "text": "World leaders meet for climate talks today",
+                "tag": "a",
+                "href": "https://text.npr.org/2026/06/08/story/123",
+                "bounds": {"x1": 10, "y1": 180, "x2": 350, "y2": 220},
+                "provenance": "web_context",
+            },
+        ],
+    }
+
+    def fake_request(method, url, json=None, timeout=None):
+        if url.endswith("/session/session-1/contexts"):
+            return FakeResponse({"value": ["NATIVE_APP", "WEBVIEW_1"]})
+        if url.endswith("/session/session-1/context"):
+            return FakeResponse({"value": None})
+        if url.endswith("/session/session-1/execute/sync"):
+            return FakeResponse({"value": snapshot})
+        raise AssertionError(f"unexpected request: {method} {url}")
+
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+    dev._session_id = "session-1"
+
+    articles = dev.extract_articles(max_items=1)
+
+    assert articles[0]["title"] == "World leaders meet for climate talks today"
+    assert articles[0]["url"] == "https://text.npr.org/2026/06/08/story/123"
+
+
+def test_web_context_article_extraction_keeps_unlinked_headings_when_noisy_links_exist(monkeypatch):
+    snapshot = {
+        "url": "https://news.example/",
+        "title": "News",
+        "bodyText": "Top Stories\nWorld leaders meet for climate talks today",
+        "entries": [
+            {
+                "text": "Sign up for our daily newsletter today",
+                "tag": "a",
+                "href": "https://news.example/newsletter",
+                "bounds": {"x1": 10, "y1": 60, "x2": 350, "y2": 90},
+                "provenance": "web_context",
+            },
+            {
+                "text": "World leaders meet for climate talks today",
+                "tag": "h2",
+                "href": "",
+                "bounds": {"x1": 10, "y1": 140, "x2": 350, "y2": 180},
+                "provenance": "web_context",
+            },
+        ],
+    }
+
+    def fake_request(method, url, json=None, timeout=None):
+        if url.endswith("/session/session-1/contexts"):
+            return FakeResponse({"value": ["NATIVE_APP", "WEBVIEW_1"]})
+        if url.endswith("/session/session-1/context"):
+            return FakeResponse({"value": None})
+        if url.endswith("/session/session-1/execute/sync"):
+            return FakeResponse({"value": snapshot})
+        raise AssertionError(f"unexpected request: {method} {url}")
+
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+    dev._session_id = "session-1"
+
+    articles = dev.extract_articles(max_items=1)
+
+    assert articles == [
+        {
+            "title": "World leaders meet for climate talks today",
+            "url": "",
+            "bounds": {"x1": 10, "y1": 140, "x2": 350, "y2": 180},
+            "center": {"x": 180, "y": 160},
+            "class": "h2",
+            "provenance": "web_context",
+        }
+    ]
+
+
+def test_web_context_article_extraction_drops_only_low_value_links(monkeypatch):
+    snapshot = {
+        "url": "https://news.example/",
+        "title": "News",
+        "bodyText": "Subscribe\nSign in",
+        "entries": [
+            {
+                "text": "Sign up for our daily newsletter today",
+                "tag": "a",
+                "href": "https://news.example/newsletter",
+                "bounds": {"x1": 10, "y1": 60, "x2": 350, "y2": 90},
+                "provenance": "web_context",
+            },
+            {
+                "text": "Subscribe to support local news coverage",
+                "tag": "a",
+                "href": "https://news.example/subscribe",
+                "bounds": {"x1": 10, "y1": 100, "x2": 350, "y2": 130},
+                "provenance": "web_context",
+            },
+        ],
+    }
+
+    def fake_request(method, url, json=None, timeout=None):
+        if url.endswith("/session/session-1/contexts"):
+            return FakeResponse({"value": ["NATIVE_APP", "WEBVIEW_1"]})
+        if url.endswith("/session/session-1/context"):
+            return FakeResponse({"value": None})
+        if url.endswith("/session/session-1/execute/sync"):
+            return FakeResponse({"value": snapshot})
+        raise AssertionError(f"unexpected request: {method} {url}")
+
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+    dev._session_id = "session-1"
+
+    assert dev.extract_articles(max_items=3) == []
+
+
+def test_ios_wait_for_url_matches_trusted_browser_url(monkeypatch):
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+    urls = ["about:blank", "https://text.npr.org/?output=1"]
+
+    monkeypatch.setattr(dev, "_current_url_from_webdriver", lambda: urls.pop(0))
+    monkeypatch.setattr(dev, "web_text_snapshot", lambda max_entries=12: {})
+    monkeypatch.setattr("gitd.bots.common.ios.time.sleep", lambda *_args, **_kwargs: None)
+
+    status = dev.wait_for_url("https://text.npr.org/?output=1", timeout=1, interval=0.01)
+
+    assert status == {
+        "ok": True,
+        "expected_url": "https://text.npr.org/?output=1",
+        "url": "https://text.npr.org/?output=1",
+        "state": "url_matched",
+    }
+
+
+def test_ios_wait_for_url_does_not_match_different_path(monkeypatch):
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+
+    monkeypatch.setattr(dev, "_current_url_from_webdriver", lambda: "https://text.npr.org/article/1")
+    monkeypatch.setattr(dev, "web_text_snapshot", lambda max_entries=12: {})
+
+    status = dev.wait_for_url("https://text.npr.org/", timeout=0, interval=0.01)
+
+    assert status["ok"] is False
+    assert status["state"] == "timeout"
+    assert status["url"] == "https://text.npr.org/article/1"
+
+
+def test_ios_wait_for_url_falls_back_to_page_text_when_url_is_hidden(monkeypatch):
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+
+    monkeypatch.setattr(dev, "_current_url_from_webdriver", lambda: "")
+    monkeypatch.setattr(
+        dev,
+        "web_text_snapshot",
+        lambda max_entries=12: {"bodyText": "Loaded article body", "entries": [{"text": "Loaded article body"}]},
+    )
+
+    status = dev.wait_for_url("https://example.com/article", timeout=0, interval=0.01)
+
+    assert status == {
+        "ok": True,
+        "expected_url": "https://example.com/article",
+        "url": "",
+        "state": "page_text_available",
+        "verified_url": False,
+    }
+
+
+def test_ios_wait_for_url_matches_native_toolbar_url_when_webview_url_is_hidden(monkeypatch):
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+
+    monkeypatch.setattr(dev, "_current_url_from_webdriver", lambda: "")
+    monkeypatch.setattr(dev, "web_text_snapshot", lambda max_entries=12: {})
+    monkeypatch.setattr(dev, "_current_url_from_native_text", lambda: "text.npr.org")
+
+    status = dev.wait_for_url("https://text.npr.org/", timeout=0, interval=0.01)
+
+    assert status == {
+        "ok": True,
+        "expected_url": "https://text.npr.org/",
+        "url": "text.npr.org",
+        "state": "url_matched_native",
+    }
+
+
+def test_ios_get_phone_state_normalizes_active_app_keyboard_and_focus(monkeypatch):
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local", bundle_id="com.google.chrome.ios")
+    dev._session_id = "session-1"
+    xml = """
+    <hierarchy>
+      <node class="XCUIElementTypeApplication" text="Chrome" visible="true" bounds="[0,0][393,852]" />
+      <node class="XCUIElementTypeTextField" text="Search or type web address" content-desc="Address"
+        resource-id="Address" focused="true" visible="true" bounds="[20,60][360,104]" />
+      <node class="XCUIElementTypeKeyboard" text="" visible="true" bounds="[0,540][393,852]" />
+    </hierarchy>
+    """
+
+    monkeypatch.setattr(dev, "_window_rect", lambda: {"x": 0, "y": 0, "width": 393, "height": 852})
+    monkeypatch.setattr(dev, "get_screen_size", lambda: (393, 852))
+    monkeypatch.setattr(
+        dev,
+        "_execute_mobile",
+        lambda command, args=None: {"name": "Chrome", "bundleId": "com.google.chrome.ios"},
+    )
+    monkeypatch.setattr(dev, "dump_xml", lambda: xml)
+
+    state = dev.get_phone_state()
+
+    assert state["platform"] == "ios"
+    assert state["device"] == "ios:abc123"
+    assert state["bundleId"] == "com.google.chrome.ios"
+    assert state["bundle_id"] == "com.google.chrome.ios"
+    assert state["packageName"] == "com.google.chrome.ios"
+    assert state["activityName"] == "com.google.chrome.ios"
+    assert state["currentApp"] == "Chrome"
+    assert state["keyboardVisible"] is True
+    assert state["screenSize"] == {"width": 393, "height": 852}
+    assert state["windowRect"] == {"x": 0, "y": 0, "width": 393, "height": 852}
+    assert state["focusedElement"] == {
+        "text": "Search or type web address",
+        "content_desc": "Address",
+        "resource_id": "Address",
+        "class": "XCUIElementTypeTextField",
+        "bounds": {"x1": 20, "y1": 60, "x2": 360, "y2": 104},
+        "center": {"x": 190, "y": 82},
+    }
+
+
+def test_ios_get_phone_state_uses_target_bundle_defaults_when_enrichment_fails(monkeypatch):
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local", bundle_id="com.google.chrome.ios")
+
+    monkeypatch.setattr(dev, "_window_rect", lambda: {"x": 0, "y": 0, "width": 393, "height": 852})
+    monkeypatch.setattr(dev, "get_screen_size", lambda: (393, 852))
+    monkeypatch.setattr(dev, "_execute_mobile", lambda command, args=None: (_ for _ in ()).throw(RuntimeError("no active app")))
+    monkeypatch.setattr(dev, "dump_xml", lambda: (_ for _ in ()).throw(RuntimeError("no source")))
+
+    state = dev.get_phone_state()
+
+    assert state["bundleId"] == "com.google.chrome.ios"
+    assert state["bundle_id"] == "com.google.chrome.ios"
+    assert state["packageName"] == "com.google.chrome.ios"
+    assert state["activityName"] == "com.google.chrome.ios"
+    assert state["currentApp"] == "Chrome"
+    assert state["keyboardVisible"] is False
+    assert state["focusedElement"] == {}
+
+
+def test_ios_open_url_returns_navigation_evidence_from_webdriver(monkeypatch):
+    calls = []
+
+    def fake_request(method, url, json=None, timeout=None):
+        calls.append({"method": method, "url": url, "json": json})
+        if method == "POST" and url.endswith("/session/session-1/url"):
+            return FakeResponse({"value": None})
+        if method == "GET" and url.endswith("/session/session-1/url"):
+            return FakeResponse({"value": "https://example.com/story?id=42&utm=agent"})
+        raise AssertionError(f"unexpected request: {method} {url}")
+
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+    dev._session_id = "session-1"
+
+    status = dev.open_url("example.com/story?id=42", delay=0)
+
+    assert status["ok"] is True
+    assert status["method"] == "webdriver_url"
+    assert status["state"] == "url_matched"
+    assert status["url"] == "https://example.com/story?id=42&utm=agent"
+    assert [call["method"] for call in calls] == ["POST", "GET"]
+
+
+def test_ios_open_url_falls_back_when_webdriver_url_is_unverified(monkeypatch):
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local", bundle_id="com.google.chrome.ios")
+    dev._session_id = "session-1"
+    requests_seen = []
+    address_calls = []
+    statuses = iter(
+        [
+            {"ok": False, "state": "timeout", "error": "not loaded"},
+            {
+                "ok": True,
+                "expected_url": "https://example.com/",
+                "url": "https://example.com/",
+                "state": "url_matched",
+            },
+        ]
+    )
+
+    monkeypatch.setattr(
+        dev,
+        "_request",
+        lambda method, path, payload=None, timeout=None: requests_seen.append((method, path, payload)),
+    )
+    monkeypatch.setattr(dev, "wait_for_url", lambda url, timeout=8.0, interval=0.5: next(statuses))
+    monkeypatch.setattr(dev, "_open_url_in_web_context", lambda url, delay=2.0: False)
+    monkeypatch.setattr(
+        dev,
+        "_open_url_via_address_bar",
+        lambda url, delay=2.0: address_calls.append((url, delay)) or "address_bar_ocr",
+    )
+
+    status = dev.open_url("example.com", delay=0)
+
+    assert status["ok"] is True
+    assert status["method"] == "address_bar"
+    assert status["address_bar_source"] == "address_bar_ocr"
+    assert status["errors"] == [
+        {
+            "method": "webdriver_url",
+            "state": "timeout",
+            "error": "not loaded",
+        }
+    ]
+    assert requests_seen == [("POST", "/session/session-1/url", {"url": "https://example.com"})]
+    assert address_calls == [("https://example.com", 0)]
+
+
+def test_ios_open_url_falls_back_when_web_context_url_is_unverified(monkeypatch):
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local", bundle_id="com.google.chrome.ios")
+    dev._session_id = "session-1"
+    address_calls = []
+    statuses = iter(
+        [
+            {"ok": False, "state": "timeout", "error": "web context did not load"},
+            {
+                "ok": True,
+                "expected_url": "https://example.com/",
+                "url": "https://example.com/",
+                "state": "url_matched",
+            },
+        ]
+    )
+
+    monkeypatch.setattr(
+        dev,
+        "_request",
+        lambda method, path, payload=None, timeout=None: (_ for _ in ()).throw(IOSBackendError("webdriver failed")),
+    )
+    monkeypatch.setattr(dev, "wait_for_url", lambda url, timeout=8.0, interval=0.5: next(statuses))
+    monkeypatch.setattr(dev, "_open_url_in_web_context", lambda url, delay=2.0: True)
+    monkeypatch.setattr(
+        dev,
+        "_open_url_via_address_bar",
+        lambda url, delay=2.0: address_calls.append((url, delay)),
+    )
+
+    status = dev.open_url("https://example.com", delay=0)
+
+    assert status["ok"] is True
+    assert status["method"] == "address_bar"
+    assert status["errors"] == [
+        {"method": "webdriver_url", "error": "webdriver failed"},
+        {
+            "method": "web_context",
+            "state": "timeout",
+            "error": "web context did not load",
+        },
+    ]
+    assert address_calls == [("https://example.com", 0)]
+
+
+def test_take_screenshot_decodes_base64(monkeypatch):
+    def fake_request(method, url, json=None, timeout=None):
+        assert method == "GET"
+        assert url.endswith("/session/session-1/screenshot")
+        return FakeResponse({"value": base64.b64encode(PNG_1X1).decode()})
+
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+    dev._session_id = "session-1"
+
+    assert dev.take_screenshot() == PNG_1X1
+
+
+def test_tap_converts_screenshot_pixels_to_wda_points(monkeypatch):
+    calls = []
+
+    def fake_request(method, url, json=None, timeout=None):
+        calls.append({"method": method, "url": url, "json": json})
+        return FakeResponse({"value": None})
+
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+    monkeypatch.setattr("gitd.bots.common.ios.time.sleep", lambda *_: None)
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+    dev._session_id = "session-1"
+    dev._scale = (3.0, 2.0)
+
+    dev.tap(30, 40)
+
+    move = calls[0]["json"]["actions"][0]["actions"][0]
+    assert calls[0]["url"].endswith("/session/session-1/actions")
+    assert move["x"] == 10
+    assert move["y"] == 20
+    assert move["origin"] == "viewport"
+
+
+def test_launch_app_uses_mobile_launch_app(monkeypatch):
+    calls = []
+
+    def fake_request(method, url, json=None, timeout=None):
+        calls.append({"method": method, "url": url, "json": json})
+        return FakeResponse({"value": None})
+
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+    monkeypatch.setattr("gitd.bots.common.ios.time.sleep", lambda *_: None)
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+    dev._session_id = "session-1"
+
+    assert dev.launch_app("com.apple.mobilesafari") == "com.apple.mobilesafari"
+    assert calls[0]["url"].endswith("/session/session-1/execute/sync")
+    assert calls[0]["json"] == {
+        "script": "mobile: launchApp",
+        "args": [{"bundleId": "com.apple.mobilesafari"}],
+    }
+
+
+def test_clipboard_get_decodes_appium_base64(monkeypatch):
+    def fake_request(method, url, json=None, timeout=None):
+        assert method == "POST"
+        assert url.endswith("/session/session-1/appium/device/get_clipboard")
+        assert json == {"contentType": "plaintext"}
+        return FakeResponse({"value": base64.b64encode("hello iOS".encode()).decode()})
+
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+    dev._session_id = "session-1"
+
+    assert dev.clipboard_get() == "hello iOS"
+
+
+def test_clipboard_set_encodes_appium_payload(monkeypatch):
+    calls = []
+
+    def fake_request(method, url, json=None, timeout=None):
+        calls.append({"method": method, "url": url, "json": json})
+        return FakeResponse({"value": None})
+
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+    dev._session_id = "session-1"
+
+    assert dev.clipboard_set("hello iOS") is True
+    assert calls[0]["method"] == "POST"
+    assert calls[0]["url"].endswith("/session/session-1/appium/device/set_clipboard")
+    assert calls[0]["json"]["contentType"] == "plaintext"
+    assert calls[0]["json"]["label"] == "Ghost in the Droid"
+    assert base64.b64decode(calls[0]["json"]["content"]).decode() == "hello iOS"
+
+
+def test_ios_paste_text_sets_clipboard_and_inserts_text(monkeypatch):
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+    calls = []
+
+    monkeypatch.setattr(dev, "clipboard_set", lambda text: calls.append(("clipboard", text)) or True)
+    monkeypatch.setattr(dev, "type_text", lambda text, delay=0.3: calls.append(("type", text, delay)))
+
+    assert dev.paste_text("hello iOS") is True
+    assert calls == [("clipboard", "hello iOS"), ("type", "hello iOS", 0.3)]
+
+
+def test_ios_clear_active_element_uses_webdriver_clear(monkeypatch):
+    calls = []
+
+    def fake_request(method, url, json=None, timeout=None):
+        calls.append({"method": method, "url": url, "json": json})
+        if method == "GET" and url.endswith("/session/session-1/element/active"):
+            return FakeResponse({"value": {"element-6066-11e4-a52e-4f735466cecf": "element-1"}})
+        if method == "POST" and url.endswith("/session/session-1/element/element-1/clear"):
+            return FakeResponse({"value": None})
+        raise AssertionError(f"unexpected request: {method} {url}")
+
+    monkeypatch.setattr("gitd.bots.common.ios.requests.request", fake_request)
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+    dev._session_id = "session-1"
+
+    assert dev._clear_active_element() is True
+    assert [call["method"] for call in calls] == ["GET", "POST"]
+    assert calls[1]["json"] == {}
+
+
+def test_ios_dismiss_browser_first_run_prompts_taps_known_actions(monkeypatch):
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local", bundle_id="com.google.chrome.ios")
+    tapped = []
+    xmls = iter(
+        [
+            """
+            <hierarchy>
+              <node class="XCUIElementTypeButton" text="Accept &amp; Continue"
+                content-desc="Accept &amp; Continue" resource-id="Accept &amp; Continue"
+                bounds="[20,600][360,650]" clickable="true"/>
+            </hierarchy>
+            """,
+            """
+            <hierarchy>
+              <node class="XCUIElementTypeButton" text="No Thanks" content-desc="No Thanks"
+                resource-id="No Thanks" bounds="[20,600][360,650]" clickable="true"/>
+            </hierarchy>
+            """,
+            """
+            <hierarchy>
+              <node class="XCUIElementTypeTextField" text="Search or type web address" content-desc="Address"
+                resource-id="Address" bounds="[20,60][360,104]" clickable="true"/>
+            </hierarchy>
+            """,
+        ]
+    )
+
+    monkeypatch.setattr(dev, "dump_xml", lambda: next(xmls))
+    monkeypatch.setattr(dev, "tap_node", lambda node, delay=0.5: tapped.append((dev.node_text(node), delay)) or True)
+
+    assert dev._dismiss_browser_first_run_prompts() == 2
+    assert tapped == [("Accept & Continue", 0.6), ("No Thanks", 0.6)]
+
+
+def test_ios_url_address_bar_fallback_clears_before_typing(monkeypatch):
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local", bundle_id="com.google.chrome.ios")
+    calls = []
+    xml = """
+    <hierarchy>
+      <node class="XCUIElementTypeTextField" text="Search or type web address" content-desc="Address"
+        resource-id="Address" bounds="[20,60][360,104]" clickable="true"/>
+    </hierarchy>
+    """
+
+    monkeypatch.setattr(dev, "launch_app", lambda bundle_id, delay=2.0: calls.append(("launch", bundle_id, delay)) or bundle_id)
+    monkeypatch.setattr(dev, "dump_xml", lambda: xml)
+    monkeypatch.setattr(dev, "tap_node", lambda node, delay=0.5: calls.append(("tap", delay)) or True)
+    monkeypatch.setattr(dev, "_clear_active_element", lambda: calls.append(("clear",)) or True)
+    monkeypatch.setattr(dev, "type_text", lambda text, delay=0.3: calls.append(("type", text, delay)))
+    monkeypatch.setattr(dev, "press_enter", lambda delay=0.5: calls.append(("enter", delay)))
+
+    dev._open_url_via_address_bar("https://example.com", delay=0.1)
+
+    assert calls == [
+        ("launch", "com.google.chrome.ios", 0.8),
+        ("tap", 0.5),
+        ("clear",),
+        ("type", "https://example.com", 0.2),
+        ("enter", 0.1),
+    ]
+
+
+def test_ios_url_address_bar_fallback_uses_ocr_when_xml_has_no_field(monkeypatch):
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local", bundle_id="com.google.chrome.ios")
+    calls = []
+
+    monkeypatch.setattr(dev, "launch_app", lambda bundle_id, delay=2.0: calls.append(("launch", bundle_id, delay)) or bundle_id)
+    monkeypatch.setattr(dev, "_dismiss_browser_first_run_prompts", lambda: 0)
+    monkeypatch.setattr(dev, "dump_xml", lambda: "<hierarchy></hierarchy>")
+    monkeypatch.setattr(
+        "gitd.services.device_context.ocr_screen",
+        lambda device: [{"text": "Search or type web address", "conf": 0.91, "x": 24, "y": 700, "w": 320, "h": 44}],
+    )
+    monkeypatch.setattr(dev, "tap", lambda x, y, delay=0.6: calls.append(("tap", x, y, delay)))
+    monkeypatch.setattr(dev, "_clear_active_element", lambda: calls.append(("clear",)) or True)
+    monkeypatch.setattr(dev, "type_text", lambda text, delay=0.3: calls.append(("type", text, delay)))
+    monkeypatch.setattr(dev, "press_enter", lambda delay=0.5: calls.append(("enter", delay)))
+
+    method = dev._open_url_via_address_bar("https://example.com", delay=0.1)
+
+    assert method == "address_bar_ocr"
+    assert calls == [
+        ("launch", "com.google.chrome.ios", 0.8),
+        ("tap", 184, 722, 0.5),
+        ("clear",),
+        ("type", "https://example.com", 0.2),
+        ("enter", 0.1),
+    ]
+
+
+def test_ios_open_notifications_swipes_from_status_bar(monkeypatch):
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+    calls = []
+
+    monkeypatch.setattr(dev, "get_screen_size", lambda: (390, 844))
+    monkeypatch.setattr(
+        dev,
+        "swipe",
+        lambda x1, y1, x2, y2, ms=500, delay=0.5: calls.append(
+            {"x1": x1, "y1": y1, "x2": x2, "y2": y2, "ms": ms, "delay": delay}
+        ),
+    )
+
+    assert dev.open_notifications() is True
+    assert calls == [{"x1": 195, "y1": 16, "x2": 195, "y2": 523, "ms": 650, "delay": 1.0}]
+
+
+def test_ios_open_camera_launches_camera_and_taps_mode_controls(monkeypatch):
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+    xml = """
+    <hierarchy>
+      <node text="Video" content-desc="Video" resource-id="Video" bounds="[10,10][90,50]"/>
+      <node text="Switch Camera" content-desc="Switch Camera" resource-id="Switch Camera" bounds="[100,10][180,50]"/>
+      <node text="Timer" content-desc="Timer" resource-id="Timer" bounds="[190,10][260,50]"/>
+      <node text="3s" content-desc="3s" resource-id="3s" bounds="[270,10][320,50]"/>
+    </hierarchy>
+    """
+    launched = []
+    taps = []
+
+    monkeypatch.setattr(dev, "launch_app", lambda bundle_id, delay=1.5: launched.append((bundle_id, delay)) or bundle_id)
+    monkeypatch.setattr(dev, "dump_xml", lambda: xml)
+    monkeypatch.setattr(dev, "tap_node", lambda node, delay=0.8: taps.append(dev.node_text(node)) or True)
+
+    result = dev.open_camera(mode="selfie_video", timer_s=2)
+
+    assert launched == [("com.apple.camera", 1.5)]
+    assert result == {
+        "platform": "ios",
+        "bundle_id": "com.apple.camera",
+        "mode": "selfie_video",
+        "opened": True,
+        "selected_mode": True,
+        "switched_camera": True,
+        "timer_s": 3,
+        "timer_set": True,
+    }
+    assert taps == ["Video", "Switch Camera", "Timer", "3s"]
+
+
+def test_ios_get_notifications_groups_visible_notification_center_text(monkeypatch):
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+
+    monkeypatch.setattr(dev, "open_notifications", lambda delay=0.8: True)
+    monkeypatch.setattr(
+        dev,
+        "native_text_entries",
+        lambda include_controls=True, max_entries=120: [
+            {"text": "Notification Center"},
+            {"text": "Slack"},
+            {"text": "New message from Dana"},
+            {"text": "Calendar"},
+            {"text": "Standup in 10 minutes"},
+            {"text": "Clear"},
+        ],
+    )
+
+    assert dev.get_notifications() == [
+        {
+            "package": "",
+            "title": "Slack",
+            "text": "New message from Dana",
+            "time": "",
+            "platform": "ios",
+            "source": "notification_center",
+        },
+        {
+            "package": "",
+            "title": "Calendar",
+            "text": "Standup in 10 minutes",
+            "time": "",
+            "platform": "ios",
+            "source": "notification_center",
+        },
+    ]
+
+
+def test_ios_clear_notifications_taps_visible_clear_control(monkeypatch):
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+    xml = '<hierarchy><node text="Clear" content-desc="Clear" resource-id="Clear" bounds="[10,10][90,50]"/></hierarchy>'
+    taps = []
+
+    monkeypatch.setattr(dev, "open_notifications", lambda delay=0.5: True)
+    monkeypatch.setattr(dev, "dump_xml", lambda: xml)
+    monkeypatch.setattr(dev, "tap_node", lambda node, delay=0.8: taps.append(node) or True)
+
+    assert dev.clear_notifications() is True
+    assert len(taps) >= 1
+
+
+@pytest.mark.skipif(
+    not (os.getenv("IOS_APPIUM_URL") and os.getenv("IOS_DEVICE_UDID")),
+    reason="set IOS_APPIUM_URL and IOS_DEVICE_UDID to run live iOS integration test",
+)
+def test_live_ios_screenshot_and_source():
+    dev = IOSDevice(f"ios:{os.environ['IOS_DEVICE_UDID']}", appium_url=os.environ["IOS_APPIUM_URL"])
+    try:
+        assert len(dev.take_screenshot()) > 100
+        assert "<hierarchy" in dev.dump_xml()
+    finally:
+        dev.close()

--- a/tests/test_ios_explorer_recorder.py
+++ b/tests/test_ios_explorer_recorder.py
@@ -1,0 +1,221 @@
+import base64
+import json
+
+from gitd.skills.auto_creator import AppExplorer, ios_state_hash
+from gitd.skills.macro_recorder import Macro, MacroRecorder, MacroStep
+
+
+PNG_BYTES = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+)
+
+IOS_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<hierarchy rotation="0" platform="ios">
+  <node index="0" text="" resource-id="" class="XCUIElementTypeApplication" content-desc="" clickable="false" bounds="[0,0][390,844]">
+    <node index="1" text="Top Story" resource-id="headline" class="XCUIElementTypeButton" content-desc="" clickable="true" bounds="[10,20][180,80]" />
+  </node>
+</hierarchy>
+"""
+
+
+class FakeIOSDevice:
+    serial = "ios:abc123"
+
+    def __init__(self):
+        self.launched: list[str] = []
+        self.taps: list[tuple[int, int]] = []
+        self.keys: list[str] = []
+        self.typed: list[str] = []
+        self.back_count = 0
+        self.browser_back_count = 0
+
+    def launch_app(self, bundle_id: str):
+        self.launched.append(bundle_id)
+
+    def dump_xml(self) -> str:
+        return IOS_XML
+
+    def take_screenshot(self) -> bytes:
+        return PNG_BYTES
+
+    def get_phone_state(self) -> dict:
+        return {"bundleId": self.launched[-1] if self.launched else "com.example.app"}
+
+    def tap(self, x: int, y: int, delay: float = 0):
+        self.taps.append((x, y))
+
+    def swipe(self, x1: int, y1: int, x2: int, y2: int, ms: int = 500, delay: float = 0):
+        pass
+
+    def back(self, delay: float = 0):
+        self.back_count += 1
+
+    def browser_back(self, delay: float = 0):
+        self.browser_back_count += 1
+
+    def type_text(self, text: str):
+        self.typed.append(text)
+
+    def press_key(self, key: str):
+        self.keys.append(key)
+
+
+def test_ios_app_explorer_uses_bundle_id_and_wda_screenshot(tmp_path):
+    dev = FakeIOSDevice()
+    explorer = AppExplorer(
+        dev=dev,
+        package="com.google.chrome.ios",
+        output_dir=str(tmp_path),
+        max_depth=0,
+        max_states=1,
+        settle_time=0,
+    )
+
+    graph = explorer.explore()
+
+    assert dev.launched == ["com.google.chrome.ios"]
+    assert graph["platform"] == "ios"
+    assert graph["package"] == "com.google.chrome.ios"
+    assert graph["state_identity"]["ios"] == ["bundle_id", "activity", "xml_structure_hash", "screenshot_hash"]
+    assert graph["total_states"] == 1
+
+    state = next(iter(graph["states"].values()))
+    assert state["activity"] == "com.google.chrome.ios"
+    assert state["elements"][0]["text"] == "Top Story"
+    assert (tmp_path / "state_graph.json").exists()
+    assert (tmp_path / "screenshots" / f"{state['state_id']}.png").read_bytes() == PNG_BYTES
+    assert json.loads((tmp_path / "state_graph.json").read_text())["platform"] == "ios"
+
+
+def test_ios_app_explorer_progress_includes_dashboard_metadata(tmp_path):
+    dev = FakeIOSDevice()
+    explorer = AppExplorer(
+        dev=dev,
+        package="com.google.chrome.ios",
+        output_dir=str(tmp_path),
+        max_depth=1,
+        max_states=3,
+        settle_time=0,
+    )
+    explorer._write_progress(current_depth=0)
+
+    progress = json.loads((tmp_path / "progress.json").read_text())
+
+    assert progress["device"] == "ios:abc123"
+    assert progress["package"] == "com.google.chrome.ios"
+    assert progress["platform"] == "ios"
+    assert progress["output_dir"] == str(tmp_path)
+    assert progress["current_activity"] == ""
+    assert progress["max_states"] == 3
+
+
+def test_ios_app_explorer_uses_browser_back_fallback_after_taps(tmp_path):
+    dev = FakeIOSDevice()
+    explorer = AppExplorer(
+        dev=dev,
+        package="com.google.chrome.ios",
+        output_dir=str(tmp_path),
+        max_depth=1,
+        max_states=2,
+        settle_time=0,
+    )
+
+    explorer.explore()
+
+    assert dev.taps == [(95, 50)]
+    assert dev.browser_back_count == 1
+    assert dev.back_count == 0
+
+
+def test_ios_state_hash_uses_bundle_activity_tree_and_screenshot():
+    same = ios_state_hash("com.example.app", "com.example.app", IOS_XML, PNG_BYTES)
+
+    assert ios_state_hash("com.example.app", "com.example.app", IOS_XML, PNG_BYTES) == same
+    assert ios_state_hash("com.other.app", "com.example.app", IOS_XML, PNG_BYTES) != same
+    assert ios_state_hash("com.example.app", "com.other.app", IOS_XML, PNG_BYTES) != same
+    assert ios_state_hash("com.example.app", "com.example.app", IOS_XML, b"different") != same
+
+
+def test_ios_macro_recorder_replays_type_and_home_with_ios_primitives():
+    dev = FakeIOSDevice()
+    recorder = MacroRecorder(dev)
+    macro = Macro(
+        name="ios_macro",
+        device_serial=dev.serial,
+        steps=[
+            MacroStep(action="type", timestamp=0.0, params={"text": "hello world"}),
+            MacroStep(action="home", timestamp=0.0),
+        ],
+    )
+
+    recorder.replay(macro, speed=10)
+
+    assert dev.typed == ["hello world"]
+    assert dev.keys == ["HOME"]
+
+
+def test_ios_macro_recorder_replays_back_with_browser_back_when_available():
+    dev = FakeIOSDevice()
+    recorder = MacroRecorder(dev)
+    macro = Macro(
+        name="ios_back_macro",
+        device_serial=dev.serial,
+        steps=[MacroStep(action="back", timestamp=0.0)],
+    )
+
+    recorder.replay(macro, speed=10)
+
+    assert dev.browser_back_count == 1
+    assert dev.back_count == 0
+
+
+def test_ios_macro_recorder_falls_back_to_generic_back_when_browser_back_fails():
+    class BrowserBackFailDevice(FakeIOSDevice):
+        def browser_back(self, delay: float = 0):
+            self.browser_back_count += 1
+            raise RuntimeError("no browser back")
+
+    dev = BrowserBackFailDevice()
+    recorder = MacroRecorder(dev)
+    macro = Macro(
+        name="ios_back_macro",
+        device_serial=dev.serial,
+        steps=[MacroStep(action="back", timestamp=0.0)],
+    )
+
+    recorder.replay(macro, speed=10)
+
+    assert dev.browser_back_count == 1
+    assert dev.back_count == 1
+
+
+def test_ios_macro_recording_includes_platform_and_bundle_metadata():
+    dev = FakeIOSDevice()
+    dev.launch_app("com.google.chrome.ios")
+    recorder = MacroRecorder(dev)
+    recorder.start()
+    recorder.type_text("hello", delay=0)
+
+    macro = recorder.stop()
+    payload = macro.to_dict()
+
+    assert payload["device_serial"] == "ios:abc123"
+    assert payload["platform"] == "ios"
+    assert payload["app_package"] == "com.google.chrome.ios"
+    assert payload["ios_bundle_id"] == "com.google.chrome.ios"
+    assert payload["steps"][0]["action"] == "type"
+
+
+def test_macro_loader_accepts_legacy_recordings_without_platform_metadata():
+    macro = Macro.from_dict(
+        {
+            "name": "legacy",
+            "device_serial": "emulator-5554",
+            "steps": [{"action": "wait", "timestamp": 0.0, "params": {"seconds": 1}}],
+        }
+    )
+
+    assert macro.platform == ""
+    assert macro.app_package == ""
+    assert macro.ios_bundle_id == ""
+    assert macro.steps[0].action == "wait"

--- a/tests/test_ios_feature_gate.py
+++ b/tests/test_ios_feature_gate.py
@@ -1,0 +1,63 @@
+"""iOS feature gate (#759 STAGE plan): OFF by default, Android path unchanged.
+
+The suite runs with GITD_ENABLE_IOS=1 (tests/conftest.py); these tests
+explicitly close the gate to pin the disabled-state contract:
+
+* `ios:` refs raise NotImplementedError from get_device()
+* iOS devices disappear from discovery
+* plain Android serials are entirely unaffected
+"""
+
+import pytest
+
+from gitd.bots.common import device as device_mod
+from gitd.bots.common.adb import Device
+
+
+@pytest.fixture()
+def gate_closed(monkeypatch):
+    monkeypatch.delenv("GITD_ENABLE_IOS", raising=False)
+    monkeypatch.setattr("gitd.config.settings.ios_platform_enabled", False)
+
+
+@pytest.fixture()
+def gate_open(monkeypatch):
+    monkeypatch.setenv("GITD_ENABLE_IOS", "1")
+
+
+def test_gate_closed_by_default_config(gate_closed):
+    assert device_mod.ios_enabled() is False
+
+
+def test_ios_ref_raises_when_disabled(gate_closed):
+    with pytest.raises(NotImplementedError, match="iOS support is disabled"):
+        device_mod.get_device("ios:0000TEST-0000000000000000")
+
+
+def test_ios_discovery_empty_when_disabled(gate_closed):
+    assert device_mod.ios_refs_from_env() == []
+    assert device_mod.ios_refs_from_host() == []
+    assert device_mod.list_configured_ios_devices() == []
+
+
+def test_android_path_unchanged_when_disabled(gate_closed):
+    dev = device_mod.get_device("ANDROIDSERIAL123")
+    assert isinstance(dev, Device)
+    assert device_mod.platform_for_device("ANDROIDSERIAL123") == "android"
+
+
+def test_env_override_opens_gate(gate_closed, monkeypatch):
+    monkeypatch.setenv("GITD_ENABLE_IOS", "1")
+    assert device_mod.ios_enabled() is True
+
+
+def test_settings_flag_opens_gate(gate_closed, monkeypatch):
+    monkeypatch.setattr("gitd.config.settings.ios_platform_enabled", True)
+    assert device_mod.ios_enabled() is True
+
+
+def test_execute_tool_surfaces_disabled_error_for_ios_ref(gate_closed):
+    from gitd.services.agent_tools import execute_tool
+
+    result = execute_tool("tap", {"device": "ios:0000TEST-0000000000000000", "x": 1, "y": 1})
+    assert "iOS support is disabled" in result

--- a/tests/test_ios_job_guards.py
+++ b/tests/test_ios_job_guards.py
@@ -1,0 +1,831 @@
+import json
+import sys
+from datetime import datetime
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from gitd.app import app
+from gitd.models.base import SessionLocal
+from gitd.routers import bot
+from gitd.routers.scheduler import _scheduler_platform_error
+from gitd.services.db_helpers import create_scheduled_job, enqueue_job
+from gitd.services.job_engine import (
+    _account_preflight,
+    _build_scheduled_cmd,
+    _job_platform_preflight,
+    _skill_config_preflight,
+)
+from gitd.services.scheduler_service import _enqueue_due_schedule
+
+
+def test_tiktok_scheduler_jobs_are_guarded_on_ios():
+    assert _job_platform_preflight("ios:abc123", "post") == (
+        "post jobs are Android-only until the iOS TikTok workflow is ported"
+    )
+    assert _job_platform_preflight("ios:abc123", "crawl") == (
+        "crawl jobs are Android-only until the iOS TikTok workflow is ported"
+    )
+    assert _job_platform_preflight("ios:abc123", "app_explore") is None
+    assert _job_platform_preflight("emulator-5554", "post") is None
+
+
+def test_ios_tiktok_skill_account_preflight_passes_on_matching_account(monkeypatch):
+    calls = []
+
+    def fake_expected_account_matches(device: str, expected: str):
+        calls.append((device, expected))
+        return {"ok": True, "reason": None}
+
+    monkeypatch.setattr(
+        "gitd.services.account_health.expected_account_matches",
+        fake_expected_account_matches,
+    )
+
+    err = _account_preflight(
+        "ios:abc123",
+        "skill_workflow",
+        {"skill": "tiktok_ios", "workflow": "profile_smoke", "account": "@ghost"},
+    )
+
+    assert err is None
+    assert calls == [("ios:abc123", "@ghost")]
+
+
+def test_ios_tiktok_skill_account_preflight_blocks_observed_mismatch(monkeypatch):
+    calls = []
+
+    def fake_expected_account_matches(device: str, expected: str):
+        calls.append((device, expected))
+        return {
+            "ok": False,
+            "reason": "wrong active account: have @other, expected @ghost",
+        }
+
+    monkeypatch.setattr(
+        "gitd.services.account_health.expected_account_matches",
+        fake_expected_account_matches,
+    )
+
+    err = _account_preflight(
+        "ios:abc123",
+        "skill_workflow",
+        {"skill": "tiktok_ios", "workflow": "profile_smoke", "account": "@ghost"},
+    )
+
+    assert err == "wrong active account: have @other, expected @ghost"
+    assert calls == [("ios:abc123", "@ghost")]
+
+
+def test_non_tiktok_skill_account_config_does_not_trigger_account_preflight(monkeypatch):
+    def fail_expected_account_matches(device: str, expected: str):
+        raise AssertionError("non-TikTok skills should not use TikTok account preflight")
+
+    monkeypatch.setattr(
+        "gitd.services.account_health.expected_account_matches",
+        fail_expected_account_matches,
+    )
+
+    err = _account_preflight(
+        "ios:abc123",
+        "skill_workflow",
+        {"skill": "safari", "workflow": "read_news", "account": "@ghost"},
+    )
+
+    assert err is None
+
+
+def test_legacy_bot_queue_rejects_ios_tiktok_post_before_launch(monkeypatch):
+    def fail_launch(job):
+        raise AssertionError("_launch_job should not be called for unsupported iOS bot jobs")
+
+    monkeypatch.setattr(bot, "_launch_job", fail_launch)
+    with bot._queue_lock:
+        queue_len = len(bot._queue)
+
+    response = TestClient(app).post(
+        "/api/bot/queue/add",
+        json={"job_type": "post", "device": "ios:abc123", "video": "/tmp/clip.mp4"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is False
+    assert body["error"] == "unsupported_platform"
+    assert body["platform"] == "ios"
+    assert body["job_type"] == "post"
+    assert body["device"] == "ios:abc123"
+    assert body["supported_platforms"] == ["android"]
+    with bot._queue_lock:
+        assert len(bot._queue) == queue_len
+
+
+def test_legacy_bot_build_cmd_rejects_ios_publish_draft():
+    with pytest.raises(ValueError, match="Android-only.*iOS TikTok"):
+        bot._build_cmd({"job_type": "publish_draft", "device": "ios:abc123", "grid_index": 0})
+
+
+def test_marketing_job_rejects_ios_device_before_enqueue(tmp_path):
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"fake")
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/marketing-jobs/enqueue",
+        json={"video_path": str(video), "phone_serial": "ios:abc123", "caption": "draft"},
+    )
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert detail["error"] == "unsupported_platform"
+    assert detail["platform"] == "ios"
+
+
+def test_marketing_job_enqueues_ios_profile_smoke_without_video():
+    client = TestClient(app)
+    db = SessionLocal()
+    job_id = None
+    try:
+        response = client.post(
+            "/api/marketing-jobs/enqueue",
+            json={
+                "phone_serial": "ios:abc123",
+                "action": "profile_smoke",
+                "account": "@ghost",
+                "max_lines": 12,
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["action"] == "profile_smoke"
+        assert body["job_type"] == "skill_workflow"
+        assert body["skill"] == "tiktok_ios"
+        assert body["workflow"] == "profile_smoke"
+        job_id = int(body["job_id"].removeprefix("ghost-job-"))
+
+        row = (
+            db.execute(text("SELECT * FROM job_queue WHERE id = :id"), {"id": job_id})
+            .mappings()
+            .one()
+        )
+        config = json.loads(row["config_json"])
+        assert row["phone_serial"] == "ios:abc123"
+        assert row["job_type"] == "skill_workflow"
+        assert row["trigger"] == "marketing_agent"
+        assert row["max_duration_s"] == 300
+        assert config == {
+            "skill": "tiktok_ios",
+            "workflow": "profile_smoke",
+            "params": {"max_lines": 12},
+            "source": "marketing_jobs",
+            "action": "profile_smoke",
+            "account": "@ghost",
+        }
+    finally:
+        if job_id:
+            db.execute(text("DELETE FROM job_queue WHERE id = :id"), {"id": job_id})
+            db.commit()
+        db.close()
+
+
+def test_marketing_job_enqueues_ios_search_smoke_with_query():
+    client = TestClient(app)
+    db = SessionLocal()
+    job_id = None
+    try:
+        response = client.post(
+            "/api/marketing-jobs/enqueue",
+            json={
+                "phone_serial": "ios:abc123",
+                "action": "search_smoke",
+                "query": "#news",
+                "account": "@ghost",
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["action"] == "search_smoke"
+        assert body["job_type"] == "skill_workflow"
+        assert body["skill"] == "tiktok_ios"
+        assert body["workflow"] == "search_smoke"
+        assert body["params"] == {"query": "#news"}
+        job_id = int(body["job_id"].removeprefix("ghost-job-"))
+
+        row = (
+            db.execute(text("SELECT * FROM job_queue WHERE id = :id"), {"id": job_id})
+            .mappings()
+            .one()
+        )
+        config = json.loads(row["config_json"])
+        assert row["phone_serial"] == "ios:abc123"
+        assert row["job_type"] == "skill_workflow"
+        assert row["trigger"] == "marketing_agent"
+        assert row["max_duration_s"] == 300
+        assert config == {
+            "skill": "tiktok_ios",
+            "workflow": "search_smoke",
+            "params": {"query": "#news"},
+            "source": "marketing_jobs",
+            "action": "search_smoke",
+            "account": "@ghost",
+        }
+    finally:
+        if job_id:
+            db.execute(text("DELETE FROM job_queue WHERE id = :id"), {"id": job_id})
+            db.commit()
+        db.close()
+
+
+def test_marketing_job_enqueues_ios_open_app_smoke_without_params():
+    client = TestClient(app)
+    db = SessionLocal()
+    job_id = None
+    try:
+        response = client.post(
+            "/api/marketing-jobs/enqueue",
+            json={
+                "phone_serial": "ios:abc123",
+                "action": "open_app_smoke",
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["action"] == "open_app_smoke"
+        assert body["workflow"] == "open_app_smoke"
+        assert body["params"] == {}
+        job_id = int(body["job_id"].removeprefix("ghost-job-"))
+
+        row = (
+            db.execute(text("SELECT * FROM job_queue WHERE id = :id"), {"id": job_id})
+            .mappings()
+            .one()
+        )
+        assert json.loads(row["config_json"]) == {
+            "skill": "tiktok_ios",
+            "workflow": "open_app_smoke",
+            "params": {},
+            "source": "marketing_jobs",
+            "action": "open_app_smoke",
+        }
+    finally:
+        if job_id:
+            db.execute(text("DELETE FROM job_queue WHERE id = :id"), {"id": job_id})
+            db.commit()
+        db.close()
+
+
+def test_marketing_job_enqueues_ios_read_news_workflow():
+    client = TestClient(app)
+    db = SessionLocal()
+    job_id = None
+    try:
+        response = client.post(
+            "/api/marketing-jobs/enqueue",
+            json={
+                "phone_serial": "ios:abc123",
+                "action": "read_news",
+                "url": "https://text.npr.org/",
+                "bundle_id": "com.google.chrome.ios",
+                "max_headlines": 4,
+                "max_articles": 2,
+                "wait_s": 3,
+                "save_screenshots": True,
+                "account": "@ghost",
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["action"] == "read_news"
+        assert body["job_type"] == "skill_workflow"
+        assert body["skill"] == "safari"
+        assert body["workflow"] == "read_news"
+        assert body["params"] == {
+            "url": "https://text.npr.org/",
+            "max_headlines": 4,
+            "max_articles": 2,
+            "wait_s": 3.0,
+            "save_screenshots": True,
+            "bundle_id": "com.google.chrome.ios",
+        }
+        job_id = int(body["job_id"].removeprefix("ghost-job-"))
+
+        row = (
+            db.execute(text("SELECT * FROM job_queue WHERE id = :id"), {"id": job_id})
+            .mappings()
+            .one()
+        )
+        config = json.loads(row["config_json"])
+        assert row["phone_serial"] == "ios:abc123"
+        assert row["job_type"] == "skill_workflow"
+        assert row["trigger"] == "marketing_agent"
+        assert row["max_duration_s"] == 600
+        assert config == {
+            "skill": "safari",
+            "workflow": "read_news",
+            "params": {
+                "url": "https://text.npr.org/",
+                "max_headlines": 4,
+                "max_articles": 2,
+                "wait_s": 3.0,
+                "save_screenshots": True,
+                "bundle_id": "com.google.chrome.ios",
+            },
+            "source": "marketing_jobs",
+            "action": "read_news",
+        }
+    finally:
+        if job_id:
+            db.execute(text("DELETE FROM job_queue WHERE id = :id"), {"id": job_id})
+            db.commit()
+        db.close()
+
+
+def test_marketing_job_rejects_ios_read_news_action_on_android(tmp_path):
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"fake")
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/marketing-jobs/enqueue",
+        json={
+            "phone_serial": "emulator-5554",
+            "action": "read_news",
+            "video_path": str(video),
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "iOS browser/news marketing actions require phone_serial like ios:<udid>"
+
+
+def test_scheduler_create_rejects_ios_android_only_job_before_enqueue():
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/schedules",
+        json={
+            "name": "iOS post should fail",
+            "job_type": "post",
+            "phone_serial": "ios:abc123",
+            "schedule_type": "interval",
+            "interval_minutes": 60,
+            "config_json": {"action": "draft"},
+        },
+    )
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert detail["error"] == "unsupported_platform"
+    assert detail["platform"] == "ios"
+    assert detail["job_type"] == "post"
+    assert "Android-only" in detail["message"]
+
+
+def test_scheduler_allows_ios_supported_skill_job():
+    assert (
+        _scheduler_platform_error(
+            {
+                "job_type": "skill_workflow",
+                "phone_serial": "ios:abc123",
+                "config_json": {"skill": "tiktok_ios", "workflow": "profile_smoke"},
+            }
+        )
+        is None
+    )
+    assert (
+        _scheduler_platform_error(
+            {
+                "job_type": "skill_workflow",
+                "phone_serial": "ios:abc123",
+                "config_json": {"skill": "safari", "workflow": "read_news"},
+            }
+        )
+        is None
+    )
+
+    err = _scheduler_platform_error(
+        {
+            "job_type": "skill_workflow",
+            "phone_serial": "ios:abc123",
+            "config_json": {"skill": "tiktok", "workflow": "upload_video"},
+        }
+    )
+    assert err["error"] == "unsupported_platform"
+    assert err["skill"] == "tiktok"
+    assert "does not support ios" in err["message"]
+
+
+def _arg_after(cmd: list[str], flag: str) -> str:
+    return cmd[cmd.index(flag) + 1]
+
+
+def test_ios_scheduled_skill_and_explorer_commands_use_current_interpreter():
+    skill_cmd = _build_scheduled_cmd(
+        "skill_workflow",
+        {"skill": "safari", "workflow": "read_news", "params": {"url": "https://text.npr.org/"}},
+        "ios:abc123",
+    )
+    action_cmd = _build_scheduled_cmd(
+        "skill_action",
+        {"skill": "safari", "action": "read_news", "params": {"max_headlines": 1}},
+        "ios:abc123",
+    )
+    explorer_cmd = _build_scheduled_cmd(
+        "app_explore",
+        {"package": "com.google.chrome.ios", "max_depth": 1, "max_states": 3},
+        "ios:abc123",
+    )
+
+    assert skill_cmd is not None
+    assert action_cmd is not None
+    assert explorer_cmd is not None
+    for cmd in (skill_cmd, action_cmd, explorer_cmd):
+        assert cmd[:2] == [sys.executable, "-u"]
+        assert _arg_after(cmd, "--device") == "ios:abc123"
+
+    assert skill_cmd.count("--skill") == 1
+    assert _arg_after(skill_cmd, "--skill") == "safari"
+    assert _arg_after(skill_cmd, "--workflow") == "read_news"
+    assert "--action" not in skill_cmd
+    assert json.loads(_arg_after(skill_cmd, "--params")) == {"url": "https://text.npr.org/"}
+
+    assert action_cmd.count("--skill") == 1
+    assert _arg_after(action_cmd, "--skill") == "safari"
+    assert _arg_after(action_cmd, "--action") == "read_news"
+    assert "--workflow" not in action_cmd
+    assert json.loads(_arg_after(action_cmd, "--params")) == {"max_headlines": 1}
+
+    assert _arg_after(explorer_cmd, "--package") == "com.google.chrome.ios"
+
+
+def test_scheduled_skill_jobs_reject_malformed_config_before_subprocess():
+    assert _skill_config_preflight("skill_workflow", {"skill": "safari"}) == (
+        "skill_workflow jobs require config.workflow"
+    )
+    assert _skill_config_preflight("skill_action", {"skill": "safari"}) == (
+        "skill_action jobs require config.action"
+    )
+    assert _skill_config_preflight("skill_workflow", {"workflow": "read_news"}) == (
+        "skill_workflow jobs require config.skill"
+    )
+    assert _skill_config_preflight(
+        "skill_workflow",
+        {"skill": "safari", "workflow": "read_news", "params": []},
+    ) == "skill_workflow jobs require config.params to be an object"
+    assert _build_scheduled_cmd("skill_workflow", {"skill": "safari"}, "ios:abc123") is None
+
+
+def test_scheduler_create_rejects_ios_skill_job_missing_workflow():
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/schedules",
+        json={
+            "name": "iOS malformed skill",
+            "job_type": "skill_workflow",
+            "phone_serial": "ios:abc123",
+            "schedule_type": "interval",
+            "interval_minutes": 60,
+            "config_json": {"skill": "safari"},
+        },
+    )
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert detail == {
+        "error": "invalid_config",
+        "platform": "ios",
+        "job_type": "skill_workflow",
+        "message": "skill_workflow jobs require config.workflow",
+        "skill": "safari",
+    }
+
+
+def test_scheduler_allows_ios_app_explore_schedule_and_run_now():
+    client = TestClient(app)
+    db = SessionLocal()
+    sid = None
+    qid = None
+    config = {"package": "com.google.chrome.ios", "max_depth": 1, "max_states": 3}
+    try:
+        created = client.post(
+            "/api/schedules",
+            json={
+                "name": "iOS Chrome app explore",
+                "job_type": "app_explore",
+                "phone_serial": "ios:abc123",
+                "schedule_type": "interval",
+                "interval_minutes": 60,
+                "config_json": config,
+                "max_duration_s": 300,
+            },
+        )
+        assert created.status_code == 200
+        sid = created.json()["id"]
+
+        run_now = client.post(f"/api/schedules/{sid}/run-now")
+        assert run_now.status_code == 200
+        qid = run_now.json()["queue_id"]
+
+        row = (
+            db.execute(text("SELECT * FROM job_queue WHERE id = :id"), {"id": qid})
+            .mappings()
+            .one()
+        )
+        assert row["scheduled_job_id"] == sid
+        assert row["phone_serial"] == "ios:abc123"
+        assert row["job_type"] == "app_explore"
+        assert json.loads(row["config_json"]) == config
+
+        queued = client.get("/api/scheduler/queue").json()
+        item = next(item for item in queued if item["id"] == qid)
+        assert item["platform"] == "ios"
+        assert item["schedule_name"] == "iOS Chrome app explore"
+    finally:
+        if qid:
+            db.execute(text("DELETE FROM job_queue WHERE id = :id"), {"id": qid})
+        if sid:
+            db.execute(text("DELETE FROM scheduled_jobs WHERE id = :id"), {"id": sid})
+        db.commit()
+        db.close()
+
+
+def test_scheduler_restart_preserves_ios_schedule_timeout():
+    client = TestClient(app)
+    db = SessionLocal()
+    sid = None
+    run_id = None
+    new_job_id = None
+    now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    config = {"skill": "safari", "workflow": "read_news", "params": {"url": "https://text.npr.org/"}}
+    try:
+        sid = create_scheduled_job(
+            db,
+            name="ios news short timeout",
+            job_type="skill_workflow",
+            phone_serial="ios:abc123",
+            schedule_type="interval",
+            interval_minutes=60,
+            config_json=config,
+            max_duration_s=300,
+            is_enabled=1,
+        )
+        db.execute(
+            text(
+                "INSERT INTO job_runs "
+                "(scheduled_job_id, phone_serial, job_type, priority, config_json, status, "
+                "enqueued_at, started_at, finished_at, duration_s, trigger) "
+                "VALUES (:sid, :phone, :job_type, :priority, :config_json, :status, "
+                ":enqueued_at, :started_at, :finished_at, :duration_s, :trigger)"
+            ),
+            {
+                "sid": sid,
+                "phone": "ios:abc123",
+                "job_type": "skill_workflow",
+                "priority": 1,
+                "config_json": json.dumps(config),
+                "status": "completed",
+                "enqueued_at": now,
+                "started_at": now,
+                "finished_at": now,
+                "duration_s": 15,
+                "trigger": "manual",
+            },
+        )
+        run_id = db.execute(text("SELECT last_insert_rowid()")).scalar()
+        db.commit()
+
+        response = client.post(f"/api/scheduler/runs/{run_id}/restart")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["platform"] == "ios"
+        new_job_id = body["new_job_id"]
+
+        row = (
+            db.execute(text("SELECT * FROM job_queue WHERE id = :id"), {"id": new_job_id})
+            .mappings()
+            .one()
+        )
+        assert row["phone_serial"] == "ios:abc123"
+        assert row["job_type"] == "skill_workflow"
+        assert row["priority"] == 1
+        assert row["max_duration_s"] == 300
+    finally:
+        if new_job_id:
+            db.execute(text("DELETE FROM job_queue WHERE id = :id"), {"id": new_job_id})
+        if run_id:
+            db.execute(text("DELETE FROM job_runs WHERE id = :id"), {"id": run_id})
+        if sid:
+            db.execute(text("DELETE FROM scheduled_jobs WHERE id = :id"), {"id": sid})
+        db.commit()
+        db.close()
+
+
+def test_scheduler_update_rejects_moving_android_only_job_to_ios():
+    client = TestClient(app)
+    sid = None
+    try:
+        created = client.post(
+            "/api/schedules",
+            json={
+                "name": "android post schedule",
+                "job_type": "post",
+                "phone_serial": "emulator-5554",
+                "schedule_type": "interval",
+                "interval_minutes": 60,
+                "config_json": {"action": "draft"},
+            },
+        )
+        assert created.status_code == 200
+        sid = created.json()["id"]
+
+        response = client.put(f"/api/schedules/{sid}", json={"phone_serial": "ios:abc123"})
+
+        assert response.status_code == 400
+        detail = response.json()["detail"]
+        assert detail["error"] == "unsupported_platform"
+        assert detail["platform"] == "ios"
+        assert detail["job_type"] == "post"
+    finally:
+        if sid:
+            client.delete(f"/api/schedules/{sid}")
+
+
+def test_scheduler_run_now_rejects_legacy_ios_android_only_schedule():
+    client = TestClient(app)
+    db = SessionLocal()
+    sid = None
+    try:
+        sid = create_scheduled_job(
+            db,
+            name="legacy ios post",
+            job_type="post",
+            phone_serial="ios:abc123",
+            schedule_type="interval",
+            interval_minutes=60,
+            config_json={"action": "draft"},
+            is_enabled=1,
+        )
+
+        response = client.post(f"/api/schedules/{sid}/run-now")
+
+        assert response.status_code == 400
+        detail = response.json()["detail"]
+        assert detail["error"] == "unsupported_platform"
+        assert detail["platform"] == "ios"
+        assert detail["job_type"] == "post"
+    finally:
+        if sid:
+            db.execute(text("DELETE FROM scheduled_jobs WHERE id = :sid"), {"sid": sid})
+            db.execute(text("DELETE FROM job_queue WHERE scheduled_job_id = :sid"), {"sid": sid})
+            db.commit()
+        db.close()
+
+
+def test_scheduler_tick_records_legacy_ios_android_only_schedule_without_queueing():
+    db = SessionLocal()
+    sid = None
+    run_id = None
+    try:
+        sid = create_scheduled_job(
+            db,
+            name="legacy ios post daemon",
+            job_type="post",
+            phone_serial="ios:abc123",
+            schedule_type="interval",
+            interval_minutes=60,
+            config_json={"action": "draft"},
+            is_enabled=1,
+        )
+        sched = (
+            db.execute(text("SELECT * FROM scheduled_jobs WHERE id = :sid"), {"sid": sid})
+            .mappings()
+            .one()
+        )
+
+        result = _enqueue_due_schedule(db, dict(sched), datetime.now())
+
+        assert result["ok"] is False
+        assert result["error"] == "post jobs are Android-only until the iOS TikTok workflow is ported"
+        run_id = result["run_id"]
+
+        queued = db.execute(
+            text("SELECT COUNT(*) FROM job_queue WHERE scheduled_job_id = :sid"),
+            {"sid": sid},
+        ).scalar()
+        assert queued == 0
+
+        run = (
+            db.execute(text("SELECT * FROM job_runs WHERE id = :id"), {"id": run_id})
+            .mappings()
+            .one()
+        )
+        assert run["scheduled_job_id"] == sid
+        assert run["phone_serial"] == "ios:abc123"
+        assert run["job_type"] == "post"
+        assert run["status"] == "failed"
+        assert run["trigger"] == "scheduled"
+        assert run["duration_s"] == 0
+        assert run["error_msg"] == (
+            "preflight: post jobs are Android-only until the iOS TikTok workflow is ported"
+        )
+    finally:
+        if sid:
+            db.execute(text("DELETE FROM job_queue WHERE scheduled_job_id = :sid"), {"sid": sid})
+            db.execute(text("DELETE FROM job_runs WHERE scheduled_job_id = :sid"), {"sid": sid})
+            db.execute(text("DELETE FROM scheduled_jobs WHERE id = :sid"), {"sid": sid})
+            db.commit()
+        db.close()
+
+
+def test_scheduler_responses_include_platform_metadata_for_ios_jobs():
+    client = TestClient(app)
+    db = SessionLocal()
+    sid = None
+    qid = None
+    run_id = None
+    now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    config = {"skill": "safari", "workflow": "read_news", "params": {"url": "https://text.npr.org/"}}
+    try:
+        sid = create_scheduled_job(
+            db,
+            name="ios news skill",
+            job_type="skill_workflow",
+            phone_serial="ios:abc123",
+            schedule_type="daily",
+            daily_times=["23:59"],
+            config_json=config,
+            is_enabled=1,
+        )
+        qid = enqueue_job(
+            db,
+            scheduled_job_id=sid,
+            phone_serial="ios:abc123",
+            job_type="skill_workflow",
+            config_json=config,
+            status="pending",
+            trigger="manual",
+        )
+        db.execute(
+            text(
+                "INSERT INTO job_runs "
+                "(scheduled_job_id, phone_serial, job_type, priority, config_json, status, "
+                "enqueued_at, started_at, finished_at, duration_s, trigger) "
+                "VALUES (:sid, :phone, :job_type, :priority, :config_json, :status, "
+                ":enqueued_at, :started_at, :finished_at, :duration_s, :trigger)"
+            ),
+            {
+                "sid": sid,
+                "phone": "ios:abc123",
+                "job_type": "skill_workflow",
+                "priority": 2,
+                "config_json": json.dumps(config),
+                "status": "completed",
+                "enqueued_at": now,
+                "started_at": now,
+                "finished_at": now,
+                "duration_s": 1,
+                "trigger": "manual",
+            },
+        )
+        run_id = db.execute(text("SELECT last_insert_rowid()")).scalar()
+        db.commit()
+
+        schedules = client.get("/api/schedules").json()
+        schedule = next(item for item in schedules if item["id"] == sid)
+        assert schedule["platform"] == "ios"
+        assert schedule["last_run"]["platform"] == "ios"
+
+        queue = client.get("/api/scheduler/queue").json()
+        queued = next(item for item in queue if item["id"] == qid)
+        assert queued["platform"] == "ios"
+        assert queued["schedule_name"] == "ios news skill"
+
+        status = client.get("/api/scheduler/status").json()
+        assert status["ios:abc123"]["platform"] == "ios"
+        assert status["ios:abc123"]["pending"] >= 1
+
+        history = client.get("/api/scheduler/history").json()
+        run = next(item for item in history if item["id"] == run_id)
+        assert run["platform"] == "ios"
+        assert run["schedule_name"] == "ios news skill"
+
+        timeline = client.get("/api/scheduler/timeline").json()
+        future = next(item for item in timeline["future"] if item["scheduled_job_id"] == sid)
+        past = next(item for item in timeline["past"] if item["id"] == run_id)
+        assert future["platform"] == "ios"
+        assert past["platform"] == "ios"
+    finally:
+        if qid:
+            db.execute(text("DELETE FROM job_queue WHERE id = :id"), {"id": qid})
+        if run_id:
+            db.execute(text("DELETE FROM job_runs WHERE id = :id"), {"id": run_id})
+        if sid:
+            db.execute(text("DELETE FROM scheduled_jobs WHERE id = :id"), {"id": sid})
+        db.commit()
+        db.close()

--- a/tests/test_ios_platform_and_health.py
+++ b/tests/test_ios_platform_and_health.py
@@ -1,0 +1,94 @@
+"""Unit tests for the iOS platform matrix + RemoteXPC health-check fix (no hardware).
+
+Covers two behaviour changes from this work:
+  - speak_text is now cross-platform (native iOS TTS via the patched WDA).
+  - remote_xpc_tunnel_status accepts the tunnel when devicectl reports it
+    connected, instead of requiring Appium's tunnel address to equal devicectl's
+    CoreDevice tunnel address (two independent tunnels that never match — the
+    original false-'stale' bug that blocked the smoke test / stream).
+"""
+
+from gitd.bots.common import ios
+from gitd.services.tool_platforms import supports_platform
+
+# ── platform matrix ──────────────────────────────────────────────────────────
+
+def test_speak_text_is_cross_platform():
+    assert supports_platform("speak_text", "ios") is True
+    assert supports_platform("speak_text", "android") is True
+
+
+def test_shell_stays_android_only():
+    assert supports_platform("shell", "android") is True
+    assert supports_platform("shell", "ios") is False
+
+
+# ── RemoteXPC health-check fix (F2) ──────────────────────────────────────────
+
+def _host():
+    return {"source": "host", "platform_version": "26.4.2"}
+
+
+def test_tunnel_available_when_devicectl_connected(monkeypatch):
+    # Registry (Appium's remotexpc tunnel) and devicectl (Apple's CoreDevice
+    # tunnel) report DIFFERENT addresses — as they always do. The fixed check
+    # must still report 'available' because devicectl says connected.
+    def fake_registry(method, url, timeout):  # noqa: ARG001
+        class R:
+            status_code = 200
+
+            @staticmethod
+            def json():
+                return {"status": "OK", "address": "fd23:a45d:8f2d::1"}
+
+        return R()
+
+    monkeypatch.setattr(ios.requests, "request", fake_registry)
+    monkeypatch.setattr(
+        ios, "devicectl_device_details",
+        lambda udid: {"tunnel_state": "connected", "tunnel_ip_address": "fd52:b220:95a3::1"},
+    )
+    status = ios.remote_xpc_tunnel_status("udid", platform_version="26.4.2", host=_host())
+    assert status["ok"] is True
+    assert status["state"] == "available"
+    # both addresses recorded, even though they differ
+    assert status.get("registry_address") == "fd23:a45d:8f2d::1"
+    assert status.get("current_address") == "fd52:b220:95a3::1"
+
+
+def test_tunnel_stale_when_devicectl_not_connected(monkeypatch):
+    def fake_registry(method, url, timeout):  # noqa: ARG001
+        class R:
+            status_code = 200
+
+            @staticmethod
+            def json():
+                return {"status": "OK", "address": "fd23:a45d:8f2d::1"}
+
+        return R()
+
+    monkeypatch.setattr(ios.requests, "request", fake_registry)
+    monkeypatch.setattr(
+        ios, "devicectl_device_details",
+        lambda udid: {"tunnel_state": "disconnected", "tunnel_ip_address": ""},
+    )
+    status = ios.remote_xpc_tunnel_status("udid", platform_version="26.4.2", host=_host())
+    assert status["ok"] is False
+    assert status["state"] == "stale"
+
+
+def test_tunnel_missing_when_registry_absent(monkeypatch):
+    def fake_registry(method, url, timeout):  # noqa: ARG001
+        class R:
+            status_code = 404
+
+            @staticmethod
+            def json():
+                return {}
+
+        return R()
+
+    monkeypatch.setattr(ios.requests, "request", fake_registry)
+    status = ios.remote_xpc_tunnel_status("udid", platform_version="26.4.2", host=_host())
+    assert status["ok"] is False
+    assert status["state"] == "missing"

--- a/tests/test_ios_popup_dismissal.py
+++ b/tests/test_ios_popup_dismissal.py
@@ -1,0 +1,82 @@
+from gitd.bots.common.ios import IOSDevice
+
+
+def test_ios_dismiss_popups_taps_skill_specific_button(monkeypatch):
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+    taps = []
+    monkeypatch.setattr(dev, "tap", lambda x, y, delay=0.8: taps.append((x, y, delay)))
+
+    xml = """
+    <hierarchy rotation="0" platform="ios">
+      <node text="Turn on notifications" content-desc="" resource-id="" class="XCUIElementTypeStaticText"
+            clickable="false" visible="true" bounds="[40,300][350,340]"/>
+      <node text="Not now" content-desc="" resource-id="" class="XCUIElementTypeButton"
+            clickable="true" visible="true" bounds="[120,420][270,470]"/>
+    </hierarchy>
+    """
+
+    dismissed = dev.dismiss_popups(
+        xml,
+        popups=[{"detect": "Turn on notifications", "button": "Not now", "label": "Notification prompt"}],
+    )
+
+    assert dismissed is True
+    assert taps == [(195, 445, 1.0)]
+
+
+def test_ios_dismiss_popups_uses_generic_compact_button_fallback(monkeypatch):
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+    taps = []
+    monkeypatch.setattr(dev, "tap", lambda x, y, delay=0.8: taps.append((x, y, delay)))
+
+    xml = """
+    <hierarchy rotation="0" platform="ios">
+      <node text="Newsletter content should not be tapped" content-desc="" resource-id=""
+            class="XCUIElementTypeStaticText" clickable="true" visible="true"
+            bounds="[0,120][390,500]"/>
+      <node text="Cancel" content-desc="" resource-id="" class="XCUIElementTypeButton"
+            clickable="false" visible="true" bounds="[140,600][250,644]"/>
+    </hierarchy>
+    """
+
+    dismissed = dev.dismiss_popups(xml, popups=[])
+
+    assert dismissed is True
+    assert taps == [(195, 622, 1.0)]
+
+
+def test_ios_dismiss_popups_supports_back_method(monkeypatch):
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+    backs = []
+    monkeypatch.setattr(dev, "back", lambda delay=1.0: backs.append(delay))
+
+    xml = """
+    <hierarchy rotation="0" platform="ios">
+      <node text="Limited offer" content-desc="" resource-id="" class="XCUIElementTypeStaticText"
+            clickable="false" visible="true" bounds="[20,200][370,260]"/>
+    </hierarchy>
+    """
+
+    dismissed = dev.dismiss_popups(xml, popups=[{"detect": "Limited offer", "method": "back"}])
+
+    assert dismissed is True
+    assert backs == [1.0]
+
+
+def test_ios_dismiss_popups_ignores_large_content_nodes(monkeypatch):
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+    taps = []
+    monkeypatch.setattr(dev, "tap", lambda x, y, delay=0.8: taps.append((x, y, delay)))
+
+    xml = """
+    <hierarchy rotation="0" platform="ios">
+      <node text="Cancel culture article headline" content-desc="" resource-id=""
+            class="XCUIElementTypeStaticText" clickable="true" visible="true"
+            bounds="[0,120][390,500]"/>
+    </hierarchy>
+    """
+
+    dismissed = dev.dismiss_popups(xml, popups=[])
+
+    assert dismissed is False
+    assert taps == []

--- a/tests/test_ios_safari_smoke.py
+++ b/tests/test_ios_safari_smoke.py
@@ -1,0 +1,53 @@
+"""Pytest wrapper for scripts/ios_safari_smoke.py verification logic.
+
+The smoke script used to exit 0 unconditionally (pass-when-broken). These
+tests pin the verify_smoke() contract: a healthy launch passes, a broken one
+produces failures.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "ios_safari_smoke", Path(__file__).resolve().parents[1] / "scripts" / "ios_safari_smoke.py"
+)
+_smoke = importlib.util.module_from_spec(_SPEC)
+sys.modules["ios_safari_smoke"] = _smoke
+_SPEC.loader.exec_module(_smoke)
+
+verify_smoke = _smoke.verify_smoke
+
+_GOOD_TREE = "\n".join(
+    [
+        '[0] Application "Chrome"',
+        '[1] TextField "Address and search bar" [clickable]',
+        '[2] StaticText "Ghost in the Droid"',
+        '[3] Link "Docs" [clickable]',
+        '[4] StaticText "Give any AI agent a phone body"',
+    ]
+)
+
+
+def test_healthy_launch_passes():
+    state = {"packageName": "com.google.chrome.ios"}
+    assert verify_smoke(state, _GOOD_TREE, "com.google.chrome.ios") == []
+    # headline-bearing content present: more than zero rendered content lines
+    assert len([ln for ln in _GOOD_TREE.splitlines() if ln.strip()]) > 0
+
+
+def test_wrong_foreground_app_fails():
+    state = {"packageName": "com.apple.springboard"}
+    failures = verify_smoke(state, _GOOD_TREE, "com.google.chrome.ios")
+    assert any("foreground app" in f for f in failures)
+
+
+def test_empty_tree_fails():
+    state = {"packageName": "com.google.chrome.ios"}
+    failures = verify_smoke(state, "", "com.google.chrome.ios")
+    assert any("screen tree looks empty" in f for f in failures)
+
+
+def test_missing_state_fails():
+    failures = verify_smoke({}, _GOOD_TREE, "com.google.chrome.ios")
+    assert any("no foreground app" in f for f in failures)

--- a/tests/test_ios_test_runner_recording.py
+++ b/tests/test_ios_test_runner_recording.py
@@ -1,0 +1,151 @@
+import sys
+
+from gitd.routers import tests as test_runner
+
+
+class FakeProc:
+    def __init__(self):
+        self.terminated = False
+        self.killed = False
+        self.returncode = None
+
+    def poll(self):
+        return self.returncode
+
+    def terminate(self):
+        self.terminated = True
+        self.returncode = 0
+
+    def wait(self, timeout=None):
+        self.returncode = 0
+        return 0
+
+    def kill(self):
+        self.killed = True
+        self.returncode = -9
+
+
+def test_ios_screen_recording_uses_wda_mjpeg_and_ffmpeg(tmp_path, monkeypatch):
+    calls = []
+    proc = FakeProc()
+
+    class FakeIOSDevice:
+        mjpeg_url = "http://127.0.0.1:9100"
+
+    monkeypatch.setattr(test_runner, "_TR_RECORDINGS_DIR", tmp_path)
+    monkeypatch.setattr(test_runner.phone_recording, "get_device", lambda serial: FakeIOSDevice())
+    test_runner.phone_recording._active.clear()
+
+    def fake_popen(cmd, stdout=None, stderr=None):
+        calls.append(cmd)
+        return proc
+
+    monkeypatch.setattr(test_runner.phone_recording.subprocess, "Popen", fake_popen)
+
+    result = test_runner._sr_start("ios:abc123", "ios_abc123_smoke.mp4")
+
+    assert result["ok"] is True
+    assert result["platform"] == "ios"
+    assert result["mode"] == "wda-mjpeg"
+    assert result["path"] == str(tmp_path / "ios_abc123_smoke.mp4")
+    assert calls == [
+        [
+            "ffmpeg",
+            "-y",
+            "-loglevel",
+            "error",
+            "-f",
+            "mjpeg",
+            "-i",
+            "http://127.0.0.1:9100",
+            "-an",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            str(tmp_path / "ios_abc123_smoke.mp4"),
+        ]
+    ]
+
+
+def test_ios_screen_recording_stop_returns_local_file(tmp_path, monkeypatch):
+    proc = FakeProc()
+    local_path = tmp_path / "ios_recording.mp4"
+    local_path.write_bytes(b"mp4")
+    test_runner.phone_recording._active.clear()
+    test_runner.phone_recording._active["ios:abc123"] = {
+        "device": "ios:abc123",
+        "platform": "ios",
+        "mode": "wda-mjpeg",
+        "filename": local_path.name,
+        "local_path": str(local_path),
+        "device_path": "",
+        "mjpeg_url": "http://127.0.0.1:9100",
+        "proc": proc,
+        "started_at": 0,
+    }
+
+    result = test_runner._sr_stop_and_pull("ios:abc123", local_path.name)
+
+    assert proc.terminated is True
+    assert result == local_path
+    assert test_runner.phone_recording.recording_status("ios:abc123")["running"] is False
+
+
+def test_recording_names_are_filesystem_safe():
+    assert test_runner._safe_recording_name("ios:abc123/test name") == "ios_abc123_test_name"
+
+
+def test_recording_metadata_restores_ios_device_ref():
+    info = test_runner._parse_recording_name("ios_abc123_20260608_123456_chrome_news.mp4")
+
+    assert info["device_ref"] == "ios:abc123"
+    assert info["device_safe"] == "ios_abc123"
+    assert info["test_name"] == "chrome_news"
+
+
+def test_recordings_list_includes_ios_metadata(tmp_path, monkeypatch):
+    recording = tmp_path / "ios_abc123_20260608_123456_chrome_news.mp4"
+    recording.write_bytes(b"mp4")
+    (tmp_path / "ios_abc123_20260608_123456_chrome_news.log").write_text("1 passed\n")
+    monkeypatch.setattr(test_runner, "_TR_RECORDINGS_DIR", tmp_path)
+    monkeypatch.setattr(test_runner, "_device_label", lambda serial: f"label:{serial}")
+
+    result = test_runner.tr_recordings()
+
+    assert len(result) == 1
+    assert result[0]["device_ref"] == "ios:abc123"
+    assert result[0]["device_label"] == "label:ios:abc123"
+    assert result[0]["device"] == "label:ios:abc123"
+    assert result[0]["platform"] == "ios"
+    assert result[0]["test_name"] == "chrome_news"
+    assert result[0]["has_log"] is True
+    assert result[0]["result"]["passed"] == 1
+
+
+def test_test_runner_uses_current_interpreter_for_pytest():
+    cmd = test_runner._pytest_cmd("tests/test_ios_device.py::test_factory_routes_ios_prefix", retry=True)
+
+    assert cmd[:3] == [sys.executable, "-u", "-m"]
+    assert cmd[3:7] == ["pytest", "-v", "--tb=short", "-s"]
+    assert "--reruns" in cmd
+    assert cmd[-1] == "tests/test_ios_device.py::test_factory_routes_ios_prefix"
+
+
+def test_test_runner_sets_ios_live_test_env(monkeypatch):
+    monkeypatch.delenv("IOS_DEVICE_UDID", raising=False)
+
+    env = test_runner._pytest_env("ios:abc123")
+
+    assert env["DEVICE"] == "ios:abc123"
+    assert env["IOS_DEVICE_UDID"] == "abc123"
+    assert env["PYTHONUNBUFFERED"] == "1"
+
+
+def test_test_runner_keeps_android_env_unchanged(monkeypatch):
+    monkeypatch.delenv("IOS_DEVICE_UDID", raising=False)
+
+    env = test_runner._pytest_env("emulator-5554")
+
+    assert env["DEVICE"] == "emulator-5554"
+    assert "IOS_DEVICE_UDID" not in env

--- a/tests/test_ios_wda_direct.py
+++ b/tests/test_ios_wda_direct.py
@@ -1,0 +1,281 @@
+"""Tests for the direct-WDA transport (IOS_WDA_DIRECT=1).
+
+When enabled, IOSDevice talks straight to WebDriverAgent's HTTP API — resolving
+the tunnel address from the RemoteXPC registry — and never touches Appium (whose
+CoreDevice device-lookup wedges as "Could not find the expected device"). These
+tests mock the WDA HTTP surface and assert every request lands on a WDA-native
+endpoint, and that the Appium path is left untouched when the flag is off.
+"""
+
+import pytest
+
+from gitd.bots.common import ios as ios_mod
+from gitd.bots.common.ios import (
+    IOSDevice,
+    _looks_like_ios_identifier,
+    normalize_wda_xml,
+    visible_text_entries_from_xml,
+)
+
+
+class FakeResponse:
+    def __init__(self, data, status_code=200, text=""):
+        self._data = data
+        self.status_code = status_code
+        self.text = text
+
+    @property
+    def ok(self):
+        return self.status_code < 400
+
+    def json(self):
+        return self._data
+
+
+class FakeWDA:
+    """Records requests and answers WDA-native endpoints; unknown paths 404."""
+
+    def __init__(self, address="fdaa::1"):
+        self.address = address
+        self.calls = []  # (method, url, payload)
+
+    # `requests.get` — used only by the registry resolver
+    def get(self, url, timeout=None, **kwargs):
+        self.calls.append(("GET", url, None))
+        if "/remotexpc/tunnels/" in url:
+            return FakeResponse({"address": self.address})
+        return self._route("GET", url, None)
+
+    # `requests.request` — session create, settings, all session ops
+    def request(self, method, url, json=None, timeout=None, **kwargs):
+        self.calls.append((method.upper(), url, json))
+        return self._route(method.upper(), url, json)
+
+    def _route(self, method, url, payload):
+        if method == "POST" and url.endswith("/session"):
+            return FakeResponse({"value": {"sessionId": "sess-direct-1"}, "sessionId": "sess-direct-1"})
+        if url.endswith("/appium/settings"):
+            return FakeResponse({"value": {}})
+        if url.endswith("/wda/apps/launch"):
+            return FakeResponse({"value": None})
+        if url.endswith("/wda/apps/terminate"):
+            return FakeResponse({"value": None})
+        if url.endswith("/wda/apps/state"):
+            return FakeResponse({"value": 4})
+        if url.endswith("/wda/pressButton"):
+            return FakeResponse({"value": {}})
+        if url.endswith("/wda/activeAppInfo"):
+            return FakeResponse({"value": {"bundleId": "com.foo.bar", "name": "Foo"}})
+        if url.endswith("/window/size"):
+            return FakeResponse({"value": {"width": 390, "height": 844}})
+        return FakeResponse({"value": {"error": "unknown command"}}, status_code=404, text=url)
+
+    def paths(self):
+        """URL path suffixes (drops the scheme://host base) for easy asserts."""
+        out = []
+        for _method, url, _payload in self.calls:
+            # keep everything from the first '/session' or '/remotexpc' onward
+            for marker in ("/session", "/remotexpc"):
+                if marker in url:
+                    out.append(url[url.index(marker):])
+                    break
+        return out
+
+
+@pytest.fixture()
+def wda(monkeypatch):
+    fake = FakeWDA()
+    monkeypatch.setattr(ios_mod.requests, "get", fake.get)
+    monkeypatch.setattr(ios_mod.requests, "request", fake.request)
+    monkeypatch.setattr(ios_mod.time, "sleep", lambda *_a, **_k: None)
+    monkeypatch.setenv("IOS_WDA_DIRECT", "1")
+    monkeypatch.setenv("IOS_REMOTEXPC_REGISTRY", "http://127.0.0.1:42314")
+    # Class-level session cache leaks across tests otherwise.
+    IOSDevice._sessions.clear()
+    return fake
+
+
+def _device():
+    return IOSDevice("ios:abc123", appium_url="http://appium.local:4723")
+
+
+def test_registry_resolves_bracketed_ipv6_base(wda):
+    dev = _device()
+    assert dev._wda_base() == "http://[fdaa::1]:8100"
+    # Resolution is cached per instance (address must not be refetched mid-session).
+    dev._wda_base()
+    registry_hits = [u for _m, u, _p in wda.calls if "/remotexpc/tunnels/" in u]
+    assert len(registry_hits) == 1
+    assert registry_hits[0].endswith("/remotexpc/tunnels/abc123")
+
+
+def test_ipv4_base_is_not_bracketed(monkeypatch, wda):
+    wda.address = "192.168.1.9"
+    dev = _device()
+    assert dev._wda_base() == "http://192.168.1.9:8100"
+
+
+def test_fixed_wda_url_bypasses_registry(wda):
+    dev = _device()
+    dev.wda_url = "http://[fe80::2]:8100/"  # normally from IOS_WDA_URL
+    assert dev._wda_base() == "http://[fe80::2]:8100"
+    assert not [u for _m, u, _p in wda.calls if "/remotexpc/tunnels/" in u]
+
+
+def test_session_uses_minimal_caps_and_applies_settings(wda):
+    dev = _device()
+    sid = dev._ensure_session()
+    assert sid == "sess-direct-1"
+
+    # session POST carries NO appium:udid (that is what triggers the CoreDevice wedge)
+    create = next(p for m, u, p in wda.calls if m == "POST" and u.endswith("/session"))
+    always = create["capabilities"]["alwaysMatch"]
+    assert always == {"platformName": "iOS"}
+    assert not any(k.startswith("appium:") for k in always)
+
+    # snappy settings applied right after create
+    settings = next(p for m, u, p in wda.calls if u.endswith("/appium/settings"))
+    assert settings["settings"]["animationCoolOffTimeout"] == 0
+    assert settings["settings"]["waitForIdleTimeout"] == 0
+
+    # every request went to the WDA base, never to Appium
+    assert all("appium.local:4723" not in u for _m, u, _p in wda.calls)
+    assert any("[fdaa::1]:8100" in u for _m, u, _p in wda.calls)
+
+
+def test_launch_app_maps_to_wda_endpoint(wda):
+    dev = _device()
+    dev.launch_app("com.foo.bar")
+    launch = next((m, u, p) for m, u, p in wda.calls if u.endswith("/wda/apps/launch"))
+    assert launch[0] == "POST"
+    assert launch[2] == {"bundleId": "com.foo.bar"}
+    # /session/<sid>/wda/apps/launch, not /execute/sync
+    assert "/execute/sync" not in " ".join(wda.paths())
+
+
+def test_app_state_maps_to_wda_state(wda):
+    dev = _device()
+    assert dev.app_state("com.foo.bar") == 4
+    state = next((m, u, p) for m, u, p in wda.calls if u.endswith("/wda/apps/state"))
+    assert state[0] == "POST"
+    assert state[2] == {"bundleId": "com.foo.bar"}
+
+
+def test_press_home_maps_to_pressbutton(wda):
+    dev = _device()
+    dev.press_key("HOME")
+    press = next((m, u, p) for m, u, p in wda.calls if u.endswith("/wda/pressButton"))
+    assert press[0] == "POST"
+    assert press[2] == {"name": "home"}
+
+
+def test_terminate_app_maps_to_wda_terminate(wda):
+    dev = _device()
+    dev.terminate_app("com.foo.bar")
+    term = next((m, u, p) for m, u, p in wda.calls if u.endswith("/wda/apps/terminate"))
+    assert term[0] == "POST"
+    assert term[2] == {"bundleId": "com.foo.bar"}
+
+
+def test_unmapped_mobile_command_raises_clear_error(wda):
+    dev = _device()
+    with pytest.raises(ios_mod.IOSBackendError, match="no WDA-native equivalent"):
+        dev._execute_mobile("mobile: siriCommand", {"text": "hi"})
+
+
+def test_mjpeg_url_uses_wda_host(wda):
+    dev = _device()
+    assert dev.mjpeg_url == "http://[fdaa::1]:9100"
+
+
+def test_contexts_native_only_in_direct_mode(wda):
+    # WDA has no /contexts endpoint; direct mode must report native-only without
+    # ever issuing the Appium request (which 404s "Unhandled endpoint").
+    dev = _device()
+    assert dev.get_contexts() == ["NATIVE_APP"]
+    assert dev.get_web_contexts() == []
+    assert not [u for _m, u, _p in wda.calls if u.endswith("/contexts")]
+
+
+def test_set_context_is_noop_in_direct_mode(wda):
+    dev = _device()
+    dev._set_context("NATIVE_APP")  # must not raise or hit /context
+    assert not [u for _m, u, _p in wda.calls if u.endswith("/context")]
+
+
+def test_web_text_snapshot_empty_in_direct_mode(wda):
+    # No web contexts → snapshot is empty → extractors fall back to native /source.
+    dev = _device()
+    assert dev.web_text_snapshot() == {}
+    assert dev.web_text_entries() == []
+    # never touched the Appium context/execute endpoints
+    assert not [u for _m, u, _p in wda.calls if u.endswith(("/contexts", "/context", "/execute/sync"))]
+
+
+@pytest.mark.parametrize(
+    "identifier",
+    [
+        "BaseCell<FeedStackSliceViewModel>",
+        "_TtGC8SliceKit20BaseListViewModel",
+        "reddit_feed__content_view_home_loaded",
+        "Home_Impl.HomeScreenView",
+        "HomeScreenView",
+    ],
+)
+def test_identifier_strings_are_detected(identifier):
+    assert _looks_like_ios_identifier(identifier) is True
+
+
+@pytest.mark.parametrize(
+    "human",
+    [
+        "Best moments from the game last night",
+        "Settings",
+        "Reddit",
+        "www.reddit.com",
+        "12 comments",
+        "",
+        "U.S. Open results",
+    ],
+)
+def test_human_text_is_not_treated_as_identifier(human):
+    assert _looks_like_ios_identifier(human) is False
+
+
+def test_native_extraction_prefers_labels_over_identifiers():
+    # A Reddit-style tree: container views carry accessibility IDENTIFIERS in
+    # `name` (no label); the real post title is a leaf StaticText with `label`.
+    raw = """<?xml version="1.0" encoding="UTF-8"?>
+    <AppiumAUT>
+      <XCUIElementTypeApplication type="XCUIElementTypeApplication" name="Reddit" x="0" y="0" width="390" height="844" visible="true">
+        <XCUIElementTypeOther type="XCUIElementTypeOther" name="reddit_feed__content_view_home_loaded" x="0" y="0" width="390" height="800" visible="true">
+          <XCUIElementTypeCell type="XCUIElementTypeCell" name="BaseCell&lt;FeedStackSliceViewModel&gt;" x="0" y="100" width="390" height="200" visible="true">
+            <XCUIElementTypeStaticText type="XCUIElementTypeStaticText" label="Best moments from the game last night" x="10" y="120" width="360" height="40" visible="true"/>
+          </XCUIElementTypeCell>
+        </XCUIElementTypeOther>
+      </XCUIElementTypeApplication>
+    </AppiumAUT>
+    """
+    xml = normalize_wda_xml(raw)
+    texts = [e["text"] for e in visible_text_entries_from_xml(xml, screen_size=(390, 844))]
+    assert "Best moments from the game last night" in texts
+    # none of the developer identifiers leak into extracted page text
+    assert not any("BaseCell" in t or "reddit_feed__" in t or "HomeScreenView" in t for t in texts)
+
+
+def test_appium_path_untouched_when_flag_off(monkeypatch):
+    monkeypatch.delenv("IOS_WDA_DIRECT", raising=False)
+    fake = FakeWDA()
+    monkeypatch.setattr(ios_mod.requests, "request", fake.request)
+    monkeypatch.setattr(ios_mod.time, "sleep", lambda *_a, **_k: None)
+    IOSDevice._sessions.clear()
+
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local:4723")
+    assert dev._direct is False
+    assert dev._url("/session") == "http://appium.local:4723/session"
+    # session creation still carries appium:udid (the Appium contract)
+    dev._ensure_session()
+    create = next(p for m, u, p in fake.calls if m == "POST" and u.endswith("/session"))
+    assert create["capabilities"]["alwaysMatch"]["appium:udid"] == "abc123"
+    # no registry lookup happens on the Appium path
+    assert not [u for _m, u, _p in fake.calls if "/remotexpc/tunnels/" in u]

--- a/tests/test_llm_backoff.py
+++ b/tests/test_llm_backoff.py
@@ -1,0 +1,171 @@
+"""Tests for the rate-limit backoff + effort-timeout helpers."""
+
+import pytest
+
+from gitd.services.llm_backoff import (
+    backoff_stream,
+    call_with_backoff,
+    effort_timeout,
+    is_rate_limited,
+)
+
+
+@pytest.mark.parametrize(
+    "err",
+    [
+        "Error code: 429 Too Many Requests",
+        "overloaded_error: the model is overloaded",
+        "rate limit exceeded",
+        "RATE_LIMIT",
+        "usage limit reached",
+        "529 server overloaded",
+        "quota exceeded for this org",
+    ],
+)
+def test_is_rate_limited_true(err):
+    assert is_rate_limited(err)
+
+
+@pytest.mark.parametrize(
+    "err",
+    ["", None, "400 bad request", "invalid api key", "connection reset", "not found"],
+)
+def test_is_rate_limited_false(err):
+    assert not is_rate_limited(err)
+
+
+def test_effort_timeout_scales_by_tier():
+    assert effort_timeout("claude-opus-4-8") == 420
+    assert effort_timeout("anthropic/claude-sonnet-4") == 300
+    assert effort_timeout("claude-haiku-4-5") == 240
+
+
+def test_effort_timeout_default_never_shortens_below_sdk_default():
+    # Regression guard (neutral-review PR #37 FIX-2): unknown models — vLLM,
+    # gemma, on-device, future ids — previously relied on the SDK's own 600s
+    # default. The fallback MUST be >= 600 so wiring an explicit timeout can
+    # never SHORTEN a call that used to work (a vLLM model can exceed 180s to
+    # first token under load).
+    assert effort_timeout("unsloth/gemma-4-E4B-it") >= 600
+    assert effort_timeout("gemma-4-e2b-q4km-gguf") >= 600
+    assert effort_timeout("") >= 600
+    assert effort_timeout(None) >= 600
+
+
+def test_call_with_backoff_passthrough_on_success():
+    calls = []
+
+    def fn():
+        calls.append(1)
+        return "ok"
+
+    slept = []
+    assert call_with_backoff(fn, sleep=slept.append) == "ok"
+    assert calls == [1]  # called exactly once, no retries
+    assert slept == []  # never slept
+
+
+def test_call_with_backoff_retries_then_succeeds():
+    attempts = {"n": 0}
+
+    def fn():
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            raise RuntimeError("429 Too Many Requests")
+        return "recovered"
+
+    slept = []
+    result = call_with_backoff(fn, backoff=(1, 2, 3), sleep=slept.append)
+    assert result == "recovered"
+    assert attempts["n"] == 3
+    assert slept == [1, 2]  # two backoff waits before the third attempt succeeded
+
+
+def test_call_with_backoff_non_rate_limit_raises_immediately():
+    attempts = {"n": 0}
+
+    def fn():
+        attempts["n"] += 1
+        raise ValueError("400 invalid request")
+
+    slept = []
+    with pytest.raises(ValueError, match="400 invalid request"):
+        call_with_backoff(fn, sleep=slept.append)
+    assert attempts["n"] == 1  # not retried
+    assert slept == []
+
+
+def test_call_with_backoff_exhausts_and_reraises():
+    def fn():
+        raise RuntimeError("overloaded")
+
+    slept = []
+    with pytest.raises(RuntimeError, match="overloaded"):
+        call_with_backoff(fn, backoff=(1, 2), sleep=slept.append)
+    assert slept == [1, 2]  # exhausted the whole schedule
+
+
+def test_call_with_backoff_on_wait_callback():
+    attempts = {"n": 0}
+
+    def fn():
+        attempts["n"] += 1
+        if attempts["n"] < 2:
+            raise RuntimeError("rate limit")
+        return "ok"
+
+    waits = []
+    call_with_backoff(
+        fn,
+        backoff=(5, 10),
+        on_wait=lambda attempt, wait, err: waits.append((attempt, wait)),
+        sleep=lambda _: None,
+    )
+    assert waits == [(1, 5)]
+
+
+# ── backoff_stream (SSE keepalive variant, PR #37 FIX-1) ──────────────────────
+
+
+def test_backoff_stream_success_yields_only_result():
+    events = list(backoff_stream(lambda: "ok", sleep=lambda _: None))
+    assert events == [{"__result__": "ok"}]  # no activity events on a clean call
+
+
+def test_backoff_stream_emits_keepalive_activity_during_wait():
+    attempts = {"n": 0}
+
+    def fn():
+        attempts["n"] += 1
+        if attempts["n"] < 2:
+            raise RuntimeError("429 overloaded")
+        return "recovered"
+
+    slept = []
+    events = list(backoff_stream(fn, backoff=(25,), sleep=slept.append))
+
+    activity = [e for e in events if e.get("type") == "activity"]
+    results = [e for e in events if "__result__" in e]
+    # 25s wait sliced into <=10s keepalives → 3 activity pings (25,15,5 remaining)
+    assert len(activity) == 3
+    assert all("Rate-limited" in e["content"] for e in activity)
+    # sleeps sum to the full wait and none exceed the keepalive slice
+    assert sum(slept) == 25
+    assert max(slept) <= 10
+    assert results == [{"__result__": "recovered"}]
+
+
+def test_backoff_stream_non_rate_limit_raises():
+    def fn():
+        raise ValueError("400 bad request")
+
+    with pytest.raises(ValueError, match="400 bad request"):
+        list(backoff_stream(fn, sleep=lambda _: None))
+
+
+def test_backoff_stream_exhausts_and_reraises():
+    def fn():
+        raise RuntimeError("overloaded")
+
+    with pytest.raises(RuntimeError, match="overloaded"):
+        list(backoff_stream(fn, backoff=(5, 10), sleep=lambda _: None))

--- a/tests/test_marketing_lookup.py
+++ b/tests/test_marketing_lookup.py
@@ -1,0 +1,75 @@
+from gitd.db import create_tables, get_connection
+from gitd.services.marketing_lookup import list_unread_leads, lookup_lead
+
+
+def test_lookup_lead_returns_fact_sheet_with_outreach_and_inbox(tmp_path):
+    db_path = tmp_path / "gitd.db"
+    conn = get_connection(db_path)
+    try:
+        create_tables(conn)
+        conn.execute(
+            """
+            INSERT INTO influencers
+                (id, handle, followers, following, total_likes, bio, niche, caption, source_query, scraped_at)
+            VALUES
+                (1, '@demo', 1200, 300, 6000, 'Pet creator', 'dogs', 'First line\nSecond line', '#dogs', '2026-06-01')
+            """
+        )
+        conn.execute("INSERT INTO outreach_strategies (id, name) VALUES (7, 'Creator collab')")
+        conn.execute(
+            """
+            INSERT INTO outreach_log
+                (influencer_id, strategy_id, status, deal_status, contacted_at, source_account, notes)
+            VALUES
+                (1, 7, 'contacted', 'negotiating', '2026-06-02', 'brandacct', 'Asked for rates')
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO inbox_replies
+                (handle, last_msg, status, unread, influencer_id, first_seen_at, last_seen_at)
+            VALUES
+                ('demo', 'Sounds good', 'reply', 2, 1, '2026-06-03', '2026-06-04')
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    result = lookup_lead("demo", db_path=db_path)
+
+    assert "HANDLE:    @demo" in result
+    assert "FOLLOWERS: 1,200" in result
+    assert "ENGAGEMENT: 5.0 likes/follower" in result
+    assert "Strategy:  Creator collab" in result
+    assert "Sent from: @brandacct" in result
+    assert "Last msg:  Sounds good" in result
+
+
+def test_list_unread_leads_returns_recent_unread(tmp_path):
+    db_path = tmp_path / "gitd.db"
+    conn = get_connection(db_path)
+    try:
+        create_tables(conn)
+        conn.execute(
+            """
+            INSERT INTO inbox_replies
+                (handle, last_msg, status, unread, first_seen_at, last_seen_at)
+            VALUES
+                ('newer', 'Latest reply', 'reply', 3, '2026-06-01', '2026-06-05'),
+                ('read', 'Already handled', 'reply', 0, '2026-06-01', '2026-06-06'),
+                ('older', 'Older reply', 'reply', 1, '2026-06-01', '2026-06-02')
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    result = list_unread_leads(db_path=db_path)
+
+    assert result.splitlines()[0] == "2 unread:"
+    assert "[3] newer" in result
+    assert "[1] older" in result
+    assert "[0] read" not in result
+    assert "Already handled" not in result
+    assert result.index("newer") < result.index("older")

--- a/tests/test_mcp_devices.py
+++ b/tests/test_mcp_devices.py
@@ -1,0 +1,54 @@
+from gitd import mcp_server
+
+
+class FakeAndroidDevice:
+    def __init__(self, serial):
+        self.serial = serial
+
+    def adb(self, *args, **kwargs):
+        assert self.serial == "emulator-5554"
+        assert args == ("shell", "getprop", "ro.product.model")
+        assert kwargs == {"timeout": 3}
+        return "Pixel 8\n"
+
+
+def test_mcp_list_devices_includes_ios_probe_status(monkeypatch):
+    def fake_ios_devices(deep_probe=False):
+        assert deep_probe is False
+        return [
+            {
+                "serial": "ios:abc123",
+                "model": "Casey's iPhone",
+                "platform": "ios",
+                "source": "host",
+                "host_state": "connected",
+                "status": "appium_down",
+                "status_message": "Start Appium on http://127.0.0.1:4723.",
+                "appium_url": "http://127.0.0.1:4723",
+            }
+        ]
+
+    monkeypatch.setattr(mcp_server, "Device", FakeAndroidDevice)
+    monkeypatch.setattr(mcp_server, "list_connected_device_refs", lambda: ["emulator-5554", "ios:abc123"])
+    monkeypatch.setattr(mcp_server, "list_configured_ios_devices", fake_ios_devices)
+
+    result = mcp_server.list_devices()
+
+    assert "emulator-5554 (Pixel 8)" in result
+    assert "ios:abc123" in result
+    assert "Casey's iPhone" in result
+    assert "status=appium_down" in result
+    assert "host=host/connected" in result
+    assert "appium=http://127.0.0.1:4723" in result
+    assert "hint=Start Appium on http://127.0.0.1:4723." in result
+
+
+def test_mcp_list_devices_falls_back_when_ios_details_fail(monkeypatch):
+    monkeypatch.setattr(mcp_server, "list_connected_device_refs", lambda: ["ios:abc123"])
+    monkeypatch.setattr(
+        mcp_server,
+        "list_configured_ios_devices",
+        lambda deep_probe=False: (_ for _ in ()).throw(RuntimeError("xctrace failed")),
+    )
+
+    assert mcp_server.list_devices() == "ios:abc123 (iOS via Appium/WDA)"

--- a/tests/test_mcp_ios_skill_creation.py
+++ b/tests/test_mcp_ios_skill_creation.py
@@ -1,0 +1,55 @@
+import json
+
+import yaml
+
+from gitd import mcp_server
+
+
+def test_mcp_create_skill_writes_ios_metadata_and_elements(tmp_path, monkeypatch):
+    fake_mcp_file = tmp_path / "gitd" / "mcp_server.py"
+    fake_mcp_file.parent.mkdir()
+    fake_mcp_file.write_text("")
+    monkeypatch.setattr(mcp_server, "__file__", str(fake_mcp_file))
+
+    steps = [{"action": "launch", "package": "com.google.chrome.ios"}]
+    elements_ios = {"address_bar": {"text": "Search or type web address"}}
+
+    result = mcp_server.create_skill(
+        name="ios_browser_demo",
+        app_package="com.google.chrome.ios",
+        steps=json.dumps(steps),
+        platforms="ios",
+        elements_ios=json.dumps(elements_ios),
+    )
+
+    skill_dir = fake_mcp_file.parent / "skills" / "ios_browser_demo"
+    meta = yaml.safe_load((skill_dir / "skill.yaml").read_text())
+
+    assert "for ios" in result
+    assert meta["platforms"] == ["ios"]
+    assert meta["app_package"] == ""
+    assert meta["android_package"] == ""
+    assert meta["ios_bundle_id"] == "com.google.chrome.ios"
+    assert json.loads((skill_dir / "workflows" / "recorded.json").read_text()) == steps
+    assert yaml.safe_load((skill_dir / "elements_ios.yaml").read_text()) == elements_ios
+
+
+def test_mcp_create_skill_preserves_legacy_android_default(tmp_path, monkeypatch):
+    fake_mcp_file = tmp_path / "gitd" / "mcp_server.py"
+    fake_mcp_file.parent.mkdir()
+    fake_mcp_file.write_text("")
+    monkeypatch.setattr(mcp_server, "__file__", str(fake_mcp_file))
+
+    result = mcp_server.create_skill(
+        name="android_demo",
+        app_package="com.example.android",
+        steps=json.dumps([{"action": "tap", "x": 1, "y": 2}]),
+    )
+
+    meta = yaml.safe_load((fake_mcp_file.parent / "skills" / "android_demo" / "skill.yaml").read_text())
+
+    assert "for android" in result
+    assert meta["platforms"] == ["android"]
+    assert meta["app_package"] == "com.example.android"
+    assert meta["android_package"] == "com.example.android"
+    assert meta["ios_bundle_id"] == ""

--- a/tests/test_ollama.py
+++ b/tests/test_ollama.py
@@ -1,6 +1,10 @@
 """Tests for Ollama tool parsing and provider config."""
 
-from gitd.services.agent_chat import PROVIDERS, _parse_tool_calls
+from gitd.services.agent_chat import (
+    PROVIDERS,
+    _parse_tool_calls,
+    normalize_tool_call,
+)
 
 
 def test_providers_ollama_has_models():
@@ -64,3 +68,45 @@ def test_parse_tool_calls_missing_tool_key():
     text = '```tool\n{"action": "screenshot", "args": {}}\n```'
     calls = _parse_tool_calls(text)
     assert len(calls) == 0
+
+
+def test_parse_tool_calls_flat_shape():
+    """Flat shape (ghost-gemma trained) — args are siblings of 'tool', no nested args."""
+    text = '```tool\n{"tool": "launch_app", "package": "com.android.settings"}\n```'
+    calls = _parse_tool_calls(text)
+    assert len(calls) == 1
+    assert calls[0]["tool"] == "launch_app"
+    assert calls[0]["package"] == "com.android.settings"
+
+
+def test_normalize_tool_call_nested():
+    """Canonical shape: {"tool": "X", "args": {...}} → args come from the nested dict."""
+    name, args = normalize_tool_call({"tool": "tap", "args": {"x": 540, "y": 1200}})
+    assert name == "tap"
+    assert args == {"x": 540, "y": 1200}
+
+
+def test_normalize_tool_call_flat():
+    """Flat shape (ghost-gemma trained): kwargs are siblings of 'tool'.
+
+    Regression guard for the on-device path silently dropping every flat arg
+    (only 'device' survived) — the exact model the feature was trained on.
+    """
+    name, args = normalize_tool_call({"tool": "launch_app", "package": "com.foo"})
+    assert name == "launch_app"
+    assert args == {"package": "com.foo"}
+
+
+def test_normalize_tool_call_does_not_mutate_input():
+    """Returned args must be a fresh dict — callers setdefault('device', ...) on it."""
+    call = {"tool": "tap", "args": {"x": 1}}
+    _, args = normalize_tool_call(call)
+    args["device"] = "emulator-5554"
+    assert "device" not in call["args"]
+
+
+def test_normalize_tool_call_empty():
+    """Missing 'tool' / no args → empty name, empty args (no crash)."""
+    name, args = normalize_tool_call({})
+    assert name == ""
+    assert args == {}

--- a/tests/test_platform_matrix.py
+++ b/tests/test_platform_matrix.py
@@ -1,0 +1,63 @@
+"""Tests for the generated platform-support matrix (docs emitter)."""
+
+from gitd.services.tool_platforms import (
+    TOOL_PLATFORM_SUPPORT,
+    render_matrix_markdown,
+    tools_for_support,
+)
+
+
+def test_matrix_covers_every_tool_exactly_once():
+    md = render_matrix_markdown()
+    for name in TOOL_PLATFORM_SUPPORT:
+        assert f"| `{name}` |" in md
+    # one row per tool (no dup across groups)
+    assert md.count("| `") == sum(len(tools_for_support(s)) for s in TOOL_PLATFORM_SUPPORT_SUPPORTS)
+
+
+def test_badges_match_support_class():
+    md = render_matrix_markdown()
+    # a cross-platform tool → ✅ on both
+    assert "| `tap` | ✅ | ✅ |" in md
+    # android-only → n/a on iOS
+    assert "| `shell` | ✅ | ⚠️ n/a |" in md
+
+
+def test_generated_header_and_legend_present():
+    md = render_matrix_markdown()
+    assert "GENERATED from gitd/services/tool_platforms.py" in md
+    assert "hardware-confirmed on iOS" in md  # honesty overlay reminder
+    assert md.endswith("\n")
+
+
+def test_html_comment_header_by_default():
+    md = render_matrix_markdown()
+    assert md.startswith("<!--")
+    assert "{/*" not in md.splitlines()[0]
+
+
+def test_mdx_mode_uses_mdx_comment_not_html():
+    md = render_matrix_markdown(mdx=True)
+    # MDX chokes on HTML comments — the header must be a {/* */} comment
+    assert md.startswith("{/*") and md.splitlines()[0].endswith("*/}")
+    assert "<!--" not in md
+    assert "--mdx" in md.splitlines()[0]  # self-documenting regen command
+    # table body identical to the default render
+    assert "| `tap` | ✅ | ✅ |" in md
+
+
+def test_deterministic_output():
+    assert render_matrix_markdown() == render_matrix_markdown()
+
+
+def test_pipe_in_notes_is_escaped():
+    # notes are cell content; a raw | would break the table
+    md = render_matrix_markdown()
+    for line in md.splitlines():
+        if line.startswith("| `"):
+            # exactly 5 pipes = 4 columns, unless an escaped \| appears
+            assert line.replace("\\|", "").count("|") == 5
+
+
+# support classes present in the registry (module-level for the count assertion)
+TOOL_PLATFORM_SUPPORT_SUPPORTS = ("cross_platform", "ios_supported", "ios_planned", "android_only")

--- a/tests/test_run_flow.py
+++ b/tests/test_run_flow.py
@@ -1,0 +1,121 @@
+"""Tests for the batch-flow MCP primitive (_run_flow / run_flow).
+
+Covers the happy path (ordered execution, one final screenshot), the fail-fast
+error behaviour, and — most importantly — the fail-closed allow-list: a flow
+naming any non-allowed tool (dangerous OR unknown) is refused as a whole,
+executing NOTHING.
+"""
+
+import json
+
+import gitd.services.agent_tools as agent_tools
+from gitd.mcp_server import FLOW_ALLOWED_TOOLS, MAX_FLOW_STEPS, _run_flow, run_flow
+
+
+def _patch(monkeypatch, calls, *, raise_on=None, screenshot="IMGB64"):
+    # _run_flow dispatches via _execute_tool_inner (NOT the wrapped execute_tool,
+    # which sleeps + appends a screen tree per step), so we patch that.
+    def fake_execute(name, args):
+        calls.append((name, dict(args)))
+        if raise_on and name == raise_on:
+            raise RuntimeError("adb ... failed (exit 1): device not found")
+        return f"{name}-ok"
+
+    shots = {"n": 0}
+
+    def fake_shot(device):
+        shots["n"] += 1
+        return screenshot
+
+    monkeypatch.setattr(agent_tools, "_execute_tool_inner", fake_execute)
+    monkeypatch.setattr(agent_tools, "get_screenshot_b64", fake_shot)
+    return shots
+
+
+def test_run_flow_executes_steps_in_order_with_one_screenshot(monkeypatch):
+    calls = []
+    shots = _patch(monkeypatch, calls)
+    steps = [
+        {"tool": "launch_app", "args": {"package": "com.x"}},
+        {"tool": "tap", "args": {"x": 5, "y": 6}},
+        {"tool": "type_text", "args": {"text": "hi"}},
+    ]
+    out = _run_flow("SER1", steps)
+
+    assert [c[0] for c in calls] == ["launch_app", "tap", "type_text"]
+    # device is injected into every step
+    assert all(c[1]["device"] == "SER1" for c in calls)
+    assert out["steps_run"] == 3 and out["stopped_early"] is False
+    assert all(r["ok"] for r in out["results"])
+    # exactly ONE final screenshot for the whole batch
+    assert shots["n"] == 1
+    assert out["final_screenshot"] == "IMGB64"
+
+
+def test_run_flow_blocks_dangerous_tool_and_runs_nothing(monkeypatch):
+    calls = []
+    _patch(monkeypatch, calls)
+    # A benign step FIRST, then a smuggled `shell` — the whole flow must be
+    # refused before the benign step runs.
+    steps = [
+        {"tool": "tap", "args": {"x": 1, "y": 2}},
+        {"tool": "shell", "args": {"command": "rm -rf /sdcard"}},
+    ]
+    out = _run_flow("SER1", steps)
+
+    assert out.get("blocked") == "shell"
+    assert "not allowed" in out["error"]
+    assert calls == [], "no step may execute when the flow contains a non-allowed tool"
+
+
+def test_run_flow_fails_closed_on_unknown_tool(monkeypatch):
+    """The whole point of the allow-list: a tool not on it (e.g. a future
+    dangerous addition to execute_tool) is refused, not auto-allowed."""
+    calls = []
+    _patch(monkeypatch, calls)
+    out = _run_flow("SER1", [{"tool": "some_new_tool_added_later", "args": {}}])
+    assert out.get("blocked") == "some_new_tool_added_later"
+    assert calls == []
+
+
+def test_run_flow_allowlist_excludes_dangerous_tools():
+    # shell / run_skill are the two exec vectors in execute_tool — never allowed.
+    assert "shell" not in FLOW_ALLOWED_TOOLS
+    assert "run_skill" not in FLOW_ALLOWED_TOOLS
+    # but the common read/UI tools are.
+    assert {"tap", "launch_app", "find_on_screen", "screenshot"} <= FLOW_ALLOWED_TOOLS
+
+
+def test_run_flow_aborts_on_first_error(monkeypatch):
+    calls = []
+    _patch(monkeypatch, calls, raise_on="tap")
+    steps = [
+        {"tool": "launch_app", "args": {"package": "com.x"}},
+        {"tool": "tap", "args": {"x": 5, "y": 6}},  # raises
+        {"tool": "type_text", "args": {"text": "never runs"}},
+    ]
+    out = _run_flow("SER1", steps)
+
+    assert [c[0] for c in calls] == ["launch_app", "tap"]  # third step not reached
+    assert out["stopped_early"] is True
+    assert out["results"][-1]["ok"] is False
+    assert "device not found" in out["results"][-1]["error"]
+
+
+def test_run_flow_rejects_bad_shapes(monkeypatch):
+    _patch(monkeypatch, [])
+    assert "list" in _run_flow("S", {"not": "a list"})["error"]
+    assert "empty" in _run_flow("S", [])["error"]
+    assert "too many" in _run_flow("S", [{"tool": "tap"}] * (MAX_FLOW_STEPS + 1))["error"]
+    assert "'tool'" in _run_flow("S", [{"args": {}}])["error"]
+
+
+def test_run_flow_wrapper_parses_json_and_reports_bad_json(monkeypatch):
+    calls = []
+    _patch(monkeypatch, calls)
+    # good JSON → executes
+    res = json.loads(run_flow("SER1", '[{"tool":"tap","args":{"x":1,"y":2}}]'))
+    assert res["steps_run"] == 1 and calls[0][0] == "tap"
+    # bad JSON → clean error, no crash
+    err = json.loads(run_flow("SER1", "{not json"))
+    assert "valid JSON" in err["error"]

--- a/tests/test_safari_ios_skill.py
+++ b/tests/test_safari_ios_skill.py
@@ -1,0 +1,89 @@
+from gitd.skills.safari import load
+from gitd.skills.safari.actions.core import ReadNews
+from gitd.skills.safari.workflows import ReadNewsWorkflow
+
+
+class FakeIOSDevice:
+    serial = "ios:abc123"
+
+
+def test_safari_skill_registers_news_reader():
+    skill = load()
+
+    assert skill.name == "safari"
+    assert "read_news" in skill.list_actions()
+    assert "read_news" in skill.list_workflows()
+
+
+def test_read_news_action_delegates_to_browser_service(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_read_news(device, url, **kwargs):
+        calls.append({"device": device, "url": url, "kwargs": kwargs})
+        return {
+            "ok": True,
+            "headlines": [{"title": "A real headline from the test"}],
+            "articles": [{"page_title": "Article", "body_snippet": "Body"}],
+        }
+
+    monkeypatch.setattr("gitd.services.browser.read_news", fake_read_news)
+
+    result = ReadNews(
+        FakeIOSDevice(),
+        url="https://text.npr.org/",
+        max_headlines=4,
+        max_articles=2,
+        bundle_id="com.google.chrome.ios",
+        wait_s=0.25,
+        save_screenshots=True,
+        out_dir=str(tmp_path),
+    ).run()
+
+    assert result.success is True
+    assert result.data["headlines"][0]["title"] == "A real headline from the test"
+    assert calls == [
+        {
+            "device": "ios:abc123",
+            "url": "https://text.npr.org/",
+            "kwargs": {
+                "max_headlines": 4,
+                "max_articles": 2,
+                "bundle_id": "com.google.chrome.ios",
+                "wait_s": 0.25,
+                "save_screenshots": True,
+                "out_dir": str(tmp_path),
+            },
+        }
+    ]
+
+
+def test_read_news_action_rejects_android_device():
+    device = FakeIOSDevice()
+    device.serial = "emulator-5554"
+
+    result = ReadNews(device).run()
+
+    assert result.success is False
+    assert "requires an iOS device ref" in result.error
+
+
+def test_read_news_workflow_is_single_product_path_action(monkeypatch):
+    monkeypatch.setattr("gitd.skills.base.time.sleep", lambda *_args, **_kwargs: None)
+    device = FakeIOSDevice()
+
+    workflow = ReadNewsWorkflow(
+        device,
+        url="https://text.npr.org/",
+        max_headlines=5,
+        max_articles=3,
+        bundle_id="com.google.chrome.ios",
+    )
+
+    steps = workflow.steps()
+
+    assert workflow.engine.auto_launch is False
+    assert [step.name for step in steps] == ["read_news"]
+    assert steps[0].url == "https://text.npr.org/"
+    assert steps[0].max_headlines == 5
+    assert steps[0].max_articles == 3
+    assert steps[0].bundle_id == "com.google.chrome.ios"

--- a/tests/test_scheduler_skill_results.py
+++ b/tests/test_scheduler_skill_results.py
@@ -1,0 +1,137 @@
+import json
+
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from gitd.app import app
+from gitd.models.base import SessionLocal
+from gitd.services._job_helpers import _parse_job_result_data, _parse_job_summary, _summarize_job_result_data
+
+
+def _read_news_skill_data() -> dict:
+    return {
+        "completed_steps": 1,
+        "step_results": [
+            {
+                "name": "read_news",
+                "success": True,
+                "data": {
+                    "ok": True,
+                    "platform": "ios",
+                    "headlines": [
+                        {"title": "First useful headline", "url": "https://text.npr.org/a"},
+                        {"title": "Second useful headline", "url": "https://text.npr.org/b"},
+                    ],
+                    "articles": [
+                        {"page_title": "First useful headline", "body_snippet": "Article body"},
+                    ],
+                    "extraction": {
+                        "headlines": {
+                            "requested": 2,
+                            "target": 2,
+                            "returned": 2,
+                            "ready": True,
+                            "attempts": 1,
+                            "source": "web_context",
+                        },
+                        "front_page_text": {
+                            "requested_lines": 120,
+                            "target_lines": 1,
+                            "returned_lines": 3,
+                            "ready": True,
+                            "attempts": 1,
+                            "source": "web_context",
+                        },
+                        "articles": [
+                            {
+                                "index": 1,
+                                "headline_provenance": "web_context",
+                                "headline_has_url": True,
+                                "open_method": "url",
+                                "text": {
+                                    "requested_lines": 160,
+                                    "target_lines": 2,
+                                    "returned_lines": 2,
+                                    "ready": True,
+                                    "attempts": 1,
+                                    "source": "web_context",
+                                },
+                            }
+                        ],
+                    },
+                },
+                "error": None,
+                "duration_ms": 123,
+            }
+        ],
+    }
+
+
+def test_scheduler_log_parser_extracts_skill_result_json(tmp_path):
+    payload = _read_news_skill_data()
+    log_path = tmp_path / "sched_job.log"
+    log_path.write_text(
+        "Loaded skill: safari\n"
+        "Running workflow: read_news\n"
+        "Result: success=True duration=123ms\n"
+        f"Data: {json.dumps(payload)}\n",
+        encoding="utf-8",
+    )
+
+    parsed = _parse_job_result_data(123, log_path=str(log_path))
+
+    assert parsed == payload
+    assert _summarize_job_result_data(parsed) == (
+        "read_news: 2 headlines | 1 article | first: First useful headline"
+    )
+    assert _parse_job_summary(123, log_path=str(log_path)) == (
+        "read_news: 2 headlines | 1 article | first: First useful headline"
+    )
+
+
+def test_scheduler_history_result_endpoint_returns_structured_skill_data(tmp_path):
+    payload = _read_news_skill_data()
+    log_path = tmp_path / "sched_job.log"
+    log_path.write_text(f"Data: {json.dumps(payload)}\n", encoding="utf-8")
+    db = SessionLocal()
+    run_id = None
+    try:
+        db.execute(
+            text(
+                "INSERT INTO job_runs "
+                "(phone_serial, job_type, priority, config_json, status, "
+                "duration_s, exit_code, error_msg, log_file, trigger) "
+                "VALUES (:phone_serial, :job_type, :priority, :config_json, :status, "
+                ":duration_s, :exit_code, :error_msg, :log_file, :trigger)"
+            ),
+            {
+                "phone_serial": "ios:abc123",
+                "job_type": "skill_workflow",
+                "priority": 2,
+                "config_json": json.dumps({"skill": "safari", "workflow": "read_news"}),
+                "status": "completed",
+                "duration_s": 3,
+                "exit_code": 0,
+                "error_msg": None,
+                "log_file": str(log_path),
+                "trigger": "scheduled",
+            },
+        )
+        run_id = db.execute(text("SELECT last_insert_rowid()")).scalar()
+        db.commit()
+
+        response = TestClient(app).get(f"/api/scheduler/history/{run_id}/result")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["ok"] is True
+        assert body["summary"] == "read_news: 2 headlines | 1 article | first: First useful headline"
+        assert body["result"]["step_results"][0]["data"]["articles"][0]["body_snippet"] == "Article body"
+        evidence = body["result"]["step_results"][0]["data"]["extraction"]
+        assert evidence["headlines"]["source"] == "web_context"
+        assert evidence["articles"][0]["text"]["returned_lines"] == 2
+    finally:
+        if run_id is not None:
+            db.execute(text("DELETE FROM job_runs WHERE id = :id"), {"id": run_id})
+            db.commit()
+        db.close()

--- a/tests/test_screenshot_downscale.py
+++ b/tests/test_screenshot_downscale.py
@@ -1,0 +1,62 @@
+"""The MCP screenshot tool must return a downscaled JPEG, not a raw full-res PNG.
+
+Raw PNG base64 overflows the MCP tool-result token cap on content-heavy screens
+(feature #8 stopgap). This proves the tool routes through the compressed path and
+that the payload is materially smaller than the raw capture.
+"""
+
+import base64
+import io
+
+from gitd import mcp_server
+from gitd.services import device_context
+
+
+def _big_png() -> bytes:
+    """A phone-sized, detail-heavy PNG (worst case for the token cap)."""
+    from PIL import Image
+
+    # deterministic high-frequency pattern → PNG doesn't compress it away
+    img = Image.new("RGB", (1080, 2400))
+    px = img.load()
+    for y in range(0, 2400, 2):
+        for x in range(0, 1080, 2):
+            px[x, y] = ((x * 7) % 256, (y * 5) % 256, ((x + y) * 3) % 256)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def test_mcp_screenshot_returns_jpeg_not_raw_png(monkeypatch):
+    raw = _big_png()
+    monkeypatch.setattr(device_context, "_raw_screenshot_bytes", lambda d: raw)
+
+    out_b64 = mcp_server.screenshot("emulator-5554")
+    out_bytes = base64.b64decode(out_b64)
+
+    # JPEG magic, not PNG
+    assert out_bytes[:2] == b"\xff\xd8"
+    assert not out_bytes.startswith(b"\x89PNG")
+
+
+def test_mcp_screenshot_payload_is_materially_smaller(monkeypatch):
+    raw = _big_png()
+    monkeypatch.setattr(device_context, "_raw_screenshot_bytes", lambda d: raw)
+
+    raw_b64_len = len(base64.b64encode(raw).decode())
+    new_b64_len = len(mcp_server.screenshot("emulator-5554"))
+
+    # the whole point: the compressed payload must be a large fraction smaller
+    assert new_b64_len < raw_b64_len / 3, f"expected >3x cut, got {raw_b64_len} -> {new_b64_len}"
+
+
+def test_mcp_screenshot_delegates_to_device_context(monkeypatch):
+    called = {}
+
+    def fake_screenshot(device):
+        called["device"] = device
+        return {"image": "ZmFrZQ==", "width": 10, "height": 20}
+
+    monkeypatch.setattr(device_context, "screenshot", fake_screenshot)
+    assert mcp_server.screenshot("ios:00008XXX-XXXX") == "ZmFrZQ=="
+    assert called["device"] == "ios:00008XXX-XXXX"  # cross-platform: iOS routes the same way

--- a/tests/test_screenshot_sequence.py
+++ b/tests/test_screenshot_sequence.py
@@ -1,0 +1,53 @@
+"""Tests for screenshot_sequence (#5) — frame-burst capture + caching."""
+
+import pytest
+
+from gitd.services import agent_tools
+from gitd.services.agent_tools import SAFE_DEVICE_TOOLS
+
+
+@pytest.fixture()
+def fast(monkeypatch):
+    """No real sleeps; deterministic frame source."""
+    monkeypatch.setattr("time.sleep", lambda _s: None)
+    agent_tools._SEQ_FRAMES.clear()
+
+
+def test_captures_n_frames_and_caches(fast, monkeypatch):
+    calls = {"n": 0}
+
+    def fake_shot(device):
+        calls["n"] += 1
+        return f"frame{calls['n']}"
+
+    monkeypatch.setattr(agent_tools, "get_screenshot_b64", fake_shot)
+    out = agent_tools._capture_sequence("dev", {"duration_seconds": 4, "fps": 1.0})
+    # 4s @ 1fps → 4 frames
+    assert agent_tools._SEQ_FRAMES["dev"] == ["frame1", "frame2", "frame3", "frame4"]
+    assert "captured 4 frames" in out and "cached for sub_agent" in out
+
+
+def test_fps_and_duration_clamped(fast, monkeypatch):
+    monkeypatch.setattr(agent_tools, "get_screenshot_b64", lambda d: "f")
+    # fps clamped to 4.0, duration min 2 → 2*4 = 8 frames
+    agent_tools._capture_sequence("dev", {"duration_seconds": 1, "fps": 99})
+    assert len(agent_tools._SEQ_FRAMES["dev"]) == 8
+
+
+def test_skips_none_frames(fast, monkeypatch):
+    seq = iter(["a", None, "b"])
+    monkeypatch.setattr(agent_tools, "get_screenshot_b64", lambda d: next(seq, None))
+    agent_tools._capture_sequence("dev", {"duration_seconds": 3, "fps": 1.0})
+    assert agent_tools._SEQ_FRAMES["dev"] == ["a", "b"]  # the None dropped
+
+
+def test_screenshot_sequence_is_safe_and_chainable():
+    # SAFE → an agent can chain it (chain gates sub-actions to SAFE_DEVICE_TOOLS)
+    assert "screenshot_sequence" in SAFE_DEVICE_TOOLS
+
+
+def test_dispatch_routes_to_capture(fast, monkeypatch):
+    monkeypatch.setattr(agent_tools, "get_screenshot_b64", lambda d: "f")
+    out = agent_tools._execute_tool_inner("screenshot_sequence", {"device": "dev", "duration_seconds": 2, "fps": 1.0})
+    assert "captured 2 frames" in out
+    assert agent_tools._SEQ_FRAMES["dev"] == ["f", "f"]

--- a/tests/test_skill_element_locators.py
+++ b/tests/test_skill_element_locators.py
@@ -1,0 +1,37 @@
+from gitd.bots.common.ios import IOSDevice
+from gitd.skills.base import Element
+
+
+IOS_XML = """
+<hierarchy rotation="0" platform="ios">
+  <node text="" content-desc="" resource-id="" class="XCUIElementTypeButton"
+        clickable="true" visible="true" bounds="[10,20][110,60]"/>
+  <node text="Address" content-desc="Address" resource-id="" class="XCUIElementTypeTextField"
+        clickable="true" visible="true" bounds="[20,80][320,124]"/>
+</hierarchy>
+"""
+
+
+def test_element_find_uses_ios_class_name_locator():
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+    element = Element.from_dict("first_button", {"class_name": "XCUIElementTypeButton"})
+
+    assert element.find(dev, IOS_XML) == (60, 40)
+
+
+def test_element_find_accepts_class_alias_from_generated_ios_yaml():
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+    element = Element.from_dict("address", {"class": "XCUIElementTypeTextField"})
+
+    assert element.class_name == "XCUIElementTypeTextField"
+    assert element.find(dev, IOS_XML) == (170, 102)
+
+
+def test_element_find_prefers_text_before_class_fallback():
+    dev = IOSDevice("ios:abc123", appium_url="http://appium.local")
+    element = Element.from_dict(
+        "address",
+        {"text": "Address", "class_name": "XCUIElementTypeButton"},
+    )
+
+    assert element.find(dev, IOS_XML) == (170, 102)

--- a/tests/test_skill_platforms.py
+++ b/tests/test_skill_platforms.py
@@ -1,0 +1,142 @@
+import json
+import subprocess
+import sys
+
+from fastapi.testclient import TestClient
+
+from gitd.app import app
+from gitd.routers.skills import _load_all_skills
+from gitd.services.agent_tools import execute_tool
+from gitd.skills.platforms import (
+    normalize_platforms,
+    skill_platform_error,
+    skill_platforms,
+    skill_supports_device,
+    skill_target_for_device,
+)
+
+
+def test_skill_platform_inference_and_targets():
+    assert normalize_platforms(["iOS", "android", "ios", "unknown"]) == ["ios", "android"]
+    assert skill_platforms({"app_package": "com.example.android"}) == ["android"]
+    assert skill_platforms({"ios_bundle_id": "com.example.ios"}) == ["ios"]
+    assert skill_platforms({"platforms": ["ios"], "app_package": "com.example.android"}) == ["ios"]
+    assert skill_platforms({}) == ["android"]
+
+    meta = {"app_package": "com.android.chrome", "ios_bundle_id": "com.google.chrome.ios", "platforms": ["android", "ios"]}
+    assert skill_supports_device(meta, "emulator-5554") is True
+    assert skill_supports_device(meta, "ios:abc123") is True
+    assert skill_target_for_device(meta, "emulator-5554") == "com.android.chrome"
+    assert skill_target_for_device(meta, "ios:abc123") == "com.google.chrome.ios"
+
+
+def test_installed_skills_expose_platform_metadata():
+    skills = _load_all_skills()
+
+    assert skills["_base"]["platforms"] == ["android", "ios"]
+    assert skills["_base"]["supports_android"] is True
+    assert skills["_base"]["supports_ios"] is True
+
+    assert skills["tiktok"]["platforms"] == ["android"]
+    assert skills["tiktok"]["supports_ios"] is False
+    assert skills["tiktok"]["android_package"] == "com.zhiliaoapp.musically"
+
+    assert skills["safari"]["platforms"] == ["ios"]
+    assert skills["safari"]["supports_ios"] is True
+    assert skills["safari"]["ios_bundle_id"] == "com.google.chrome.ios"
+    assert skills["safari"]["elements_ios_count"] >= 1
+
+    assert skills["tiktok_ios"]["platforms"] == ["ios"]
+    assert skills["tiktok_ios"]["supports_ios"] is True
+    assert skills["tiktok_ios"]["supports_android"] is False
+    assert skills["tiktok_ios"]["ios_bundle_id"] == "com.zhiliaoapp.musically"
+    assert skills["tiktok_ios"]["elements_ios_count"] >= 1
+
+
+def test_skill_platform_error_payload_is_stable():
+    err = skill_platform_error("tiktok", {"platforms": ["android"]}, "ios:abc123")
+
+    assert err["ok"] is False
+    assert err["error"] == "unsupported_platform"
+    assert err["skill"] == "tiktok"
+    assert err["platform"] == "ios"
+    assert err["supported_platforms"] == ["android"]
+
+
+def test_rest_skills_include_device_support_flags_and_guard_runs():
+    client = TestClient(app)
+
+    listed = client.get("/api/skills", params={"device": "ios:abc123"})
+    assert listed.status_code == 200
+    by_dir = {item["dir"]: item for item in listed.json()}
+    assert by_dir["_base"]["supported_on_device"] is True
+    assert by_dir["tiktok"]["supported_on_device"] is False
+    assert by_dir["safari"]["supported_on_device"] is True
+    assert "Upload/posting is not implemented yet" in by_dir["tiktok_ios"]["platform_limitations"]["ios"][0]
+    assert by_dir["tiktok_ios"]["default_params"]["workflows"]["search_smoke"]["query"] == "#fyp"
+
+    tiktok_run = client.post(
+        "/api/skills/tiktok/run",
+        json={"device": "ios:abc123", "workflow": "upload_video", "params": {}},
+    )
+    assert tiktok_run.status_code == 400
+    assert tiktok_run.json()["detail"]["error"] == "unsupported_platform"
+
+    safari_run = client.post(
+        "/api/skills/safari/run",
+        json={"device": "emulator-5554", "workflow": "open_ghost_site", "params": {}},
+    )
+    assert safari_run.status_code == 400
+    assert safari_run.json()["detail"]["error"] == "unsupported_platform"
+
+
+def test_agent_skill_tools_filter_and_guard_by_device():
+    payload = json.loads(execute_tool("list_skills", {"device": "ios:abc123", "supported_only": True}))
+    by_name = {item["name"]: item for item in payload}
+    names = set(by_name)
+
+    assert "base" in names
+    assert "safari" in names
+    assert "tiktok_ios" in names
+    assert "tiktok" not in names
+    assert "Upload/posting is not implemented yet" in by_name["tiktok_ios"]["platform_limitations"]["ios"][0]
+    assert by_name["tiktok_ios"]["default_params"]["workflows"]["search_smoke"]["max_lines"] == 80
+
+    result = execute_tool("run_skill", {"device": "ios:abc123", "skill": "tiktok", "workflow": "upload_video"})
+    assert result.startswith("ERROR: Skill 'tiktok' does not support ios")
+
+
+def test_mcp_skill_listing_filters_and_exposes_ios_context():
+    from gitd import mcp_server
+
+    payload = json.loads(mcp_server.list_skills("ios:abc123", supported_only=True))
+    by_name = {item["name"]: item for item in payload}
+
+    assert "tiktok" not in by_name
+    assert by_name["tiktok_ios"]["supported_on_device"] is True
+    assert "Upload/posting is not implemented yet" in by_name["tiktok_ios"]["platform_limitations"]["ios"][0]
+    assert by_name["tiktok_ios"]["default_params"]["workflows"]["search_smoke"]["query"] == "#fyp"
+
+
+def test_skill_runner_rejects_unsupported_platform_before_device_access():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "gitd.skills._run_skill",
+            "--skill",
+            "tiktok",
+            "--workflow",
+            "upload_video",
+            "--device",
+            "ios:abc123",
+            "--params",
+            "{}",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+
+    assert result.returncode == 2
+    assert "does not support ios" in result.stderr

--- a/tests/test_stop_agent.py
+++ b/tests/test_stop_agent.py
@@ -1,0 +1,81 @@
+"""Tests for stop_agent session isolation.
+
+stop_agent used to run a global `pkill -f claude...stream-json` safety net that
+matched EVERY claude stream-json process on the box — so stopping session A (or
+just A completing normally, since the router calls stop_agent in every stream's
+finally) would reap session B mid-tap. The fix relies solely on the per-session
+process group (claude is launched start_new_session=True), so a stop stays
+scoped to its own session.
+"""
+
+import subprocess
+import time
+
+from gitd.services import agent_chat
+from gitd.services.agent_chat import _active_procs, stop_agent
+
+
+def _spawn_group():
+    """A long-lived process in its own session/process group (like claude)."""
+    return subprocess.Popen(["sleep", "30"], start_new_session=True)
+
+
+def _dead(proc, timeout=3.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            return True
+        time.sleep(0.05)
+    return proc.poll() is not None
+
+
+def test_stop_agent_kills_only_target_session():
+    target = _spawn_group()  # session A — registered
+    sibling = _spawn_group()  # session B — a different live session, NOT stopped
+    _active_procs["sess-A"] = target
+    try:
+        stop_agent("sess-A")
+        assert _dead(target), "the target session's process group must be killed"
+        # The sibling must still be running — this is the whole bug being fixed.
+        time.sleep(0.2)
+        assert sibling.poll() is None, "a different session must survive stop_agent(A)"
+    finally:
+        for p in (target, sibling):
+            try:
+                p.kill()
+            except Exception:
+                pass
+        _active_procs.pop("sess-A", None)
+
+
+def test_stop_agent_unknown_session_is_noop():
+    """No registered proc (e.g. anthropic/ollama providers) → clean no-op, no sweep."""
+    _active_procs.pop("ghost-missing", None)
+    stop_agent("ghost-missing")  # must not raise
+
+
+def test_stop_agent_never_runs_global_pkill(monkeypatch):
+    """Regression guard: stop_agent must never shell out to a global pkill."""
+    seen = []
+    real_run = agent_chat.subprocess.run
+
+    def spy_run(cmd, *a, **k):
+        seen.append(cmd)
+        return real_run(["true"])
+
+    monkeypatch.setattr(agent_chat.subprocess, "run", spy_run)
+
+    target = _spawn_group()
+    _active_procs["sess-guard"] = target
+    try:
+        stop_agent("sess-guard")
+    finally:
+        try:
+            target.kill()
+        except Exception:
+            pass
+        _active_procs.pop("sess-guard", None)
+
+    assert not any(isinstance(c, list) and c and c[0] == "pkill" for c in seen), (
+        "stop_agent must not run a global pkill"
+    )

--- a/tests/test_sub_agent.py
+++ b/tests/test_sub_agent.py
@@ -1,0 +1,100 @@
+"""Tests for the vision sub-agent (#4) + its agent-tool wiring."""
+
+import pytest
+
+from gitd.services import agent_tools, sub_agent
+from gitd.services.agent_tools import EXEC_CAPABLE_TOOLS, SAFE_DEVICE_TOOLS
+from gitd.services.sub_agent import MAX_SUB_AGENT_FRAMES, _subsample, run_sub_agent
+
+
+@pytest.fixture()
+def with_key(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+
+
+def test_missing_task_returns_error():
+    assert "missing 'task'" in run_sub_agent("", ["frame"])
+    assert "missing 'task'" in run_sub_agent("   ", ["frame"])
+
+
+def test_no_frames_returns_hint():
+    assert "no frames available" in run_sub_agent("read it", [])
+
+
+def test_no_api_key_degrades_gracefully(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    out = run_sub_agent("read it", ["frame1"])
+    assert "unavailable" in out and "ANTHROPIC_API_KEY" in out
+
+
+def test_happy_path_calls_vision_and_returns_text(with_key, monkeypatch):
+    captured = {}
+
+    def fake_call(system, content, model):
+        captured["system"] = system
+        captured["content"] = content
+        captured["model"] = model
+        return "milk, eggs, bread"
+
+    monkeypatch.setattr(sub_agent, "_anthropic_vision_call", fake_call)
+    out = run_sub_agent("transcribe the list", ["f1", "f2"], model="claude-sonnet-5")
+    assert out == "milk, eggs, bread"
+    # content = 2 (text+image) per frame + 1 task text
+    assert len(captured["content"]) == 2 * 2 + 1
+    assert captured["content"][-1] == {"type": "text", "text": "transcribe the list"}
+    imgs = [c for c in captured["content"] if c.get("type") == "image"]
+    assert all(c["source"]["media_type"] == "image/jpeg" for c in imgs)
+    assert captured["model"] == "claude-sonnet-5"
+
+
+def test_api_error_is_caught_not_raised(with_key, monkeypatch):
+    def boom(system, content, model):
+        raise RuntimeError("429 overloaded")
+
+    monkeypatch.setattr(sub_agent, "_anthropic_vision_call", boom)
+    out = run_sub_agent("x", ["f1"])
+    assert out.startswith("sub_agent error:") and "429" in out
+
+
+def test_frames_subsampled_to_cap(with_key, monkeypatch):
+    seen = {}
+    monkeypatch.setattr(
+        sub_agent,
+        "_anthropic_vision_call",
+        lambda s, content, m: seen.setdefault("imgs", sum(1 for c in content if c.get("type") == "image")) or "ok",
+    )
+    run_sub_agent("x", [f"frame{i}" for i in range(200)], max_frames=10)
+    assert seen["imgs"] == 10
+
+
+def test_subsample_never_exceeds_hard_cap():
+    out = _subsample([f"f{i}" for i in range(500)], max_frames=999)
+    assert len(out) == MAX_SUB_AGENT_FRAMES
+    # order preserved
+    assert out == sorted(out, key=lambda s: int(s[1:]))
+
+
+def test_subsample_returns_all_when_under_cap():
+    assert _subsample(["a", "b", "c"], 60) == ["a", "b", "c"]
+
+
+# ── agent-tool wiring ────────────────────────────────────────────────────────
+
+
+def test_sub_agent_is_exec_capable_not_safe():
+    assert "sub_agent" in EXEC_CAPABLE_TOOLS
+    assert "sub_agent" not in SAFE_DEVICE_TOOLS
+
+
+def test_tool_reads_cached_frames_and_labels_result(with_key, monkeypatch):
+    agent_tools._SEQ_FRAMES.clear()
+    agent_tools._SEQ_FRAMES["dev"] = ["f1", "f2", "f3"]
+    monkeypatch.setattr("gitd.services.sub_agent._anthropic_vision_call", lambda s, c, m: "answer text")
+    out = agent_tools._run_sub_agent_tool("dev", {"task": "read"})
+    assert out == "SUB_AGENT RESULT (3 frames): answer text"
+
+
+def test_tool_no_frames_returns_hint(with_key):
+    agent_tools._SEQ_FRAMES.clear()
+    out = agent_tools._run_sub_agent_tool("dev", {"task": "read"})
+    assert "no frames available" in out

--- a/tests/test_tiktok_ios_skill.py
+++ b/tests/test_tiktok_ios_skill.py
@@ -1,0 +1,196 @@
+import html
+import re
+
+from gitd.skills.tiktok_ios import load
+from gitd.skills.tiktok_ios.actions import (
+    CaptureVisibleText,
+    DismissPopup,
+    NavigateToProfile,
+    OpenApp,
+    TapSearch,
+    TypeAndSearch,
+    VerifyVisibleText,
+    WaitVisibleText,
+)
+from gitd.skills.tiktok_ios.actions.core import TIKTOK_IOS_BUNDLE_ID
+from gitd.skills.tiktok_ios.workflows import OpenAppSmoke, ProfileSmoke, SearchSmoke
+
+
+TIKTOK_XML = """<hierarchy>
+<node text="TikTok" content-desc="TikTok" resource-id="TikTok" class="XCUIElementTypeApplication" clickable="false" bounds="[0,0][390,844]" />
+<node text="Close" content-desc="Close" resource-id="Close" class="XCUIElementTypeButton" clickable="true" bounds="[344,44][384,84]" />
+<node text="Search" content-desc="Search" resource-id="Search" class="XCUIElementTypeButton" clickable="true" bounds="[300,44][380,96]" />
+<node text="Search or enter URL" content-desc="Search field" resource-id="Search field" class="XCUIElementTypeSearchField" clickable="true" bounds="[20,90][370,134]" />
+<node text="Profile" content-desc="Profile" resource-id="Profile" class="XCUIElementTypeButton" clickable="true" bounds="[300,780][380,836]" />
+</hierarchy>"""
+
+
+class FakeIOSDevice:
+    serial = "ios:abc123"
+
+    def __init__(self):
+        self.launched = []
+        self.typed = []
+        self.keys = []
+        self.tapped = []
+
+    def launch_app(self, bundle_id, *args, **kwargs):
+        self.launched.append(bundle_id)
+
+    def dump_xml(self) -> str:
+        if self.typed:
+            query = html.escape(self.typed[-1])
+            return (
+                TIKTOK_XML.replace("</hierarchy>", "")
+                + f'<node text="{query}" content-desc="{query}" resource-id="Search query" '
+                + 'class="XCUIElementTypeStaticText" clickable="false" bounds="[20,150][370,190]" />'
+                + "</hierarchy>"
+            )
+        return TIKTOK_XML
+
+    def nodes(self, xml: str) -> list[str]:
+        return re.findall(r"<node[^>]+/?>", xml)
+
+    def node_text(self, node: str) -> str:
+        return self._attr(node, "text")
+
+    def node_content_desc(self, node: str) -> str:
+        return self._attr(node, "content-desc")
+
+    def node_rid(self, node: str) -> str:
+        return self._attr(node, "resource-id")
+
+    def tap_node(self, node: str, delay=0.8) -> bool:
+        self.tapped.append(self.node_text(node) or self.node_content_desc(node) or self.node_rid(node))
+        return True
+
+    def type_text(self, text: str, *args, **kwargs):
+        self.typed.append(text)
+
+    def press_enter(self, *args, **kwargs):
+        self.keys.append("ENTER")
+
+    @staticmethod
+    def _attr(node: str, attr: str) -> str:
+        m = re.search(rf'\b{re.escape(attr)}="([^"]*)"', node)
+        return html.unescape(m.group(1).strip()) if m else ""
+
+
+def test_tiktok_ios_skill_loads_actions_workflows_and_elements():
+    skill = load()
+    device = FakeIOSDevice()
+
+    assert skill.name == "tiktok_ios"
+    assert skill.platforms == ["ios"]
+    assert skill.ios_bundle_id == TIKTOK_IOS_BUNDLE_ID
+    assert set(skill.list_actions()) == {
+        "open_app",
+        "dismiss_popup",
+        "tap_search",
+        "type_and_search",
+        "navigate_to_profile",
+        "capture_visible_text",
+        "wait_visible_text",
+        "verify_visible_text",
+    }
+    assert set(skill.list_workflows()) == {"open_app_smoke", "search_smoke", "profile_smoke"}
+    assert "search_tab" in skill._elements_for_device(device)
+
+
+def test_tiktok_ios_actions_use_normalized_ios_tree(monkeypatch):
+    monkeypatch.setattr("gitd.skills.tiktok_ios.actions.core.time.sleep", lambda *_args, **_kwargs: None)
+    device = FakeIOSDevice()
+
+    assert OpenApp(device).run().success is True
+    assert device.launched == [TIKTOK_IOS_BUNDLE_ID]
+
+    assert DismissPopup(device).run().data == {"dismissed": True}
+    assert TapSearch(device).run().success is True
+    assert TypeAndSearch(device, query="#cats").run().data == {"query": "#cats"}
+    assert WaitVisibleText(device, expected="#cats", timeout=0).run().success is True
+    assert NavigateToProfile(device).run().success is True
+    captured = CaptureVisibleText(device, max_lines=3).run()
+    assert captured.success is True
+    assert captured.data["lines"] == [
+        "TikTok TikTok TikTok",
+        "Close Close Close",
+        "Search Search Search",
+    ]
+    assert VerifyVisibleText(device, expected="TikTok").run().success is True
+
+    assert device.tapped[:4] == ["Close", "Search", "Search", "Profile"]
+    assert device.typed == ["#cats"]
+    assert device.keys == ["ENTER"]
+
+
+def test_tiktok_ios_wait_visible_text_returns_evidence_on_timeout(monkeypatch):
+    monkeypatch.setattr("gitd.skills.tiktok_ios.actions.core.time.sleep", lambda *_args, **_kwargs: None)
+    device = FakeIOSDevice()
+
+    result = WaitVisibleText(device, expected="not on screen", timeout=0).run()
+
+    assert result.success is False
+    assert result.error == "Expected text not visible: not on screen"
+    assert result.data["expected"] == "not on screen"
+    assert result.data["attempts"] == 1
+    assert "TikTok" in result.data["visible_text"]
+
+
+def test_tiktok_ios_rejects_android_device(monkeypatch):
+    monkeypatch.setattr("gitd.skills.tiktok_ios.actions.core.time.sleep", lambda *_args, **_kwargs: None)
+    device = FakeIOSDevice()
+    device.serial = "emulator-5554"
+
+    result = OpenApp(device).run()
+
+    assert result.success is False
+    assert "requires an iOS device ref" in result.error
+    assert device.launched == []
+
+
+def test_tiktok_ios_smoke_workflows_are_registered_with_safe_steps(monkeypatch):
+    monkeypatch.setattr("gitd.skills.tiktok_ios.actions.core.time.sleep", lambda *_args, **_kwargs: None)
+    device = FakeIOSDevice()
+
+    open_wf = OpenAppSmoke(device)
+    search_wf = SearchSmoke(device, query="#news", max_lines=3)
+    profile_wf = ProfileSmoke(device, max_lines=2)
+    search_steps = search_wf.steps()
+
+    assert [step.name for step in open_wf.steps()] == ["open_app", "dismiss_popup"]
+    assert [step.name for step in search_steps] == [
+        "open_app",
+        "dismiss_popup",
+        "tap_search",
+        "type_and_search",
+        "wait_visible_text",
+        "capture_visible_text",
+    ]
+    assert [step.name for step in profile_wf.steps()] == [
+        "open_app",
+        "dismiss_popup",
+        "navigate_to_profile",
+        "wait_visible_text",
+        "capture_visible_text",
+    ]
+    assert search_steps[-3].query == "#news"
+    assert search_steps[-1].max_lines == 3
+    assert search_steps[-2].expected == "#news"
+    assert profile_wf.steps()[-1].max_lines == 2
+
+    search_result = load().get_workflow("search_smoke", device, query="#news").run()
+    assert search_result.success is True
+    assert search_result.data["completed_steps"] == 6
+    assert search_result.data["step_results"][-3]["data"] == {"query": "#news"}
+    assert search_result.data["step_results"][-2]["name"] == "wait_visible_text"
+    assert search_result.data["step_results"][-2]["data"]["expected"] == "#news"
+    assert search_result.data["step_results"][-1]["name"] == "capture_visible_text"
+    assert search_result.data["step_results"][-1]["data"]["line_count"] == 6
+
+    profile_result = load().get_workflow("profile_smoke", device, max_lines=2).run()
+    assert profile_result.success is True
+    assert profile_result.data["completed_steps"] == 5
+    assert profile_result.data["step_results"][-2]["name"] == "wait_visible_text"
+    assert profile_result.data["step_results"][-2]["data"]["expected"] == "Profile"
+    assert profile_result.data["step_results"][-1]["name"] == "capture_visible_text"
+    assert profile_result.data["step_results"][-1]["data"]["line_count"] == 2

--- a/tests/test_tool_allowlist.py
+++ b/tests/test_tool_allowlist.py
@@ -1,0 +1,58 @@
+"""Allow-list classification regression tests (#666 / iOS reconciliation).
+
+SAFE_DEVICE_TOOLS is the fail-closed allow-list gating run_flow and the
+framework adapters. These tests pin the two invariants that make it safe to
+keep adding tools:
+
+* every dispatchable tool is classified — either vetted-safe or explicitly
+  exec-capable. A new TOOLS entry that lands in neither set fails CI, forcing
+  a deliberate classification instead of silent exposure (or silent blocking).
+* the exec-capable set can never leak into the safe set.
+"""
+
+from gitd.services.agent_tools import EXEC_CAPABLE_TOOLS, SAFE_DEVICE_TOOLS, TOOLS
+
+
+def test_every_tool_is_classified():
+    """A tool in TOOLS but in neither set is a classification hole — fail CI."""
+    names = {t["name"] for t in TOOLS}
+    unclassified = names - SAFE_DEVICE_TOOLS - EXEC_CAPABLE_TOOLS
+    assert not unclassified, (
+        f"Unclassified tools {sorted(unclassified)}: add each to SAFE_DEVICE_TOOLS "
+        "(vetted safe) or EXEC_CAPABLE_TOOLS (exec-capable) in agent_tools.py"
+    )
+
+
+def test_safe_and_exec_sets_are_disjoint():
+    overlap = SAFE_DEVICE_TOOLS & EXEC_CAPABLE_TOOLS
+    assert not overlap, f"Tools classified both safe and exec-capable: {sorted(overlap)}"
+
+
+def test_allowlist_names_exist_in_dispatch():
+    """No stale allow-list entries pointing at tools that no longer exist."""
+    names = {t["name"] for t in TOOLS}
+    assert SAFE_DEVICE_TOOLS <= names, f"Stale safe entries: {sorted(SAFE_DEVICE_TOOLS - names)}"
+    assert EXEC_CAPABLE_TOOLS <= names, f"Stale exec entries: {sorted(EXEC_CAPABLE_TOOLS - names)}"
+
+
+def test_exec_vectors_stay_denied():
+    """The known exec-capable tools (incl. every iOS-added one) never go safe."""
+    for tool in (
+        "shell",
+        "run_skill",
+        "run_workflow",
+        "run_action",
+        "create_skill",
+        "launch_intent",
+        "explore_app",
+        "fix_device_health",
+    ):
+        assert tool in EXEC_CAPABLE_TOOLS, f"{tool} missing from EXEC_CAPABLE_TOOLS"
+        assert tool not in SAFE_DEVICE_TOOLS, f"exec-capable {tool} leaked into SAFE_DEVICE_TOOLS"
+
+
+def test_flow_allowlist_is_the_same_object():
+    """run_flow must gate on the identical frozenset (#668), not a copy that can drift."""
+    from gitd.mcp_server import FLOW_ALLOWED_TOOLS
+
+    assert FLOW_ALLOWED_TOOLS is SAFE_DEVICE_TOOLS

--- a/tests/test_tool_platforms.py
+++ b/tests/test_tool_platforms.py
@@ -1,0 +1,755 @@
+import ast
+import json
+import sys
+from pathlib import Path
+
+from gitd.services.agent_chat import DEFAULT_SYSTEM, openai_tools_for_device, platform_context, system_prompt_for_device
+from gitd.services.agent_tools import TOOLS, execute_tool, tool_prompt_list, tools_for_device
+from gitd.services.tool_platforms import TOOL_PLATFORM_SUPPORT, supports_platform, tool_platform_info
+
+
+def _mcp_tool_names() -> set[str]:
+    tree = ast.parse(Path("gitd/mcp_server.py").read_text(encoding="utf-8"))
+    names = set()
+    for node in tree.body:
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        for dec in node.decorator_list:
+            if isinstance(dec, ast.Call) and isinstance(dec.func, ast.Attribute) and dec.func.attr == "tool":
+                names.add(node.name)
+    return names
+
+
+def _mcp_public_docstrings() -> dict[str, str]:
+    tree = ast.parse(Path("gitd/mcp_server.py").read_text(encoding="utf-8"))
+    docs = {"__module__": ast.get_docstring(tree) or ""}
+    for node in tree.body:
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        for dec in node.decorator_list:
+            if isinstance(dec, ast.Call) and isinstance(dec.func, ast.Attribute) and dec.func.attr == "tool":
+                docs[node.name] = ast.get_docstring(node) or ""
+    return docs
+
+
+def test_every_agent_and_mcp_tool_has_platform_classification():
+    agent_names = {tool["name"] for tool in TOOLS}
+    names = agent_names | _mcp_tool_names()
+
+    missing = sorted(name for name in names if name not in TOOL_PLATFORM_SUPPORT)
+
+    assert missing == []
+
+
+def test_agent_and_mcp_tool_catalogs_match():
+    agent_names = {tool["name"] for tool in TOOLS}
+
+    # Deliberately NOT exposed over MCP: raw exec vectors, plus the agent-loop
+    # frame tools (screenshot_sequence caches frames for the in-process sub_agent
+    # fan-out; neither is useful to a standalone MCP client). MCP clients get
+    # run_flow (fail-closed allow-list) + run_workflow/run_action instead.
+    # `chain` is the agent-chat batch primitive — the mirror image of run_flow
+    # (which is MCP-only): MCP clients batch via run_flow, so chain stays out of
+    # the MCP catalog.
+    mcp_excluded = {"shell", "run_skill", "chain", "screenshot_sequence", "sub_agent"}
+    # MCP-only: batched flow + crash reports have no in-process agent-tool
+    # equivalent (agents read crashes via their own transcript context).
+    mcp_only = {"run_flow", "list_crashes", "get_crash"}
+
+    assert sorted(agent_names - _mcp_tool_names() - mcp_excluded) == []
+    assert sorted(_mcp_tool_names() - agent_names - mcp_only) == []
+
+
+def test_platform_classifications_have_stable_ios_semantics():
+    assert supports_platform("screenshot", "ios") is True
+    assert supports_platform("start_screen_recording", "ios") is True
+    assert supports_platform("stop_screen_recording", "ios") is True
+    assert supports_platform("screen_recording_status", "ios") is True
+    assert supports_platform("get_stream_info", "ios") is True
+    assert supports_platform("get_stream_info", "android") is True
+    assert supports_platform("open_url", "ios") is True
+    assert supports_platform("device_health", "ios") is True
+    assert supports_platform("device_health", "android") is True
+    assert supports_platform("fix_device_health", "ios") is True
+    assert supports_platform("fix_device_health", "android") is True
+    assert supports_platform("get_screen_xml", "ios") is True
+    assert supports_platform("press_back", "ios") is True
+    assert supports_platform("press_home", "ios") is True
+    assert supports_platform("type_unicode", "ios") is True
+    assert supports_platform("get_current_url", "ios") is True
+    assert supports_platform("get_current_url", "android") is False
+    assert supports_platform("shell", "ios") is False
+    assert supports_platform("clipboard_get", "ios") is True
+    assert supports_platform("clipboard_set", "ios") is True
+    assert supports_platform("paste_text", "ios") is True
+    assert supports_platform("list_apps", "ios") is True
+    assert supports_platform("search_apps", "ios") is True
+    assert supports_platform("list_packages", "ios") is True
+    assert supports_platform("app_state", "ios") is True
+    assert supports_platform("get_notifications", "ios") is True
+    assert supports_platform("open_notifications", "ios") is True
+    assert supports_platform("clear_notifications", "ios") is True
+    assert supports_platform("open_camera", "ios") is True
+    assert supports_platform("explore_app", "ios") is True
+    assert supports_platform("create_skill", "ios") is True
+    assert supports_platform("read_news", "ios") is True
+    assert supports_platform("read_news", "android") is False
+    assert supports_platform("launch_intent", "ios") is False
+    assert supports_platform("launch_intent", "android") is True
+    assert supports_platform("toggle_overlay", "ios") is False
+    assert supports_platform("toggle_overlay", "android") is True
+
+    assert tool_platform_info("shell").support == "android_only"
+    assert tool_platform_info("launch_intent").support == "android_only"
+    assert tool_platform_info("toggle_overlay").support == "android_only"
+    assert tool_platform_info("device_health").support == "cross_platform"
+    assert tool_platform_info("fix_device_health").support == "cross_platform"
+    assert tool_platform_info("get_screen_xml").support == "cross_platform"
+    assert tool_platform_info("press_back").support == "cross_platform"
+    assert tool_platform_info("press_home").support == "cross_platform"
+    assert tool_platform_info("type_unicode").support == "cross_platform"
+    assert tool_platform_info("start_screen_recording").support == "cross_platform"
+    assert tool_platform_info("get_stream_info").support == "cross_platform"
+    assert tool_platform_info("clipboard_get").support == "cross_platform"
+    assert tool_platform_info("clipboard_set").support == "cross_platform"
+    assert tool_platform_info("paste_text").support == "cross_platform"
+    assert tool_platform_info("list_apps").support == "cross_platform"
+    assert tool_platform_info("app_state").support == "cross_platform"
+    assert tool_platform_info("get_notifications").support == "cross_platform"
+    assert tool_platform_info("open_camera").support == "cross_platform"
+    assert tool_platform_info("explore_app").support == "cross_platform"
+    assert tool_platform_info("create_skill").support == "cross_platform"
+    assert tool_platform_info("read_news").support == "ios_supported"
+
+
+def test_mcp_public_docs_are_ios_safe_for_cross_platform_primitives():
+    docs = _mcp_public_docstrings()
+
+    assert "mobile automation" in docs["__module__"]
+    assert "Android automation" not in docs["__module__"]
+
+    assert "normalized Appium/WDA XML" in docs["get_screen_xml"]
+    assert "raw UI XML dump from the device (uiautomator)" not in docs["get_screen_xml"]
+
+    assert "WDA text entry" in docs["type_unicode"]
+    assert "ADBKeyboard broadcast" not in docs["type_unicode"]
+
+    assert "iOS supports WDA-backed HOME, ENTER/RETURN, and BACK/ESCAPE" in docs["press_key"]
+    assert "Full list" not in docs["press_key"]
+
+
+def test_execute_tool_uses_platform_registry_for_ios_errors(monkeypatch):
+    monkeypatch.setattr("gitd.services.device_context.clipboard_get", lambda device: "ios clipboard")
+    monkeypatch.setattr(
+        "gitd.services.device_context.get_notifications",
+        lambda device: [{"title": "Slack", "text": "New message", "platform": "ios"}],
+    )
+    monkeypatch.setattr("gitd.services.device_context.open_notifications", lambda device: True)
+    monkeypatch.setattr("gitd.services.device_context.clear_notifications", lambda device: True)
+    monkeypatch.setattr(
+        "gitd.services.device_context.device_health",
+        lambda device: {
+            "serial": device,
+            "platform": "ios",
+            "connection": {"type": "appium-wda", "status": "wda_signing_failed"},
+            "recommended_fix": "fix_wda_signing",
+        },
+    )
+    monkeypatch.setattr(
+        "gitd.services.device_context.fix_device_health",
+        lambda device, issue: {
+            "ok": False,
+            "platform": "ios",
+            "issue": issue,
+            "manual_action_required": True,
+        },
+    )
+    monkeypatch.setattr(
+        "gitd.routers.streaming.phone_stream_info",
+        lambda **kwargs: {
+            "ok": True,
+            "device": kwargs["device"],
+            "platform": "ios",
+            "effective_mode": "wda-mjpeg",
+            "stream_url": "/api/phone/stream?device=ios%3Aabc123&fps=5&mode=wda-mjpeg",
+        },
+    )
+
+    shell = execute_tool("shell", {"device": "ios:abc123", "command": "ls"})
+    launch_intent = execute_tool("launch_intent", {"device": "ios:abc123", "action": "android.intent.action.VIEW"})
+    toggle_overlay = execute_tool("toggle_overlay", {"device": "ios:abc123", "visible": True})
+    clipboard = execute_tool("clipboard_get", {"device": "ios:abc123"})
+    notifications = json.loads(execute_tool("get_notifications", {"device": "ios:abc123"}))
+    opened = execute_tool("open_notifications", {"device": "ios:abc123"})
+    cleared = execute_tool("clear_notifications", {"device": "ios:abc123"})
+    health = json.loads(execute_tool("device_health", {"device": "ios:abc123"}))
+    fix = json.loads(execute_tool("fix_device_health", {"device": "ios:abc123", "issue": "fix_wda_signing"}))
+    stream_info = json.loads(execute_tool("get_stream_info", {"device": "ios:abc123", "mode": "mjpeg"}))
+    unknown = execute_tool("does_not_exist", {"device": "ios:abc123"})
+    android_current_url = execute_tool("get_current_url", {"device": "emulator-5554"})
+    android_news = execute_tool(
+        "read_news",
+        {"device": "emulator-5554", "url": "https://text.npr.org/"},
+    )
+
+    assert shell.startswith("ERROR: shell is Android-only")
+    assert launch_intent.startswith("ERROR: launch_intent is Android-only")
+    assert toggle_overlay.startswith("ERROR: toggle_overlay is Android-only")
+    assert clipboard == "ios clipboard"
+    assert notifications == [{"title": "Slack", "text": "New message", "platform": "ios"}]
+    assert opened == "Notification Center opened"
+    assert cleared == "Notifications cleared"
+    assert health["connection"]["status"] == "wda_signing_failed"
+    assert health["recommended_fix"] == "fix_wda_signing"
+    assert fix["issue"] == "fix_wda_signing"
+    assert fix["manual_action_required"] is True
+    assert stream_info["effective_mode"] == "wda-mjpeg"
+    assert stream_info["stream_url"].endswith("mode=wda-mjpeg")
+    assert unknown == "Unknown tool: does_not_exist"
+    assert android_current_url == "ERROR: get_current_url is currently implemented only for iOS"
+    assert android_news == "ERROR: read_news is currently implemented only for iOS"
+
+
+def test_android_only_agent_tools_dispatch_through_shared_helpers(monkeypatch):
+    calls = []
+
+    def fake_launch_intent(device, action="", data="", package="", component="", extras=None):
+        calls.append(("intent", device, action, data, package, component, extras))
+        return "intent launched"
+
+    def fake_toggle_overlay(device, visible=True):
+        calls.append(("overlay", device, visible))
+        return True
+
+    monkeypatch.setattr("gitd.services.device_context.launch_intent", fake_launch_intent)
+    monkeypatch.setattr("gitd.services.device_context.toggle_overlay", fake_toggle_overlay)
+
+    intent = execute_tool(
+        "launch_intent",
+        {
+            "device": "emulator-5554",
+            "action": "android.intent.action.VIEW",
+            "data": "https://example.com",
+            "package": "com.android.chrome",
+            "component": ".Main",
+            "extras": {"demo": "yes"},
+        },
+    )
+    overlay = execute_tool("toggle_overlay", {"device": "emulator-5554", "visible": False})
+
+    assert intent == "intent launched"
+    assert overlay == "Overlay disabled"
+    assert calls == [
+        (
+            "intent",
+            "emulator-5554",
+            "android.intent.action.VIEW",
+            "https://example.com",
+            "com.android.chrome",
+            ".Main",
+            {"demo": "yes"},
+        ),
+        ("overlay", "emulator-5554", False),
+    ]
+
+
+def test_mcp_open_notifications_uses_platform_terms(monkeypatch):
+    from gitd import mcp_server
+
+    monkeypatch.setattr("gitd.services.device_context.open_notifications", lambda device: True)
+
+    assert mcp_server.open_notifications("ios:abc123") == "Notification Center opened"
+    assert mcp_server.open_notifications("emulator-5554") == "Notification shade opened"
+
+
+def test_mcp_agent_parity_wrappers_delegate_to_agent_tools(monkeypatch):
+    from gitd import mcp_server
+
+    calls = []
+
+    def fake_execute_tool(name: str, args: dict):
+        calls.append((name, args))
+        return f"{name}:{json.dumps(args, sort_keys=True)}"
+
+    monkeypatch.setattr("gitd.services.agent_tools.execute_tool", fake_execute_tool)
+
+    force_stopped = mcp_server.force_stop("ios:abc123", "com.google.chrome.ios")
+    packages = mcp_server.list_packages("ios:abc123")
+    waited = mcp_server.wait(0.25)
+
+    assert force_stopped.startswith("force_stop:")
+    assert packages.startswith("list_packages:")
+    assert waited.startswith("wait:")
+    assert calls == [
+        ("force_stop", {"device": "ios:abc123", "package": "com.google.chrome.ios"}),
+        ("list_packages", {"device": "ios:abc123"}),
+        ("wait", {"seconds": 0.25}),
+    ]
+    # Raw exec vectors must NOT be MCP tools at all.
+    assert not hasattr(mcp_server, "shell")
+    assert not hasattr(mcp_server, "run_skill")
+
+
+def test_mcp_has_no_run_skill_alias():
+    """run_skill is not exposed over MCP — run_workflow is the single entry point."""
+    from gitd import mcp_server
+
+    assert not hasattr(mcp_server, "run_skill")
+    assert callable(mcp_server.run_workflow)
+
+
+def test_agent_list_devices_returns_android_and_ios_metadata(monkeypatch):
+    monkeypatch.setattr(
+        "gitd.bots.common.device.list_connected_device_refs",
+        lambda: ["emulator-5554", "ios:abc123"],
+    )
+    monkeypatch.setattr(
+        "gitd.bots.common.device.list_configured_ios_devices",
+        lambda deep_probe=False: [
+            {
+                "serial": "ios:abc123",
+                "status": "available",
+                "device_name": "Test iPhone",
+                "appium_url": "http://127.0.0.1:4723",
+            }
+        ],
+    )
+
+    devices = json.loads(execute_tool("list_devices", {}))
+
+    assert devices == [
+        {"serial": "emulator-5554", "platform": "android"},
+        {
+            "serial": "ios:abc123",
+            "platform": "ios",
+            "status": "available",
+            "device_name": "Test iPhone",
+            "appium_url": "http://127.0.0.1:4723",
+        },
+    ]
+
+
+def test_agent_marketing_lookup_tools_use_shared_service(monkeypatch):
+    monkeypatch.setattr("gitd.services.marketing_lookup.lookup_lead", lambda handle: f"lead:{handle}")
+    monkeypatch.setattr("gitd.services.marketing_lookup.list_unread_leads", lambda: "2 unread")
+
+    assert execute_tool("lookup_lead", {"handle": "demo"}) == "lead:demo"
+    assert execute_tool("list_unread_leads", {}) == "2 unread"
+
+
+def test_agent_crm_lookup_tools_use_shared_service(monkeypatch):
+    monkeypatch.setattr("gitd.services.crm_lookup.crm_lookup_contact", lambda handle: f"contact:{handle}")
+    monkeypatch.setattr("gitd.services.crm_lookup.crm_list_unread_messages", lambda: "2 unread")
+
+    assert execute_tool("crm_lookup_contact", {"handle": "demo"}) == "contact:demo"
+    assert execute_tool("crm_list_unread_messages", {}) == "2 unread"
+
+
+def test_agent_run_skill_uses_current_interpreter(monkeypatch):
+    captured = {}
+
+    class FakeRun:
+        returncode = 0
+        stdout = "skill ok"
+        stderr = ""
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return FakeRun()
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    result = execute_tool(
+        "run_skill",
+        {
+            "device": "ios:abc123",
+            "skill": "safari",
+            "workflow": "read_news",
+            "params": {"url": "https://text.npr.org/"},
+        },
+    )
+
+    assert result == "skill ok"
+    assert captured["cmd"][:2] == [sys.executable, "-u"]
+    assert "gitd/skills/_run_skill.py" in captured["cmd"][2]
+    assert captured["kwargs"]["timeout"] == 120
+
+
+def test_agent_run_action_uses_current_interpreter(monkeypatch):
+    captured = {}
+
+    class FakeRun:
+        returncode = 0
+        stdout = "action ok"
+        stderr = ""
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return FakeRun()
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    result = execute_tool(
+        "run_action",
+        {
+            "device": "ios:abc123",
+            "skill": "safari",
+            "action": "read_news",
+            "params": {"url": "https://text.npr.org/"},
+        },
+    )
+
+    assert result == "action ok"
+    assert captured["cmd"][:2] == [sys.executable, "-u"]
+    assert "gitd/skills/_run_skill.py" in captured["cmd"][2]
+    assert "--action" in captured["cmd"]
+    assert captured["cmd"][captured["cmd"].index("--action") + 1] == "read_news"
+    assert "--workflow" not in captured["cmd"]
+    assert captured["kwargs"]["timeout"] == 120
+
+
+def test_agent_create_skill_uses_shared_creator(monkeypatch):
+    captured = {}
+
+    def fake_create_recorded_skill(**kwargs):
+        captured.update(kwargs)
+        return {
+            "ok": True,
+            "skill": kwargs["name"],
+            "steps": len(kwargs["steps"]),
+            "dir": "/tmp/skills/ios_agent_demo",
+            "platforms": ["ios"],
+            "metadata": {
+                "name": kwargs["name"],
+                "app_package": "",
+                "android_package": "",
+                "ios_bundle_id": kwargs["app_package"],
+                "platforms": ["ios"],
+            },
+        }
+
+    monkeypatch.setattr("gitd.services.skill_creation.create_recorded_skill", fake_create_recorded_skill)
+
+    result = json.loads(
+        execute_tool(
+            "create_skill",
+            {
+                "name": "ios_agent_demo",
+                "app_package": "com.google.chrome.ios",
+                "steps": [{"action": "launch", "package": "com.google.chrome.ios"}],
+                "platforms": ["ios"],
+                "elements_ios": [{"text": "Search", "class": "XCUIElementTypeTextField"}],
+            },
+        )
+    )
+
+    assert result["ok"] is True
+    assert result["metadata"]["ios_bundle_id"] == "com.google.chrome.ios"
+    assert captured["name"] == "ios_agent_demo"
+    assert captured["app_package"] == "com.google.chrome.ios"
+    assert captured["platforms"] == ["ios"]
+    assert captured["elements_ios"] == [{"text": "Search", "class": "XCUIElementTypeTextField"}]
+
+
+def test_agent_explore_app_uses_auto_creator_subprocess(monkeypatch):
+    captured = {}
+
+    class FakeRun:
+        returncode = 0
+        stdout = "explorer ok"
+        stderr = ""
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return FakeRun()
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    result = execute_tool(
+        "explore_app",
+        {
+            "device": "ios:abc123",
+            "package": "com.example.agentexplorepytest",
+            "max_depth": 1,
+            "max_states": 2,
+        },
+    )
+
+    assert result == "Exploration finished. Output:\nexplorer ok"
+    assert captured["cmd"][:2] == [sys.executable, "-u"]
+    assert "gitd/skills/auto_creator.py" in captured["cmd"][2]
+    assert captured["cmd"][captured["cmd"].index("--package") + 1] == "com.example.agentexplorepytest"
+    assert captured["cmd"][captured["cmd"].index("--device") + 1] == "ios:abc123"
+    assert captured["cmd"][captured["cmd"].index("--max-depth") + 1] == "1"
+    assert captured["cmd"][captured["cmd"].index("--max-states") + 1] == "2"
+    assert captured["kwargs"]["timeout"] == 300
+
+
+def test_tools_for_device_filters_by_platform():
+    ios_names = {tool["name"] for tool in tools_for_device("ios:abc123")}
+    android_names = {tool["name"] for tool in tools_for_device("emulator-5554")}
+
+    assert "open_url" in ios_names
+    assert "list_devices" in ios_names
+    assert "start_screen_recording" in ios_names
+    assert "stop_screen_recording" in ios_names
+    assert "screen_recording_status" in ios_names
+    assert "get_stream_info" in ios_names
+    assert "get_screen_xml" in ios_names
+    assert "device_health" in ios_names
+    assert "fix_device_health" in ios_names
+    assert "extract_articles" in ios_names
+    assert "shell" not in ios_names
+    assert "launch_intent" not in ios_names
+    assert "clipboard_get" in ios_names
+    assert "clipboard_set" in ios_names
+    assert "paste_text" in ios_names
+    assert "press_back" in ios_names
+    assert "press_home" in ios_names
+    assert "type_unicode" in ios_names
+    assert "get_current_url" in ios_names
+    assert "list_apps" in ios_names
+    assert "search_apps" in ios_names
+    assert "list_packages" in ios_names
+    assert "run_workflow" in ios_names
+    assert "run_action" in ios_names
+    assert "create_skill" in ios_names
+    assert "lookup_lead" in ios_names
+    assert "list_unread_leads" in ios_names
+    assert "crm_lookup_contact" in ios_names
+    assert "crm_list_unread_messages" in ios_names
+    assert "app_state" in ios_names
+    assert "get_notifications" in ios_names
+    assert "open_notifications" in ios_names
+    assert "clear_notifications" in ios_names
+    assert "open_camera" in ios_names
+    assert "explore_app" in ios_names
+    assert "read_news" in ios_names
+
+    assert "shell" in android_names
+    assert "list_devices" in android_names
+    assert "get_screen_xml" in android_names
+    assert "press_back" in android_names
+    assert "press_home" in android_names
+    assert "type_unicode" in android_names
+    assert "run_workflow" in android_names
+    assert "run_action" in android_names
+    assert "create_skill" in android_names
+    assert "lookup_lead" in android_names
+    assert "list_unread_leads" in android_names
+    assert "crm_lookup_contact" in android_names
+    assert "crm_list_unread_messages" in android_names
+    assert "start_screen_recording" in android_names
+    assert "get_stream_info" in android_names
+    assert "device_health" in android_names
+    assert "fix_device_health" in android_names
+    assert "app_state" in android_names
+    assert "explore_app" in android_names
+    assert "get_current_url" not in android_names
+    assert "read_news" not in android_names
+
+
+def test_ios_app_listing_tools_use_ios_inventory(monkeypatch):
+    class FakeIOSDevice:
+        def list_apps(self, query="", verify=True):
+            apps = [
+                {
+                    "name": "Chrome",
+                    "package": "com.google.chrome.ios",
+                    "bundle_id": "com.google.chrome.ios",
+                    "platform": "ios",
+                    "verified": True,
+                    "installed": True,
+                },
+                {
+                    "name": "TikTok",
+                    "package": "com.zhiliaoapp.musically",
+                    "bundle_id": "com.zhiliaoapp.musically",
+                    "platform": "ios",
+                    "verified": True,
+                    "installed": True,
+                },
+            ]
+            if query:
+                needle = query.lower()
+                apps = [app for app in apps if needle in app["name"].lower() or needle in app["bundle_id"].lower()]
+            return apps
+
+    monkeypatch.setattr("gitd.services.device_context.get_device", lambda device: FakeIOSDevice())
+
+    search = json.loads(execute_tool("search_apps", {"device": "ios:abc123", "query": "chrome"}))
+    packages = json.loads(execute_tool("list_packages", {"device": "ios:abc123"}))
+
+    assert search == [
+        {
+            "name": "Chrome",
+            "package": "com.google.chrome.ios",
+            "bundle_id": "com.google.chrome.ios",
+            "platform": "ios",
+            "verified": True,
+            "installed": True,
+        }
+    ]
+    assert packages == ["com.google.chrome.ios", "com.zhiliaoapp.musically"]
+
+
+def test_ios_open_camera_tool_uses_ios_backend(monkeypatch):
+    class FakeIOSDevice:
+        def open_camera(self, mode="photo", timer_s=0):
+            return {
+                "mode": mode,
+                "selected_mode": True,
+                "switched_camera": True,
+                "timer_set": True,
+            }
+
+    monkeypatch.setattr("gitd.services.agent_tools.get_device", lambda device: FakeIOSDevice())
+
+    result = execute_tool("open_camera", {"device": "ios:abc123", "mode": "selfie", "timer_s": 3})
+
+    assert result == "Opened iOS Camera - selfie"
+
+
+def test_ios_paste_text_tool_uses_ios_backend(monkeypatch):
+    calls = []
+
+    class FakeIOSDevice:
+        def paste_text(self, text):
+            calls.append(text)
+            return True
+
+    monkeypatch.setattr("gitd.services.agent_tools.get_device", lambda device: FakeIOSDevice())
+
+    result = execute_tool("paste_text", {"device": "ios:abc123", "text": "hello"})
+
+    assert result == "Inserted text on iOS: hello"
+    assert calls == ["hello"]
+
+
+def test_ios_agent_primitive_aliases_use_ios_backend(monkeypatch):
+    calls = []
+
+    class FakeIOSDevice:
+        def tap(self, x, y):
+            calls.append(("tap", x, y))
+
+        def swipe(self, x1, y1, x2, y2, ms=500):
+            calls.append(("swipe", x1, y1, x2, y2, ms))
+
+        def long_press(self, x, y, duration_ms=1000):
+            calls.append(("long_press", x, y, duration_ms))
+
+        def type_text(self, text):
+            calls.append(("type", text))
+
+        def back(self):
+            calls.append(("back",))
+
+        def press_key(self, key):
+            calls.append(("key", key))
+
+    monkeypatch.setattr("gitd.services.agent_tools.get_device", lambda device: FakeIOSDevice())
+    monkeypatch.setattr("gitd.services.agent_tools.ctx.get_screen_tree", lambda device: "(empty screen)")
+    monkeypatch.setattr("gitd.services.agent_tools.ctx.get_screen_xml", lambda device: "<hierarchy />")
+
+    tapped = execute_tool("tap", {"device": "ios:abc123", "x": 10, "y": 20})
+    swiped = execute_tool("swipe", {"device": "ios:abc123", "x1": 1, "y1": 2, "x2": 3, "y2": 4})
+    long_pressed = execute_tool("long_press", {"device": "ios:abc123", "x": 8, "y": 9, "duration_ms": 1500})
+    typed = execute_tool("type_unicode", {"device": "ios:abc123", "text": "cafe\u0301"})
+    back = execute_tool("press_back", {"device": "ios:abc123"})
+    home = execute_tool("press_home", {"device": "ios:abc123"})
+    xml = execute_tool("get_screen_xml", {"device": "ios:abc123"})
+
+    assert tapped == "Tapped (10, 20)"
+    assert swiped == "Swiped (1,2) -> (3,4)"
+    assert long_pressed == "Long pressed (8, 9)"
+    assert typed == "Typed (unicode): cafe\u0301"
+    assert back == "Pressed Back"
+    assert home == "Pressed Home"
+    assert xml == "<hierarchy />"
+    assert calls == [
+        ("tap", 10, 20),
+        ("swipe", 1, 2, 3, 4, 500),
+        ("long_press", 8, 9, 1500),
+        ("type", "cafe\u0301"),
+        ("back",),
+        ("key", "HOME"),
+    ]
+
+
+def test_platform_prompts_do_not_offer_android_only_tools_to_ios():
+    ios_tools = tools_for_device("ios:abc123")
+    ios_tool_list = tool_prompt_list(ios_tools)
+    ios_system = system_prompt_for_device("ios:abc123", DEFAULT_SYSTEM.replace("{tool_list}", ios_tool_list))
+
+    assert "Target platform: iOS via Appium/WebDriverAgent" in ios_system
+    assert "open_url" in ios_system
+    assert "extract_articles" in ios_system
+    assert "read_news" in ios_system
+    assert "call search_apps/list_apps if you need to discover a bundle id" in ios_system
+    assert "shell:" not in ios_system
+    assert "launch_intent:" not in ios_system
+    assert "toggle_overlay:" not in ios_system
+    assert "open_camera:" in ios_system
+    assert "standard Android intents" not in ios_system
+    assert "camera package name" not in ios_system
+    assert "Use search_apps to find the package name" not in ios_system
+    assert "Android-only concepts" in ios_system
+
+    android_system = system_prompt_for_device(
+        "emulator-5554",
+        DEFAULT_SYSTEM.replace("{tool_list}", tool_prompt_list(tools_for_device("emulator-5554"))),
+    )
+    assert "Target platform: Android via ADB/Portal" in android_system
+    assert "shell:" in android_system
+    assert "get_current_url:" not in android_system
+
+
+def test_platform_context_for_ios_and_android():
+    assert "iOS via Appium/WebDriverAgent" in platform_context("ios:abc123")
+    assert "discover a bundle id" in platform_context("ios:abc123")
+    assert "Android via ADB/Portal" in platform_context("emulator-5554")
+
+
+def test_openai_tool_schema_is_filtered_by_device():
+    ios_names = {tool["function"]["name"] for tool in openai_tools_for_device("ios:abc123")}
+    android_names = {tool["function"]["name"] for tool in openai_tools_for_device("emulator-5554")}
+
+    assert "open_url" in ios_names
+    assert "list_devices" in ios_names
+    assert "device_health" in ios_names
+    assert "fix_device_health" in ios_names
+    assert "shell" not in ios_names
+    assert "press_back" in ios_names
+    assert "press_home" in ios_names
+    assert "type_unicode" in ios_names
+    assert "get_screen_xml" in ios_names
+    assert "run_workflow" in ios_names
+    assert "run_action" in ios_names
+    assert "create_skill" in ios_names
+    assert "lookup_lead" in ios_names
+    assert "list_unread_leads" in ios_names
+    assert "crm_lookup_contact" in ios_names
+    assert "crm_list_unread_messages" in ios_names
+    assert "get_current_url" in ios_names
+    assert "read_news" in ios_names
+    assert "shell" in android_names
+    assert "list_devices" in android_names
+    assert "device_health" in android_names
+    assert "fix_device_health" in android_names
+    assert "press_back" in android_names
+    assert "press_home" in android_names
+    assert "type_unicode" in android_names
+    assert "get_screen_xml" in android_names
+    assert "run_workflow" in android_names
+    assert "run_action" in android_names
+    assert "create_skill" in android_names
+    assert "lookup_lead" in android_names
+    assert "list_unread_leads" in android_names
+    assert "crm_lookup_contact" in android_names
+    assert "crm_list_unread_messages" in android_names
+    assert "get_current_url" not in android_names
+    assert "read_news" not in android_names

--- a/tests/test_traces.py
+++ b/tests/test_traces.py
@@ -1,0 +1,349 @@
+"""Tests for local tracing — observability storage layer + /api/traces endpoints.
+
+Run:
+    .venv/bin/pytest tests/test_traces.py -v
+
+These tests run against a throwaway SQLite file (redirected via DB_PATH in
+tests/conftest.py, verified by the _verify_db_isolated guard) — NOT the real
+data/gitd.db. Each test truncates the trace tables via the ``fresh_db`` fixture
+for a clean slate. They cover:
+
+- The observability helpers (`trace_chat_turn`, `record_generation`, …) write
+  the right rows with the right values.
+- Token/cost accumulation across multiple `record_generation` calls in one trace.
+- Status transitions (success / error).
+- The router endpoints (list, stats, detail, delete) return the expected shape
+  and respect filters.
+- Edge cases: empty queries, missing trace, FK-free conversation_id.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Iterator
+
+import pytest
+
+
+@pytest.fixture
+def fresh_db() -> Iterator[None]:
+    """Truncate the trace tables before (and after) each test for a clean slate.
+
+    Safe because tests/conftest.py has redirected DB_PATH to a throwaway file
+    before gitd was imported, so these deletes hit the temp test DB, never the
+    real data/gitd.db.
+    """
+    from gitd.models.base import engine
+    from gitd.models import Base
+    from gitd.models.trace import Trace, TraceSpan
+    Base.metadata.create_all(engine)  # idempotent, ensures tables exist
+    from gitd.models.base import SessionLocal
+    db = SessionLocal()
+    try:
+        db.query(TraceSpan).delete()
+        db.query(Trace).delete()
+        db.commit()
+    finally:
+        db.close()
+    yield
+    # Post-test cleanup so subsequent runs / unrelated tests don't see our rows
+    db = SessionLocal()
+    try:
+        db.query(TraceSpan).delete()
+        db.query(Trace).delete()
+        db.commit()
+    finally:
+        db.close()
+
+
+# ── Storage layer ────────────────────────────────────────────────────────────
+
+def test_basic_trace_roundtrip(fresh_db):
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import Trace, TraceSpan
+    from gitd.services.observability import (
+        trace_chat_turn, record_generation, record_tool_result, set_trace_output,
+    )
+
+    with trace_chat_turn(session_id="conv-1", user_message="hi",
+                         provider="claude-code", model="sonnet",
+                         device="dev1", source="mac") as t:
+        s = t.span(name="tool:web_search", input={"args": {"q": "x"}})
+        record_tool_result(s, "ok")
+        record_generation(t, model="sonnet", prompt="p", output="r",
+                          input_tokens=100, output_tokens=20, cost_usd=0.001)
+        set_trace_output(t, "final reply")
+
+    db = SessionLocal()
+    try:
+        traces = db.query(Trace).all()
+        assert len(traces) == 1
+        tr = traces[0]
+        assert tr.provider == "claude-code"
+        assert tr.model == "sonnet"
+        assert tr.source == "mac"
+        assert tr.status == "success"
+        assert tr.user_input == "hi"
+        assert tr.final_output == "final reply"
+        assert tr.input_tokens == 100
+        assert tr.output_tokens == 20
+        assert tr.cost_usd == pytest.approx(0.001)
+        assert tr.duration_ms >= 0
+
+        spans = db.query(TraceSpan).filter_by(trace_id=tr.id).all()
+        kinds = sorted([s.kind for s in spans])
+        assert kinds == ["generation", "tool"]
+        tool = next(s for s in spans if s.kind == "tool")
+        assert tool.name == "tool:web_search"
+        assert tool.level == "DEFAULT"
+    finally:
+        db.close()
+
+
+def test_token_accumulation_across_generations(fresh_db):
+    """on-device gemma calls record_generation per turn — totals should sum."""
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import Trace
+    from gitd.services.observability import trace_chat_turn, record_generation
+
+    with trace_chat_turn(session_id="c", user_message="hi", provider="on-device",
+                         model="g4-e4b", device="d", source="android") as t:
+        record_generation(t, model="g4-e4b", prompt="p1", output="r1",
+                          input_tokens=50, output_tokens=10, cost_usd=0.0)
+        record_generation(t, model="g4-e4b", prompt="p2", output="r2",
+                          input_tokens=70, output_tokens=15, cost_usd=0.0)
+        record_generation(t, model="g4-e4b", prompt="p3", output="r3",
+                          input_tokens=80, output_tokens=5, cost_usd=0.0)
+
+    db = SessionLocal()
+    try:
+        tr = db.query(Trace).first()
+        assert tr.input_tokens == 200
+        assert tr.output_tokens == 30
+    finally:
+        db.close()
+
+
+def test_error_status_on_exception(fresh_db):
+    """If the wrapped block raises, trace.status should flip to 'error'."""
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import Trace
+    from gitd.services.observability import trace_chat_turn
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with trace_chat_turn(session_id="c", user_message="hi", provider="x",
+                             model="m", device="d", source="mac"):
+            raise RuntimeError("boom")
+
+    db = SessionLocal()
+    try:
+        tr = db.query(Trace).first()
+        assert tr.status == "error"
+        assert "boom" in tr.error_text
+    finally:
+        db.close()
+
+
+def test_tool_error_marks_span_error(fresh_db):
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import TraceSpan
+    from gitd.services.observability import (
+        trace_chat_turn, record_tool_result,
+    )
+
+    with trace_chat_turn(session_id="c", user_message="x", provider="x",
+                         model="m", device="d", source="mac") as t:
+        s_ok = t.span(name="tool:a", input={})
+        record_tool_result(s_ok, "fine")
+        s_err = t.span(name="tool:b", input={})
+        record_tool_result(s_err, "boom", error=True)
+
+    db = SessionLocal()
+    try:
+        spans = {s.name: s for s in db.query(TraceSpan).all()}
+        assert spans["tool:a"].level == "DEFAULT"
+        assert spans["tool:b"].level == "ERROR"
+    finally:
+        db.close()
+
+
+def test_orphan_conversation_id_does_not_break(fresh_db):
+    """conversation_id is a soft reference, not a FK — non-existent IDs are fine."""
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import Trace
+    from gitd.services.observability import trace_chat_turn
+
+    with trace_chat_turn(session_id="never-existed", user_message="hi",
+                         provider="x", model="m", device="d", source="mac"):
+        pass
+
+    db = SessionLocal()
+    try:
+        assert db.query(Trace).count() == 1
+    finally:
+        db.close()
+
+
+def test_truncation_keeps_rows_bounded(fresh_db):
+    """Huge tool inputs/outputs shouldn't blow the row size."""
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import TraceSpan
+    from gitd.services.observability import (
+        trace_chat_turn, record_tool_result,
+    )
+
+    huge = "X" * 50_000
+    with trace_chat_turn(session_id="c", user_message="x", provider="x",
+                         model="m", device="d", source="mac") as t:
+        s = t.span(name="tool:big", input={"giant": huge})
+        record_tool_result(s, huge)
+
+    db = SessionLocal()
+    try:
+        sp = db.query(TraceSpan).filter_by(name="tool:big").first()
+        # Truncated to ~4000 chars + ellipsis marker
+        assert len(sp.input_json) < 5000
+        assert len(sp.output_json) < 5000
+        assert "[truncated]" in sp.input_json
+    finally:
+        db.close()
+
+
+# ── API endpoints ────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def client(fresh_db):
+    """FastAPI TestClient against the gitd app."""
+    from fastapi.testclient import TestClient
+    from gitd.app import create_app
+    app = create_app()
+    with TestClient(app) as c:
+        yield c
+
+
+def _seed(provider="claude-code", source="mac", status_set="success"):
+    """Helper — create one full trace in the DB and return its id."""
+    from gitd.services.observability import (
+        trace_chat_turn, record_tool_result, record_generation, set_trace_output,
+    )
+    if status_set == "error":
+        try:
+            with trace_chat_turn(session_id="c", user_message="bad",
+                                 provider=provider, model="m1",
+                                 device="d", source=source) as t:
+                s = t.span(name="tool:thing", input={})
+                record_tool_result(s, "err", error=True)
+                raise RuntimeError("simulated")
+        except RuntimeError:
+            pass
+        # Find the most recent and return its id
+        from gitd.models.base import SessionLocal
+        from gitd.models.trace import Trace
+        db = SessionLocal()
+        try:
+            return db.query(Trace).order_by(Trace.started_at.desc()).first().id
+        finally:
+            db.close()
+
+    with trace_chat_turn(session_id="c", user_message="hi",
+                         provider=provider, model="m1",
+                         device="d", source=source) as t:
+        s = t.span(name="tool:thing", input={"x": 1})
+        record_tool_result(s, "ok")
+        record_generation(t, model="m1", prompt="p", output="r",
+                          input_tokens=5, output_tokens=3, cost_usd=0.001)
+        set_trace_output(t, "out")
+    from gitd.models.base import SessionLocal
+    from gitd.models.trace import Trace
+    db = SessionLocal()
+    try:
+        return db.query(Trace).order_by(Trace.started_at.desc()).first().id
+    finally:
+        db.close()
+
+
+def test_list_endpoint_returns_paginated(client):
+    for _ in range(3):
+        _seed()
+    r = client.get("/api/traces?limit=2")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] == 3
+    assert len(body["data"]) == 2
+    assert all("provider" in t for t in body["data"])
+
+
+def test_list_endpoint_filters_by_provider(client):
+    _seed(provider="claude-code", source="mac")
+    _seed(provider="on-device", source="android")
+    _seed(provider="ollama", source="mac")
+
+    r = client.get("/api/traces?provider=on-device")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] == 1
+    assert body["data"][0]["provider"] == "on-device"
+
+
+def test_list_endpoint_filters_by_status_error(client):
+    _seed(status_set="success")
+    _seed(status_set="error")
+    r = client.get("/api/traces?status=error")
+    body = r.json()
+    assert body["total"] == 1
+    assert body["data"][0]["status"] == "error"
+
+
+def test_stats_endpoint(client):
+    _seed(provider="claude-code")
+    _seed(provider="claude-code")
+    _seed(provider="on-device", status_set="error")
+
+    r = client.get("/api/traces/stats")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] == 3
+    assert body["errors"] == 1
+    assert body["success_rate"] == pytest.approx(2 / 3, rel=1e-3)
+    providers = {p["provider"]: p["count"] for p in body["by_provider"]}
+    assert providers["claude-code"] == 2
+    assert providers["on-device"] == 1
+
+
+def test_detail_endpoint_includes_spans(client):
+    tid = _seed()
+    r = client.get(f"/api/traces/{tid}")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["trace"]["id"] == tid
+    assert body["trace"]["final_output"] == "out"
+    kinds = sorted(s["kind"] for s in body["spans"])
+    assert kinds == ["generation", "tool"]
+    tool = next(s for s in body["spans"] if s["kind"] == "tool")
+    assert tool["input"] == {"args": None} or "x" in (tool["input"] or {})
+
+
+def test_detail_endpoint_404_on_unknown(client):
+    r = client.get("/api/traces/does-not-exist")
+    assert r.status_code == 404
+
+
+def test_delete_single_trace(client):
+    tid = _seed()
+    r = client.delete(f"/api/traces/{tid}")
+    assert r.status_code == 200
+    assert r.json()["deleted"] == tid
+    r2 = client.get(f"/api/traces/{tid}")
+    assert r2.status_code == 404
+
+
+def test_clear_all_traces(client):
+    for _ in range(3):
+        _seed()
+    r = client.delete("/api/traces")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["deleted_traces"] == 3
+    list_r = client.get("/api/traces")
+    assert list_r.json()["total"] == 0


### PR DESCRIPTION
**Part 2 of 3 for the v1.3.0 release.**

All the feature code (no docs — those land in Part 3 to keep this PR focused on the runtime).

## Ships in this PR

- 🍏 **iOS support** — Appium + WebDriverAgent adapters, ios-aware tool routing, `ios:<udid>` device refs. Feature-flag `GITD_ENABLE_IOS=1`. Companion PR **#8** from @blah-mad landed the initial core; this bundles the follow-on integration + tests.
- 📱 **On-device inference** — llama.cpp + MediaPipe on Android, llama.cpp/Metal on iPhone, MLX opt-in path. Portal companion app updates + Kotlin bridge.
- 🔗 **LangChain + LlamaIndex adapters** — Ghost tool surface behind a fail-closed allow-list.
- 💻 **`ghost` CLI** — task-first one-liner: `ghost "check reddit" --device pixel`.
- 🧨 **`run_flow` MCP primitive** — batched multi-step execution.
- 🚀 **`uvx ghost-in-the-droid up`** — one-command install + boot.
- 62 MCP tools across browser primitives, camera, TTS, crash reporting, batched exec.
- Ghost Bench harness + evaluators.
- Version bump to 1.3.0.

## Related open community PRs

- **#8** @blah-mad — iOS core (merge first if not already)
- **#10** @sebastiondev — CORS/CWE-352 fix (this PR includes the follow-on integration)
- **#11** @sebastiondev — skills/install admin-token + URL validation

## Requires

- Part 1 merged: **#chore/cleanup-and-workflows** (for the CI workflows this PR's tests run under)

Follow-up: **#release/v1.3.0-docs-and-demos**.