### PR TITLE
docs(readme): add mcp-name comment for MCP registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- mcp-name: io.github.ghost-in-the-droid/android-agent -->
 <p align="center">
   <img src="docs/assets/mascot/12-the-tap.png" alt="Ghost tapping a phone" width="200" />
 </p>


### PR DESCRIPTION
One-line HTML comment at top of README.md so the modelcontextprotocol/registry can auto-ingest ghost-in-the-droid by its canonical id `io.github.ghost-in-the-droid/android-agent`. Renders invisible on GitHub / PyPI / the site. Ships as v1.3.2 to update the PyPI-hosted README so PulseMCP's daily crawl picks it up.