### PR TITLE
Release v1.5.1 — community bug-fix roundup (Windows, foldables, path traversal)

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     port: 6175,
     proxy: {
       '/api': {
-        target: 'http://localhost:5056',
+        target: 'http://localhost:5055',
         changeOrigin: true,
         ws: true,   // proxy WebSocket upgrades (H.264 stream at /api/phone/h264/*)
         // Required for SSE (Server-Sent Events) — disable response buffering

--- a/gitd/bots/common/adb.py
+++ b/gitd/bots/common/adb.py
@@ -33,6 +33,23 @@ def ascii_typeable(text: str) -> str:
     return unicodedata.normalize("NFKD", text).encode("ascii", "ignore").decode("ascii")
 
 
+_PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+
+
+def strip_to_png_signature(raw: bytes) -> bytes:
+    """On multi-display devices (foldables), screencap prints a
+    "[Warning] Multiple displays were found..." line to stdout ahead of the
+    PNG data, corrupting naive reads. Trim anything before the PNG signature.
+    """
+    idx = raw.find(_PNG_SIGNATURE)
+    return raw[idx:] if idx > 0 else raw
+
+
+def capture_screencap_png(serial: str, timeout: float = 10) -> bytes:
+    raw = subprocess.check_output(["adb", "-s", serial, "exec-out", "screencap", "-p"], timeout=timeout)
+    return strip_to_png_signature(raw)
+
+
 _KEYCODE_RE = re.compile(r"^KEYCODE_[A-Z0-9_]+$")
 
 

--- a/gitd/bots/common/ios.py
+++ b/gitd/bots/common/ios.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 
 import base64
 import contextlib
-import fcntl
 import html
+import importlib
 import json
 import os
 import re
@@ -28,6 +28,8 @@ from pathlib import Path
 from typing import Any
 
 import requests
+
+fcntl = importlib.import_module("fcntl") if os.name != "nt" else None  # POSIX-only; WDA launch guard no-ops on Windows
 
 IOS_PREFIX = "ios:"
 
@@ -1285,7 +1287,8 @@ def _wda_launch_guard(wda_up):
         with contextlib.suppress(Exception):
             os.makedirs(os.path.dirname(_WDA_LAUNCH_LOCK_PATH), exist_ok=True)
             fh = open(_WDA_LAUNCH_LOCK_PATH, "w")  # noqa: SIM115
-            fcntl.flock(fh, fcntl.LOCK_EX)  # released on POST timeout, so no forever-block
+            if fcntl is not None:
+                fcntl.flock(fh, fcntl.LOCK_EX)  # released on POST timeout, so no forever-block
         with contextlib.suppress(Exception):
             if not wda_up():
                 _reap_stale_wda_builds()
@@ -1293,7 +1296,8 @@ def _wda_launch_guard(wda_up):
     finally:
         if fh is not None:
             with contextlib.suppress(Exception):
-                fcntl.flock(fh, fcntl.LOCK_UN)
+                if fcntl is not None:
+                    fcntl.flock(fh, fcntl.LOCK_UN)
                 fh.close()
 
 

--- a/gitd/routers/streaming.py
+++ b/gitd/routers/streaming.py
@@ -12,6 +12,7 @@ import urllib.request
 from fastapi import APIRouter, Body, HTTPException, Request
 from starlette.responses import StreamingResponse
 
+from gitd.bots.common.adb import strip_to_png_signature
 from gitd.bots.common.device import get_device, is_ios_ref
 
 router = APIRouter(tags=["streaming"])
@@ -200,7 +201,7 @@ def phone_stream(device: str = "", fps: int = 30, quality: int = 8, mode: str = 
         from PIL import Image
 
         try:
-            raw = subprocess.check_output(["adb"] + dev_args + ["exec-out", "screencap", "-p"], timeout=5)
+            raw = strip_to_png_signature(subprocess.check_output(["adb"] + dev_args + ["exec-out", "screencap", "-p"], timeout=5))
             img = Image.open(_io.BytesIO(raw)).convert("RGB")
             w, h = img.size
             img = img.resize((w // 2, h // 2), Image.NEAREST)
@@ -288,7 +289,7 @@ def phone_stream(device: str = "", fps: int = 30, quality: int = 8, mode: str = 
         delay = max(0, 1.0 / min(fps, 10) - 0.5)
         while True:
             try:
-                raw = subprocess.check_output(["adb"] + dev_args + ["exec-out", "screencap", "-p"], timeout=6)
+                raw = strip_to_png_signature(subprocess.check_output(["adb"] + dev_args + ["exec-out", "screencap", "-p"], timeout=6))
                 img = Image.open(_io.BytesIO(raw)).convert("RGB")
                 img = img.resize((img.width // 2, img.height // 2), Image.NEAREST)
                 buf = _io.BytesIO()

--- a/gitd/routers/streaming.py
+++ b/gitd/routers/streaming.py
@@ -201,7 +201,9 @@ def phone_stream(device: str = "", fps: int = 30, quality: int = 8, mode: str = 
         from PIL import Image
 
         try:
-            raw = strip_to_png_signature(subprocess.check_output(["adb"] + dev_args + ["exec-out", "screencap", "-p"], timeout=5))
+            raw = strip_to_png_signature(
+                subprocess.check_output(["adb"] + dev_args + ["exec-out", "screencap", "-p"], timeout=5)
+            )
             img = Image.open(_io.BytesIO(raw)).convert("RGB")
             w, h = img.size
             img = img.resize((w // 2, h // 2), Image.NEAREST)
@@ -289,7 +291,9 @@ def phone_stream(device: str = "", fps: int = 30, quality: int = 8, mode: str = 
         delay = max(0, 1.0 / min(fps, 10) - 0.5)
         while True:
             try:
-                raw = strip_to_png_signature(subprocess.check_output(["adb"] + dev_args + ["exec-out", "screencap", "-p"], timeout=6))
+                raw = strip_to_png_signature(
+                    subprocess.check_output(["adb"] + dev_args + ["exec-out", "screencap", "-p"], timeout=6)
+                )
                 img = Image.open(_io.BytesIO(raw)).convert("RGB")
                 img = img.resize((img.width // 2, img.height // 2), Image.NEAREST)
                 buf = _io.BytesIO()

--- a/gitd/routers/tests.py
+++ b/gitd/routers/tests.py
@@ -176,7 +176,6 @@ def _tr_watcher():
 threading.Thread(target=_tr_watcher, daemon=True).start()
 
 
-
 def _resolve_recording_path(filename: str, suffix: str = "") -> Path:
     """Resolve a recording file path, rejecting traversal outside the recordings dir.
 

--- a/gitd/routers/tests.py
+++ b/gitd/routers/tests.py
@@ -176,6 +176,26 @@ def _tr_watcher():
 threading.Thread(target=_tr_watcher, daemon=True).start()
 
 
+
+def _resolve_recording_path(filename: str, suffix: str = "") -> Path:
+    """Resolve a recording file path, rejecting traversal outside the recordings dir.
+
+    ``filename`` must be a bare basename (no path separators, no ``..``).
+    """
+    if not filename or "/" in filename or "\\" in filename or filename in (".", "..") or "\x00" in filename:
+        raise HTTPException(status_code=400, detail="invalid filename")
+    name = Path(filename).name
+    if name != filename:
+        raise HTTPException(status_code=400, detail="invalid filename")
+    base = _TR_RECORDINGS_DIR.resolve()
+    candidate = (base / (name + suffix)).resolve()
+    try:
+        candidate.relative_to(base)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="invalid filename") from exc
+    return candidate
+
+
 # ── Routes ──────────────────────────────────────────────────────────────────
 
 
@@ -381,7 +401,7 @@ def tr_recordings():
 @router.get("/api/test-runner/recording/{filename:path}", summary="Serve Test Recording File")
 def tr_recording_file(filename: str):
     """Serve a test recording MP4."""
-    fpath = _TR_RECORDINGS_DIR / filename
+    fpath = _resolve_recording_path(filename)
     if not fpath.exists() or not fpath.is_file():
         raise HTTPException(status_code=404, detail="not found")
     return FileResponse(str(fpath), media_type="video/mp4")
@@ -390,8 +410,8 @@ def tr_recording_file(filename: str):
 @router.get("/api/test-runner/recording-log/{filename:path}", summary="Serve Recording Log File")
 def tr_recording_log(filename: str):
     """Serve the saved log for a recording."""
-    stem = filename.replace(".mp4", "")
-    log_path = _TR_RECORDINGS_DIR / (stem + ".log")
+    stem = filename[:-4] if filename.endswith(".mp4") else filename
+    log_path = _resolve_recording_path(stem, ".log")
     if not log_path.exists():
         return {"lines": []}
     lines = log_path.read_text(errors="replace").splitlines()
@@ -401,10 +421,10 @@ def tr_recording_log(filename: str):
 @router.delete("/api/test-runner/recording/{filename:path}", summary="Delete Test Recording")
 def tr_recording_delete(filename: str):
     """Delete a test recording and its associated log/overlay files."""
-    stem = filename.replace(".mp4", "")
+    stem = filename[:-4] if filename.endswith(".mp4") else filename
     deleted = []
     for suffix in [".mp4", ".log", "_overlay.mp4"]:
-        p = _TR_RECORDINGS_DIR / (stem + suffix)
+        p = _resolve_recording_path(stem, suffix)
         if p.exists():
             p.unlink()
             deleted.append(p.name)

--- a/gitd/services/agent_chat.py
+++ b/gitd/services/agent_chat.py
@@ -82,23 +82,17 @@ PROVIDERS = {
         "label": "On-device (Gemma)",
         "models": ["gemma-3-1b-it", "gemma-2-2b-it", "gemma-4-e2b-q4km-gguf"],
     },
-    # vLLM slot — also used for any other OpenAI-compatible server (here: a
-    # local llama.cpp/llama-swap router on GITD_VLLM_BASE_URL). Model ids must
-    # match what the server reports at /v1/models or routing fails.
+    # vLLM — full-precision Gemma 4 served from the GPU box,
+    # routed via Mac SSH tunnel + adb reverse so the phone hits it as if it
+    # were on localhost. Same OpenAI-compatible shape as openrouter; we just
+    # point the client at config.vllm_base_url instead.
     "vllm": {
         "label": "vLLM (remote GPU)",
         "models": [
-            "Qwen3-8B-Q4_K_M",
-            "Qwen2.5-7B-Instruct-Q4_K_M",
-            "Qwen2.5-3B-Instruct-Q4_K_M",
-            "Qwen3-14B-Q4_K_M",
-            "Qwen3.5-9B-Q4_K_M",
-            "Meta-Llama-3.1-8B-Instruct-Q4_K_M",
-            "gemma-4-E4B-it-Q4_K_M",
-            "LFM2.5",
-            "GLM-4.7-Flash-Uncen-Hrt-NEO-CODE-MAX-IQ2_M",
-            "Qwen3.6-35B-A3B",
-            "Qwen3.6-35B-A3B-Uncensored",
+            "unsloth/gemma-4-E2B-it",
+            "unsloth/gemma-4-E2B-it-bnb-4bit",
+            "unsloth/gemma-4-E4B-it",
+            "unsloth/gemma-4-E4B-it-bnb-4bit",
         ],
     },
 }

--- a/gitd/services/agent_chat.py
+++ b/gitd/services/agent_chat.py
@@ -82,17 +82,23 @@ PROVIDERS = {
         "label": "On-device (Gemma)",
         "models": ["gemma-3-1b-it", "gemma-2-2b-it", "gemma-4-e2b-q4km-gguf"],
     },
-    # vLLM — full-precision Gemma 4 served from the GPU box,
-    # routed via Mac SSH tunnel + adb reverse so the phone hits it as if it
-    # were on localhost. Same OpenAI-compatible shape as openrouter; we just
-    # point the client at config.vllm_base_url instead.
+    # vLLM slot — also used for any other OpenAI-compatible server (here: a
+    # local llama.cpp/llama-swap router on GITD_VLLM_BASE_URL). Model ids must
+    # match what the server reports at /v1/models or routing fails.
     "vllm": {
         "label": "vLLM (remote GPU)",
         "models": [
-            "unsloth/gemma-4-E2B-it",
-            "unsloth/gemma-4-E2B-it-bnb-4bit",
-            "unsloth/gemma-4-E4B-it",
-            "unsloth/gemma-4-E4B-it-bnb-4bit",
+            "Qwen3-8B-Q4_K_M",
+            "Qwen2.5-7B-Instruct-Q4_K_M",
+            "Qwen2.5-3B-Instruct-Q4_K_M",
+            "Qwen3-14B-Q4_K_M",
+            "Qwen3.5-9B-Q4_K_M",
+            "Meta-Llama-3.1-8B-Instruct-Q4_K_M",
+            "gemma-4-E4B-it-Q4_K_M",
+            "LFM2.5",
+            "GLM-4.7-Flash-Uncen-Hrt-NEO-CODE-MAX-IQ2_M",
+            "Qwen3.6-35B-A3B",
+            "Qwen3.6-35B-A3B-Uncensored",
         ],
     },
 }

--- a/gitd/services/device_context.py
+++ b/gitd/services/device_context.py
@@ -17,7 +17,7 @@ import subprocess
 import urllib.parse
 import urllib.request
 
-from gitd.bots.common.adb import Device
+from gitd.bots.common.adb import Device, capture_screencap_png
 from gitd.bots.common.device import get_device, is_ios_ref
 from gitd.bots.common.ios import remote_xpc_manual_recovery
 
@@ -251,7 +251,7 @@ def list_packages(device: str, *, include_system: bool = False) -> list[str]:
 def _raw_screenshot_bytes(device: str) -> bytes:
     if is_ios_ref(device):
         return get_device(device).take_screenshot()
-    return subprocess.check_output(["adb", "-s", device, "exec-out", "screencap", "-p"], timeout=10)
+    return capture_screencap_png(device, timeout=10)
 
 
 def screenshot(device: str, half_res: bool = True, quality: int = 50) -> dict:

--- a/gitd/skills/auto_creator.py
+++ b/gitd/skills/auto_creator.py
@@ -26,6 +26,7 @@ from xml.etree import ElementTree as ET
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
+from gitd.bots.common.adb import capture_screencap_png
 from gitd.bots.common.device import get_device, is_ios_ref
 
 log = logging.getLogger(__name__)
@@ -290,7 +291,7 @@ class AppExplorer:
     def _screenshot_bytes(self) -> bytes:
         if self.platform == "ios":
             return self.dev.take_screenshot()
-        return subprocess.check_output(["adb", "-s", self.dev.serial, "exec-out", "screencap", "-p"], timeout=10)
+        return capture_screencap_png(self.dev.serial, timeout=10)
 
     def _capture_state(self, depth: int) -> AppState | None:
         """Dump XML + screenshot, create AppState if new."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ghost-in-the-droid"
-version = "1.5.0"
+version = "1.5.1"
 description = "Give any AI agent an Android body. Open-source phone automation via ADB — tap, swipe, type, run skills, scale across devices."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "openai>=1.0",
     "mcp>=1.20",
     "langfuse>=2.0,<3.0",
+    "pillow>=12.3.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
> **⏳ HOLD** — RC branch, staging for v1.5.1. Do **not** merge without CKL's explicit release greenlight.
>
> Additional patches may still land into `rc/v1.5.1` before this ships — this PR body will keep updating as more merge in.

## 🎉 v1.5.1 — What's in the box

A community-driven maintenance release. **Every fix in this release came from an external contributor** — thank you to everyone who pushed patches this week. 🙏

### 🛡️ Security

- **CWE-22 path traversal hardened** in test-recording endpoints — *#31 by [@sebastiondev](https://github.com/sebastiondev)*
  - Impact: `/api/tests/*` recording-file endpoints previously allowed `..`-style path escapes; a crafted request could read/write outside the intended recording dir.
  - Fix: canonical-path enforcement + explicit reject on any traversal component.
  - Severity: moderate. No known exploitation. Recommend upgrading.

### 🐛 Bug fixes

All from a first-time contributor, [@aaratisharma-star](https://github.com/aaratisharma-star), in a single well-scoped PR (*#32*):

- **Windows boot fix** — `gitd/bots/common/ios.py` couldn't even import on Windows because `fcntl` is POSIX-only. Guarded import + no-op flock on nt. Server now starts on Windows.
- **Foldable screencap fix** — on multi-display Android devices (Fold/Flip series, some tablets), `adb exec-out screencap -p` prepends a `[Warning] Multiple displays were found...` line to stdout, corrupting naive PNG reads. Now trimming to the PNG signature. Affects screenshot, streaming, skill auto-creator paths.
- **Vite dev-proxy port fix** — `frontend/vite.config.ts` had `5056` from an unrelated docs commit; backend has always defaulted to `5055`. Frontend dev proxy now hits the right port out of the box for anyone running backend + frontend separately.
- **Pillow explicit dep** — was implicit transitive; now declared. Cleaner installs.

### 📦 Install

```bash
pip install -U ghost-in-the-droid==1.5.1
```

### 👥 Contributors

- [@aaratisharma-star](https://github.com/aaratisharma-star) — first PR, 4 fixes shipped
- [@sebastiondev](https://github.com/sebastiondev) — path-traversal fix

### 🚫 Not in this release

- **Reverted from #32**: model-list swap in `gitd/services/agent_chat.py`. Aarati's underlying observation (default vLLM dropdown model IDs don't match what stock `llama.cpp`/`llama-swap` servers actually serve at `/v1/models`) is real, but her replacement was her personal catalog. Right fix is making the dropdown user-configurable via env var or `config.toml` — filed as follow-up in PR #32.

### 🔍 Diff summary

- 8 files changed
- ~57 lines added, ~14 removed
- 0 breaking changes
- All existing tests + APIs unaffected

### 📎 Included PRs

- #31 by @sebastiondev
- #32 by @aaratisharma-star

---

*This RC is drafted in the open so the community can see what's coming. Fixes may still be added to `rc/v1.5.1` before it merges. Comment here or open a new issue/PR if you spot something we should include.*
