### PR TITLE
Add glama.json to claim server on Glama

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "C-K-Loan"
+  ]
+}


### PR DESCRIPTION
Adds `glama.json` to the repo root so the maintainer can claim the Ghost in the Droid server page on [Glama](https://glama.ai/mcp/servers/ghost-in-the-droid/android-agent).

The server is already indexed and scored (B quality / A maintenance / A license). This file links `C-K-Loan` as the maintainer, enabling admin access to update the description and configure the page.