### PR TITLE
site: wire GA4 tracking (G-5H5CYJFJLJ)

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -41,6 +41,18 @@ export default defineConfig({
 				},
 				{
 					tag: 'script',
+					attrs: {
+						async: true,
+						src: 'https://www.googletagmanager.com/gtag/js?id=G-5H5CYJFJLJ',
+					},
+				},
+				{
+					tag: 'script',
+					content:
+						"window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)}gtag('js',new Date());gtag('config','G-5H5CYJFJLJ');",
+				},
+				{
+					tag: 'script',
 					content: `
 document.addEventListener('DOMContentLoaded', function() {
 	var nav = document.querySelector('header nav .right-group, header nav');

--- a/site/src/pages/bg-test.astro
+++ b/site/src/pages/bg-test.astro
@@ -6,6 +6,8 @@
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<title>Background Effects Test</title>
+	<script async src="https://www.googletagmanager.com/gtag/js?id=G-5H5CYJFJLJ"></script>
+	<script is:inline>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)}gtag('js',new Date());gtag('config','G-5H5CYJFJLJ');</script>
 	<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />
 	<style>
 		*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -16,6 +16,8 @@
 	<meta name="twitter:card" content="summary_large_image" />
 	<meta name="twitter:title" content="Ghost in the Droid" />
 	<meta name="twitter:image" content="/mascot/40-lineup-banner.png" />
+	<script async src="https://www.googletagmanager.com/gtag/js?id=G-5H5CYJFJLJ"></script>
+	<script is:inline>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)}gtag('js',new Date());gtag('config','G-5H5CYJFJLJ');</script>
 	<link rel="preconnect" href="https://fonts.googleapis.com" />
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 	<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />

--- a/site/src/pages/showcase.astro
+++ b/site/src/pages/showcase.astro
@@ -32,6 +32,8 @@ const grouped = CATEGORY_ORDER.map((cat) => ({
 		<meta property="og:description" content="Every Ghost demo in one place. Real phones. Any AI. Zero cloud." />
 		<meta property="og:image" content="https://ghostinthedroid.com/showcase/hero-poster.png" />
 		<meta property="og:type" content="website" />
+		<script async src="https://www.googletagmanager.com/gtag/js?id=G-5H5CYJFJLJ"></script>
+		<script is:inline>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)}gtag('js',new Date());gtag('config','G-5H5CYJFJLJ');</script>
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 		<link


### PR DESCRIPTION
GA4 property live via Measurement ID G-5H5CYJFJLJ (property 'Ghost in the Droid', stream 'ghost-stream', URL ghostinthedroid.com).

Adds gtag.js loader + config to Starlight head[] (covers all docs pages) and to <head> of standalone pages (index.astro, showcase.astro, bg-test.astro).

Playwright-verified locally: /gtag/js loads + /g/collect POSTs fire on every page, dataLayer populated.