### PR TITLE
docs(release-notes): mark v1.3.0 as released

### DIFF
--- a/docs/release-notes/v1.3.0.md
+++ b/docs/release-notes/v1.3.0.md
@@ -1,6 +1,6 @@
 # Ghost in the Droid v1.3.0
 
-_Release candidate — target ship: TBD_
+_Released 2026-07-18._
 
 <!-- Hero reel served from a relative repo path so it plays on the mirror preview AND the public repo. Poster + linked image are the older-renderer fallback. -->
 <p align="center">


### PR DESCRIPTION
Small doc fix — v1.3.0 shipped 2026-07-18 (PyPI + GitHub Release live). Updates the header from 'Release candidate — target ship: TBD' to 'Released 2026-07-18.' and drops the stale RC-blocker line.