### PR TITLE
chore(release): bump pyproject version 1.3.0 → 1.3.2 (unblock PyPI publish)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ghost-in-the-droid"
-version = "1.3.0"
+version = "1.3.2"
 description = "Give any AI agent an Android body. Open-source phone automation via ADB — tap, swipe, type, run skills, scale across devices."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
The v1.3.1 + v1.3.2 tags didn't publish because pyproject.toml stayed at 1.3.0 → PyPI 400 file-already-exists. This bumps the version field so the next tag push actually publishes.