### PR TITLE
fix(deps): pin mcp<2.0 to unblock v1.5.1 PyPI publish

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "psutil>=5.9",
     "docker>=7.0",
     "openai>=1.0",
-    "mcp>=1.20",
+    "mcp>=1.20,<2.0",
     "langfuse>=2.0,<3.0",
     "pillow>=12.3.0",
 ]


### PR DESCRIPTION
**Hotfix on top of v1.5.1.**

v1.5.1 tag build (workflow run 30654540664) failed 'Verify package' step with:

```
File "gitd/mcp_server.py", line 16
    from mcp.server.fastmcp import FastMCP
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

Root cause: mcp==2.0.0 (released between v1.5.0 and today's v1.5.1 tag) removed the fastmcp import path. Our `mcp>=1.20` constraint had no upper bound, so pip resolved to 2.0.

Fix: pin `mcp>=1.20,<2.0`. Proper migration to mcp 2.x is a v1.6.0 task.

After merge, v1.5.1 tag will be force-moved to include this fix + publish workflow re-triggered.