### PR TITLE
fix(test-runner): prevent path traversal in recording endpoints

### DIFF
--- a/gitd/routers/tests.py
+++ b/gitd/routers/tests.py
@@ -176,7 +176,6 @@ def _tr_watcher():
 threading.Thread(target=_tr_watcher, daemon=True).start()
 
 
-
 def _resolve_recording_path(filename: str, suffix: str = "") -> Path:
     """Resolve a recording file path, rejecting traversal outside the recordings dir.
 

--- a/gitd/routers/tests.py
+++ b/gitd/routers/tests.py
@@ -176,6 +176,26 @@ def _tr_watcher():
 threading.Thread(target=_tr_watcher, daemon=True).start()
 
 
+
+def _resolve_recording_path(filename: str, suffix: str = "") -> Path:
+    """Resolve a recording file path, rejecting traversal outside the recordings dir.
+
+    ``filename`` must be a bare basename (no path separators, no ``..``).
+    """
+    if not filename or "/" in filename or "\\" in filename or filename in (".", "..") or "\x00" in filename:
+        raise HTTPException(status_code=400, detail="invalid filename")
+    name = Path(filename).name
+    if name != filename:
+        raise HTTPException(status_code=400, detail="invalid filename")
+    base = _TR_RECORDINGS_DIR.resolve()
+    candidate = (base / (name + suffix)).resolve()
+    try:
+        candidate.relative_to(base)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="invalid filename") from exc
+    return candidate
+
+
 # ── Routes ──────────────────────────────────────────────────────────────────
 
 
@@ -381,7 +401,7 @@ def tr_recordings():
 @router.get("/api/test-runner/recording/{filename:path}", summary="Serve Test Recording File")
 def tr_recording_file(filename: str):
     """Serve a test recording MP4."""
-    fpath = _TR_RECORDINGS_DIR / filename
+    fpath = _resolve_recording_path(filename)
     if not fpath.exists() or not fpath.is_file():
         raise HTTPException(status_code=404, detail="not found")
     return FileResponse(str(fpath), media_type="video/mp4")
@@ -390,8 +410,8 @@ def tr_recording_file(filename: str):
 @router.get("/api/test-runner/recording-log/{filename:path}", summary="Serve Recording Log File")
 def tr_recording_log(filename: str):
     """Serve the saved log for a recording."""
-    stem = filename.replace(".mp4", "")
-    log_path = _TR_RECORDINGS_DIR / (stem + ".log")
+    stem = filename[:-4] if filename.endswith(".mp4") else filename
+    log_path = _resolve_recording_path(stem, ".log")
     if not log_path.exists():
         return {"lines": []}
     lines = log_path.read_text(errors="replace").splitlines()
@@ -401,10 +421,10 @@ def tr_recording_log(filename: str):
 @router.delete("/api/test-runner/recording/{filename:path}", summary="Delete Test Recording")
 def tr_recording_delete(filename: str):
     """Delete a test recording and its associated log/overlay files."""
-    stem = filename.replace(".mp4", "")
+    stem = filename[:-4] if filename.endswith(".mp4") else filename
     deleted = []
     for suffix in [".mp4", ".log", "_overlay.mp4"]:
-        p = _TR_RECORDINGS_DIR / (stem + suffix)
+        p = _resolve_recording_path(stem, suffix)
         if p.exists():
             p.unlink()
             deleted.append(p.name)


### PR DESCRIPTION
## Summary

The three test-recording endpoints on the `/api/test-runner` router build filesystem paths by directly concatenating the URL-supplied `filename` onto `_TR_RECORDINGS_DIR`, with no validation. Because each route is declared with the FastAPI `{filename:path}` converter, slashes and `..` segments pass through unchanged. The DELETE variant is the most damaging: any file the server process can write to on disk can be removed by a single unauthenticated HTTP request.

- File: `gitd/routers/tests.py`
- Affected routes:
  - `GET  /api/test-runner/recording/{filename:path}` — arbitrary file read (served as `video/mp4`)
  - `GET  /api/test-runner/recording-log/{filename:path}` — arbitrary text file read via `.log` suffix append
  - `DELETE /api/test-runner/recording/{filename:path}` — **arbitrary file delete** (tries `<name>.mp4`, `<name>.log`, `<name>_overlay.mp4`; if any matches, it is unlinked)
- CWE: [CWE-22 — Improper Limitation of a Pathname to a Restricted Directory](https://cwe.mitre.org/data/definitions/22.html)

The `test-runner` router is mounted without any `Depends(...)` auth gate, and there is no app-wide auth middleware — I checked both the router definition (`router = APIRouter(tags=["tests"])` at `gitd/routers/tests.py:23`) and the FastAPI app assembly. Any client that can reach the HTTP port can hit these endpoints.

## Fix

Introduce a small `_resolve_recording_path(filename, suffix="")` helper that:

1. Rejects empty names, path separators (`/`, `\`), `.`, `..`, and NUL bytes up front.
2. Verifies `Path(filename).name == filename` (defence in depth against odd inputs).
3. Resolves the candidate against `_TR_RECORDINGS_DIR.resolve()` and requires `candidate.relative_to(base)` to succeed — this catches symlinks that would escape the directory.

All three handlers are updated to use it. The suffix handling for `.log` / `_overlay.mp4` is preserved but now applied *after* the basename check, so `../../etc/passwd` can never reach the filesystem call. The log-suffix logic also switches from `filename.replace(".mp4", "")` (which strips `.mp4` anywhere in the string) to a proper `endswith` check.

The diff is 25 lines of additions plus 5 lines changed in the three handlers — minimal and localised.

## Proof of Concept

Run the agent locally (`android-agent serve` or the container `run.py`, which binds `0.0.0.0`) and:

```bash
# 1. Arbitrary file delete — no auth, no CSRF token
curl -X DELETE "http://127.0.0.1:8000/api/test-runner/recording/..%2F..%2F..%2Ftmp%2Fvictim"
#    Server will attempt to unlink /tmp/victim.mp4, /tmp/victim.log, /tmp/victim_overlay.mp4

# 2. Arbitrary file read as video/mp4
curl "http://127.0.0.1:8000/api/test-runner/recording/..%2F..%2F..%2Fetc%2Fhosts" -o out.bin
file out.bin   # contents of /etc/hosts

# 3. Arbitrary .log read
curl "http://127.0.0.1:8000/api/test-runner/recording-log/..%2F..%2F..%2Fvar%2Flog%2Fsystem"
```

Route existence verified in the current tree:

```
$ grep -n 'test-runner/recording' gitd/routers/tests.py
401:@router.get("/api/test-runner/recording/{filename:path}", ...)
410:@router.get("/api/test-runner/recording-log/{filename:path}", ...)
421:@router.delete("/api/test-runner/recording/{filename:path}", ...)
```

After the fix, each of the requests above returns `400 {"detail":"invalid filename"}` and no filesystem access is attempted.

## Testing

- Traversal payloads (`../`, URL-encoded `..%2F`, absolute paths `/etc/passwd`, backslashes, NUL byte, `.`, `..`) all return `HTTP 400` from the helper.
- Legitimate basenames (e.g. `run-2025-01-01-abcd.mp4`) continue to resolve inside `_TR_RECORDINGS_DIR` and serve/delete as before.
- The `.log` suffix path continues to return `{"lines": []}` for non-existent-but-valid names (behaviour preserved).
- Symlink escape is blocked by the `resolve().relative_to(base)` check.

## Adversarial review

Before submitting I tried to talk myself out of this. The main mitigation to consider is deployment posture: the CLI defaults to binding `127.0.0.1`, which limits exposure to same-host attackers. However, (a) `--host 0.0.0.0` is a first-class documented option in `cli.py`, (b) the shipped container entry point (`run.py`) binds `0.0.0.0`, and (c) even on localhost-only deployments the GET endpoints are reachable from a malicious webpage via a simple `<img>`/`fetch` (no CORS preflight needed for a simple GET), so a browsing user is enough to trigger arbitrary file reads. The DELETE requires CORS to be permissive to be cross-origin exploitable, but is trivially exploitable from any local process or LAN peer regardless. There is no auth on the `test-runner` router and no framework-level gate above it, so nothing else in the stack blocks the request. The fix is the correct layer to address this — validating the untrusted path segment before it reaches the filesystem API.