### PR TITLE
chore: add smithery.yaml for auto-listing on smithery.ai

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,9 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    properties: {}
+  commandFunction: |-
+    (config) => ({command: 'python', args: ['-m', 'ghost_in_the_droid'], env: {}})


### PR DESCRIPTION
One-file addition. Smithery's crawler discovers repos via the smithery.yaml at root. Enables auto-listing across their 57k+ server index without a manual submission.